### PR TITLE
Add ;absorb utility for experience pulses

### DIFF
--- a/scripts/absorb.lic
+++ b/scripts/absorb.lic
@@ -1,0 +1,128 @@
+=begin
+  version: 1.0
+
+  Experience pulse utility script
+
+  By default, this script will run in the background and announce experience
+  gains as they are absorbed.
+
+  Also supports some actions around pulses and mind saturation:
+    * Run until experience absorbed and then exit (ala ;pulse.lic)
+    * Run a command or start another script on an experience pulse (ala ;errand.lic)
+    * Log off when mind clears or reaches a specified level
+
+  Usage:
+    # Run in background and announce absorbed experience
+    ;absorb announce
+
+    # Announce experience until mind clears below 50% full, then stop script
+    ;absorb unfry
+
+    # Announce experience until mind clears below 100% full, then logoff
+    ;absorb unsat --auto-logoff
+
+    # Wait until some exp is absorbed then run a script
+    ;absorb script go2 bank
+
+    # Wait until some exp is absorbed then perform a command
+    ;absorb do gird
+
+  Author: Kragdruk
+  Tags: util
+=end
+
+last_pulse_at = nil
+wait_for_pulse = proc do
+  exper = XMLData.next_level_text
+  wait_while { XMLData.next_level_text == exper }
+
+  if last_pulse_at
+    echo "INFO: been %.1f seconds since last experience gain" % [Time.now - last_pulse_at]
+  end
+  last_pulse_at = Time.now
+
+  gained = if exper =~ /until next/
+             exper.to_i - XMLData.next_level_text.to_i
+           else
+             XMLData.next_level_text.to_i - exper.to_i
+           end
+  gained
+end
+
+announce_loop = proc do
+  loop do
+    echo "Gained #{wait_for_pulse.call} experience"
+  end
+end
+
+logoff_grace_period = 10
+message_count = 50
+logoff_with_countdown = proc do
+  exit_at = Time.now + logoff_grace_period
+
+  message_count.times do
+    time_remaining = exit_at - Time.now
+    break if time_remaining <= 0
+    echo "INFO: logging off in %i seconds" % [time_remaining]
+    pause (logoff_grace_period / message_count.to_f)
+  end
+
+  fput "exit"
+end
+
+mind_level_for = {
+  unfry: 3,
+  unsat: 7,
+}
+
+absorb_until_mind_at = proc do |level|
+  while checkmind level
+    echo "Gained %i experience and your mind is %s" %
+      [wait_for_pulse.call, checkmind]
+    echo "Waiting for your mind to #{mind_level_for.invert[level]}"
+  end
+end
+
+echo "DEBUG: script.vars: #{script.vars.inspect}" if $debug_absorb
+logoff_at_end = if script.vars.any? { |v| v == "--auto-logoff" }
+                script.vars.delete("--auto-logoff")
+                #script.vars[0].gsub!("--auto-logoff", "")
+                true
+              else
+                false
+              end
+echo "DEBUG: logoff_at_end: #{logoff_at_end.inspect}" if $debug_absorb
+echo "DEBUG: script.vars: #{script.vars.inspect}" if $debug_absorb
+
+if script.vars.any? { |v| v =~ /pulse/ }
+  if checkmind(3)
+    echo "Waiting for pulse..."
+    amount_gained = wait_for_pulse.call
+    echo "Gained #{amount_gained} experience" if amount_gained > 0
+  else
+    echo "Not waiting because your mind is mostly clear already"
+  end
+elsif script.vars.any? { |v| v =~ /unfry/ }
+  absorb_until_mind_at.call mind_level_for[:unfry]
+  logoff_with_countdown.call if logoff_at_end
+elsif script.vars.any? { |v| v =~ /unsat/ }
+  absorb_until_mind_at.call mind_level_for[:unsat]
+  logoff_with_countdown.call if logoff_at_end
+elsif script.vars.any? { |v| v =~ /announce/ }
+  announce_loop.call
+elsif script.vars[1] == "script" && script.vars[2]
+  wait_for_pulse.call
+  Script.start(script.vars[2], script.vars[3])
+  announce_loop.call
+elsif script.vars[1].start_with? "exec"
+  wait_for_pulse.call
+  ExecScript.start(script.vars[2], flags={ :quiet => false, :trusted => true })
+  announce_loop.call
+elsif script.vars[1].start_with? "do"
+  wait_for_pulse.call
+  fput script.vars[2..-1].join(" ")
+  announce_loop.call
+else
+  echo "INFO: you didn't give me a command. Defaulting to exp gain announcement behavior."
+  announce_loop.call
+end


### PR DESCRIPTION
Experience pulse utility script

By default, this script will run in the background and announce experience gains as they are absorbed.

Also supports some actions around pulses and mind saturation:

  * Run until experience absorbed and then exit (ala ;pulse.lic)
  * Run a command or start another script on an experience pulse (ala ;errand.lic)
  * Log off when mind clears or reaches a specified level
