### PR TITLE
;notify tweaks

### DIFF
--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -98,6 +98,7 @@ module Notify
     ;notify                      turn on the notify watcher
     ;notify sounds               list all sounds that notify can find on your system
     ;notify set-sound <sound>    set the sound to play when 
+    ;notify play <sound>         play a sound one time without changing any settings
     ;notify mute                 turns off sound
   """
 
@@ -227,11 +228,18 @@ module Notify
         else incoming = line.match(IC_WHISPER).to_struct
           incoming[:type] = "whisper:ic"
         end
-        unless ignored.include?(incoming.from)
+        if should_notify_about?(incoming)
           notify(incoming)
         end
       end
     end
+  end
+
+  IGNORED_BODIES = /^Clearcheck\.|^Clear:/
+
+  def self.should_notify_about?(incoming)
+    !ignored.include?(incoming.from) &&
+      incoming.body !~ IGNORED_BODIES
   end
 
   def self.fork!

--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -362,6 +362,7 @@ if Script.current.vars.include?("set-sound")
   Notify::Sounds.set Script.current.vars.last
   if Notify::Sounds.full_sound_path
     respond "[notify] playing -> #{Notify::Sounds.full_sound_path}"
+    Notify::Sounds.play Notify::Sounds[Notify::Sounds.full_sound_path]
   else
     respond "[notify] muted"
   end

--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -73,16 +73,6 @@ class Hash
   end
 end
 
-class Regexp
-  def or(re)
-    Regexp.new self.to_s + "|" + re.to_s
-  end
-  # define union operator for regex instance
-  def |(re)
-    self.or(re)
-  end
-end
-
 module OS
   def OS.windows?
     (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
@@ -120,7 +110,7 @@ module Notify
   SHOP_SALE       = /^Your (?<item>.*?) just sold for (?<silvers>.*?) silvers from/
   RAFFLE          = /^You\ssense\syou\shave\sjust\swon\sa\sraffle/
 
-  MESSAGE         = (PRIVATE_MESSAGE | IC_WHISPER | OOC_WHISPER | SPEECH | SPINNER | LEVELED_UP)
+  MESSAGE         = Regexp.union(PRIVATE_MESSAGE, IC_WHISPER, OOC_WHISPER, SPEECH, SPINNER, LEVELED_UP)
   DURATION        = :duration
   APP_NAME        = "lnet"
   ICON            = "mail-send-receive"


### PR DESCRIPTION
Some minor changes to ;notify that I have been meaning to submit for a bit for discussion. These three commits should all be independent from each other so we can take out/change anything you don't like.

The Regexp.union change has almost the exact same behavior as your existing monkey patch, but I try to minimize the use of those if there is a built in way of doing it. The Regexp method also preserves flags like `/ignore case/i` when combining regexs.

I updated the help to include the play command but also made the script try to play a sound when changing it as this is the behavior I expected.