### PR TITLE
use a tcp message sink;

### DIFF
--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -30,7 +30,7 @@
     # because it is in a different thread
     Notify::Sounds.set "zelda/email"
   
-    Notify.notify(from: "taters", body: "i'm important", type: Script.current.name)
+    Notify.notify("Ondreian", from: "taters", body: "i'm important", type: Script.current.name)
 
   notes:
     * to be able to use Notify from another script it must be ;trusted
@@ -49,6 +49,7 @@
 =end
 require "ostruct"
 require "socket"
+require "json"
 
 class String
   def is_i?
@@ -311,9 +312,10 @@ module Notify
 
     attr_reader :bridge, :consumer, :acceptor, :clients, :inbox
     def initialize()
-      @bridge = TCPServer.open(HOST, PORT)
+      @bridge  = TCPServer.open(HOST, PORT)
+      @clients = []
+      @inbox   = Queue.new
       Log.out("creating notify background server at #{HOST}:#{PORT}", label: :server)
-      @inbox  = Queue.new
       consume()
       accept_clients()
     end
@@ -325,7 +327,7 @@ module Notify
     def consume()
       @consumer = Thread.new do 
         loop do 
-          handle_message(@inbox.shift) until @inbox.empty?
+          handle_message(*@inbox.shift) until @inbox.empty?
           sleep 0.1
         end
       end
@@ -335,23 +337,27 @@ module Notify
       @acceptor = Thread.new do
         loop do
           Thread.fork(bridge.accept) do |client|
-            Log.out("accepted connection", label: :server)
             clients << client
             while message = client.gets
-              Log.out(message, label: :server_incoming)
-              @inbox << message
-              sleep 0.1
+              begin
+                Log.out(message, label: :server_incoming)
+                @inbox << JSON.parse(message)
+                sleep 0.1
+              rescue => exception
+                Log.out(exception, label: :error)
+              end 
             end
+            clients.delete(client)
           end
         end
       end
     end
 
-    def handle_message(message)
+    def handle_message(char, message)
       begin
-        message = Notify.fmt_message(message)
+        message = Notify.fmt_message(char, message)
         if Notify.should_notify_about?(message)
-          Notify.notify(message)
+          Notify.notify(char, message)
           COOLDOWN.put(message.from, 1)
         else
           Log.out("skipping from #{message.from}", label: :server)
@@ -378,8 +384,7 @@ module Notify
     
     def self.cast(message)
       return if @@socket.nil? or @@socket.closed?
-      message = message + "\n" unless message.end_with?("\n")
-      @@socket << message
+      @@socket << [Char.name, message].to_json + "\n"
       self
     end
   end
@@ -421,9 +426,9 @@ module Notify
   ## system messages on Linux are of a fixed interval
   ## you cannot easily configure this
   ## 
-  def self.show(message)
+  def self.show(char, message)
     message = message.to_struct if message.is_a?(Hash)
-    title = [message.from, Char.name].join(" => ")
+    title = [message.from, char].join(" => ")
     if OS.linux?
       %x{#{NOTIFY} "#{title} [#{message.type}]" "#{message.body}" --icon=#{ICON} --app-name=#{APP_NAME}}
     elsif OS.mac?
@@ -433,9 +438,9 @@ module Notify
     end
   end
 
-  def self.notify(incoming)
+  def self.notify(char, incoming)
     incoming = incoming.to_struct if incoming.is_a?(Hash)
-    show incoming
+    Notify.show(char, incoming)
     Sounds.play Sounds.current
   end
 
@@ -516,7 +521,7 @@ module Notify
 
   PLAYER_MESSAGES = %w(lnet speech whisper)
 
-  def self.fmt_message(line)
+  def self.fmt_message(char, line)
     if incoming = line.match(PRIVATE_MESSAGE).to_struct
       incoming[:type] = "lnet"
     elsif incoming = line.match(SPEECH).to_struct
@@ -527,19 +532,19 @@ module Notify
       incoming = OpenStruct.new(
         from: :merchant,
         type: :spinner,
-        body: "#{Char.name} has been spun for a service"
+        body: "#{char} has been spun for a service"
       )
     elsif line =~ RAFFLE
       incoming = OpenStruct.new(
         from: :raffle,
         type: :win,
-        body: "#{Char.name} won a raffle"
+        body: "#{char} won a raffle"
       )
     elsif data = line.match(LEVELED_UP).to_struct
       incoming = OpenStruct.new(
         from: :game,
         type: :level_up,
-        body: "#{Char.name} is now level #{data.level}"
+        body: "#{char} is now level #{data.level}"
       )
     elsif data = line.match(SHOP_SALE).to_struct
       incoming = OpenStruct.new(

--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -48,6 +48,7 @@
   
 =end
 require "ostruct"
+require "socket"
 
 class String
   def is_i?
@@ -89,45 +90,9 @@ module OS
   def OS.linux?
     OS.unix? and not OS.mac?
   end
-end
 
-module Notify
-  HELP = """
-    ;notify@1.0.0
 
-    ;notify                      turn on the notify watcher
-    ;notify sounds               list all sounds that notify can find on your system
-    ;notify set-sound <sound>    set the sound to play when 
-    ;notify play <sound>         play a sound one time without changing any settings
-    ;notify mute                 turns off sound
-  """
-
-  PRIVATE_MESSAGE = /^\[Private\]\-GSIV:(?<from>.*?): "(?<body>.*?)"/
-  OOC_WHISPER     = /^\(OOC\) (?<from>.*?)'s player whispers(| to the group), "(?<body>.*?)"$/
-  IC_WHISPER      = /^(?<from>.*?) whispers(| to the group), "(?<body>.*?)"$/
-  SPEECH          = /^Speaking (.*?|)to you, (?<from>.*?) (.*?), "(?<body>.*?)"$/
-  SPINNER         = /^(.*?) comes to a stop pointing directly at you!$/
-  LEVELED_UP      = /^You are now level (?<level>\d+)!$/
-  SHOP_SALE       = /^Your (?<item>.*?) just sold for (?<silvers>.*?) silvers from/
-  RAFFLE          = /^You\ssense\syou\shave\sjust\swon\sa\sraffle/
-
-  MESSAGE         = Regexp.union(PRIVATE_MESSAGE, IC_WHISPER, OOC_WHISPER, SPEECH, SPINNER, LEVELED_UP)
-  DURATION        = :duration
-  APP_NAME        = "lnet"
-  ICON            = "mail-send-receive"
-  TIMEOUT         = 30 # seconds
-  
-  TRAINING_AREAS  = [16994]
-
-  NOTIFY = if OS.linux?
-    "notify-send"
-  elsif OS.mac?
-    "osascript"
-  else
-    nil
-  end
-
-  def self.which?(cmd)
+  def OS.which?(cmd)
     exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
     ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
       exts.each { |ext|
@@ -137,137 +102,39 @@ module Notify
     end
     return nil
   end
+end
+
+module Notify
   ##
-  ## system messages on Linux are of a fixed interval
-  ## you cannot easily configure this
-  ## 
-  def self.show(message)
-    message = message.to_struct if message.is_a?(Hash)
-    title = [message.from, Char.name].join(" => ")
-    if OS.linux?
-      %x{#{NOTIFY} "#{title} [#{message.type}]" "#{message.body}" --icon=#{ICON} --app-name=#{APP_NAME}}
-    elsif OS.mac?
-      %x{#{NOTIFY} -e 'display notification "#{message.body}" with title "#{title} #{message.type}"'}
-    else
-      # silence is golden
+  ## contextual logging
+  ##
+  module Log
+    def self.bold(msg)
+      _respond "<pushBold/>#{msg}<popBold/>"
     end
-  end
-
-  def self.notify(incoming)
-    incoming = incoming.to_struct if incoming.is_a?(Hash)
-    show incoming
-    Sounds.play Sounds.current
-  end
-
-  def self.duration=(milliseconds)
-    Settings[DURATION] = milliseconds
-    Settings.save
-  end
-
-  def self.duration
-    Settings[DURATION] ||= 3000
-  end
-
-  def self.ignore(*chars)
-    Settings[:ignored] = ignored + chars
-    Settings.save
-  end
-
-  def self.unignore(*chars)
-    Settings[:ignored] = ignored - chars
-    Settings.save
-  end
-
-  def self.ignored
-    Settings[:ignored] ||= []
-  end
-
-  def self.play(sound)
-    Sounds.play sound
-  end
-
-  def self.watch!
-    fork!
-
-    before_dying {
-      @@background.join.kill
-    }
-
-    while line = get
-      if line =~ MESSAGE
-        if incoming = line.match(PRIVATE_MESSAGE).to_struct
-          incoming[:type] = "lnet"
-        elsif incoming = line.match(SPEECH).to_struct
-          incoming[:type] = "speech"
-        elsif incoming = line.match(OOC_WHISPER).to_struct
-          incoming[:type] = "whisper:ooc"
-        elsif line =~ SPINNER
-          incoming = OpenStruct.new(
-            from: :merchant,
-            type: :spinner,
-            body: "#{Char.name} has been spun for a service"
-          )
-        elsif line =~ RAFFLE
-          incoming = OpenStruct.new(
-            from: :raffle,
-            type: :win,
-            body: "#{Char.name} won a raffle"
-          )
-        elsif data = line.match(LEVELED_UP).to_struct
-          incoming = OpenStruct.new(
-            from: :game,
-            type: :level_up,
-            body: "#{Char.name} is now level #{data.level}"
-          )
-        elsif data = line.match(SHOP_SALE).to_struct
-          incoming = OpenStruct.new(
-            from: :shop,
-            type: :sale,
-            body: line,
-          )
-        else incoming = line.match(IC_WHISPER).to_struct
-          incoming[:type] = "whisper:ic"
-        end
-        if should_notify_about?(incoming)
-          notify(incoming)
-        end
+    
+    def self.out(msg, label: :debug)
+      return if !Script.current.vars.include?("--debug") && !msg.is_a?(Exception)
+      if msg.is_a?(Exception)
+        msg = %{
+          #{msg.message}
+          #{msg.backtrace.join("\n")}
+        }
       end
+
+      bold _view(msg, label)
     end
-  end
 
-  IGNORED_BODIES = /^Clearcheck\.|^Clear:/
+    def self._view(msg, label)
+      %{[#{Script.current.name}.#{label}] #{msg}}
+    end
 
-  def self.should_notify_about?(incoming)
-    !ignored.include?(incoming.from) &&
-      incoming.body !~ IGNORED_BODIES
-  end
+    def self.pp(msg, label = :debug)
+      respond _view(msg.inspect, label)
+    end
 
-  def self.fork!
-    @@background = Thread.new {
-      ttl = nil
-      loop {
-        sleep 0.15
-        ttl = nil if ttl < Time.new - TIMEOUT
-        next unless ttl.nil?
-        if message = should_inform_user?
-          ttl = Time.now
-          notify(
-            from: "notify",
-            type: "danger",
-            body: message,
-          )
-        end
-      }
-    }
-  end
-
-  def self.should_inform_user?
-    if stunned? && !TRAINING_AREAS.include?(Room.current.id)
-      "#{Char.name} has been stunned!"
-    elsif percenthealth < 90
-      "#{Char.name}'s health is at #{percenthealth}%"
-    else
-      false
+    def self.dump(*args)
+      pp *args
     end
   end
 
@@ -319,7 +186,381 @@ module Notify
     end
 
     def self.play(sound = full_sound_path)
-      %x{#{BIN} #{self[sound]}} if Notify.which?(BIN) && sound
+      %x{#{BIN} #{self[sound]}} if OS.which?(BIN) && sound
+    end
+  end
+
+  class Cooldown
+    attr_accessor :max_size
+    ##
+    ## only allow notifications from
+    ## a particular source to happen
+    ## as most every 5 seconds
+    ##
+    ## TODO : make this configurable?
+    ##
+    def self.ttl()
+      Time.now + 5
+    end
+  
+    def initialize(max_size = 4)
+      @data = {}
+      @max_size = max_size
+    end
+  
+    def put(key, value)
+      @data.store key, {cycles: 0, ttl: Cooldown.ttl(), value: value}
+      age_keys
+      prune
+    end
+
+    def has_key?(key)
+      !read(key).nil?
+    end
+  
+    def read(key)
+      if value = @data[key]
+        touch(key)
+        age_keys
+        prune
+      end
+      value
+    end
+
+    def touch(key)
+      @data[key][:cycles] = 0
+    end
+  
+    def age_keys
+      @data.each{ |k,v| @data[k][:cycles] += 1 }
+    end
+  
+    def prune
+      max     = 0
+      stale   = []
+      now     = Time.now
+      @data.each do |k, v|
+        ## if this key is no longer on cooldown
+        ## flush it from the hybrid LRU Cache
+        if now > v[:ttl]
+          Log.out("pruning #{k} >> :ttl", label: :cooldown)
+          @data.delete(k)
+        ## if it's a new max cycle
+        ## clear the previously scheduled keys
+        ## and schedule it for removal
+        elsif v[:cycles] > max
+          stale.clear
+          stale << k
+        ## if it matches the current max cycles
+        ## also add it to the schedule
+        elsif v[:cycles].eql?(max)
+          stale << k
+        end
+      end
+      ## skip stale prunes if the cache is still small
+      return unless @data.size > @max_size
+      stale.each do |k|
+        Log.out("pruning #{k} >> :cycles", label: :cooldown)
+        @data.delete(k)
+      end
+    end
+  end
+
+  class Server
+    PORT = 3434
+    HOST = "localhost"
+
+    @@self = nil
+
+    def self.exists?
+      begin
+        Timeout::timeout(1) do
+          begin
+            s = TCPSocket.new(HOST, PORT)
+            s.close
+            return true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            return false
+          end
+        end
+      rescue Timeout::Error
+        # silence is golden
+      end
+      return false
+    end
+
+    def self.local?
+      !@@self.nil?
+    end
+
+    def self.close()
+      Log.out(">> closing", label: :server)
+      @@self.close()
+      @@self = nil
+    end
+
+    def self.self()
+      @@self
+    end
+
+    def self.link()
+      return [Sink.link()] if Server.exists?
+      @@self = Server.new
+      return [Sink.link(), @@self]
+    end
+
+    attr_reader :bridge, :consumer, :acceptor, :clients, :inbox
+    def initialize()
+      @bridge = TCPServer.open(HOST, PORT)
+      Log.out("creating notify background server at #{HOST}:#{PORT}", label: :server)
+      @inbox  = Queue.new
+      consume()
+      accept_clients()
+    end
+
+    def close()
+      @bridge.close()
+    end
+
+    def consume()
+      @consumer = Thread.new do 
+        loop do 
+          handle_message(@inbox.shift) until @inbox.empty?
+          sleep 0.1
+        end
+      end
+    end
+
+    def accept_clients()
+      @acceptor = Thread.new do
+        loop do
+          Thread.fork(bridge.accept) do |client|
+            Log.out("accepted connection", label: :server)
+            clients << client
+            while message = client.gets
+              Log.out(message, label: :server_incoming)
+              @inbox << message
+              sleep 0.1
+            end
+          end
+        end
+      end
+    end
+
+    def handle_message(message)
+      begin
+        message = Notify.fmt_message(message)
+        if Notify.should_notify_about?(message)
+          Notify.notify(message)
+          COOLDOWN.put(message.from, 1)
+        else
+          Log.out("skipping from #{message.from}", label: :server)
+        end
+      rescue => exception
+        Log.out(exception, label: :error)
+      end
+    end
+  end
+
+  class Sink
+    @@socket = nil
+
+    def self.link()
+      @@socket = TCPSocket.open(Server::HOST, Server::PORT)
+      self
+    end
+
+    def self.close()
+      Log.out(">> closing", label: :sink)
+      @@socket.close
+      self
+    end
+    
+    def self.cast(message)
+      return if @@socket.nil? or @@socket.closed?
+      message = message + "\n" unless message.end_with?("\n")
+      @@socket << message
+      self
+    end
+  end
+
+  HELP = <<-HELP
+    ;notify@1.0.0
+
+    ;notify                      turn on the notify watcher
+    ;notify sounds               list all sounds that notify can find on your system
+    ;notify set-sound <sound>    set the sound to play when 
+    ;notify play <sound>         play a sound one time without changing any settings
+    ;notify mute                 turns off sound
+  HELP
+
+  PRIVATE_MESSAGE = /^\[Private\]\-GSIV:(?<from>.*?): "(?<body>.*?)"/
+  OOC_WHISPER     = /^\(OOC\) (?<from>.*?)'s player whispers(| to the group), "(?<body>.*?)"$/
+  IC_WHISPER      = /^(?<from>.*?) whispers(| to the group), "(?<body>.*?)"$/
+  SPEECH          = /^Speaking (.*?|)to you, (?<from>.*?) (.*?), "(?<body>.*?)"$/
+  SPINNER         = /^(.*?) comes to a stop pointing directly at you!$/
+  LEVELED_UP      = /^You are now level (?<level>\d+)!$/
+  SHOP_SALE       = /^Your (?<item>.*?) just sold for (?<silvers>.*?) silvers from/
+  RAFFLE          = /^You\ssense\syou\shave\sjust\swon\sa\sraffle/
+
+  MESSAGE_PATTERN = Regexp.union(PRIVATE_MESSAGE, IC_WHISPER, OOC_WHISPER, SPEECH, SPINNER, LEVELED_UP)
+  APP_NAME        = "gemstone"
+  ICON            = "mail-send-receive"
+  TIMEOUT         = 30 # seconds
+  COOLDOWN        = Cooldown.new
+  TRAINING_AREAS  = [16994]
+
+  NOTIFY = if OS.linux?
+    "notify-send"
+  elsif OS.mac?
+    "osascript"
+  else
+    nil
+  end
+  ##
+  ## system messages on Linux are of a fixed interval
+  ## you cannot easily configure this
+  ## 
+  def self.show(message)
+    message = message.to_struct if message.is_a?(Hash)
+    title = [message.from, Char.name].join(" => ")
+    if OS.linux?
+      %x{#{NOTIFY} "#{title} [#{message.type}]" "#{message.body}" --icon=#{ICON} --app-name=#{APP_NAME}}
+    elsif OS.mac?
+      %x{#{NOTIFY} -e 'display notification "#{message.body}" with title "#{title} #{message.type}"'}
+    else
+      # silence is golden
+    end
+  end
+
+  def self.notify(incoming)
+    incoming = incoming.to_struct if incoming.is_a?(Hash)
+    show incoming
+    Sounds.play Sounds.current
+  end
+
+  def self.duration=(milliseconds)
+    Settings[:duration] = milliseconds
+    Settings.save
+  end
+
+  def self.duration
+    Settings[:duration] ||= 3000
+  end
+
+  def self.ignore(*chars)
+    Settings[:ignored] = ignored + chars
+    Settings.save
+  end
+
+  def self.unignore(*chars)
+    Settings[:ignored] = ignored - chars
+    Settings.save
+  end
+
+  def self.ignored
+    Settings[:ignored] ||= []
+  end
+
+  def self.play(sound)
+    Sounds.play sound
+  end
+
+  def self.watch()
+    Notify::Server.link()
+    Notify.fork()
+    
+    before_dying do
+      @@background.join.kill
+      Sink.close()
+      Notify::Server.close() if Notify::Server.local?
+    end
+
+    while line = get
+      if line =~ MESSAGE_PATTERN
+        Sink.cast(line)
+      end
+    end
+  end
+
+  IGNORED_BODIES = /^Clearcheck\.|^Clear:/
+
+  def self.should_notify_about?(incoming)
+    not should_skip_message?(incoming)
+  end
+
+  def self.should_skip_message?(incoming)
+    ignored.include?(incoming.from)  ||
+    incoming.body =~ IGNORED_BODIES  ||
+    COOLDOWN.has_key?(incoming.from)
+  end
+  
+  def self.fork()
+    @@background = Thread.new {
+      ttl = nil
+      loop {
+        sleep 0.15
+        ttl = nil if ttl < Time.new - TIMEOUT
+        next unless ttl.nil?
+        if message = should_inform_user?
+          ttl = Time.now
+          notify(
+            from: "notify",
+            type: "danger",
+            body: message,
+          )
+        end
+      }
+    }
+  end
+
+  PLAYER_MESSAGES = %w(lnet speech whisper)
+
+  def self.fmt_message(line)
+    if incoming = line.match(PRIVATE_MESSAGE).to_struct
+      incoming[:type] = "lnet"
+    elsif incoming = line.match(SPEECH).to_struct
+      incoming[:type] = "speech"
+    elsif incoming = line.match(OOC_WHISPER).to_struct
+      incoming[:type] = "whisper"
+    elsif line =~ SPINNER
+      incoming = OpenStruct.new(
+        from: :merchant,
+        type: :spinner,
+        body: "#{Char.name} has been spun for a service"
+      )
+    elsif line =~ RAFFLE
+      incoming = OpenStruct.new(
+        from: :raffle,
+        type: :win,
+        body: "#{Char.name} won a raffle"
+      )
+    elsif data = line.match(LEVELED_UP).to_struct
+      incoming = OpenStruct.new(
+        from: :game,
+        type: :level_up,
+        body: "#{Char.name} is now level #{data.level}"
+      )
+    elsif data = line.match(SHOP_SALE).to_struct
+      incoming = OpenStruct.new(
+        from: :shop,
+        type: :sale,
+        body: line,
+      )
+    else incoming = line.match(IC_WHISPER).to_struct
+      incoming[:type] = "whisper:ic"
+    end
+    
+    return incoming
+  end
+
+  def self.should_inform_user?
+    if stunned? && !TRAINING_AREAS.include?(Room.current.id)
+      "#{Char.name} has been stunned!"
+    elsif percenthealth < 90
+      "#{Char.name}'s health is at #{percenthealth}%"
+    else
+      false
     end
   end
 end
@@ -362,7 +603,7 @@ if Script.current.vars[1] == "unignore"
   exit
 end
 
-unless Notify.which?(Notify::NOTIFY)
+unless OS.which?(Notify::NOTIFY)
   raise Exception.new "expected #{Notify::NOTIFY} exectuable (notify-send) not found in $PATH"
 end
 
@@ -377,10 +618,10 @@ if Script.current.vars.include?("set-sound")
   exit
 end
 
-if Script.current.vars.first
+unless Script.current.vars.first.eql?("--debug") or Script.current.vars.empty?
   # unhandled argument
   respond Notify::HELP
   exit
 end
 
-Notify.watch!
+Notify.watch()

--- a/scripts/notify.lic
+++ b/scripts/notify.lic
@@ -30,7 +30,7 @@
     # because it is in a different thread
     Notify::Sounds.set "zelda/email"
   
-    Notify.notify("Ondreian", from: "taters", body: "i'm important", type: Script.current.name)
+    Notify.notify(to: "Ondreian", from: "taters", body: "i'm important", type: Script.current.name)
 
   notes:
     * to be able to use Notify from another script it must be ;trusted
@@ -220,10 +220,10 @@ module Notify
     end
   
     def read(key)
+      prune
       if value = @data[key]
         touch(key)
         age_keys
-        prune
       end
       value
     end
@@ -327,7 +327,20 @@ module Notify
     def consume()
       @consumer = Thread.new do 
         loop do 
-          handle_message(*@inbox.shift) until @inbox.empty?
+          until @inbox.empty?
+            begin
+              packet, client = @inbox.shift
+              kind, message = packet
+              case kind.to_sym
+              when :ping
+                pong(client)
+              else
+                schedule_notification(kind, message)
+              end
+            rescue => exception
+              Log.out(exception, label: :error)
+            end
+          end
           sleep 0.1
         end
       end
@@ -341,7 +354,7 @@ module Notify
             while message = client.gets
               begin
                 Log.out(message, label: :server_incoming)
-                @inbox << JSON.parse(message)
+                @inbox << [JSON.parse(message), client]
                 sleep 0.1
               rescue => exception
                 Log.out(exception, label: :error)
@@ -353,11 +366,11 @@ module Notify
       end
     end
 
-    def handle_message(char, message)
+    def schedule_notification(char, message)
       begin
         message = Notify.fmt_message(char, message)
         if Notify.should_notify_about?(message)
-          Notify.notify(char, message)
+          Notify.notify(message)
           COOLDOWN.put(message.from, 1)
         else
           Log.out("skipping from #{message.from}", label: :server)
@@ -366,14 +379,46 @@ module Notify
         Log.out(exception, label: :error)
       end
     end
+
+    def pong(client)
+      client << ["pong", 1].to_json + "\n"
+    end
   end
 
   class Sink
-    @@socket = nil
+    @@socket    = nil
+    @@reader    = nil
+    @@ping      = nil
+    @@keepalive = Time.now
 
     def self.link()
       @@socket = TCPSocket.open(Server::HOST, Server::PORT)
+      @@reader = Sink.read()
+      @@ping   = Sink.ping()
       self
+    end
+
+    def self.read()
+      Thread.new do 
+        while from_server = @@socket.gets
+          begin
+            Log.out(JSON.parse(from_server))
+            Sink.consume *JSON.parse(from_server)
+          rescue => exception
+            Log.out(exception, label: :error)
+          end
+          break if Sink.closed?
+        end
+      end
+    end
+
+    def self.consume(kind, message)
+      case kind.to_sym
+      when :pong
+        @@keepalive = Time.now
+      else
+        Log.out(message, label: kind.to_sym)
+      end
     end
 
     def self.close()
@@ -384,8 +429,25 @@ module Notify
     
     def self.cast(message)
       return if @@socket.nil? or @@socket.closed?
-      @@socket << [Char.name, message].to_json + "\n"
+      begin
+        @@socket << [Char.name, message].to_json + "\n"  
+      rescue => exception
+        # reconnect
+      end
       self
+    end
+
+    def self.ping()
+      Thread.new do 
+        loop do
+          @@socket << ["ping"].to_json + "\n"
+          sleep(5)
+        end
+      end
+    end
+
+    def self.closed?
+      @@keepalive < Time.now - 11 || @@socket.closed?
     end
   end
 
@@ -426,9 +488,9 @@ module Notify
   ## system messages on Linux are of a fixed interval
   ## you cannot easily configure this
   ## 
-  def self.show(char, message)
+  def self.show(message)
     message = message.to_struct if message.is_a?(Hash)
-    title = [message.from, char].join(" => ")
+    title = [message.from, message.to || Char.name].join(" => ")
     if OS.linux?
       %x{#{NOTIFY} "#{title} [#{message.type}]" "#{message.body}" --icon=#{ICON} --app-name=#{APP_NAME}}
     elsif OS.mac?
@@ -438,9 +500,9 @@ module Notify
     end
   end
 
-  def self.notify(char, incoming)
+  def self.notify(incoming)
     incoming = incoming.to_struct if incoming.is_a?(Hash)
-    Notify.show(char, incoming)
+    Notify.show(incoming)
     Sounds.play Sounds.current
   end
 
@@ -483,6 +545,10 @@ module Notify
 
     while line = get
       if line =~ MESSAGE_PATTERN
+        if Sink.closed?
+          Log.out("restarting tcp sink service", label: :sink)
+          Notify::Server.link()
+        end
         Sink.cast(line)
       end
     end
@@ -555,7 +621,8 @@ module Notify
     else incoming = line.match(IC_WHISPER).to_struct
       incoming[:type] = "whisper:ic"
     end
-    
+
+    incoming[:to] = char
     return incoming
   end
 


### PR DESCRIPTION
1. Updates notify to create a background TCP server that accepts messages from all clients and forwards them to the system notification library
2. Uses a hybrid TTL/LRU cache mechanism to rate limit messages from clients