### PR TITLE
;wps: Smithy helper script v1.0

### DIFF
--- a/scripts/wps.lic
+++ b/scripts/wps.lic
@@ -1,0 +1,138 @@
+=begin
+
+  WPS smithy service helper script
+
+  This script will request multiple services from the smithy. It tries to be
+  strict about what it will accept for input and to verify that a blacksmith
+  NPC is present before requesting services.
+
+  Usage:
+
+  ;wps <count> <crit, damage, or sighting>
+
+  author: Kragdruk
+  version: 1.0
+  tags: util, ccf, duskruin, festival, merchant, wps, smithy
+
+=end
+
+module WPS
+  class Error < StandardError
+    def for_cmdline
+      <<-OUTPUT
+
+    ERROR: #{message}
+
+      OUTPUT
+    end
+  end
+
+  class ArgumentError < Error; end
+
+  SERVICE_TYPES = %w[critical damage sighting]
+
+  def self.determine_service_type_from(arg)
+    SERVICE_TYPES.find { |t| t.start_with? arg.downcase }
+  end
+
+  BLACKSMITH_DESCRIPTIONS = [
+    "old dwarven blacksmith",
+  ]
+
+  def self.blacksmith
+    GameObj.npcs.find do |npc|
+      BLACKSMITH_DESCRIPTIONS.include? npc.name
+    end
+  end
+
+  def self.print_usage
+    respond <<-USAGE
+    Usage:
+
+    #{$clean_lich_char}#{Script.current.name} <count> <crit, damage, or sighting>
+
+    USAGE
+  end
+
+  def self.perform_services(opts)
+    opts.fetch(:count).times do
+      perform_service_request(opts.fetch(:service))
+      perform_service_confirmation
+    end
+  end
+
+  def self.perform_service_request(service_type)
+    if result = dothistimeout("ask ##{blacksmith.id} about #{service_type}", 5, /Modified \w+ Type: #{service_type}/i)
+      result
+    else
+      fail Error.new("doesn't seem that we were able to ask the blacksmith for work")
+    end
+  end
+
+  def self.perform_service_confirmation
+    if result = dothistimeout( "ask ##{blacksmith.id} about confirm", 5, /quickly returns, idly polishing it with a dirty rag as it hands it back to you/)
+      result
+    else
+      fail Error.new("doesn't seem that we were able to ask the blacksmith for work")
+    end
+  end
+
+  def self.validate_script_arguments
+    Script.current.vars[2] or
+      fail WPS::ArgumentError.new("Not enough script arguments given")
+
+    Script.current.vars[1] =~ /\A\d+\Z/ or
+      fail WPS::ArgumentError.new("Didn't recognize #{Script.current.vars[1]} as a valid number of services")
+
+    determine_service_type_from(Script.current.vars[2]) or
+      fail WPS::ArgumentError.new("Didn't recognize #{Script.current.vars[2]} as a valid service type")
+
+    Script.current.vars
+  end
+
+  def self.validate_blacksmith_presence
+    blacksmith or
+      fail WPS::Error.new("I don't see a blacksmith in this list of npcs: #{GameObj.npcs.map(&:name).inspect}")
+  end
+
+  def self.validate
+    validate_script_arguments && validate_blacksmith_presence
+  end
+
+  def self.normalize_input(count_input, service_input)
+    {}.tap do |opts|
+      opts[:count] = count_input.to_i
+      opts[:service] = determine_service_type_from service_input
+    end
+  end
+
+  def self.pause_for_confirmation_of(opts)
+    respond <<-CONFIRMATION
+
+    Unpause #{$clean_lich_char}#{Script.current.name} to request:"
+
+    #{opts[:count]} #{opts[:service]} services from #{blacksmith.name}"
+
+    CONFIRMATION
+    pause_script
+  end
+
+  def self.run
+    begin
+      if validate
+        opts = normalize_input(*Script.current.vars[1..-1])
+        pause_for_confirmation_of(opts)
+        perform_services(opts)
+      end
+    rescue WPS::ArgumentError => e
+      respond e.for_cmdline
+      print_usage
+    rescue WPS::Error => e
+      respond e.for_cmdline
+    end
+  end
+end
+
+if defined? Lich
+  WPS.run
+end


### PR DESCRIPTION
This script will request multiple services from the smithy. It tries to be strict about what it will accept for input and to verify that a blacksmith NPC is present before requesting services.

This is kind of overkill for a script that provides minimal utility over `;e count.times { ... }`, but I wanted to ride out the command pattern and some simple extract method refactoring to see where it landed. Welcome any feedback if you have any as I have a couple points for discussion.

