### PR TITLE
Move lich repo publishing to deploy step in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: ruby
 rvm:
   - 2.3
-# whitelist branches that can publish
-# to the repo
+# whitelist branches that run in CI
 branches:
   only:
   - master
+  - canary
 
-script:
-  util/repo
+script: true
+
+# deploy changes on master to lich repo
+deploy:
+  provider: script
+  script: util/repo
+  on:
+    branch: master


### PR DESCRIPTION
I was paranoid about accidentally publishing in #17, so I created this PR to just to move `util/repo` from the script step to the deploy step.