### PR TITLE
Allow all branches to build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: ruby
 rvm:
   - 2.3
-# whitelist branches that run in CI
-branches:
-  only:
-  - master
-  - canary
 
 script: true
 


### PR DESCRIPTION
Now that we have:

* Moved util/repo to the deploy step
* Set the deploy step to only run on the master branch
* Moved the elanthia-online lich repo credentials into secret
  environmental vars to prevent untrusted builds from accessing them

we can safely allow any branch to build in Travis.