### PR TITLE
gameobj-data.xml specs for NPC categories

### DIFF
--- a/lib/lich/gameobj.rb
+++ b/lib/lich/gameobj.rb
@@ -1,0 +1,341 @@
+require 'rexml/document'
+
+# GameObj#load_data depends on this monkey patch
+class NilClass
+  def method_missing(*); end
+end
+
+# Tell GameObj where to find the GameObj data XML file
+class GameObj
+  DATA_DIR = Pathname.new('./scripts').expand_path
+end
+
+# Lich 4.6.44
+class GameObj
+  @@loot          = Array.new
+  @@npcs          = Array.new
+  @@npc_status    = Hash.new
+  @@pcs           = Array.new
+  @@pc_status     = Hash.new
+  @@inv           = Array.new
+  @@contents      = Hash.new
+  @@right_hand    = nil
+  @@left_hand     = nil
+  @@room_desc     = Array.new
+  @@fam_loot      = Array.new
+  @@fam_npcs      = Array.new
+  @@fam_pcs       = Array.new
+  @@fam_room_desc = Array.new
+  @@type_data     = Hash.new
+  @@sellable_data = Hash.new
+  @@elevated_load = proc { GameObj.load_data }
+
+  attr_reader :id
+  attr_accessor :noun, :name, :before_name, :after_name
+  def initialize(id, noun, name, before=nil, after=nil)
+    @id = id
+    @noun = noun
+    @noun = 'lapis' if @noun == 'lapis lazuli'
+    @noun = 'hammer' if @noun == "Hammer of Kai"
+    @noun = 'mother-of-pearl' if (@noun == 'pearl') and (@name =~ /mother\-of\-pearl/)
+    @name = name
+    @before_name = before
+    @after_name = after
+  end
+  def type
+    GameObj.load_data if @@type_data.empty?
+    list = @@type_data.keys.find_all { |t| (@name =~ @@type_data[t][:name] or @noun =~ @@type_data[t][:noun]) and (@@type_data[t][:exclude].nil? or @name !~ @@type_data[t][:exclude]) }
+    if list.empty?
+      nil
+    else
+      list.join(',')
+    end
+  end
+  def sellable
+    GameObj.load_data if @@sellable_data.empty?
+    list = @@sellable_data.keys.find_all { |t| (@name =~ @@sellable_data[t][:name] or @noun =~ @@sellable_data[t][:noun]) and (@@sellable_data[t][:exclude].nil? or @name !~ @@sellable_data[t][:exclude]) }
+    if list.empty?
+      nil
+    else
+      list.join(',')
+    end
+  end
+  def status
+    if @@npc_status.keys.include?(@id)
+      @@npc_status[@id]
+    elsif @@pc_status.keys.include?(@id)
+      @@pc_status[@id]
+    elsif @@loot.find { |obj| obj.id == @id } or @@inv.find { |obj| obj.id == @id } or @@room_desc.find { |obj| obj.id == @id } or @@fam_loot.find { |obj| obj.id == @id } or @@fam_npcs.find { |obj| obj.id == @id } or @@fam_pcs.find { |obj| obj.id == @id } or @@fam_room_desc.find { |obj| obj.id == @id } or (@@right_hand.id == @id) or (@@left_hand.id == @id) or @@contents.values.find { |list| list.find { |obj| obj.id == @id  } }
+      nil
+    else
+      'gone'
+    end
+  end
+  def status=(val)
+    if @@npcs.any? { |npc| npc.id == @id }
+      @@npc_status[@id] = val
+    elsif @@pcs.any? { |pc| pc.id == @id }
+      @@pc_status[@id] = val
+    else
+      nil
+    end
+  end
+  def to_s
+    @noun
+  end
+  def empty?
+    false
+  end
+  def contents
+    @@contents[@id].dup
+  end
+  def GameObj.[](val)
+    if val.class == String
+      if val =~ /^\-?[0-9]+$/
+        obj = @@inv.find { |o| o.id == val } || @@loot.find { |o| o.id == val } || @@npcs.find { |o| o.id == val } || @@pcs.find { |o| o.id == val } || [ @@right_hand, @@left_hand ].find { |o| o.id == val } || @@room_desc.find { |o| o.id == val }
+      elsif val.split(' ').length == 1
+        obj = @@inv.find { |o| o.noun == val } || @@loot.find { |o| o.noun == val } || @@npcs.find { |o| o.noun == val } || @@pcs.find { |o| o.noun == val } || [ @@right_hand, @@left_hand ].find { |o| o.noun == val } || @@room_desc.find { |o| o.noun == val }
+      else
+        obj = @@inv.find { |o| o.name == val } || @@loot.find { |o| o.name == val } || @@npcs.find { |o| o.name == val } || @@pcs.find { |o| o.name == val } || [ @@right_hand, @@left_hand ].find { |o| o.name == val } || @@room_desc.find { |o| o.name == val } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i }
+      end
+    elsif val.class == Regexp
+      obj = @@inv.find { |o| o.name =~ val } || @@loot.find { |o| o.name =~ val } || @@npcs.find { |o| o.name =~ val } || @@pcs.find { |o| o.name =~ val } || [ @@right_hand, @@left_hand ].find { |o| o.name =~ val } || @@room_desc.find { |o| o.name =~ val }
+    end
+  end
+  def GameObj
+    @noun
+  end
+  def full_name
+    "#{@before_name}#{' ' unless @before_name.nil? or @before_name.empty?}#{name}#{' ' unless @after_name.nil? or @after_name.empty?}#{@after_name}"
+  end
+  def GameObj.new_npc(id, noun, name, status=nil)
+    obj = GameObj.new(id, noun, name)
+    @@npcs.push(obj)
+    @@npc_status[id] = status
+    obj
+  end
+  def GameObj.new_loot(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@loot.push(obj)
+    obj
+  end
+  def GameObj.new_pc(id, noun, name, status=nil)
+    obj = GameObj.new(id, noun, name)
+    @@pcs.push(obj)
+    @@pc_status[id] = status
+    obj
+  end
+  def GameObj.new_inv(id, noun, name, container=nil, before=nil, after=nil)
+    obj = GameObj.new(id, noun, name, before, after)
+    if container
+      @@contents[container].push(obj)
+    else
+      @@inv.push(obj)
+    end
+    obj
+  end
+  def GameObj.new_room_desc(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@room_desc.push(obj)
+    obj
+  end
+  def GameObj.new_fam_room_desc(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@fam_room_desc.push(obj)
+    obj
+  end
+  def GameObj.new_fam_loot(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@fam_loot.push(obj)
+    obj
+  end
+  def GameObj.new_fam_npc(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@fam_npcs.push(obj)
+    obj
+  end
+  def GameObj.new_fam_pc(id, noun, name)
+    obj = GameObj.new(id, noun, name)
+    @@fam_pcs.push(obj)
+    obj
+  end
+  def GameObj.new_right_hand(id, noun, name)
+    @@right_hand = GameObj.new(id, noun, name)
+  end
+  def GameObj.right_hand
+    @@right_hand.dup
+  end
+  def GameObj.new_left_hand(id, noun, name)
+    @@left_hand = GameObj.new(id, noun, name)
+  end
+  def GameObj.left_hand
+    @@left_hand.dup
+  end
+  def GameObj.clear_loot
+    @@loot.clear
+  end
+  def GameObj.clear_npcs
+    @@npcs.clear
+    @@npc_status.clear
+  end
+  def GameObj.clear_pcs
+    @@pcs.clear
+    @@pc_status.clear
+  end
+  def GameObj.clear_inv
+    @@inv.clear
+  end
+  def GameObj.clear_room_desc
+    @@room_desc.clear
+  end
+  def GameObj.clear_fam_room_desc
+    @@fam_room_desc.clear
+  end
+  def GameObj.clear_fam_loot
+    @@fam_loot.clear
+  end
+  def GameObj.clear_fam_npcs
+    @@fam_npcs.clear
+  end
+  def GameObj.clear_fam_pcs
+    @@fam_pcs.clear
+  end
+  def GameObj.npcs
+    if @@npcs.empty?
+      nil
+    else
+      @@npcs.dup
+    end
+  end
+  def GameObj.loot
+    if @@loot.empty?
+      nil
+    else
+      @@loot.dup
+    end
+  end
+  def GameObj.pcs
+    if @@pcs.empty?
+      nil
+    else
+      @@pcs.dup
+    end
+  end
+  def GameObj.inv
+    if @@inv.empty?
+      nil
+    else
+      @@inv.dup
+    end
+  end
+  def GameObj.room_desc
+    if @@room_desc.empty?
+      nil
+    else
+      @@room_desc.dup
+    end
+  end
+  def GameObj.fam_room_desc
+    if @@fam_room_desc.empty?
+      nil
+    else
+      @@fam_room_desc.dup
+    end
+  end
+  def GameObj.fam_loot
+    if @@fam_loot.empty?
+      nil
+    else
+      @@fam_loot.dup
+    end
+  end
+  def GameObj.fam_npcs
+    if @@fam_npcs.empty?
+      nil
+    else
+      @@fam_npcs.dup
+    end
+  end
+  def GameObj.fam_pcs
+    if @@fam_pcs.empty?
+      nil
+    else
+      @@fam_pcs.dup
+    end
+  end
+  def GameObj.clear_container(container_id)
+    @@contents[container_id] = Array.new
+  end
+  def GameObj.delete_container(container_id)
+    @@contents.delete(container_id)
+  end
+  def GameObj.dead
+    dead_list = Array.new
+    for obj in @@npcs
+      dead_list.push(obj) if obj.status == "dead"
+    end
+    return nil if dead_list.empty?
+    return dead_list
+  end
+  def GameObj.containers
+    @@contents.dup
+  end
+  def GameObj.load_data(filename=nil)
+    if $SAFE == 0
+      if filename.nil?
+        if File.exists?("#{DATA_DIR}/gameobj-data.xml")
+          filename = "#{DATA_DIR}/gameobj-data.xml"
+        elsif File.exists?("#{SCRIPT_DIR}/gameobj-data.xml") # deprecated
+          filename = "#{SCRIPT_DIR}/gameobj-data.xml"
+        else
+          filename = "#{DATA_DIR}/gameobj-data.xml"
+        end
+      end
+      if File.exists?(filename)
+        begin
+          @@type_data = Hash.new
+          @@sellable_data = Hash.new
+          File.open(filename) { |file|
+            doc = REXML::Document.new(file.read)
+            doc.elements.each('data/type') { |e|
+              if type = e.attributes['name']
+                @@type_data[type] = Hash.new
+                @@type_data[type][:name]    = Regexp.new(e.elements['name'].text) unless e.elements['name'].text.nil? or e.elements['name'].text.empty?
+                @@type_data[type][:noun]    = Regexp.new(e.elements['noun'].text) unless e.elements['noun'].text.nil? or e.elements['noun'].text.empty?
+                @@type_data[type][:exclude] = Regexp.new(e.elements['exclude'].text) unless e.elements['exclude'].text.nil? or e.elements['exclude'].text.empty?
+              end
+            }
+            doc.elements.each('data/sellable') { |e|
+              if sellable = e.attributes['name']
+                @@sellable_data[sellable] = Hash.new
+                @@sellable_data[sellable][:name]    = Regexp.new(e.elements['name'].text) unless e.elements['name'].text.nil? or e.elements['name'].text.empty?
+                @@sellable_data[sellable][:noun]    = Regexp.new(e.elements['noun'].text) unless e.elements['noun'].text.nil? or e.elements['noun'].text.empty?
+                @@sellable_data[sellable][:exclude] = Regexp.new(e.elements['exclude'].text) unless e.elements['exclude'].text.nil? or e.elements['exclude'].text.empty?
+              end
+            }
+          }
+          true
+        rescue
+          @@type_data = nil
+          @@sellable_data = nil
+          echo "error: GameObj.load_data: #{$!}"
+          respond $!.backtrace[0..1]
+          false
+        end
+      else
+        @@type_data = nil
+        @@sellable_data = nil
+        echo "error: GameObj.load_data: file does not exist: #{filename}"
+        false
+      end
+    else
+      @@elevated_load.call
+    end
+  end
+  def GameObj.type_data
+    @@type_data
+  end
+  def GameObj.sellable_data
+    @@sellable_data
+  end
+end

--- a/lib/spec/factories.rb
+++ b/lib/spec/factories.rb
@@ -1,0 +1,7 @@
+require 'lich/gameobj'
+
+module GameObjFactory
+  def self.npc_from_name(npc_name)
+    GameObj.new_npc("fake_id", npc_name.split.last, npc_name)
+  end
+end

--- a/spec/gameobj-data/aggressive_npc_spec.rb
+++ b/spec/gameobj-data/aggressive_npc_spec.rb
@@ -1,0 +1,658 @@
+require 'lich/gameobj'
+require 'spec/factories'
+
+describe GameObj do
+  describe "aggressive NPCs" do
+    describe "grimswarm" do
+      [
+        "", # no prefix
+        "battle-scarred ",
+        "grizzled ",
+        "haggard ",
+        "hulking ",
+        "seasoned ",
+        "veteran ",
+        "weathered ",
+      ].each do |prename|
+        %w[giant troll orc].each do |race|
+          %w[
+            acolyte
+            adept
+            archer
+            barbarian
+            battlemage
+            champion
+            cleric
+            crusader
+            destroyer
+            dissembler
+            elementalist
+            empath
+            fighter
+            guard
+            healer
+            hunter
+            huntmaster
+            huntmistress
+            initiate
+            mage
+            marauder
+            paladin
+            pillager
+            raider
+            ranger
+            scourge
+            scout
+            shaman
+            skirmisher
+            sniper
+            soldier
+            sorcerer
+            sorceress
+            warchief
+            warlock
+            warmage
+            warrior
+            witch
+            wizard
+            wrathbringer
+            zealot
+          ].each do |profession|
+            grimswarm = "#{prename}Grimswarm #{race} #{profession}"
+
+            it "recognizes #{grimswarm} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(grimswarm).type).to include "aggressive npc"
+            end
+
+            it "recognizes #{grimswarm} as a grimswarm" do
+              expect(GameObjFactory.npc_from_name(grimswarm).type).to include "grimswarm"
+            end
+          end
+
+          %w[warmonger spellbinder].each do |profession|
+            grimswarm = "#{prename}Grimswarm #{race} #{profession}"
+
+            it "recognizes #{grimswarm} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(grimswarm).type).to include "aggressive npc"
+            end
+
+            # FIXME: GameObj should recognize these as grimswarm but current regex in XML is broken
+            xit "recognizes #{grimswarm} as a grimswarm" do
+              expect(GameObjFactory.npc_from_name(grimswarm).type).to include "grimswarm"
+            end
+          end
+        end
+      end
+    end
+
+    describe "bandit" do
+      [
+        "", # no prefix
+        "seasoned ",
+      ].each do |prename|
+        %w[
+          dwarven
+          elven
+          erithian
+          giantman
+          gnomish
+          half-elven
+          half-krolvin
+          halfling
+          human
+        ].each do |race|
+          %w[
+            bandit
+            brigand
+            highwayman
+            marauder
+            mugger
+            outlaw
+            robber
+            rogue
+            thief
+            thug
+          ].each do |profession|
+            bandit = "#{prename}#{race} #{profession}"
+
+            it "recognizes #{bandit} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(bandit).type).to include "aggressive npc"
+            end
+
+            it "recognizes #{bandit} as a bandit" do
+              expect(GameObjFactory.npc_from_name(bandit).type).to include "bandit"
+            end
+          end
+        end
+      end
+    end
+
+    describe "undead" do
+      [
+        "ancient ghoul master",
+        "arch wight",
+        "baesrukha",
+        "banshee",
+        "barghest",
+        "bog wight",
+        "bog wraith",
+        "bone golem",
+        "carceris",
+        "crazed zombie",
+        "dark apparition",
+        "darkwoode",
+        "death dirge",
+        "decaying Citadel guardsman",
+        "dybbuk",
+        "eidolon",
+        "elder ghoul master",
+        "elder tree spirit",
+        "ethereal mage apprentice",
+        "ethereal triton sentry",
+        "firephantom",
+        "flesh golem",
+        "frozen corpse",
+        "gaunt spectral servant",
+        "ghost",
+        "ghostly mara",
+        "ghostly pooka",
+        "ghostly warrior",
+        "ghost wolf",
+        "ghoul master",
+        "greater ghoul",
+        "greater moor wight",
+        "greater vruul",
+        "ice skeleton",
+        "ice wraith",
+        "lesser frost shade",
+        "lesser ghoul",
+        "lesser moor wight",
+        "lesser mummy",
+        "lesser shade",
+        "lesser vruul",
+        "lich qyn'arj",
+        "lost soul",
+        "mist wraith",
+        "moaning phantom",
+        "moaning spirit",
+        "monastic lich",
+        "naisirc",
+        "n'ecare",
+        "nedum vereri",
+        "night mare",
+        "nightmare steed",
+        "nonomino",
+        "phantasma",
+        "phantasmal bestial swordsman",
+        "phantom",
+        "putrefied Citadel herald",
+        "revenant",
+        "rock troll zombie",
+        "rotting chimera",
+        "rotting Citadel arbalester",
+        "rotting corpse",
+        "rotting farmhand",
+        "rotting krolvin pirate",
+        "rotting woodsman",
+        "seeker",
+        "seraceris",
+        "shadow mare",
+        "shadow steed",
+        "shadowy spectre",
+        "shrickhen",
+        "skeletal giant",
+        "skeletal ice troll",
+        "skeletal lord",
+        "skeletal soldier",
+        "skeletal warhorse",
+        "skeleton",
+        "snow spectre",
+        "soul golem",
+        "spectral fisherman",
+        "spectral lord",
+        "spectral miner",
+        "spectral monk",
+        "spectral shade",
+        "spectral triton defender",
+        "spectral warrior",
+        "spectral woodsman",
+        "tomb wight",
+        "tree spirit",
+        "troll wraith",
+        "vaespilon",
+        "vourkha",
+        "waern",
+        "werebear",
+        "wind wraith",
+        "wolfshade",
+        "wood wight",
+        "wraith",
+        "zombie",
+        "zombie rolton",
+      ].each do |undead|
+        it "recognizes #{undead} as an aggressive NPC" do
+          expect(GameObjFactory.npc_from_name(undead).type).to include "aggressive npc"
+        end
+
+        it "recognizes #{undead} as undead" do
+          expect(GameObjFactory.npc_from_name(undead).type).to include "undead"
+        end
+      end
+
+      describe "undead with data issues" do
+        describe "creatures recognized as undead but not aggressive" do
+          [
+            "frostborne lich",
+            "infernal lich",
+            "murky soul siphon",
+            "necrotic snake",
+          ].each do |undead|
+            xit "recognizes #{undead} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(undead).type).to include "aggressive npc"
+            end
+
+            it "recognizes #{undead} as undead" do
+              expect(GameObjFactory.npc_from_name(undead).type).to include "undead"
+            end
+          end
+        end
+
+        describe "creatures missing from both undead and aggressive" do
+          ["spectre"].each do |undead|
+            xit "recognizes #{undead} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(undead).type).to include "aggressive npc"
+            end
+
+            xit "recognizes #{undead} as undead" do
+              expect(GameObjFactory.npc_from_name(undead).type).to include "undead"
+            end
+          end
+        end
+      end
+    end
+
+    describe "living" do
+      [
+        "aivren",
+        "albino tomb spider",
+        "animated slush",
+        "arctic manticore",
+        "arctic puma",
+        "arctic titan",
+        "arctic wolverine",
+        "ash hag",
+        "banded rattlesnake",
+        "bighorn sheep",
+        "big ugly kobold",
+        "black bear",
+        "black boar",
+        "black forest ogre",
+        "black forest viper",
+        "black leopard",
+        "black panther",
+        "black rolton",
+        "black urgh",
+        "black-winged daggerbeak",
+        "blood eagle",
+        "blue myklian",
+        "bobcat",
+        "bog spectre",
+        "bog troll",
+        "Bresnahanini rolton",
+        "brown boar",
+        "brown gak",
+        "brown spinner",
+        "burly reiver",
+        "caedera",
+        "caribou",
+        "carrion worm",
+        "cave bear",
+        "cave gnoll",
+        "cave gnome",
+        "cave lizard",
+        "cave nipper",
+        "cave troll",
+        "cave worm",
+        "centaur",
+        "cinder wasp",
+        "cobra",
+        "cockatrice",
+        "cold guardian",
+        "colossus vulture",
+        "cougar",
+        "coyote",
+        "crested basilisk",
+        "crocodile",
+        "crystal crab",
+        "crystal golem",
+        "csetairi",
+        "cyclops",
+        "darken",
+        "darkly inked fetish master",
+        "dark orc",
+        "dark panther",
+        "dark shambler",
+        "dark vortece",
+        "dark vysan",
+        "deranged sentry",
+        "dhu goleras",
+        "dobrem",
+        "dreadnought raptor",
+        "dust beetle",
+        "earth elemental",
+        "emaciated hierophant",
+        "enormous rift crawler",
+        "fanged goblin",
+        "fanged rodent",
+        "fanged viper",
+        "farlook",
+        "fenghai",
+        "festering taint",
+        "fire ant",
+        "fire cat",
+        "fire elemental",
+        "fire giant",
+        "fire guardian",
+        "fire mage",
+        "fire ogre",
+        "fire rat",
+        "fire salamander",
+        "fire sprite",
+        "firethorn shoot",
+        "forest ogre",
+        "forest trali",
+        "forest trali shaman",
+        "forest troll",
+        "frost giant",
+        "giant albino scorpion",
+        "giant albino tomb spider",
+        "giant ant",
+        "giant fog beetle",
+        "giant hawk-owl",
+        "giant marmot",
+        "giant rat",
+        "giant veaba",
+        "giant weasel",
+        "glacial morph",
+        "glistening cerebralite",
+        "gnarled being",
+        "gnoll guard",
+        "gnoll jarl",
+        "gnoll priest",
+        "gnoll ranger",
+        "gnoll thief",
+        "gnoll worker",
+        "goblin",
+        "great boar",
+        "great brown bear",
+        "greater bog troll",
+        "greater burrow orc",
+        "greater construct",
+        "greater earth elemental",
+        "greater faeroth",
+        "greater ice giant",
+        "greater ice spider",
+        "greater kappa",
+        "greater krynch",
+        "greater orc",
+        "greater spider",
+        "greater water elemental",
+        "great stag",
+        "green myklian",
+        "greenwing hornet",
+        "gremlock",
+        "grey orc",
+        "grifflet",
+        "grizzly bear",
+        "hill troll",
+        "hisskra chieftain",
+        "hisskra shaman",
+        "hisskra warrior",
+        "hobgoblin",
+        "hobgoblin shaman",
+        "hooded figure",
+        "horned vor'taz",
+        "huge mein golem",
+        "humpbacked puma",
+        "hunch-backed dogmatist",
+        "hunter troll",
+        "ice elemental",
+        "ice golem",
+        "ice hound",
+        "ice troll",
+        "Illoke elder",
+        "Illoke jarl",
+        "Illoke mystic",
+        "Illoke shaman",
+        "Ithzir adept",
+        "Ithzir herald",
+        "Ithzir initiate",
+        "Ithzir janissary",
+        "Ithzir scout",
+        "Ithzir seer",
+        "jungle troll",
+        "jungle troll chieftain",
+        "ki-lin",
+        "kiramon defender",
+        "kiramon worker",
+        "kobold",
+        "kobold shepherd",
+        "krag dweller",
+        "krag yeti",
+        "krolvin corsair",
+        "krolvin mercenary",
+        "krolvin slaver",
+        "krolvin warfarer",
+        "krolvin warrior",
+        "large ogre",
+        "lava golem",
+        "lava troll",
+        "leaper",
+        "lesser burrow orc",
+        "lesser construct",
+        "lesser faeroth",
+        "lesser griffin",
+        "lesser ice elemental",
+        "lesser ice giant",
+        "lesser minotaur",
+        "lesser orc",
+        "lesser red orc",
+        "lesser stone gargoyle",
+        "luminous arachnid",
+        "magru",
+        "major glacei",
+        "major spider",
+        "mammoth arachnid",
+        "manticore",
+        "massive black boar",
+        "massive grahnk",
+        "massive pyrothag",
+        "massive troll king",
+        "mastodonic leopard",
+        "maw spore",
+        "mezic",
+        "minor glacei",
+        "minotaur magus",
+        "minotaur warrior",
+        "Mistydeep siren",
+        "mongrel hobgoblin",
+        "mongrel kobold",
+        "mongrel troll",
+        "mongrel wolfhound",
+        "monkey",
+        "moor eagle",
+        "moor hound",
+        "moor witch",
+        "mottled thrak",
+        "moulis",
+        "mountain goat",
+        "mountain lion",
+        "mountain ogre",
+        "mountain rolton",
+        "mountain snowcat",
+        "mountain troll",
+        "mud wasp",
+        "muscular supplicant",
+        "Neartofar orc",
+        "night golem",
+        "ogre warrior",
+        "orange myklian",
+        "pale crab",
+        "panther",
+        "phosphorescent worm",
+        "plains lion",
+        "plains ogre",
+        "plains orc chieftain",
+        "plains orc scout",
+        "plains orc shaman",
+        "plains orc warrior",
+        "plumed cockatrice",
+        "polar bear",
+        "pra'eda",
+        "puma",
+        "purple myklian",
+        "rabid guard dog",
+        "rabid squirrel",
+        "raider orc",
+        "raving lunatic",
+        "red bear",
+        "red myklian",
+        "red-scaled thrak",
+        "red tsark",
+        "reiver",
+        "relnak",
+        "ridgeback boar",
+        "ridge orc",
+        "roa'ter",
+        "roa'ter wormling",
+        "rolton",
+        "sabre-tooth tiger",
+        "sand beetle",
+        "sand devil",
+        "scaly burgee",
+        "sea nymph",
+        "shan cleric",
+        "shan ranger",
+        "shan warrior",
+        "shan wizard",
+        "shelfae chieftain",
+        "shelfae soldier",
+        "shelfae warlord",
+        "Sheruvian harbinger",
+        "Sheruvian initiate",
+        "Sheruvian monk",
+        "shimmering fungus",
+        "silverback orc",
+        "siren",
+        "siren lizard",
+        "skayl",
+        "slimy little grub",
+        "snow crone",
+        "snow leopard",
+        "snow madrinol",
+        "snowy cockatrice",
+        "spiked cavern urchin",
+        "spotted gak",
+        "spotted gnarp",
+        "spotted leaper",
+        "spotted lynx",
+        "spotted velnalin",
+        "steel golem",
+        "stone gargoyle",
+        "stone giant",
+        "stone mastiff",
+        "stone sentinel",
+        "stone troll",
+        "storm giant",
+        "storm griffin",
+        "striped gak",
+        "striped relnak",
+        "striped warcat",
+        "swamp hag",
+        "swamp troll",
+        "tawny brindlecat",
+        "thrak",
+        "three-toed tegu",
+        "thunder troll",
+        "thyril",
+        "tomb troll",
+        "tomb troll necromancer",
+        "tree viper",
+        "triton combatant",
+        "triton dissembler",
+        "triton executioner",
+        "triton magus",
+        "triton radical",
+        "troglodyte",
+        "troll chieftain",
+        "tundra giant",
+        "tusked ursian",
+        "undertaker bat",
+        "urgh",
+        "velnalin",
+        "vesperti",
+        "veteran reiver",
+        "Vvrael destroyer",
+        "Vvrael warlock",
+        "Vvrael witch",
+        "wall guardian",
+        "war griffin",
+        "warrior shade",
+        "warthog",
+        "war troll",
+        "wasp nest",
+        "water elemental",
+        "water moccasin",
+        "water witch",
+        "water wyrd",
+        "whiptail",
+        "white vysan",
+        "wild hound",
+        "wind witch",
+        "wolverine",
+        "wood sprite",
+        "wooly mammoth",
+        "yellow myklian",
+        "yeti",
+        "young grass snake",
+        "young myklian",
+      ].each do |creature|
+        it "recognizes #{creature} as an aggressive NPC" do
+          expect(GameObjFactory.npc_from_name(creature).type).to include "aggressive npc"
+        end
+      end
+
+      describe "creatures with data issues" do
+        describe "incorrect capitalization" do
+          [
+            "Agresh bear",
+            "Agresh troll chieftain",
+            "Agresh troll scout",
+            "Agresh troll warrior",
+            "Arachne acolyte",
+            "Arachne priest",
+            "Arachne priestess",
+            "Arachne servant",
+            "Grutik savage",
+            "Grutik shaman",
+            "Neartofar troll",
+          ].each do |creature|
+            xit "recognizes #{creature} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(creature).type).to include "aggressive npc"
+            end
+          end
+        end
+
+        describe "missing from data" do
+          [
+            "wild dog",
+          ].each do |creature|
+            xit "recognizes #{creature} as an aggressive NPC" do
+              expect(GameObjFactory.npc_from_name(creature).type).to include "aggressive npc"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/gameobj-data/core_spec.rb
+++ b/spec/gameobj-data/core_spec.rb
@@ -1,0 +1,56 @@
+require 'lich/gameobj'
+
+describe GameObj do
+  it "can load data from the XML file" do
+    expect(GameObj.load_data).to be_truthy
+    expect(GameObj.type_data).to_not be_nil
+    expect(GameObj.type_data).to_not be_empty
+  end
+
+  context "after the XML data has been loaded" do
+    before { GameObj.load_data }
+
+    it "has the expected types" do
+      expect(GameObj.type_data.keys).to contain_exactly(
+        "aggressive npc",     # npc_spec
+        "alchemy equipment",  # alchemy
+        "alchemy product",    # alchemy
+        "ammo",               # arms_and_armor
+        "armor",              # arms_and_armor
+        "bandit",             # npc_spec
+        "box",                # picking
+        "clothing",           # clothing
+        "cursed",             # item_property
+        "ebongate",           # festival
+        "escort",             # npc
+        "food",               # misc
+        "gem",                # gems_and_jewelry
+        "grimswarm",          # npc
+        "herb",               # herb
+        "instrument",         # misc
+        "jar",                # misc
+        "jewelry",            # gems_and_jewelry
+        "junk",               # junk
+        "lm tool",            # picking
+        "lm trap",            # picking
+        "lockpick",           # picking
+        "magic",              # magic
+        "note",               # misc
+        "passive npc",        # npc
+        "plinite",            # gems_and_jewelry
+        "quest",              # festival
+        "reagent",            # alchemy
+        "scarab",             # gems_and_jewelry
+        "scroll",             # magic
+        "skin",               # skin
+        "spirit beast talismans", # alchemy
+        "toy",                # misc
+        "uncommon",           # item_property
+        "undead",             # npc
+        "valuable",           # gems_and_jewelry
+        "wand",               # magic
+        "weapon"              # arms_and_armor
+      )
+    end
+  end
+end

--- a/spec/gameobj-data/passive_npc_spec.rb
+++ b/spec/gameobj-data/passive_npc_spec.rb
@@ -1,0 +1,161 @@
+require 'lich/gameobj'
+require 'spec/factories'
+
+describe GameObj do
+  describe "passive NPCs" do
+    describe "familiars" do
+      [
+        "blue wolf",
+        "grey-headed hawk",
+        "rock falcon",
+        "sleek charcoal cat",
+        "sleek red-tailed hawk",
+        "speckled green frog",
+        "spotted bull frog",
+        "tiny black mouse",
+      ].each do |familiar|
+        it "recognizes #{familiar} as a passive NPC" do
+          expect(GameObjFactory.npc_from_name(familiar).type).to include "passive npc"
+        end
+      end
+    end
+
+    describe "spirit servants" do
+      [
+        "acrimonious marsh spirit",
+        "angry forest spirit",
+        "capricious lake spirit",
+        "cheerful forest spirit",
+        "cunning luck spirit",
+        "delighted lake spirit",
+        "delusive solar spirit",
+        "desolate woodland spirit",
+        "disconsolate marsh spirit",
+        "disgruntled luck spirit",
+        "dismal mountain spirit",
+        "dolorous mountain spirit",
+        "downtrodden solar spirit",
+        "enraged lake spirit",
+        "erratic glacier spirit",
+        "erratic marsh spirit",
+        "erratic river spirit",
+        "erratic solar spirit",
+        "expressive mountain spirit",
+        "fidgety luck spirit",
+        "fierce marsh spirit",
+        "fluctuant lake spirit",
+        "friendly woodland spirit",
+        "frisky forest spirit",
+        "frolicsome marsh spirit",
+        "gleeful woodland spirit",
+        "goofy solar spirit",
+        "grim mountain spirit",
+        "irate luck spirit",
+        "jubilant marsh spirit",
+        "lively luck spirit",
+        "lonely glacier spirit",
+        "outgoing luck spirit",
+        "perturbed luck spirit",
+        "playful solar spirit",
+        "puckish island spirit",
+        "quirky marsh spirit",
+        "quirky mountain spirit",
+        "recalcitrant forest spirit",
+        "reluctant solar spirit",
+        "sad forest spirit",
+        "somber glacier spirit",
+        "somber solar spirit",
+        "sprightly forest spirit",
+        "sullen mountain spirit",
+        "tremulous marsh spirit",
+        "troublesome forest spirit",
+        "unstable lake spirit",
+        "upset mountain spirit",
+        "vacillating marsh spirit",
+        "vengeful luck spirit",
+        "volatile luck spirit",
+        "volatile marsh spirit",
+        "wary woodland spirit",
+        "whimsical luck spirit",
+        "wrathful lake spirit",
+        "wretched forest spirit",
+        "wretched glacier spirit",
+      ].each do |spirit|
+        it "recognizes #{spirit} as a passive NPC" do
+          expect(GameObjFactory.npc_from_name(spirit).type).to include "passive npc"
+        end
+      end
+
+      it "knows that tree spirits and moaning spirits are not passive spirit servants" do
+        [
+          "moaning spirit",
+          "tree spirit",
+        ].each do |spirit|
+          expect(GameObjFactory.npc_from_name(spirit).type).to_not include "passive npc"
+        end
+      end
+    end
+
+    describe "escorts" do
+      %w[
+          dwarven
+          elven
+          erithian
+          giantman
+          gnomish
+          half-elven
+          half-krolvin
+          halfling
+          human
+      ].each do |race|
+        %w[
+            dignitary
+            magistrate
+            merchant
+            official
+            scribe
+            traveller
+        ].each do |noun|
+          escort_name = "#{race} #{noun}"
+          it "recognizes #{escort_name} as a passive NPC" do
+            expect(GameObjFactory.npc_from_name(escort_name).type).to include "passive npc"
+          end
+
+          it "recognizes #{escort_name} as an escort" do
+            expect(GameObjFactory.npc_from_name(escort_name).type).to include "escort"
+          end
+        end
+      end
+    end
+
+    describe "other misc passive NPCs" do
+      [
+        "blind ferryman",
+        "city guardsman",
+        "dirty rat",
+        "drunken sailor",
+        "dusty miner",
+        "Dwarven deputy",
+        "dwarven recruiter",
+        "elven captain",
+        "hazel-eyed dwarven priestess",
+        "middle-aged human priestess",
+        "overgrown snail",
+        "peddler Gertie",
+        "peglegged cat",
+        "pelican",
+        "pretty flowery hooker",
+        "South Gate guard",
+        "stooped old woman",
+        "street urchin",
+        "tunnel sweeper",
+        "wizened gnome",
+        "yellow canary",
+      ].each do |npc|
+        it "recognizes #{npc} as a passive NPC" do
+          expect(GameObjFactory.npc_from_name(npc).type).to include "passive npc"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds specs for the NPC types in the GameObj XML data file. I added Lich's GameObj implementation in `lib/lich/gameobj.rb` since it doesn't seem feasible to require the full lich.rb.

I set these specs up with one assertion per example and there are roughly 3000 examples here, but the suite still completes in ~2 seconds in Travis.

While creating these specs, I found a few issues with the existing data and have left these as pending examples to fix in the future in a separate PR.