### PR TITLE
add collectible to core_spec

### DIFF
--- a/spec/gameobj-data/core_spec.rb
+++ b/spec/gameobj-data/core_spec.rb
@@ -19,6 +19,7 @@ describe GameObj do
         "armor",              # arms_and_armor
         "bandit",             # npc_spec
         "box",                # picking
+        "collectible",        # collectible
         "clothing",           # clothing
         "cursed",             # item_property
         "ebongate",           # festival


### PR DESCRIPTION
added collectible to core_spec to allow new collectible gameobj to pass travis-ci builds.