### PR TITLE
wps: fix confirm msg and register items after service

### DIFF
--- a/scripts/wps.lic
+++ b/scripts/wps.lic
@@ -109,9 +109,9 @@ module WPS
   def self.pause_for_confirmation_of(opts)
     respond <<-CONFIRMATION
 
-    Unpause #{$clean_lich_char}#{Script.current.name} to request:"
+    Unpause #{$clean_lich_char}#{Script.current.name} to request:
 
-    #{opts[:count]} #{opts[:service]} services from #{blacksmith.name}"
+    #{opts[:count]} #{opts[:service]} services from #{blacksmith.name}
 
     CONFIRMATION
     pause_script

--- a/scripts/wps.lic
+++ b/scripts/wps.lic
@@ -123,6 +123,7 @@ module WPS
         opts = normalize_input(*Script.current.vars[1..-1])
         pause_for_confirmation_of(opts)
         perform_services(opts)
+        fput "register ##{GameObj.right_hand.id}"
       end
     rescue WPS::ArgumentError => e
       respond e.for_cmdline


### PR DESCRIPTION
Removes a couple of extra quotation marks from the confirmation message and automatically registers the item after performing services.