### PR TITLE
Update bigshot.lic

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -715,7 +715,7 @@ class Bigshot
 		$bigshot_aim = -1 if manualaim != "" && $bigshot_aim == 0
 		mstrike_taken = false
 		volnsmite(npc) if !$bigshot_smite_list.any?{|a| a.to_i == npc.id.to_i} && npc.type.split(',').any?{|a| a == "noncorporeal"} && $bigshot_unarmed_tier == 3 && Spell[9821].known? && @UAC_SMITE
-		mstrike_spell_check()
+		mstrike_spell_check() if Char.prof =~ /Paladin|Empath/i && Skills.multiopponentcombat >= 5
 		if Skills.multiopponentcombat >= 5 && GameObj.npcs.all? { |i| i.noun !~ /nest/i }
 			#9005 - Mstrike recovery
 			#9699 - popped muscles

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -994,11 +994,11 @@ class Bigshot
 				waitcastrt?
 				spell[1107].cast
 				$bigshot_adrenal_surge = Time.now + 301
-			elsif (Spell[9699].active? || ((checkstamina + (50 if Skills.slblessings >= 35 )) >= (@MSTRIKE_STAMINA_COOLDOWN || @MSTRIKE_STAMINA_QUICKSTRIKE)))
+			elsif (Spell[9699].active? || ((checkstamina + (Skills.slblessings >= 35 ? 50 : 0)) >= (@MSTRIKE_STAMINA_COOLDOWN || @MSTRIKE_STAMINA_QUICKSTRIKE)))
 				waitcastrt?
 				spell[1107].cast
 				$bigshot_adrenal_surge = Time.now + 301
-			elsif (Spell[9699].active? || ((checkstamina + (25 if Skills.slblessings >= 35 )) >= (@MSTRIKE_STAMINA_COOLDOWN || @MSTRIKE_STAMINA_QUICKSTRIKE)))
+			elsif (Spell[9699].active? || ((checkstamina + (Skills.slblessings >= 35 ? 25 : 0)) >= (@MSTRIKE_STAMINA_COOLDOWN || @MSTRIKE_STAMINA_QUICKSTRIKE)))
 				waitcastrt?
 				spell[1107].cast
 				$bigshot_adrenal_surge = Time.now + 301


### PR DESCRIPTION
fix addition of nil when knowing less than 35 spiritual lore blessings.