### PR TITLE
WebUI: A web interface for Lich scripts

### DIFF
--- a/scripts/webui.lic
+++ b/scripts/webui.lic
@@ -1,13 +1,67 @@
 require "erb"
 require "webrick"
 
-Settings["webui"] ||= {
-  "port"  => nil,
-  "host"  => nil,
-}
-echo Settings.to_hash
-
 module WebUI
+  DEFAULT_PORT = 3000
+  DEFAULT_HOST = "localhost"
+
+  def self.start(name, *subapps)
+    opts = Opts.parse
+
+    port = opts.port || ::Settings["webui"]["port"] || DEFAULT_PORT
+    host = opts.host || ::Settings["webui"]["host"] || DEFAULT_HOST
+
+    server = WEBrick::HTTPServer.new(
+      :Port => port,
+      :BindAddress => host,
+    )
+
+    server.mount "/", WebUI::Servlet, name, Thread.current.group, subapps
+
+    before_dying do
+      server.shutdown
+    end
+
+    server.start
+  end
+
+  ##
+  ## minimal options parser
+  ##
+  module Opts
+    FLAG_PREFIX    = "--"
+
+    def self.parse_command(h, c)
+      h[c.to_sym] = true
+    end
+
+    def self.parse_flag(h, f)
+      (name, val) = f[2..-1].split("=")
+      if val.nil?
+        h[name.to_sym] = true
+      else
+        val = val.split(",")
+
+        h[name.to_sym] = val.size == 1 ? val.first : val
+      end
+    end
+
+    def self.parse(args = Script.current.vars[1..-1])
+      OpenStruct.new(**args.to_a.reduce(Hash.new) do |opts, v|
+        if v.start_with?(FLAG_PREFIX)
+          Opts.parse_flag(opts, v)
+        else
+          Opts.parse_command(opts, v)
+        end
+        opts
+      end)
+    end
+
+    def self.method_missing(method, *args)
+      parse.send(method, *args)
+    end
+  end
+
   class Servlet < WEBrick::HTTPServlet::AbstractServlet
     attr_reader :name, :subapps, :thread_group
 
@@ -106,13 +160,9 @@ module WebUI
         @routes ||= {}
       end
 
-      def add_route(path, action)
+      def route(path, action, opts={})
+        self.default_route = path if opts[:default]
         routes[path] = action
-      end
-
-      def add_default_route(path, action)
-        self.default_route = path
-        add_route(path, action)
       end
 
       def name
@@ -143,7 +193,7 @@ module WebUI
 
     def render_with_layout(template)
       render_layout do
-        template.result
+        template.result(binding)
       end
     end
     alias :render :render_with_layout
@@ -155,13 +205,14 @@ module WebUI
   end
 end
 
+
 class WebUI::Vars < WebUI::App
   #self.name = "Vars"
 
   class Update < WebUI::Action
     def call
       params.each do |name, value|
-        Vars[name.to_s] = value.to_s
+        ::Vars[name.to_s] = value.to_s
         echo "Updating Vars.#{name} = #{Vars[name]}"
       end
     end
@@ -171,7 +222,7 @@ class WebUI::Vars < WebUI::App
     def call
       name = params.fetch("name").to_s
       value = params.fetch("value").to_s
-      Vars[name] = value
+      ::Vars[name] = value
       echo "Adding Vars.#{name} = #{Vars[name]}"
     end
   end
@@ -180,7 +231,7 @@ class WebUI::Vars < WebUI::App
     def call
       params.each do |name, value|
         echo "Deleting Vars.#{name}"
-        Vars[name.to_s] = nil
+        ::Vars[name.to_s] = nil
       end
     end
   end
@@ -196,7 +247,7 @@ class WebUI::Vars < WebUI::App
           <h2>Lich Variables for <%= Char.name %></h2>
         </div>
 
-        <% Vars.list.each do |name, value| %>
+        <% ::Vars.list.each do |name, value| %>
           <div class="row">
             <div class="col-10 pr-2">
               <form action="/vars/update" method="post">
@@ -251,10 +302,10 @@ class WebUI::Vars < WebUI::App
     end
   end
 
-  add_route "/vars/add", Create
-  add_route "/vars/update", Update
-  add_route "/vars/delete", Delete
-  add_default_route "/vars", Show
+  route "/vars/add", Create
+  route "/vars/update", Update
+  route "/vars/delete", Delete
+  route "/vars", Show, default: true
 end
 
 class WebUI::Settings < WebUI::App
@@ -262,7 +313,7 @@ class WebUI::Settings < WebUI::App
     def call
       params.each do |name, value|
         echo "Updating Settings[#{name}] = #{value}"
-        Settings["webui"][name.to_s] = value.to_s
+        ::Settings["webui"][name.to_s] = value.to_s
       end
     end
   end
@@ -275,10 +326,10 @@ class WebUI::Settings < WebUI::App
     def template
       @template ||= ERB.new <<~HTMLDOC
         <div class="py-3 text-center">
-          <h2>WebUI Settings</h2>
+          <h2><%= servlet.name %> WebUI Settings</h2>
         </div>
 
-        <% Settings["webui"].each do |name, value| %>
+        <% ::Settings["webui"].each do |name, value| %>
           <div class="row">
             <div class="col-6">
               <form action="/settings/update" method="post">
@@ -301,25 +352,16 @@ class WebUI::Settings < WebUI::App
     end
   end
 
-  add_route "/settings/update", Update
-  add_default_route "/settings", Show
+  route "/settings/update", Update
+  route "/settings", Show, default: true
 end
 
-port = Settings["webui"]["port"] || 1234
-host = Settings["webui"]["host"] || "localhost"
+Settings ||= {
+  "port"  => nil,
+  "host"  => nil,
+}
 
-server = WEBrick::HTTPServer.new(
-  :Port => port,
-  :BindAddress => host,
-)
-
-server.mount "/", WebUI::Servlet, "Lich", Thread.current.group, [
+WebUI.start('Lich',
   WebUI::Vars,
   WebUI::Settings,
-]
-
-before_dying do
-  server.shutdown
-end
-
-server.start
+)

--- a/scripts/webui.lic
+++ b/scripts/webui.lic
@@ -1,0 +1,193 @@
+require "erb"
+require "webrick"
+
+class WebuiServlet < WEBrick::HTTPServlet::AbstractServlet
+  attr_reader :subapps
+
+  def initialize(server, apps=[])
+    super server
+    @subapps = apps
+  end
+
+  def do_GET(request, response)
+    dispatch(request, response)
+    response.status = 200
+  end
+
+  def do_POST(request, response)
+    dispatch(request, response)
+    response.set_redirect WEBrick::HTTPStatus::Found, '/'
+  end
+
+  def dispatch(request, response)
+    if app = find_app_for(request)
+      app.action_for(request).new(request, response).call
+    else
+      raise WEBrick::HTTPStatus::NotFound
+    end
+  end
+
+  def find_app_for(request)
+    subapps.find { |app| app.has_route?(request) }
+  end
+
+  class Action
+    attr_reader :request, :response
+
+    def initialize(request, response)
+      @request = request
+      @response = response
+    end
+
+    def params
+      request.query
+    end
+
+    def call
+      raise NotImplemented
+    end
+  end
+end
+
+class LichVarsService
+  class Update < WebuiServletAction
+    def call
+      params.each do |name, value|
+        Vars[name.to_s] = value.to_s
+        echo "Updating Vars.#{name} = #{Vars[name]}"
+      end
+    end
+  end
+
+  class Create < WebuiServletAction
+    def call
+      name = params.fetch("name").to_s
+      value = params.fetch("value").to_s
+      Vars[name] = value
+      echo "Adding Vars.#{name} = #{Vars[name]}"
+    end
+  end
+
+  class Delete < WebuiServletAction
+    def call
+      params.each do |name, value|
+        echo "Deleting Vars.#{name}"
+        Vars[name.to_s] = nil
+      end
+    end
+  end
+
+  class List < WebuiServletAction
+    def call
+      response.body = template.result
+    end
+
+    def template
+      @template ||= ERB.new <<~HTMLDOC
+        <!doctype html>
+        <html lang="en">
+          <head>
+            <!-- Required meta tags -->
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+            <!-- Bootstrap CSS -->
+            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+            <title>Lich: <%= Char.name %></title>
+          </head>
+          <body class="bg-light">
+
+            <div class="container-fluid">
+              <div class="py-2 text-center">
+                <h2>Lich Variables for <%= Char.name %></h2>
+              </div>
+
+              <% Vars.list.each do |name, value| %>
+                <div class="row">
+                  <div class="col-10 pr-2">
+                    <form action="/update" method="post">
+                      <div class="form-row">
+                        <label for="<%= ERB::Util.html_escape(name) %>" class="col-4 col-form-label">
+                          <%= ERB::Util.html_escape(name) %>
+                        </label>
+                        <div class="col-6">
+                          <input type="text" class="form-control" id="<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>" value="<%= ERB::Util.html_escape(value) %>">
+                        </div>
+                        <div class="col-2">
+                          <button class="btn btn-primary mb-1 w-100" type="submit">Save</button>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                  <div class="col-2 pl-2">
+                    <form action="/delete" method="post">
+                      <div class="form-row">
+                        <input type="hidden" id="<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>">
+                        <button class="btn btn-danger mb-2 w-100" type="submit">Delete</button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              <% end %>
+              <div class="row">
+                <div class="col-10 pr-2">
+                  <form action="/add" method="post">
+                    <div class="form-row">
+                      <div class="col-4">
+                        <input type="text" class="form-control" id="name" name="name" value="" placeholder="name" required>
+                      </div>
+                      <div class="col-6">
+                        <input type="text" class="form-control" id="value" name="value" value="" placeholder="value" required>
+                      </div>
+                      <div class="col-2">
+                        <button class="btn btn-outline-primary mb-2 w-100" type="submit">Add</button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+                <div class="col-2 pl-2">
+                  <form action="/" method="get">
+                    <div class="form-row">
+                      <button class="btn btn-outline-danger mb-2 w-100" type="submit">Clear</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+
+            <!-- Bootstrap core JavaScript
+            ================================================== -->
+            <!-- Placed at the end of the document so the pages load faster -->
+            <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+          </body>
+        </html>
+      HTMLDOC
+    end
+  end
+
+  ROUTES = {
+    "/" => List, # GET
+    "/update" => Update, # POST
+    "/add" => Create, # POST
+    "/delete" => Delete, # POST
+  }
+
+  def self.has_route?(request)
+    ROUTES.keys.include? request.path.downcase
+  end
+
+  def self.action_for(request)
+    ROUTES.fetch(request.path.downcase)
+  end
+end
+
+server = WEBrick::HTTPServer.new(:Port => 1234)
+
+server.mount "/", WebuiServlet, [LichVarsService]
+
+before_dying do
+  server.shutdown
+end
+
+server.start

--- a/scripts/webui.lic
+++ b/scripts/webui.lic
@@ -1,159 +1,83 @@
 require "erb"
 require "webrick"
 
-class WebuiServlet < WEBrick::HTTPServlet::AbstractServlet
-  attr_reader :subapps
+Settings["webui"] ||= {
+  "port"  => nil,
+  "host"  => nil,
+}
+echo Settings.to_hash
 
-  def initialize(server, apps=[])
-    super server
-    @subapps = apps
-  end
+module WebUI
+  class Servlet < WEBrick::HTTPServlet::AbstractServlet
+    attr_reader :name, :subapps, :thread_group
 
-  def do_GET(request, response)
-    dispatch(request, response)
-    response.status = 200
-  end
-
-  def do_POST(request, response)
-    dispatch(request, response)
-    response.set_redirect WEBrick::HTTPStatus::Found, '/'
-  end
-
-  def dispatch(request, response)
-    if app = find_app_for(request)
-      app.action_for(request).new(request, response).call
-    else
-      raise WEBrick::HTTPStatus::NotFound
-    end
-  end
-
-  def find_app_for(request)
-    subapps.find { |app| app.has_route?(request) }
-  end
-
-  class Action
-    attr_reader :request, :response
-
-    def initialize(request, response)
-      @request = request
-      @response = response
+    def initialize(server, name, thread_group, apps=[])
+      super server
+      @name = name
+      @subapps = apps
+      thread_group.add Thread.current
     end
 
-    def params
-      request.query
+    def do_GET(request, response)
+      dispatch(request, response)
+      response.status = 200
     end
 
-    def call
-      raise NotImplemented
+    def do_POST(request, response)
+      app = dispatch(request, response)
+      response.set_redirect WEBrick::HTTPStatus::Found, app.default_route
     end
-  end
-end
 
-class LichVarsService
-  class Update < WebuiServletAction
-    def call
-      params.each do |name, value|
-        Vars[name.to_s] = value.to_s
-        echo "Updating Vars.#{name} = #{Vars[name]}"
+    def dispatch(request, response)
+      if request.path == "/"
+        subapps.first.tap do |app|
+          app.action_for(app.default_route).new(app, request, response, self).call
+        end
+      elsif app = find_app_for(request)
+        app.tap do |app|
+          app.action_for(request.path).new(app, request, response, self).call
+        end
+      else
+        raise WEBrick::HTTPStatus::NotFound
       end
     end
-  end
 
-  class Create < WebuiServletAction
-    def call
-      name = params.fetch("name").to_s
-      value = params.fetch("value").to_s
-      Vars[name] = value
-      echo "Adding Vars.#{name} = #{Vars[name]}"
-    end
-  end
-
-  class Delete < WebuiServletAction
-    def call
-      params.each do |name, value|
-        echo "Deleting Vars.#{name}"
-        Vars[name.to_s] = nil
-      end
-    end
-  end
-
-  class List < WebuiServletAction
-    def call
-      response.body = template.result
+    def find_app_for(request)
+      subapps.find { |app| app.has_route?(request) }
     end
 
-    def template
-      @template ||= ERB.new <<~HTMLDOC
+    def layout
+      @layout ||= ERB.new <<~HTMLDOC
         <!doctype html>
         <html lang="en">
           <head>
             <!-- Required meta tags -->
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
             <!-- Bootstrap CSS -->
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-
-            <title>Lich: <%= Char.name %></title>
+            <title><%= servlet.name %>: <%= Char.name %></title>
           </head>
           <body class="bg-light">
-
-            <div class="container-fluid">
-              <div class="py-2 text-center">
-                <h2>Lich Variables for <%= Char.name %></h2>
+            <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+              <a class="navbar-brand" href="/"><%= servlet.name %></a>
+              <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+              </button>
+              <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+                <ul class="navbar-nav mr-auto">
+                  <% servlet.subapps.each do |subapp| %>
+                    <li class="nav-item <%= "active" if subapp.name == app.name %>">
+                      <a class="nav-link" href="<%= subapp.default_route %>"><%= subapp.name %></a>
+                    </li>
+                  <% end %>
+                </ul>
               </div>
-
-              <% Vars.list.each do |name, value| %>
-                <div class="row">
-                  <div class="col-10 pr-2">
-                    <form action="/update" method="post">
-                      <div class="form-row">
-                        <label for="<%= ERB::Util.html_escape(name) %>" class="col-4 col-form-label">
-                          <%= ERB::Util.html_escape(name) %>
-                        </label>
-                        <div class="col-6">
-                          <input type="text" class="form-control" id="<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>" value="<%= ERB::Util.html_escape(value) %>">
-                        </div>
-                        <div class="col-2">
-                          <button class="btn btn-primary mb-1 w-100" type="submit">Save</button>
-                        </div>
-                      </div>
-                    </form>
-                  </div>
-                  <div class="col-2 pl-2">
-                    <form action="/delete" method="post">
-                      <div class="form-row">
-                        <input type="hidden" id="<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>">
-                        <button class="btn btn-danger mb-2 w-100" type="submit">Delete</button>
-                      </div>
-                    </form>
-                  </div>
-                </div>
-              <% end %>
-              <div class="row">
-                <div class="col-10 pr-2">
-                  <form action="/add" method="post">
-                    <div class="form-row">
-                      <div class="col-4">
-                        <input type="text" class="form-control" id="name" name="name" value="" placeholder="name" required>
-                      </div>
-                      <div class="col-6">
-                        <input type="text" class="form-control" id="value" name="value" value="" placeholder="value" required>
-                      </div>
-                      <div class="col-2">
-                        <button class="btn btn-outline-primary mb-2 w-100" type="submit">Add</button>
-                      </div>
-                    </div>
-                  </form>
-                </div>
-                <div class="col-2 pl-2">
-                  <form action="/" method="get">
-                    <div class="form-row">
-                      <button class="btn btn-outline-danger mb-2 w-100" type="submit">Clear</button>
-                    </div>
-                  </form>
-                </div>
-              </div>
+            </nav>
+            <div class="pt-5">
+              <main role="main" class="container pt-2">
+                <%= yield %>
+              </main><!-- /.container -->
             </div>
 
             <!-- Bootstrap core JavaScript
@@ -166,25 +90,233 @@ class LichVarsService
     end
   end
 
-  ROUTES = {
-    "/" => List, # GET
-    "/update" => Update, # POST
-    "/add" => Create, # POST
-    "/delete" => Delete, # POST
-  }
+  class App
+    class << self
+      attr_accessor :default_route
 
-  def self.has_route?(request)
-    ROUTES.keys.include? request.path.downcase
+      def has_route?(request)
+        routes.keys.include? request.path.downcase
+      end
+
+      def action_for(path)
+        routes.fetch(path.downcase)
+      end
+
+      def routes
+        @routes ||= {}
+      end
+
+      def add_route(path, action)
+        routes[path] = action
+      end
+
+      def add_default_route(path, action)
+        self.default_route = path
+        add_route(path, action)
+      end
+
+      def name
+        super.
+          sub(/^Scripting::/, '').
+          sub(/^WebUI::/, '')
+      end
+    end
   end
 
-  def self.action_for(request)
-    ROUTES.fetch(request.path.downcase)
+  class Action
+    attr_reader :app, :request, :response, :servlet
+
+    def initialize(app, request, response, servlet)
+      @app = app
+      @request = request
+      @response = response
+      @servlet = servlet
+    end
+
+    def params
+      request.query
+    end
+
+    def call
+      raise NotImplemented
+    end
+
+    def render_with_layout(template)
+      render_layout do
+        template.result
+      end
+    end
+    alias :render :render_with_layout
+
+    def render_layout
+      servlet.layout.result(binding)
+    end
+
   end
 end
 
-server = WEBrick::HTTPServer.new(:Port => 1234)
+class WebUI::Vars < WebUI::App
+  #self.name = "Vars"
 
-server.mount "/", WebuiServlet, [LichVarsService]
+  class Update < WebUI::Action
+    def call
+      params.each do |name, value|
+        Vars[name.to_s] = value.to_s
+        echo "Updating Vars.#{name} = #{Vars[name]}"
+      end
+    end
+  end
+
+  class Create < WebUI::Action
+    def call
+      name = params.fetch("name").to_s
+      value = params.fetch("value").to_s
+      Vars[name] = value
+      echo "Adding Vars.#{name} = #{Vars[name]}"
+    end
+  end
+
+  class Delete < WebUI::Action
+    def call
+      params.each do |name, value|
+        echo "Deleting Vars.#{name}"
+        Vars[name.to_s] = nil
+      end
+    end
+  end
+
+  class Show < WebUI::Action
+    def call
+      response.body = render template
+    end
+
+    def template
+      @template ||= ERB.new <<~HTMLDOC
+        <div class="py-3 text-center">
+          <h2>Lich Variables for <%= Char.name %></h2>
+        </div>
+
+        <% Vars.list.each do |name, value| %>
+          <div class="row">
+            <div class="col-10 pr-2">
+              <form action="/vars/update" method="post">
+                <div class="form-row">
+                  <label for="<%= ERB::Util.html_escape(name) %>" class="col-4 col-form-label">
+                    <%= ERB::Util.html_escape(name) %>
+                  </label>
+                  <div class="col-6">
+                    <input type="text" class="form-control" id="update_<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>" value="<%= ERB::Util.html_escape(value) %>">
+                  </div>
+                  <div class="col-2">
+                    <button class="btn btn-primary mb-1 w-100" type="submit">Save</button>
+                  </div>
+                </div>
+              </form>
+            </div>
+            <div class="col-2 pl-2">
+              <form action="/vars/delete" method="post">
+                <div class="form-row">
+                  <input type="hidden" id="delete_<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>">
+                  <button class="btn btn-danger mb-2 w-100" type="submit">Delete</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        <% end %>
+        <div class="row">
+          <div class="col-10 pr-2">
+            <form action="/vars/add" method="post">
+              <div class="form-row">
+                <div class="col-4">
+                  <input type="text" class="form-control" id="add_name" name="name" value="" placeholder="name" required>
+                </div>
+                <div class="col-6">
+                  <input type="text" class="form-control" id="add_value" name="value" value="" placeholder="value" required>
+                </div>
+                <div class="col-2">
+                  <button class="btn btn-outline-primary mb-2 w-100" type="submit">Add</button>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="col-2 pl-2">
+            <form action="/vars" method="get">
+              <div class="form-row">
+                <button class="btn btn-outline-danger mb-2 w-100" type="submit">Clear</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      HTMLDOC
+    end
+  end
+
+  add_route "/vars/add", Create
+  add_route "/vars/update", Update
+  add_route "/vars/delete", Delete
+  add_default_route "/vars", Show
+end
+
+class WebUI::Settings < WebUI::App
+  class Update < WebUI::Action
+    def call
+      params.each do |name, value|
+        echo "Updating Settings[#{name}] = #{value}"
+        Settings["webui"][name.to_s] = value.to_s
+      end
+    end
+  end
+
+  class Show < WebUI::Action
+    def call
+      response.body = render template
+    end
+
+    def template
+      @template ||= ERB.new <<~HTMLDOC
+        <div class="py-3 text-center">
+          <h2>WebUI Settings</h2>
+        </div>
+
+        <% Settings["webui"].each do |name, value| %>
+          <div class="row">
+            <div class="col-6">
+              <form action="/settings/update" method="post">
+                <div class="form-row">
+                  <label for="<%= ERB::Util.html_escape(name) %>" class="col-4 col-form-label">
+                    <%= ERB::Util.html_escape(name) %>
+                  </label>
+                  <div class="col-6">
+                    <input type="text" class="form-control" id="update_<%= ERB::Util.html_escape(name) %>" name="<%= ERB::Util.html_escape(name) %>" value="<%= ERB::Util.html_escape(value) %>">
+                  </div>
+                  <div class="col-2">
+                    <button class="btn btn-primary mb-1 w-100" type="submit">Save</button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        <% end %>
+      HTMLDOC
+    end
+  end
+
+  add_route "/settings/update", Update
+  add_default_route "/settings", Show
+end
+
+port = Settings["webui"]["port"] || 1234
+host = Settings["webui"]["host"] || "localhost"
+
+server = WEBrick::HTTPServer.new(
+  :Port => port,
+  :BindAddress => host,
+)
+
+server.mount "/", WebUI::Servlet, "Lich", Thread.current.group, [
+  WebUI::Vars,
+  WebUI::Settings,
+]
 
 before_dying do
   server.shutdown


### PR DESCRIPTION
## Summary

Basic proof of concept of web app for presenting a configuration UI and info display from lich scripts. The server spawns in a separate thread and renders a server-rendered UI for editing Lich variables and WebUI server settings. I started to separate some concerns to create the beginnings of a framework that other scripts could use as well, but wanted to get some feedback before I committed to any direction.

Here are some screenshots:

![webui_lichvars](https://user-images.githubusercontent.com/901865/45381161-2bf07400-b5ca-11e8-8e2e-5ea43fd1930d.png)
![webui_settings](https://user-images.githubusercontent.com/901865/45381164-2e52ce00-b5ca-11e8-825f-cd78a88758cd.png)

## Design Overview

An explicit goal of this script was to only use gems available in the Ruby standard library. I generally avoid [WEBrick](https://ruby-doc.org/stdlib-2.0.0/libdoc/webrick/rdoc/WEBrick.html) in production because it is single-threaded, but I felt like it worked well enough for this purpose. I implemented a server-side UI built around HTML forms using [ERB](https://ruby-doc.org/stdlib-2.5.1/libdoc/erb/rdoc/ERB.html) as a templating engine. 

I considered using JS to render the UI on the front end and providing a RESTful API, but adding another layer on top of Ruby and HTML/ERB felt like a lot of languages for one lich script. I do think there would be advantages to that approach like real time updates (e.g. health/mana/etc) and advanced browser features like notifications, but I think that can be explored outside of this script which is focused on the server.

The framework provides a container servlet (this is a WEBrick concept) that handles shared server tasks and accepts a list of apps that are rendered as separate pages in the UI. Each app can define the paths it responds to declaratively using a super simple router, associating each path with an Action, which is kind of like a very dumbed down controller/method object for responding to the request.

The Lich variables are an example of a script-specific page, but the goal of the Settings page is to provide a generic subapp that can be reused in other scripts.

## Some Known Issues

#### Values are all stringly-typed

All input comes into the server as strings and it doesn't try to coerce the values to any other type before updating them. It can display other types of values, but updating something like a boolean or Hash will overwrite it with a String. 

I think Boolean and Fixnum values are fairly straightforward to address, but Hashes are a little more complicated. While we could accept a full hash and coerce it in the server, we would need to use [Ripper](http://ruby-doc.org/stdlib-2.0.0/libdoc/ripper/rdoc/Ripper.html) to avoid RCE and it wouldn't be a great UI for people editing values. I think it makes more sense to create a UI that it aware of nested Hashes as a common variable/setting type and supports editing/adding entries inside of the hash. Interested in other opinions on this though.

#### General Settings UI

I have the template for WebUI settings basically hardcoded right now, but would like to provide a way for the app to generate UI based on either the existing settings or preferably by passing some kind of schema declaration to WebUI::Settings. I started creating a `SettingsSchema` class to define name/type/defaults for settings, but punted on it for now to explore at a later date in the future.

#### Port Selection / Multiple Servers

Right now this is kind of annoying to use with multiple characters because it requires each server to listen on a different port. While I did create a setting for it, the server could also support a method for attempting to find an available port to listen on and reporting this to the user. I think this problem would become more annoying if multiple scripts had separate WebUI servers running and it might make more sense to have other scripts register their pages with the main web server instead of spawning their own.