### PR TITLE
gameobj-data: use xmllint to verify and autoformat compiled output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,9 @@ deploy:
   script: bin/repo
   on:
     branch: master
+
+addons:
+  apt:
+    packages:
+    # installs xmllint for bin/migrate
+    - libxml2-utils

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,2 +1,19 @@
 #!/usr/bin/env ruby
 require_relative("./tasks/migrate.rb")
+
+gameobj_xml_path = Pathname.new("./dist/gameobj-data.xml")
+formatted_xml_path = Pathname.new("./dist/gameobj-data.formatted.xml")
+xmllint_cmd = "xmllint --format #{gameobj_xml_path} > #{formatted_xml_path}"
+
+if gameobj_xml_path.exist?
+  print "Formatting XML output with xmllint... "
+  if system(xmllint_cmd) && formatted_xml_path.rename(gameobj_xml_path)
+    puts "Done!"
+  else
+    puts "Error: xmllint failed"
+    exit 2
+  end
+else
+  puts "Error: couldn't find #{gameobj_xml_path}"
+  exit 1
+end


### PR DESCRIPTION
This uses the `xmllint` cmd from the libxml` library to verify that the compiled output is valid XML and to autoformat it using xmllint's default rules. libxml2/xmllint are available out of the box on OSX and many linux distros (and easy to install on distros where it doesn't come by default, but it doesn't look like there is an easy way to make it work on Windows. The best directions I found were from [Atom's xmllint package](https://atom.io/packages/linter-xmllint) but they are pretty complicated and use a somewhat out of date version of xmllint.

@horibu if you get a chance, could you try to run `bin/migrate` on Windows without installing anything? You should get an error message about formatting the XML file but everything else should work right.

@ondreian do you think this is the best approach or should we try something different? I didn't expect xmllint to be this difficult to get working on Windows. I know that you, TIllmen, and I are mostly using unix platforms, but the vast majority of the rest of the player base and potential contributors are on Windows. 