### PR TITLE
String check fix for puritan cast attempts

### DIFF
--- a/scripts/puritan.lic
+++ b/scripts/puritan.lic
@@ -233,7 +233,7 @@ module Puritan
 
   def self.wait_for_own_song()
     while line=get
-      return :ok if line.start_with?(%[You sing a melody, directing the sound of your voice at])
+      return :ok if line.include?(%[directing the sound of your voice at])
     end
   end
 


### PR DESCRIPTION
Fixes a bug where the script would hang if you attempted to use puritan with some set of other spellsongs active. When this occurs, the string reads "You weave another verse into your harmony, directing the sound of your voice at ..." The script, however, only returns "ok" upon encountering "You sing a melody, directing the sound of your voice at ..."

My fix simple checks for the presence of the shared portion of those two strings. Alternatively, you could solve this with comparing two different strings using starts_with; I felt this was more elegant. YMMV!