### PR TITLE
Update manaleech.lic

### DIFF
--- a/scripts/manaleech.lic
+++ b/scripts/manaleech.lic
@@ -12,9 +12,11 @@
      author: Tysong (horibu on PC)
        name: manaleech
        tags: mana leech, mana, leech, 516, wizard
-    version: 2.2
+    version: 2.3
 
     changelog:
+        2.3 (2019-01-03)
+            Changed cast() calls to Spell.cast() instead
         2.2 (2018-08-23)
             Fix issue to prevent casting at dead/gone NPCs
         2.1 (2018-06-29)
@@ -54,7 +56,7 @@ loop {
 		waitrt?
 		put "stance defensive"
 		waitcastrt?
-		cast(516, valid_targets.first.noun ) if !muckled? && valid_targets.first.status !~ /dead|gone/
+		Spell[516].cast(valid_targets.first.noun) if !muckled? && valid_targets.first.status !~ /dead|gone/
 		unpause_script('bigshot')
 		unpause_script('botcamp')
 		sleep UserVars.manaleechsleeptimer


### PR DESCRIPTION
change uses cast() function to Spell.cast() function to not conflict with other scripts that have custom cast() functions.