### PR TITLE
travis: update rubygems version to support new bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm:
   - 2.3
 
+before_install:
+  gem update --system
+
 before_script:
   bin/migrate --run
 


### PR DESCRIPTION
Bundle 2.0 was released today and requires rubygems to be at least version 3.0. This tells our build to update `gem` before trying to install bundler and the rest of our dependencies.