### PR TITLE
Orb outcome from 1004 overrides other outcomes

### DIFF
--- a/scripts/puritan.lic
+++ b/scripts/puritan.lic
@@ -112,13 +112,13 @@ end
 ##
 module Puritan
   module Outcomes
-    ALL       = /what were you|cannot|must be holding|shatter|song misfires/i
     MAX       = /cannot be/
     SHATTERED = /shatter/
     MISFIRE   = /misfire/
     STRAIN    = /you hear it crack loudly and strain/
     PURE      = /begins to twist and turn as the very essence flows into it filling the imperfections/
     IMPROVED  = /more perfect|what were you|improves somewhat|crack|shatter|cannot be|must be holding|smoother and more pure in color/
+    ALL       = Regexp.union(MAX, SHATTERED, MISFIRE, STRAIN, PURE, IMPROVED)
   end
 end
 
@@ -313,6 +313,33 @@ module Puritan
     end
   end
 
+  def self.select_outcome_from_1004_output()
+    while line=get
+      if line =~ Puritan::Outcomes::ALL
+        outcome = line
+      end
+      if Puritan.stop_processing_1004_result_on?(line)
+        outcome ||= line
+        return outcome
+      end
+    end
+  end
+
+  def self.stop_processing_1004_result_on?(line)
+    [
+        "turn as the very essence",
+        "sparkles a little more",
+        "shatter",
+        "must be holding",
+        "what were you",
+        "cannot be",
+        "Sing Roundtime",
+        "Wait",
+        'Spell Hindrance',
+        "song misfires"
+    ].any? { |s| line.include?(s) }
+  end
+
   def self.outcome_of_1004(gem)
     waitcastrt?
     waitrt?
@@ -320,21 +347,7 @@ module Puritan
     prep_1004()
     fput("sing ##{gem.id}")
     if wait_for_own_song().eql?(:ok)
-      result = matchwait(
-        #"gem becomes more perfect",
-        #"improves somewhat",
-        "turn as the very essence",
-        "sparkles a little more",
-        "shatter",
-        "crack",
-        "must be holding",
-        "what were you",
-        "appearing smoother and more pure",
-        "cannot be", 
-        "Sing Roundtime",
-        "Wait",
-        'Spell Hindrance',
-        "song misfires")
+      result = Puritan.select_outcome_from_1004_output()
       Spell.unlock_cast()
       Log.out(result, label: %w(1004))
       return result


### PR DESCRIPTION
When using 1004 on a gem, the gem damage messaging (i.e. improvement or strain) comes before the messaging for a gem purified to orb status. This updates the script to continue processing the 1004 result after the gem damage messaging until sees the orb messaging, the generic non-orb messaging from 1004, or another result that cannot result in an orb gem.