### PR TITLE
Adds create_key command for migrations

### DIFF
--- a/lib/migration/migrator.rb
+++ b/lib/migration/migrator.rb
@@ -25,8 +25,20 @@ module Migration
     end
 
     def apply()
+      apply_creations()
       apply_insertions()
       apply_deletions()
+    end
+
+    def apply_creations()
+      @changesets.each do |changeset|
+        changeset.creates.each do |key|
+          Migration.log(%[#{changeset.table.log_name} CREATE KEY "#{key}"],
+            label: %i[changeset],
+            color: :light_blue)
+          changeset.table.create_key(key)
+        end
+      end
     end
 
     def apply_insertions()

--- a/lib/migration/migrator.rb
+++ b/lib/migration/migrator.rb
@@ -33,7 +33,7 @@ module Migration
     def apply_creations()
       @changesets.each do |changeset|
         changeset.creates.each do |key|
-          Migration.log(%[#{changeset.table.log_name} CREATE KEY "#{key}"],
+          Migration.log(%[#{changeset.table.log_name} CREATE key "#{key}"],
             label: %i[changeset],
             color: :light_blue)
           changeset.table.create_key(key)
@@ -45,7 +45,7 @@ module Migration
       @changesets.each do |changeset| 
         changeset.inserts.each do |key, rules|
           rules.each do |rule|
-            Migration.log(%[#{changeset.table.log_name} INSERT "#{rule}"], 
+            Migration.log(%[#{changeset.table.log_name} INSERT #{key} "#{rule}"],
               label: %i[changeset],
               color: :green)
           end
@@ -58,7 +58,7 @@ module Migration
       @changesets.each do |changeset| 
         changeset.deletes.each do |key, rules|
           rules.each do |rule|
-            Migration.log(%[#{changeset.table.log_name} DELETE "#{rule}"], 
+            Migration.log(%[#{changeset.table.log_name} DELETE #{key} "#{rule}"],
               label: %i[changeset],
               color: :yellow)
           end

--- a/lib/migration/table.rb
+++ b/lib/migration/table.rb
@@ -125,6 +125,12 @@ module Migration
       end
     end
     #
+    # creates a new key with an empty ruleset
+    #
+    def create_key(key)
+      insert(key)
+    end
+    #
     # dumps the table key/ruleset pairs to 
     # a Map(Key, Regexp) that can be used
     #

--- a/type_data/migrations/5_data_consistency_fixes.rb
+++ b/type_data/migrations/5_data_consistency_fixes.rb
@@ -93,3 +93,9 @@ end
 migrate :valuable do
   delete(:name, %{piece of petrified maoral})
 end
+
+migrate :armor do
+  create_key(:exclude)
+  insert(:exclude, %{steel shield})
+  insert(:exclude, %{scratched steel helm})
+end

--- a/type_data/tables/armor.yaml
+++ b/type_data/tables/armor.yaml
@@ -4,9 +4,6 @@ name:
   - .*?chain mail
   - .*?half plate
   - .*?augmented chain
-exclude:
-  - steel shield
-  - scratched steel helm
 noun:
   - mantlet
   - doublet


### PR DESCRIPTION
Adds a `create_key` command to the migration DSL. Refactors one of the existing migrations to exercise the new command.