### PR TITLE
cluster: faster response processing

### DIFF
--- a/scripts/cluster.lic
+++ b/scripts/cluster.lic
@@ -169,20 +169,16 @@ class Cluster
         uuid:    req_id,
         channel: [payload.fetch(:channel), %(request)]
       }))
-    ttl = Time.now + payload.fetch(:timeout, TTL)
-    @pending_requests[req_id] = ttl
-    
-    loop do
-      if pending_requests[req_id].is_a?(Time) and Time.now < ttl
-        sleep 0.001
-      else
-        break
-      end
-    end
+    ttl = payload.fetch(:timeout, TTL)
+    @pending_requests[req_id] = Thread.current
+    timeout_thread = Thread.new { sleep ttl; @pending_requests[req_id].wakeup }
+    Thread.stop
+
+    timeout_thread.kill
     resp = pending_requests[req_id]
     pending_requests.delete(req_id)
     # request timed out
-    return TimeoutError.new("request to #{person} failed in #{TTL}s") if resp.is_a?(Time)
+    return TimeoutError.new("request to #{person} failed in #{ttl}s") if resp.is_a?(Thread)
     # remote or local error happened during response/request cycle
     return Exception.new(resp.fetch(:error)) if resp.fetch(:error, false)
     # it's a real boy!
@@ -254,6 +250,7 @@ class Cluster
       resp_id  = incoming.fetch(:uuid)
       pending  = @pending_requests.fetch(resp_id, false)
       @pending_requests[resp_id] = incoming if pending
+      pending.wakeup
     rescue Exception => err
       #Log.out(err, label: %i[local response error] + channel.split("."))
       @pending_requests[resp_id] = err.message

--- a/scripts/cluster.lic
+++ b/scripts/cluster.lic
@@ -33,78 +33,13 @@ class Cluster
     end
 
     def self.dump(*args)
-      pp(*args)
-    end
-  end
-  ##
-  ## minimal options parser
-  ##
-  module Opts
-    FLAG_PREFIX    = "--"
-    
-    def self.parse_command(h, c)
-      h[c.to_sym] = true
-    end
-
-    def self.parse_flag(h, f)
-      (name, val) = f[2..-1].split("=")
-      if val.nil?
-        h[name.to_sym] = true
-      else
-        val = val.split(",")
-
-        h[name.to_sym] = val.size == 1 ? val.first : val
-      end
-    end
-
-    def self.parse(args = Script.current.vars[1..-1])        
-      OpenStruct.new(**args.to_a.reduce(Hash.new) do |opts, v|
-        if v.start_with?(FLAG_PREFIX)
-          Opts.parse_flag(opts, v)
-        else
-          Opts.parse_command(opts, v)
-        end
-        opts
-      end)
-    end
-
-    def self.method_missing(method, *args)
-      parse.send(method, *args)
-    end
-  end
-end
-
-class Cluster
-  ##
-  ## contextual logging
-  ##
-  module Log  
-    def self.out(msg, label: :debug)
-      #return unless Opts.debug
-      if msg.is_a?(Exception)
-        msg = %{
-          #{msg.message}
-          #{msg.backtrace.join("\n")}
-        }
-      end
-
-      _respond Preset.as(:debug, 
-        _view(msg, label))
-    end
-
-    def self._view(msg, label)
-      label = [Script.current.name, label].flatten.compact.join(".")
-      safe = msg.inspect
-      safe = safe.gsub("<", "(").gsub(">", ")") if safe.include?("<") and safe.include?(">")
-      "[#{label}] #{safe}"
-    end
-
-    def self.pp(msg, label = :debug)
-      respond _view(msg, label)
-    end
-
-    def self.dump(*args)
       pp *args
+    end
+
+    module Preset
+      def self.as(kind, body)
+        %[<preset id="#{kind}">#{body}</preset>]
+      end
     end
   end
   ##

--- a/scripts/cluster.lic
+++ b/scripts/cluster.lic
@@ -172,7 +172,13 @@ class Cluster
     ttl = Time.now + payload.fetch(:timeout, TTL)
     @pending_requests[req_id] = ttl
     
-    wait_while do pending_requests[req_id].is_a?(Time) and Time.now < ttl end
+    loop do
+      if pending_requests[req_id].is_a?(Time) and Time.now < ttl
+        sleep 0.001
+      else
+        break
+      end
+    end
     resp = pending_requests[req_id]
     pending_requests.delete(req_id)
     # request timed out


### PR DESCRIPTION
Lich's `wait_while` / `wait_until` are too slow imho for the busy wait that checks for a response to a request. This replaces the `wait_while` block in `Cluster.request` with a loop on a 1ms sleep. I tested this out and didn't notice an increase in CPU usage, but I am going to try some other things too. I think I can have `_handle_response` invoke a block or resume execution of a fiber instead of polling.