### PR TITLE
gameobj: use names instead of nouns for treasure boxes

### DIFF
--- a/lib/migration/table.rb
+++ b/lib/migration/table.rb
@@ -142,6 +142,7 @@ module Migration
       # name rules are different, as they can be quite convoluted
       regex_map[:name] = Convert.ruleset_to_regex(name_rules, prefix, suffix) unless name_rules.eql?(false)
       @rules.select do |kind| (%i[name prefix] & [kind]).empty? end.each do |kind, ruleset|
+        next if ruleset.empty?
         regex_map[kind] = Validate.regexp(self, kind,
           Convert.ruleset_to_regex(ruleset))
       end

--- a/spec/gameobj-data/boxes_and_picking_spec.rb
+++ b/spec/gameobj-data/boxes_and_picking_spec.rb
@@ -43,6 +43,24 @@ describe GameObj do
         box = GameObjFactory.item_from_name(full_box_description)
         expect(box.type).to eq "box"
       end
+
+    end
+
+    short_box_descriptions = box_nouns.product(box_woods) + box_nouns.product(box_metals)
+    short_box_descriptions.each do |noun, material|
+      short_box_description = "#{material} #{noun}"
+
+      it "recognizes #{short_box_description} as a box" do
+        box = GameObjFactory.item_from_name(short_box_description)
+        expect(box.type).to eq "box"
+      end
+
+      phased_box_description = "shifting #{short_box_description}"
+
+      it "recognizes #{phased_box_description} as a phased box" do
+        box = GameObjFactory.item_from_name(phased_box_description)
+        expect(box.type).to eq "box"
+      end
     end
 
     describe "things that are not boxes" do

--- a/type_data/migrations/13_use_names_not_nouns_for_loot_boxes.rb
+++ b/type_data/migrations/13_use_names_not_nouns_for_loot_boxes.rb
@@ -1,0 +1,15 @@
+migrate :box do
+  delete(:noun, %{box})
+  delete(:noun, %{chest})
+  delete(:noun, %{coffer})
+  delete(:noun, %{strongbox})
+  delete(:noun, %{trunk})
+  delete(:exclude, %{polished modwir box})
+
+  create_key(:prefix)
+  insert(:prefix, %{shifting})
+
+  create_key(:name)
+  insert(:name, %{(?:(?:acid-pitted|badly damaged|battered|corroded|dented|engraved|enruned|plain|scratched|sturdy) )?(?:brass|gold|iron|mithril|silver|steel) (?:box|chest|coffer|strongbox|trunk)})
+  insert(:name, %{(?:(?:badly damaged|engraved|enruned|iron-bound|plain|rotting|scratched|simple|sturdy|weathered) )?(?:fel|haon|maoral|modwir|monir|tanik|thanot|wooden) (?:box|chest|coffer|strongbox|trunk)})
+end


### PR DESCRIPTION
Updates the `box` type to use exact names instead of just relying on the noun. This lets up drop the existing excludes we had as well. `;xmlpatch` has been doing this with a very similar regex for a while and I feel pretty confident that my list of box combinations in the specs is exhaustive, so I think this is safe to deploy to everyone.

This also updates the migration code to not write XML tags for empty rulesets. It was putting a couple tags like `<noun>^()$</noun>` in the XML which would never match but are kind of confusing.