### PR TITLE
fix(wps.lic): remove registration call

### DIFF
--- a/scripts/wps.lic
+++ b/scripts/wps.lic
@@ -123,7 +123,6 @@ module WPS
         opts = normalize_input(*Script.current.vars[1..-1])
         pause_for_confirmation_of(opts)
         perform_services(opts)
-        fput "register ##{GameObj.right_hand.id}"
       end
     rescue WPS::ArgumentError => e
       respond e.for_cmdline


### PR DESCRIPTION
According to Estild, wps changes are automatically registered, and this is a double registration.