### PR TITLE
Adds skayl hearts as sellable gems

### DIFF
--- a/spec/gameobj-data/gem_spec.rb
+++ b/spec/gameobj-data/gem_spec.rb
@@ -344,6 +344,7 @@ describe GameObj do
         %{green peridot},
         %{green starstone},
         %{grey moonstone},
+        %{heart of smooth black glaes},
         %{leopard quartz},
         %{opaline moonstone},
         %{pink dreamstone},

--- a/spec/gameobj-data/junk_spec.rb
+++ b/spec/gameobj-data/junk_spec.rb
@@ -23,6 +23,18 @@ describe GameObj do
       end
     end
 
+    describe "junk specific to certain creatures" do
+      [
+        %{hollow smooth black glaes},
+      ].each do |junk_name|
+        it "recognizes critter dropped #{junk_name} as junk" do
+          junk = GameObjFactory.item_from_name(junk_name)
+          expect(junk.type).to eq "junk"
+          expect(junk.sellable).to be nil
+        end
+      end
+    end
+
     describe "randomized junk names from treasure system" do
       junk_nouns = %w[coin cup doorknob fork horseshoe nail spoon]
       junk_descriptors = %w[bent corroded dented polished rusty scratched shiny tarnished]

--- a/type_data/migrations/21_gh_133_teras_creature_drops.rb
+++ b/type_data/migrations/21_gh_133_teras_creature_drops.rb
@@ -1,0 +1,12 @@
+migrate :gem, :gemshop do
+  insert(:name, %{heart of smooth black glaes})
+end
+
+migrate :junk do
+  insert(:name, %{hollow smooth black glaes})
+end
+
+migrate :uncommon do
+  insert(:exclude, %{heart of smooth black glaes})
+  insert(:exclude, %{hollow smooth black glaes})
+end


### PR DESCRIPTION
Also adds the occasional "hollow smooth black glaes" drop as junk since its heavy and wasn't sellable anywhere for me. Also excludes both of these from uncommon. 

Fixes #133 