### PR TITLE
feat: adds calc option for tears.lic

### DIFF
--- a/scripts/tears.lic
+++ b/scripts/tears.lic
@@ -7,12 +7,14 @@
     OPTION Selections Include:
          CHART - Prints off enchant cast tear cost chart for each +1
          SENSE - Tells you how much tears you have based on SENSE messaging.
+         CALC  - calculate cost for an enchant project from x to y
+                 ;tears calc [starting enchant] [ending enchant]
 
        todo: add parsing of reim info command and show condensed info
      author: Elanthia-Online
        name: tears
        tags: tears, essence, enchant, enchanting, 925
-    version: 1.0
+    version: 1.1
 
     changelog:
         1.0 (2019-05-06)
@@ -21,12 +23,70 @@
 =end
 
 tear_cost = ["0", "100", "200", "300", "400", "500", "600", "700", "800", "900", "1000", "1100", "1200", "1300", "1400", "1500", "1600", "1700", "1800", "1900", "2000", "2100", "2200", "2300", "2400", "4800", "7200", "9600", "12000", "14400", "16800", "19200", "21600", "24000", "26400", "28800", "31200", "33600", "36000", "38400", "40800", "43200", "45600", "48000", "50400", "52800", "55200", "57600", "60000", "62400"]
+WEEK = 16000.0
+PAD = 91
+
+def rowout(msg_arr, mbold = false)
+        out = '| '
+        msg_arr.each { |m|
+                out += '%-12.12s | ' % m
+        }
+        if mbold == true
+                _respond "#{monsterbold_start}#{out}#{monsterbold_end}"
+        else
+                _respond out
+        end
+end
+
+def do_calc(tear_cost)
+	starting_bonus = variable[2].to_i
+	if variable[3] and variable[3].to_i <= 50
+		ending_bonus = variable[3].to_i
+	elsif not variable[3] or variable[3].to_i > 50
+		ending_bonus = 50
+	end
+	if ending_bonus <= starting_bonus
+		_respond "Ending bonus must be greater than starting bonus"
+		_respond ";tears calc [starting bonus] [ending bonus]"
+		exit
+	end
+
+	_respond "Calculating essence needed to take an item from #{starting_bonus} to #{ending_bonus}"
+	_respond ""
+
+	_respond "-" * PAD
+	headers = ['Current', 'New', 'Cost (ess)', 'Cost (wks)', 'Total (ess)', 'Total (wks)']
+	rowout(headers, true)
+	_respond "-" * PAD
+
+	current_bonus = starting_bonus
+	running_total_ess = 0
+	while current_bonus < ending_bonus
+		if current_bonus < 0
+			step_cost = 0
+		else
+			step_cost = tear_cost[current_bonus].to_i
+		end
+		running_total_ess += step_cost
+		response_array = [current_bonus, 
+                                  current_bonus + 1, 
+                                  step_cost, 
+                                  (step_cost / WEEK).round(2), 
+                                  running_total_ess, 
+                                  (running_total_ess / WEEK).round(2)]
+		rowout(response_array)
+		current_bonus += 1
+	end
+	_respond "-" * PAD	
+end
 
 if variable[0].nil?
 	respond "You need to give an otption. See below:"
 	respond ""
 	respond "   ;tears chart - Prints off enchant cast tear cost chart for each +1"
 	respond "   ;tears sense - Tells you how much tears you have based on SENSE messaging."
+	respond "   ;tears calc [starting bonus] [ending bonus]"
+        respond "       Tells you the cost for enchanting an item from starting bonus to ending bonus"
 	respond
 elsif variable[0] =~ /chart/
 	respond "Tears needed to do a single +1 cast"
@@ -37,6 +97,8 @@ elsif variable[0] =~ /chart/
 	respond ""
 	
 	exit
+elsif variable[0] =~ /calc/
+	do_calc(tear_cost)
 elsif variable[0] =~ /sense/
 	line = dothistimeout "sense", 5, /You sense that you have accumulated enough essence to complete a +(.*) enchantment\./
 	if line =~ /You sense that you have accumulated enough essence to complete a +(.*) enchantment\./


### PR DESCRIPTION
Was about to upload a quick script I hacked together to do tear calculation, figured it just made more sense to pull in changes here and keep it all together.

```
>;tears calc 25 30
-------------------------------------------------------------------------------------------
| Current      | New          | Cost (ess)   | Cost (wks)   | Total (ess)  | Total (wks)  | 
-------------------------------------------------------------------------------------------
| 25           | 26           | 4800         | 0.3          | 4800         | 0.3          | 
| 26           | 27           | 7200         | 0.45         | 12000        | 0.75         | 
| 27           | 28           | 9600         | 0.6          | 21600        | 1.35         | 
| 28           | 29           | 12000        | 0.75         | 33600        | 2.1          | 
| 29           | 30           | 14400        | 0.9          | 48000        | 3.0          | 
-------------------------------------------------------------------------------------------
--- Lich: tears has exited.

```