### PR TITLE
add flying check

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,12 +8,14 @@
         contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong
                 game: Gemstone
                 tags: hunting
-             version: 3.76
+             version: 3.77
  
 		Setup instructions: https://gswiki.play.net/Script_Bigshot
 		To help contribute: https://github.com/elanthia-online/scripts
 		Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
 		
+		v3.77 (2019-05-10)
+			-Added flying/!flying as command checks for attacks
 		v3.76 (2018-07-04)
 			-Fixed INCANT command to respect Spell.stance setting
 		v3.75 (2018-07-02)
@@ -578,7 +580,7 @@ class Bigshot
 						mobcheck = $2
 						commandcheckreturn = true if GameObjNpcCheck() > mobcheck.to_i
 					end
-				elsif s =~ /((?:prone|!prone|undead|!undead|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs))/i
+				elsif s =~ /((?:prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs))/i
 					if( $1 == 'prone' )
 						commandcheckreturn = true if npc.status =~ PRONE
 					elsif( $1 == '!prone' )
@@ -587,6 +589,10 @@ class Bigshot
 						commandcheckreturn = true if !npc.type.split(',').any?{|a| a == "undead"}
 					elsif( $1 == '!undead' )
 						commandcheckreturn = true if npc.type.split(',').any?{|a| a == "undead"}
+					elsif( $1 == 'flying' )
+						commandcheckreturn = true if !npc.status.split(',').any?{|a| a == "flying"}
+					elsif( $1 == '!flying' )
+						commandcheckreturn = true if npc.status.split(',').any?{|a| a == "flying"}
 					elsif( $1 == 'hidden' )
 						commandcheckreturn = true if !hiding?
 					elsif( $1 == '!hidden' )

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1174,7 +1174,7 @@ class Bigshot
             string.concat('| ' + text)
         end
         if $fake_stormfront then string.concat("\034GSM\r\n ") else string.concat("<popBold\/>") end
-        puts string
+        _respond string
     end
  
     def dead_man_switch()


### PR DESCRIPTION
added flying and !flying as command checks for bigshot. Useful to issue commands to knock something out of the air or to not attack if the creature is still in the air.