### PR TITLE
feat(tilde.lic): add ability to integrate with ;vars

### DIFF
--- a/scripts/bodega.lic
+++ b/scripts/bodega.lic
@@ -18,6 +18,7 @@ require "json"
 require "net/http"
 require "fileutils"
 require "pp"
+require "pathname"
 
 unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3")
   fail "your ruby@#{RUBY_VERSION} is too old"
@@ -92,7 +93,7 @@ module Bodega
   ## minimal options parser
   ##
   module Opts
-    FLAG_PREFIX    = "--"
+    FLAG_PREFIX = "--"
     
     def self.parse_command(h, c)
       h[c.to_sym] = true
@@ -110,7 +111,13 @@ module Bodega
     end
 
     def self.parse(args = Script.current.vars[1..-1])        
-      @opts ||= OpenStruct.new(**args.to_a.reduce(Hash.new) do |opts, v|
+      return @opts ||= _parse(args) if @script.eql?(Script.current)
+      @script = Script.current
+      return @opts = _parse(args) if @script.eql?(Script.current)
+    end
+
+    def self._parse(args)
+      OpenStruct.new(**args.to_a.reduce(Hash.new) do |opts, v|
         if v.start_with?(FLAG_PREFIX)
           Opts.parse_flag(opts, v)
         else
@@ -186,25 +193,44 @@ module Bodega
       %r[^You get no sense of whether or not (.*?) may be further lightened.],
       %r[there is no recorded information on that item],
       %r[^You determine that you could not wear the shard\.],
+      %r[^You see nothing unusual\.$],
+      %r[^It imparts no bonus more than usual\.$],
       %r[^It is difficult to see the (.*?) clearly from this distance\.])
 
-    ENHANCIVE = %r[^It provides a boost of (?<num>\d+) to (?<attr>.*?)\.]
+    ENHANCIVE = {
+          boost: %r[^It provides a boost of (?<boost>\d+) to (?<ability>.*?)\.],
+      level_req: %r[^This enhancement may not be used by adventurers who have not trained (?<level>\d+) times.],
+    }
 
     BOOLS = {
         max_deep: %r[pockets could not possibly get any deeper],
+       max_light: %r[^You can tell that the (?:.*?) is as light as it can get],
          purpose: %r[appears to serve some purpose],
+      deepenable: %r[you might be able to have a talented merchant deepen its pockets for you],
      lightenable: %r[You might be able to have a talented merchant lighten (.*?) for you.],
+        persists: %r[^It will persist after its last charge is depleted|^It will persist after its last enhancive charge],
+         crumbly: %r[but crumble after its last enhancive charge is depleted|^It will crumble into dust after its last charge is depleted\.$|^It will disintegrate after its last charge is depleted\.$],
+           small: %r[^It is a small item, under a pound],
+      imbeddable: %r[^It is a magical item which could be imbedded with a spell],
+    not_wearable: %r[^You determine that you could not wear],
+            holy: %r[^It is a holy item\.],
     }
 
     PROPS = {
-      skill: %r[requires skill in (?<skill>.*?) to use effectively\.],
-    enchant: %r[^It imparts a bonus of \+(?<enchant>\d+) more than usual\.],
-     weight: %r[^It appears to weigh about (?<weight>\d+) pounds.],
-      flare: %r[^It has been infused with the power of (a|an) (?<flare>.*?)\.],
-   material: %r[^It looks like this item has been mainly crafted out of (?<material>.*?)\.],
-       cost: %r[will cost (?<cost>\d+) coins\.$],
-       worn: %r[You determine that you could wear the belt (?<worn>.*?)\.],
-    }
+        skill: %r[requires skill in (?<skill>.*?) to use effectively\.],
+      enchant: %r[^It imparts a bonus of \+(?<enchant>\d+) more than usual\.],
+      weight: %r[^It appears to weigh about (?<weight>\d+) pounds.],
+        flare: %r[^It has been infused with the power of (a|an) (?<flare>.*?)\.],
+    material: %r[^It looks like this item has been mainly crafted out of (?<material>.*?)\.],
+        cost: %r[will cost (?<cost>\d+) coins\.$],
+        worn: %r[You determine that you could wear the (?:.*?)(, slinging it| around| on| over) (?<worn>.*?)\.],
+    activator: %r[^It could be activated by (?<activator>\w+) it\.$],
+        spell: %r[^It is currently imbedded with the (?<spell>.*?) spell.],
+      charges: %r[The (?:\w+) looks to have (?<charges>.*?) charges remaining\.$|It has (?<charges>.*?) charges remaining.],
+  shield_size: %r[Your careful inspection of an ornate villswood shield allows you to conclude that it is a (?<size>\w+) shield that],
+   armor_type: %r[ allows you to conclude that it is (?<armor_type>.*?)\.],
+        flare: %r[It has been infused with (?<flare>.*?)\.$],
+  }
     
     def self.of(details)
       # todo: implement detail extractor
@@ -213,7 +239,7 @@ module Bodega
 
     attr_reader :props
     def initialize(details)
-      @props   = {raw: []}
+      @props   = {raw: [], tags: []}
       _extract(details)
     end
 
@@ -227,14 +253,30 @@ module Bodega
       details.each do |line| 
         maybe_raw(line,
           _props(line),
-          _bools(line))
+          _bools(line), 
+          _enhancive(line.strip))
       end
     end
 
     def _bools(line)
       BOOLS.select do |prop, pattern|
-        line.match(pattern) and @props[prop] = true
+        line.match(pattern) and @props[:tags].push(prop)
       end.size > 0
+    end
+
+    def _enhancive(line)
+      if boost = line.match(ENHANCIVE[:boost])
+        enhancives = @props[:enhancives] ||= []
+        enhancives.push(boost.to_h)
+        return true
+      end
+
+      if level_req = line.match(ENHANCIVE[:level_req])
+        enhancives.last.merge!(level_req.to_h)
+        return true
+      end
+
+      return false
     end
 
     def _props(line)
@@ -744,7 +786,7 @@ module Bodega
       ##
       if Opts.parser
         Log.out(Opts.to_h, label: :opts)
-        Bodega::Parser.main()     if (Opts.save or Opts["dry-run"])
+        Bodega::Parser.to_json()  if (Opts.save or Opts["dry-run"])
         Bodega::Parser.manifest() if Opts.manifest
       end
 

--- a/scripts/tilde.lic
+++ b/scripts/tilde.lic
@@ -2,15 +2,26 @@
 	quick shortcuts for dealing with containers
 
 	examples:
-	  ~cloak             => look in my cloak
-	  ~cloak box         => put box in my cloak
-	  ~pants ruby amulet => put ruby amulet in my pants
+	  ~cloak                 => look in my cloak
+	  ~cloak box         		 => put box in my cloak
+		~pants ruby amulet     => put ruby amulet in my pants
+		~:lootsack ruby amulet => put ruby amulet in your lootsack
+		^:harness small statue => remove a small statue from your Vars[:harness]
 
 	additive search algorithm weights:
 		1. right hand
 		2. left hand
 		3. loot
 		4. items in GameObj.containers.keys
+
+	profanity integration:
+		This script makes it trivial to have portable macros across all of your characters
+		using ProfanityFE.
+		
+		example:
+			<key id='ctrl+p' macro='\x~:lootsack \?'/>
+
+		this macro will be rebound across all of your characters to use your ;vars in Lich
 
 	Notes:
 
@@ -27,6 +38,9 @@
 =end
 module Tilde
 	@vars = Script.current.vars
+	VAR_TOKEN = %[:]
+	TTL       = 3 # s
+
 	class TildeError < Exception; end
 	module CLI
 		TILDE     = %[<c>~]
@@ -95,18 +109,41 @@ module Tilde
 		end
 	end
 
-	def self.find_container(search)
-		GameObj.inv.find do |item|
-			item.noun.start_with?(search) 
-		end or container_not_found(search)
+	def self.check_user_vars(symbolized_var)
+		var = (Vars[symbolized_var.slice(1..-1)] or container_not_found("Vars[#{symbolized_var}]"))
+		if var.split(" ").size > 1 
+			GameObj.inv.find do |item| item.name.eql?(var) end or container_not_found("Vars[#{symbolized_var}]")
+		else
+			matches = GameObj.inv.select do |item| item.noun.eql?(var) end 
+			return container_not_found("Vars[#{symbolized_var}]") if matches.empty?
+			return ambigious_container("Vars[#{symbolized_var}]", matches) if matches.size > 1
+			return matches.first
+		end
 	end
 
-	def self.container_not_found(noun)
-		fail TildeError, <<-ERROR
-		   <b>could not find Container[noun: #{noun}] in your inventory</b>
+	def self.find_container(search)
+		return check_user_vars(search) if search.start_with?(VAR_TOKEN)
+		GameObj.inv.find do |item| item.noun.start_with?(search) end or 
+		container_not_found(search)
+	end
 
-		   options: #{GameObj.inv.map(&:noun).join(", ")}
-		ERROR
+	def self.items_view(items)
+		names = items.to_a.map(&:name).sort {|n1, n2| n2.size <=> n1.size }
+		names.map.with_index { |n, i| "... #{i+1}> " + n }.join("\n")
+	end
+
+	def self.ambigious_container(search, matches)
+		fail TildeError, [
+			%(<b>ambigious container found for #{search} in your inventory</b>),
+			%(details:),
+			items_view(matches) ].join("\n")
+	end
+
+	def self.container_not_found(search)
+		fail TildeError, [
+			%(<b>could not find a container matching #{search} in your inventory</b>),
+			%(inventory:),
+			items_view(GameObj.inv) ].join("\n")
 	end
 
 	def self.build_search_list()
@@ -115,10 +152,31 @@ module Tilde
 			GameObj.containers.values.flatten)
 	end
 
+	def self.peek_container(obj)
+		fput "look in ##{obj.id}"
+		ttl = Time.now + TTL 
+		wait_while do Time.now < ttl and GameObj.containers[container.id].nil? end
+		fail TildeError, "failed to check contents of #{obj.name} in #{TTL}s" if Time.now > ttl
+	end
+
 	def self.find_item(desc)
-		build_search_list.reject do |item| item.id.nil? end
-			.find do |item| item.name.include?(desc) end or 
+		words = desc.split(" ")
+
+		if words.first.start_with?(VAR_TOKEN)
+			(symbolized_var, *rest) = words
+			query = rest.join(" ")
+			container = find_container(symbolized_var)
+			GameObj.containers[container.id] or peek_container(container)
+			GameObj.containers[container.id]
+				.reject do |item| item.id.nil? end
+				.find do |item| item.name.include?(query) end or
+				fail TildeError, %[could not find any matches for Item[desc: #{desc}] in #{container.name}]
+		else
+			build_search_list
+				.reject do |item| item.id.nil? end
+				.find do |item| item.name.include?(desc) end or
 				fail TildeError, %[could not find any matches for Item[desc: #{desc}]]
+		end
 	end
 
 	def self.schedule(args)

--- a/scripts/tilde.lic
+++ b/scripts/tilde.lic
@@ -153,9 +153,9 @@ module Tilde
 	end
 
 	def self.peek_container(obj)
-		fput "look in ##{obj.id}"
-		ttl = Time.now + TTL 
-		wait_while do Time.now < ttl and GameObj.containers[container.id].nil? end
+		Tilde::OPERATIONS << {kind: :tilde, container: obj, item: nil}
+		ttl = Time.now + TTL
+		until GameObj.containers.include?(obj.id) or Time.now > ttl do sleep 0.01 end
 		fail TildeError, "failed to check contents of #{obj.name} in #{TTL}s" if Time.now > ttl
 	end
 
@@ -181,7 +181,7 @@ module Tilde
 
 	def self.schedule(args)
 		respond "Tilde.schedule(#{args})" if @vars.include?("--debug")
-		container = if args.fetch(:container)
+		container = if args.fetch(:container, false)
 			Tilde.find_container(
 				args.fetch(:container))
 		else
@@ -197,7 +197,7 @@ module Tilde
 		else
 			Tilde::OPERATIONS << args.merge({ 
 				container: container,
-				item: Tilde.find_item(item)})
+				item:      Tilde.find_item(item)})
 		end
 	end
 
@@ -205,12 +205,12 @@ module Tilde
 
 	def self.init()
 		loop do 
-			wait_while do OPERATIONS.empty? end
-			Tilde.run_in_main_thread **OPERATIONS.shift until OPERATIONS.empty?
+			while OPERATIONS.empty? do sleep 0.01 end
+			Tilde.run_in_main_thread(**OPERATIONS.shift) until OPERATIONS.empty?
 		end
 	end
 
-	def self.run_in_main_thread(kind: kind, container: container, item: item)
+	def self.run_in_main_thread(kind:, container:, item:)
 		respond "Tilde.schedule(item: #{item}, container: #{container}, kind: #{kind})" if @vars.include?("--debug")
 		Tilde.unwrap_error do 
 			case kind
@@ -228,16 +228,30 @@ module Tilde
 		end
 	end
 
+	def self.try_or_fail(seconds: 5, command: nil)
+		fput(command)
+		expiry = Time.now + seconds
+		wait_until do yield or Time.now > expiry end
+		return {error: "Error[command: #{command}, seconds: #{seconds}]"} if Time.now > expiry
+		return {ok: command}
+	end
+
 	def self._drag(container, item)
-		fput %[_drag ##{item.id} ##{container.id}]
+		try_or_fail(command: %[_drag ##{item.id} ##{container.id}]) do
+			GameObj.containers[container.id].to_a.map(&:id).include?(item.id)
+		end
 	end
 
 	def self.look_in(container)
-		fput %[look in ##{container.id}]
+		try_or_fail(command: %[look in ##{container.id}]) do
+			GameObj.containers.include?(container.id)
+		end
 	end
 
 	def self.fetch(item)
-		fput %[get ##{item.id}]
+		try_or_fail(command: %[get ##{item.id}]) do
+			[GameObj.right_hand, GameObj.left_hand].map(&:id).include?(item.id)
+		end
 	end
 
 	Tilde.init()

--- a/scripts/tilde.lic
+++ b/scripts/tilde.lic
@@ -170,7 +170,7 @@ module Tilde
 			GameObj.containers[container.id]
 				.reject do |item| item.id.nil? end
 				.find do |item| item.name.include?(query) end or
-				fail TildeError, %[could not find any matches for Item[desc: #{desc}] in #{container.name}]
+				fail TildeError, %[could not find any matches for Item[desc: #{query}] in Container[name: #{container.name}]]
 		else
 			build_search_list
 				.reject do |item| item.id.nil? end


### PR DESCRIPTION
### Overview

Adds the ability for `:` to be used to integrate `vars.lic` settings with `tilde.lic`, which means you can trivially create cross character macros without caring about each character's underlying settings.

example:
```xml
<key id='alt'>
	<key id='p' macro='\x~:lootsack \?' comment='put :thing in my :lootsack'/>
  	<key id='t' macro='\x^:lootsack \?' comment='take :thing from my :lootsack'/>
  	<key id='l' macro='\x~:lootsack\r' comment='look in my :lootsack'/>
  	<key id='n' macro='\x~:harness \?'/>
  	<key id='u' macro='\x^:harness \?'/>
</key>
```

![examples](https://user-images.githubusercontent.com/1090434/58985611-b9ec3a80-87a9-11e9-9850-20d081e90421.png)
