### PR TITLE
Update bigshot.lic

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -16,6 +16,7 @@
 		
 		v3.80 (2019-06-10)
 			-Fix for wands with extra descriptors in hand vs grab name
+			-Add 1020 as an option for fleeing
 		v3.79 (2019-05-25)
 			-Removed 309 from hardcoded selfcast list
 		v3.78 (2019-05-10)
@@ -1594,6 +1595,10 @@ class Bigshot
 						Spell[130].cast()
 					end
 				end
+			elsif @FOG_RETURN.to_i == 3
+				if Spell[1020].known? && Spell[1020].affordable?
+					Spell[1020].cast()
+				end
 			end
 		end
         goto(@RESTING_ROOM_ID)
@@ -2407,7 +2412,7 @@ class Bigshot
             add_label_entry($OP_TABLE2, "*room id:", 'resting_room_id')
             add_label_entry($OP_TABLE2, "pre-rest commands:", 'resting_commands')
             add_label_entry($OP_TABLE2, "active resting scripts:", 'resting_scripts')
-			add_dropdown($OP_TABLE2, "Fog Options:", 'fog_return', 'None,Spirit Guide(130),Voln Symbol of Return')
+            add_dropdown($OP_TABLE2, "Fog Options:", 'fog_return', 'None,Spirit Guide(130),Voln Symbol of Return,Traveler\'s Song')
             add_label_entry($OP_TABLE3, "*starting room ID:", 'hunting_room_id')
             add_label_entry($OP_TABLE3, "*boundary rooms:", 'hunting_boundaries')
             add_label_entry($OP_TABLE4, "valid targets:", 'targets')
@@ -2536,7 +2541,7 @@ class Bigshot
 			flee_tip = "Input any text that when the game sends you want to move out of the room from\nlike a Roa'ter burrow attack \"You feel a rumble come from beneath your feet.\"\nSeperate different messages with a | in between them."
 			$OP_TOOLTIPS.set_tip($OP_ENTRY['flee_message'], flee_tip, "")
 
-			fog_tip = "None: Dont use any fog options when you return from a hunt\n\nSpirit Guide(130): Use 130 first, then if that fails Symbol of Return\n\nVoln Symbol of Return: Use Symbol of Return first, then if that fails 130"
+			fog_tip = "None: Dont use any fog options when you return from a hunt\n\nSpirit Guide(130): Use 130 first, then if that fails Symbol of Return\n\nVoln Symbol of Return: Use Symbol of Return first, then if that fails 130\n\nTraveler's Song(1020): Use 1020 only"
 			$OP_TOOLTIPS.set_tip($OP_ENTRY['fog_return'], fog_tip, "")
  
             size = $OP_TABLE_SIZE[$OP_TABLE3]

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,12 +8,14 @@
         contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong
                 game: Gemstone
                 tags: hunting
-             version: 3.79
+             version: 3.80
  
 		Setup instructions: https://gswiki.play.net/Script_Bigshot
 		To help contribute: https://github.com/elanthia-online/scripts
 		Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
 		
+		v3.80 (2019-06-10)
+			-Fix for wands with extra descriptors in hand vs grab name
 		v3.79 (2019-05-25)
 			-Removed 309 from hardcoded selfcast list
 		v3.78 (2019-05-10)
@@ -949,7 +951,7 @@ class Bigshot
 		echo "cmd_wand" if $bigshot_debug
         if(@FRESH_WAND_CONTAINER)
             hands = GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s
-            until( (GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand]}/i)
+            until( (GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i)
                 result = dothistimeout( "get #{@WAND[$bigshot_wand]} from my #{@FRESH_WAND_CONTAINER}", 3, /You remove|You slip|Get what/ )
                 if( result =~ /Get what/ )
 					$bigshot_wand += 1

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -2412,7 +2412,7 @@ class Bigshot
             add_label_entry($OP_TABLE2, "*room id:", 'resting_room_id')
             add_label_entry($OP_TABLE2, "pre-rest commands:", 'resting_commands')
             add_label_entry($OP_TABLE2, "active resting scripts:", 'resting_scripts')
-            add_dropdown($OP_TABLE2, "Fog Options:", 'fog_return', 'None,Spirit Guide(130),Voln Symbol of Return,Traveler\'s Song')
+            add_dropdown($OP_TABLE2, "Fog Options:", 'fog_return', 'None,Spirit Guide(130),Voln Symbol of Return,Traveler\'s Song(1020)')
             add_label_entry($OP_TABLE3, "*starting room ID:", 'hunting_room_id')
             add_label_entry($OP_TABLE3, "*boundary rooms:", 'hunting_boundaries')
             add_label_entry($OP_TABLE4, "valid targets:", 'targets')


### PR DESCRIPTION
replaced regex match to support wands that have extra adjectives in the descriptor that could not get matched.

Example:
a silver and crimson swirled rod
in hands: a crimson swirled rod
to grab: GET CRIMSON ROD