### PR TITLE
Adding "scrub" option to support mstrike + 435

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -43,7 +43,7 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 2.11
+    version: 2.12
 
     changelog:
         2.12 (2019-09-03)

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -14,10 +14,11 @@
          PHYSICAL      - mstrike and attack boss for all you physical attackers
          UAC           - mstrike punch and punch boss for all your UAC needs
          RANGED        - ranged attack
+	 SCRUB         - combination mstrike and 435 cast routine
          NONE          - won't attack, useful if manually wish to attack
 	
     Running Commands
-         ;send reimcount   - shows current group leader, group count, and previos group count
+         ;send reimcount   - shows current group leader, group count, and previous group count
          whisper ooc group clearcheck - if group members are running script,
                     reports back clear and scrip status
                     MUST BE LEADER TO HAVE GROUP MEMBERS RESPOND
@@ -45,6 +46,8 @@
     version: 2.11
 
     changelog:
+        2.12 (2019-09-03)
+            Adding scrub option
         2.11 (2019-08-05)
             Stopped spam control scripts IF enabled.
         2.10 (2019-07-21)
@@ -230,6 +233,36 @@ def attack_routine(attack_target)
 		fput "stance offensive" if Char.stance !~ /offensive/
 		fput "fire #{attack_target}"
 		return 1
+	elsif UserVars.treim[:attack_type] == "scrub"
+		if Spell[435].affordable? && attack_target == ""
+			waitrt?
+			waitcastrt?
+			put "incant 435 closed"
+			end
+			return 1
+		else 
+			waitrt?
+			fput "stance offensive" if checkstance != "offensive"
+			if attack_target == ""
+				fput "mstrike"
+			else
+				fput "mstrike #{attack_target}"
+				pause 1
+				waitrt
+				if Spell[435].affordable?
+					waitrt?
+					waitcastrt?
+					put "incant 435 closed"
+				else
+					fput "mstrike"
+				end
+			end
+			if UserVars.treim[:stance_dance]
+				pause 1
+				waitrt?
+				fput "stance defensive"
+			end
+			return 1
 	elsif UserVars.treim[:attack_type] == "none"
 		return 1
 	elsif UserVars.treim[:attack_type] == "1030"


### PR DESCRIPTION
Logic is pretty simple:

• If you have sufficient mana and there's no rare, use 435
• If you have insufficient mana and there's no rare, use open mstrike
• If there's a rare, use focused mstrike - then, if you have sufficient mana, use 435 - otherwise, use open mstrike

