### PR TITLE
Improved treim 1030 performance

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -44,9 +44,11 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 2.13
+    version: 2.14
 
     changelog:
+        2.14 (2019-11-02)
+	    Improved 1030 performance
         2.13 (2019-10-05)
 	    Added the "bardass" option
         2.12 (2019-09-03)

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -310,11 +310,7 @@ def attack_routine(attack_target)
 		if Spell[1030].affordable?
 			waitrt?
 			waitcastrt?
-			line = dothistimeout "renew 1030", 5, /But you are not singing that spellsong\.|You continue to sing a disruptive song\./
-			if line =~ /But you are not singing that spellsong\./
-				put "prep 1030"
-				put "sing"
-			end
+			put "incant 1030 open"
 		end
 		return 1
 	elsif UserVars.treim[:attack_type] =~ /435|709|635/


### PR DESCRIPTION
Treim 1030 has the unfortunate side effect of issuing several commands. This prevents getting hits in on many fast-dying waves. As such, I've modified the routine to send a single command that handles the casting: `incant 1030 open`

Based on verified bardic research, this command uses the RENEW 1030 cost where appropriate and is open-targeted as desired.