### PR TITLE
bigshot: track obvious hiding msg separately from ambusher_here

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,12 +8,14 @@
         contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong
                 game: Gemstone
                 tags: hunting
-             version: 3.83
+             version: 3.84
  
 		Setup instructions: https://gswiki.play.net/Script_Bigshot
 		To help contribute: https://github.com/elanthia-online/scripts
 		Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
 		
+		v3.84 (2020-02-15)
+			-Fix a bug with "obvious hiding" players detection
 		v3.83 (2020-02-13)
 			-Added check for "obvious hiding" players (SET ObviousHiding ON)
 		v3.82 (2020-02-02)
@@ -175,7 +177,7 @@ bigshot_monitor = proc { |server_string|
 			$ambusher_here = true
 		end
 	elsif server_string =~ /obvious signs of someone hiding/i
-		$ambusher_here = true
+		$obvious_hiding_player = true
 	elsif server_string =~ /crimson mist.*?surround.*?<pushBold\/>.*?<a exist="(.*?)" noun=".*?">.*?<\/a><popBold\/>.*?(?:corporeal plane!|vulnerable!)/i
 		$bigshot_smite_list.push($1)
 	elsif server_string =~ /crimson mist.*?<pushBold\/>.*?<a exist="(.*?)" noun=".*?">.*?<\/a><popBold\/>.*?(?:returns to an ethereal state.|appears less vulnerable.)/i
@@ -1499,13 +1501,13 @@ class Bigshot
     def no_players()
 		echo "no_players" if $bigshot_debug
         return false if GameObj.loot.find { |obj| obj.noun == 'disk' and obj.name !~ /#{Char.name}/}
-        return false if ((checkpcs - $grouplist).count > 0) or $ambusher_here
+        return false if ((checkpcs - $grouplist).count > 0) or $ambusher_here or $obvious_hiding_player
         return true
     end
 	
 	def no_players_hunt()
 		echo "no_players_hunt" if $bigshot_debug
-        return false if $ambusher_here
+        return false if $ambusher_here or $obvious_hiding_player
         return true
     end
  
@@ -2166,6 +2168,7 @@ class Bigshot
             npcs.delete_if { |npc| (npc.status =~ /dead/) }
             sort_npcs.each{ |i| return i if valid_target?( i, true ) and no_players == true and (GameObjNpcCheck() > 0) }
             return if should_rest?
+            $obvious_hiding_player = false
 			wander.call
             sleep 0.1
 			$bigshot_flee = false


### PR DESCRIPTION
`$ambusher_here` is reset during `variables_reset`, which is called after a character walks into a new room, which is also after the server_string has already been processed (so the subsequent variables_reset then clears `$ambusher_here` immediately after the flag is set).

This switches to using a separate variable and resets it in a different spot to work around this issue.