### PR TITLE
bigshot: add outside/!outside checks for attack commands

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,12 +8,14 @@
         contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias
                 game: Gemstone
                 tags: hunting
-             version: 3.85
+             version: 3.86
  
 		Setup instructions: https://gswiki.play.net/Script_Bigshot
 		To help contribute: https://github.com/elanthia-online/scripts
 		Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
 		
+		v3.86 (2020-03-11)
+            -Added outside & !outside command checks
 		v3.85 (2020-02-28)
 			-Resolved `block in setup` error when running setup in Fedora
 		v3.84 (2020-02-15)
@@ -108,7 +110,7 @@ end
 
 require 'drb'
 
-BIGSHOT_VERSION = '3.85'
+BIGSHOT_VERSION = '3.86'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_quick = false
@@ -577,7 +579,7 @@ class Bigshot
 		
         # check mana/stamina/health(percentage)/encumbrance/unarmed tiering/mobs in room/target not prone/target undead
 		# ! means the inverse/opposite effect
-        if( command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs).*?)\)$/i )
+        if( command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside).*?)\)$/i )
 			command = $1
 			commandcheckreturn = false
 			$2.split(" ").each{|s|
@@ -613,7 +615,7 @@ class Bigshot
 						mobcheck = $2
 						commandcheckreturn = true if GameObjNpcCheck() > mobcheck.to_i
 					end
-				elsif s =~ /((?:prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs))/i
+				elsif s =~ /((?:prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside))/i
 					if( $1 == 'prone' )
 						commandcheckreturn = true if npc.status =~ PRONE
 					elsif( $1 == '!prone' )
@@ -646,6 +648,10 @@ class Bigshot
 						commandcheckreturn = true if !((checkpcs - $grouplist).count > 0)
 					elsif( $1 == '!pcs' )
 						commandcheckreturn = true if ((checkpcs - $grouplist).count > 0)
+					elsif( $1 == 'outside' )
+						commandcheckreturn = true if !outside?
+					elsif( $1 == '!outside' )
+						commandcheckreturn = true if outside?
 					end
 				end
 			}


### PR DESCRIPTION
adds inside / outside command checks

useful for baby rangers and, to a lesser extent, anyone who uses 125 for anything other than opening boxes.