### PR TITLE
treim: adds empoof routine to avoid poofing rares

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -382,13 +382,19 @@ def attack_routine(attack_target)
 				put "incant #{UserVars.treim[:attack_type]}"
 			end
 			return 1
+		elsif UserVars.treim[:attack_type].downcase =~ /empoof/ && attack_target != ""
+			if (cast(118,"#{attack_target}", @@after_stance=afterstance) if Spell[UserVars.treim[:attack_type]].affordable?) =~ /(?:.*)Spell Hindrance(?:.*)/
+				return nil
+			else
+				return 1
+			end
 		elsif UserVars.treim[:attack_type].downcase =~ /135/ && attack_target != ""
 			if (cast(1115,"#{attack_target}", @@after_stance=afterstance) if Spell[UserVars.treim[:attack_type]].affordable?) =~ /(?:.*)Spell Hindrance(?:.*)/
 				return nil
 			else
 				return 1
 			end
-		elsif UserVars.treim[:attack_type] =~ /135/ && attack_target == ""
+		elsif UserVars.treim[:attack_type] =~ /135|empoof/ && attack_target == ""
 			if Spell[UserVars.treim[:attack_type]].affordable?
 				waitrt?
 				waitcastrt?


### PR DESCRIPTION
I had this changed to cast 118 instead of 1115 locally for a while but switched back to master and poofed all the rares on our nightly Reim run. I thought about changing it for everyone but a lot of people have trouble warding rares with 100s and the poofing isn't an issue if you don't have manipulation lore.