### PR TITLE
EG Necrotic Ring - ghostly mobs fix

### DIFF
--- a/type_data/migrations/28_necrotic_ring_ghostly.rb
+++ b/type_data/migrations/28_necrotic_ring_ghostly.rb
@@ -1,0 +1,3 @@
+migrate :aggressive, :undead do
+  insert(:prefix, %{ghostly})
+end

--- a/type_data/migrations/28_necrotic_ring_ghostly.rb
+++ b/type_data/migrations/28_necrotic_ring_ghostly.rb
@@ -1,3 +1,3 @@
-migrate :aggressive, :undead do
+migrate :aggressive_npc, :undead do
   insert(:prefix, %{ghostly})
 end


### PR DESCRIPTION
Initial start of fixing ghostly mobs to be detectable that were introduced from the EG 2019 necrotic ring.