### PR TITLE
treim v2.20

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -52,9 +52,11 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 2.18
+    version: 2.19
 
     changelog:
+        2.19 (2020-05-13)
+	    Removed targeting of boss on boss waves as new group tag credit change should negate need to specifically hit it.
         2.18 (2020-05-01)
 	    Added FLAG NOAMBIENTMSG toggling, default FALSE (if true, toggles on while running treim and toggles off after)
         2.17 (2020-04-29)
@@ -704,7 +706,7 @@ loop {
 							until attack_routine(""); end
 						else
 							echo bossname.noun if Char.name =~ /Tysong/
-							until attack_routine("#{bossname.noun}"); end
+							until attack_routine(""); end
 							silence.call
 							clearto, scrip, timeleft = clearcheck(bossname.id)
 							_respond "\nCleared Through: #{clearto}


### PR DESCRIPTION
Removed targeting of boss on boss waves as new group tag credit change should negate need to specifically hit it.