### PR TITLE
briefcombat v0.0.7

### DIFF
--- a/scripts/briefcombat.lic
+++ b/scripts/briefcombat.lic
@@ -14,7 +14,7 @@
      author: Daedeus (updates by Tysong/Ragz)
        name: briefcombat
        tags: brief, briefcombat, condensing, condense, combat, squelch
-    version: 0.0.6
+    version: 0.0.7
 
     changelog:
         0.0.7 (2020-05-14)

--- a/scripts/briefcombat.lic
+++ b/scripts/briefcombat.lic
@@ -1,6 +1,15 @@
 =begin
-    Dramaticaaly shortens most combat text.
-    Designed for use in group combat or invasions to manage the spam and screen scroll.
+    Dramatically shortens most combat text.
+    Designed for use in big group combat (cough REIM cough) or invasions to manage the spam and screen scroll.
+    USAGE:
+        ;briefcombat [self|You] [player] [-x]
+        ;briefcombat                - default settings
+        ;briefcombat -x             - extreme settings; will completely silence searches, remove cast descriptions (might interfere with GameObj? not sure)
+        ;briefcombat self           - default settings, exclude your self
+        ;briefcombat You            - Same as self
+        ;briefcombat self Player1 Player2  - exclude yourself, Player1 and Player2 actions from being shortened
+        ;briefcombat -x self        - extreme settings, but excluding yourself
+        
 
      author: Daedeus (updates by Tysong/Ragz)
        name: briefcombat
@@ -8,6 +17,16 @@
     version: 0.0.6
 
     changelog:
+        0.0.7 (2020-05-14)
+            Added parameter options:
+                -x        Extreme mode, will squelch searches and spell messaging.
+                [player]  Added ability to not shorten actions by specific players
+            Removed spell number to improve immersion
+            Now retains a little bit of spell cast color, for immersion
+              - This can be disabled with the "-x" parameter
+            Improve handling of bard song weaving
+            Fixed a known issue, now (more) accurately counts kills and status effects
+            Added indentation to kill / stunned counts
         0.0.6 (2020-05-05)
             Revert 0.0.5 changes and added a bunch of new code
             Detection of most common AOE spells, and more aggressive shortening of their text
@@ -25,11 +44,26 @@
             cleaned up some comments, unused code
         0.0.1 (unknown)
             initial release
-			
-    Known Issues:
-        will show an npc's status as knocked down or stunned, if they were stunned/prone before the spell in question.
-	
 =end
+
+$BC_EXTREME = script.vars.include? "-x"
+
+if $BC_EXTREME
+    echo "Extreme mode!  Will more aggressively shorten non-essential text, at the cost of immersion." 
+    script.vars.delete "-x"
+else
+    echo "Standard mode!  Run with -x parameter for Extreme mode." 
+end
+
+$BC_EXCLUDE = script.vars[1..script.vars.length];
+_self = $BC_EXCLUDE.index("self")
+_you = $BC_EXCLUDE.index("you")
+$BC_EXCLUDE[_self] = "You" if _self > -1
+$BC_EXCLUDE[_you] = "You" if _you > -1
+
+if $BC_EXCLUDE.length > 0
+    echo "Will exclude actions by #{$BC_EXCLUDE.join(',')}"
+end
 
 $debug = false
 put 'set MonsterBold On' #required for monster recognition
@@ -44,6 +78,7 @@ verbs = ['gestures? at',
          'swings? an? [\w \-\']+ at',
          'thrusts?(?: with)? a [\w \-\']+ at',
          'continues to sing a disruptive song',
+         'draws an intricately glowing pattern in the air before',
          'skillfully begins to weave another verse into (?:.*) harmony',
          'voice carries the power of thunder as (?:.*) calls out an angry incantation in an unknown language',
          '(?:.*) directing the sound of (?:.*) voice at',
@@ -52,12 +87,31 @@ verbs = ['gestures? at',
 
 target = '<pushBold\/>(.*)<popBold\/>' #npc targets are in bold thanks to MonsterBold setting
 
+$StatusEffects = {
+    "stunned" => /stunned|strength of holy incantation/,
+    "frozen" => /freezes|encased in a thick block of ice|stops all movement/,
+    "knockdown" => /falls over|(?:dragged|knocked|down) to the (?:\w+)/,
+    "sympathized" => /eyes begin to glow purple/,
+    "pinned" => /pins? (?:.*) to the/,
+    "buffeted" => /buffeted by/,
+    "dead" => /tries to crawl away on the (?:ground|floor) but|
+               rolls over on the (?:ground|floor) and goes still|
+               body falls to the (?:ground|floor) as it is consumed by ethereal flame|
+               crashes to the (?:ground|floor)|
+               grows dim as s?he falls to the (?:ground|floor)|
+               falls to the (ground|floor) motionless/x
+}
+
+# Had to add death detection in REIM because for some reason GameObj detection was unreliable -
+# either the scrolling is too fast for GameObj to update, or it doesn't recognize some of the death strings
+
 $combat_regex = /(#{pc_or_you}) (#{verbs.join('|')})(?: (#{target}))?/
 
 n = -1
 $compressing = false
 $compressed = nil
 $compress_last = nil
+$compress_you_last = nil
 $targets_damage = nil
 $target = nil
 $targets_last_message = nil
@@ -67,17 +121,12 @@ $is_buff = false
 $shorteningSearch = false 
 $is_self = false
 
-
 def SpellName(id)
     if id == "709"
         return "Grasp of the Grave" #because Spell[709].name returns "Quake"
     else
         return Spell[id].name
     end
-end
-
-unless script.vars.empty? 
-    n = script.vars[0].strip.to_i
 end
 
 $compressing_spell_guess = nil
@@ -92,14 +141,17 @@ def begin_compress(s, targetstr)
     unless $compressing
         $compressing = true
         $compressing_spell_guess = nil
+        $compressing_spell_guess = 9811 if s =~ /draws an intricately glowing pattern in the air before/
+        $spell_cast_string = nil
         #$compressing_mstrike = s.include? "looks determined and focused"
         $compressing_better_action_message = nil
         $targets_damage = Hash.new
         $targets_last_message = Hash.new
         $targets_status = Hash.new
+        $compress_you_last = nil
         $compress_last = nil
         $is_buff = false
-
+        
         $compressed = Array.new    
         $compressed.push(s.chomp)
         $target = nil
@@ -122,13 +174,33 @@ def end_compress(s)
         if $compressing_spell_guess == "ball"
             $compressed[0] = $compressing_better_action_message
         else
-            literal = "casts #{SpellName($compressing_spell_guess)} (#{$compressing_spell_guess})"
-            $compressed[0] = $compressed[0].gsub(/gestures/, literal)
+            if $is_self
+                literal = "cast #{SpellName($compressing_spell_guess)}" #(#{$compressing_spell_guess})
+                $compressed[0] = $compressed[0].gsub(/gesture/, literal)
+            else
+                if $compressing_spell_guess == 1030
+                    literal = "weaves #{SpellName($compressing_spell_guess)}" #(#{$compressing_spell_guess})
+                    $compressed[0] = $compressed[0].gsub(/skillfully begins to weave another verse/, literal)
+                else
+                    literal = "casts #{SpellName($compressing_spell_guess)}" #(#{$compressing_spell_guess})
+                    $compressed[0] = $compressed[0].gsub(/gestures/, literal)
+                end
+            end
         end
     end
 
+    #if we have better messaging to retain "game feel", we'll use it
+    unless $spell_cast_string.nil? || $BC_EXTREME
+        $compressed.push($spell_cast_string)
+    end
+
     if num_targets == 0
-        $compressed.push($compress_last)
+        #echo "scs: #{$spell_cast_string}, last: #{$compress_last}, cyl: #{$compress_you_last}, c: #{$compressed}, s: #{s}"
+        if $spell_cast_string.nil?
+            $compressed.push($compress_last) 
+        elsif !$compress_you_last.nil?
+            $compressed.push($compress_you_last)
+        end
     elsif $is_no_target
         $compressed[0] += " #{num_targets} targets affected."
     elsif num_targets > 1
@@ -140,40 +212,60 @@ def end_compress(s)
     #tiny sleep to allow GameObj to update npcs in memory
     sleep 0.05
 
-    if !$compressing_spell_guess.nil? && num_targets > 0
+    if num_targets > 0 #!$compressing_spell_guess.nil? && num_targets > 0
+        #echo "Spell guess is #{$compressing_spell_guess}"
         #aoe attack spell
-        #primarily a knockdown spell
-        num_prone = 0
         num_stunned = 0
         num_knockdown = 0
+        num_frozen = 0
+        num_confused = 0
         num_dead = 0
+        num_sympathized = 0
+        num_pinned = 0
+        num_buffeted = 0
         total_damage = 0
+        killed = Array.new
         $targets_damage.each { |targetid, damage| 
             targ = GameObj.npcs.find{ |i| i.id == targetid}
             num_dead += 1 if targ.status =~ /dead|gone/
-            num_stunned += 1 if targ.status =~ /stunned|frozen/
-            num_knockdown +=1 if targ.status =~ /prone|kneeling/
+            killed.push(targetid)
             total_damage += damage
-            
         }
 
-        if num_dead + num_stunned + num_knockdown + total_damage == 0
+        $targets_status.each { |targetid, statusArr| 
+            num_stunned += 1 if statusArr.any? "stunned"
+            
+            if statusArr.any? "knockdown"
+                num_knockdown += 1 
+            elsif statusArr.any? "buffeted"
+                num_buffeted += 1 
+            end
+            num_frozen += 1 if statusArr.any? "frozen"
+            num_pinned += 1 if statusArr.any? "pinned"
+            num_sympathized += 1 if statusArr.any? "sympathized"
+            num_dead += 1 if statusArr.any?("dead") && killed.include?(targetid)
+        }
+
+        if num_dead + num_stunned + num_knockdown + num_sympathized + num_frozen + num_confused + num_pinned + num_buffeted + total_damage == 0
             #echo "Possible buff spell, last was #{$compress_last}"
             #probably a buff spell or something else, just send the previous message
-            $compressed.push($compress_last)
+            $compressed.push($compress_last) if $spell_cast_string.nil?
         else
             str = []
             str.push "#{num_dead} targets <pushBold/>KILLED<popBold/>" if num_dead > 0
             str.push "#{num_knockdown} targets knocked down" if num_knockdown > 0
-            str.push "#{num_stunned} targets stunned" if num_stunned > 0
+            str.push "#{num_stunned} targets stunned" if num_stunned > 0 #&& $compressing_spell_guess !~ /709|512|410/
+            str.push "#{num_frozen} targets frozen" if num_frozen > 0
+            str.push "#{num_sympathized} targets sympathized" if num_sympathized > 0
+            str.push "#{num_pinned} targets pinned" if num_pinned > 0
+            str.push "#{num_buffeted} targets buffeted" if num_buffeted > 0
             str.push "#{total_damage} damage dealt" if total_damage > 0
-            $compressed.push(str.join(', ').concat '!')
+            $compressed.push("  ... #{str.join(', ')}!") if str.length > 0
         end
-    elsif num_targets > 0
+    elsif false #num_targets > 0
+        #OLDER BLOCK OF CODE NO LONGER USED AS OF MAY 2020!
         $targets_damage.each { |targetid,damage| 
-
             targ = GameObj.npcs.find{ |i| i.id == targetid}
-            
             str = "A <pushBold/><a exist=\"#{targ.id}\">#{targ.name}</a><popBold/> "
             
             str.concat "takes #{damage} damage and " if damage > 0
@@ -218,14 +310,16 @@ end
 def compress(s)
     return if s =~ /Cast Roundtime/
     $compress_last = s
+    $compress_you_last = s if s =~ /You/
 
     s.chomp!
     checkstatus = proc { |s, targetid|
-        $targets_status[$target] = Array.new if $target_status[$target].nil?
-
-        if s =~ /stunned|freezes|falls over|(dragged|knocked|down) to the (w+)|buffeted by the dark ethereal waves/
-            $targets_status[$target].push($&)
-        end
+        $StatusEffects.each { |status, regex|
+            if s =~ regex
+                $targets_status[$target] = Array.new if $targets_status[$target].nil?
+                $targets_status[$target].push(status)
+            end
+        }
     }
 
     if s =~ /(\d+) points of damage/
@@ -238,38 +332,60 @@ def compress(s)
         checkstatus.call s
 
         $targets_last_message[$target] = s
-    elsif s !~ /Cast Roundtime|Forcing stance down|appears to gain succour|Feeling nervous yet|A hit/
+    elsif s !~ /Cast Roundtime|Forcing stance down|appears to gain succour|Feeling nervous yet|A hit|Warding failed/
         #this will catch "A clean miss" or 'Warded Off'.... probably
         $targets_last_message[$target] = s
     elsif s =~ /CS:|AS:|UAF:/
+        #just numbers
+    else
+        #unknown string
+        checkstatus.call s
     end
 
     if s =~ /arms snatch viciously|grotesque limbs/
         $compressing_spell_guess = '709'
+        $spell_cast_string = s if $spell_cast_string.nil?
     elsif s =~ /dark ethereal (waves|sphere)/
         $compressing_spell_guess = '410'
-    elsif s =~ /ethereal (waves|sphere)|formless black (ripples|waves|sphere)/
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /(?:waves?|sphere) of .* (?:expands|moves)/
         #sphere of formless black ripples expands outward
+        #A wave of crimson ethereal ripples moves outward from Treeva.
         $compressing_spell_guess = '435'
+        $spell_cast_string = s if $spell_cast_string.nil?
     elsif s =~ /radiant burst of light/
         $compressing_spell_guess = '135'
-    elsif s =~ /The surroundings advance upon/
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /multitude of sharp pieces of debris splinter off from underfoot|debris explodes from the ground beneath|The surroundings advance upon/
+        #You hear and feel a resounding low thrumming sound just as a multitude of sharp pieces of debris splinter off from underfoot, savagely assailing the area
         $compressing_spell_guess = '635'
-    elsif s =~ /thick block of ice/
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /An airy mist rolls into the (?:area|room)/
         $compressing_spell_guess = '512'
+        $spell_cast_string = s if $spell_cast_string.nil?
     elsif s =~ /force of the sonic vibrations/
         $compressing_spell_guess = '1030'
-    elsif s =~ /(?:hurl|fire|swing|thrust)s? an? [\w \-\']+ at'/
+    elsif s =~ /eyes begin to glow purple/ #possible other eye colors
+        $compressing_spell_guess = '1120'
+    elsif s =~ /A nebulous haze shimmers into view around/
+        $compressing_spell_guess - '1115'
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /(?:hurl|fire|hurtles forth)s? an? [\w \-\']+ at/
         $compressing_spell_guess = 'ball'
         $compressing_better_action_message = s
-    elsif s =~ /flurry of golden snowflake-shaped motes/
+    elsif s =~ /hand before it takes the shape of an ethereal chain of keys|A cold mist drifts in, blanketing the area|thunderous din echoes all around as the very earth shudders beneath/
+        #there are possibly many more 335 spell messaging that I am not aware of
         $compressing_spell_guess = '335'
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /utters a pious chant (.*) Suddenly a divine force radiates out from/
+        $compressing_spell_guess = '1618'
+        $spell_cast_string = s if $spell_cast_string.nil?
     elsif s =~ /an invisible force guides|considerably more powerful|feel the magic surge through you/
         #$is_buff = true
     end
 
 end
-#debris explodes from the ground beneath
+
 #the main enchilada - this method gets attached to the DownstreamHook, s = the string from the server
 def brief(s)
 
@@ -286,15 +402,11 @@ def brief(s)
     no_roundtime = proc { |s|
         return nil if s =~ /Roundtime:/
     }
-
     no_709_decay = proc { |s|
         return nil if s =~ /briefly before decaying into dust./
     }
     no_mstrike_prep = proc { |s| 
-        return nil if s =~ /In a breathtaking display of ability and combat mastery|spins about looking mighty stirred up/
-    }
-    no_spinning = proc { |s|
-        return nil if s =~ /looks determined and focused/
+        return nil if s =~ /In a breathtaking display of ability and combat mastery|spins about looking mighty stirred up|looks determined and focused/
     }
     no_get_arrow = proc { |s|
         return nil if s =~ /removes a single(.*)from/
@@ -313,7 +425,8 @@ def brief(s)
         #<a exist="-10425992" noun="Tziporah">Tziporah</a> searches <pushBold/>an <a exist="117327336" noun="commoner">ethereal commoner</a><popBold/>.
         if s =~ /(<a exist="(?:-\d+)" noun="\w+">\w+<\/a>) searches (<pushBold\/>.*<popBold\/>)/
             $shorteningSearch = true 
-            return s
+            return s unless $BC_EXTREME
+            return nil
         end
     }
 
@@ -321,7 +434,8 @@ def brief(s)
         if s =~ /<prompt/ #a new prompt indicates the search is finished for one mob
             #echo "search done: #{s}"
             $shorteningSearch = false
-            return s
+            #return s unless $BC_EXTREME
+            return nil
         else
             #echo "not a prompt, squelching search: #{s}"
             return nil #squelch the search message
@@ -333,9 +447,10 @@ def brief(s)
         if s =~ $combat_regex
             target_string = $4
             $is_self = $1 == 'You'
-
-            #echo "beginning compress on: #{s}"
+            
             begin_compress(s, target_string) # if is_pc
+            #echo "beginning compress on: #{s}"
+            
             return nil
         end
     }
@@ -347,11 +462,15 @@ def brief(s)
         return nil
     end
 
+    if !$BC_EXCLUDE.nil? && $BC_EXCLUDE.any? { |x| s.include? x }
+        return s
+    end
+    
     #main code
     no_roundtime.call s #squelch any mention of roundtime
 
     compress_combat.call s
-    no_self_spells.call s
+    no_self_spells.call s unless $BC_EXCLUDE.include? "You"
     no_self_search.call s
     shorten_searches.call s
     no_mstrike_prep.call s


### PR DESCRIPTION
        0.0.7 (2020-05-14)
            Added parameter options:
                -x        Extreme mode, will squelch searches and spell messaging.
                [player]  Added ability to not shorten actions by specific players
            Removed spell number to improve immersion
            Now retains a little bit of spell cast color, for immersion
              - This can be disabled with the "-x" parameter
            Improve handling of bard song weaving
            Fixed a known issue, now (more) accurately counts kills and status effects
            Added indentation to kill / stunned counts