### PR TITLE
briefcombat v0.0.8

### DIFF
--- a/scripts/briefcombat.lic
+++ b/scripts/briefcombat.lic
@@ -14,9 +14,11 @@
      author: Daedeus (updates by Tysong/Ragz)
        name: briefcombat
        tags: brief, briefcombat, condensing, condense, combat, squelch
-    version: 0.0.7
+    version: 0.0.8
 
     changelog:
+        0.0.8 (2020-06-01)
+            Fixed 917 so it's identified properly instead of being lumped with 635
         0.0.7 (2020-05-14)
             Added parameter options:
                 -x        Extreme mode, will squelch searches and spell messaging.
@@ -356,9 +358,12 @@ def compress(s)
     elsif s =~ /radiant burst of light/
         $compressing_spell_guess = '135'
         $spell_cast_string = s if $spell_cast_string.nil?
-    elsif s =~ /multitude of sharp pieces of debris splinter off from underfoot|debris explodes from the ground beneath|The surroundings advance upon/
+    elsif s =~ /multitude of sharp pieces of debris splinter off from underfoot|The surroundings advance upon/
         #You hear and feel a resounding low thrumming sound just as a multitude of sharp pieces of debris splinter off from underfoot, savagely assailing the area
         $compressing_spell_guess = '635'
+        $spell_cast_string = s if $spell_cast_string.nil?
+    elsif s =~ /debris explodes from the ground beneath/
+        $compressing_spell_guess = '917'
         $spell_cast_string = s if $spell_cast_string.nil?
     elsif s =~ /An airy mist rolls into the (?:area|room)/
         $compressing_spell_guess = '512'


### PR DESCRIPTION
Fixed 917 so it's identified properly instead of being lumped with 635