### PR TITLE
fix(0net.lic): RCE exploit when on lnet

### DIFF
--- a/scripts/0net.lic
+++ b/scripts/0net.lic
@@ -79,7 +79,7 @@ class Callbacks
   def run(from, params, req)
     @registered.values.map do |callback|
       begin
-        callback.call(from, params, req)  
+        #callback.call(from, params, req)  
       rescue Exception => e
         echo "error in callback : #{e}"
         respond e.backtrace
@@ -247,7 +247,7 @@ class LNet
       xml = REXML::Document.new
       element = xml.add_element('data')
       attributes.each_pair { |name,val| element.add_attribute(name, val) }
-      element.text = [Marshal.dump(data)].pack('m').strip
+      element.text = nil
       @@server.puts(xml)
       @@last_send = Time.now
     else
@@ -388,7 +388,7 @@ class LNet
         type_and_params = type
 
         unless params.nil?
-          type_and_params = type_and_params + ":" +[Marshal.dump(params)].pack('m').strip
+          type_and_params = type_and_params + ":security error" 
         end
 
         LNet.send_request(attr={'type'=> type_and_params, 'to'=>name })
@@ -418,7 +418,7 @@ class LNet
     if name.to_s.downcase =~ /^lnet_/ && Script.current.name != "0net"
       raise Exception.new "you may not use the reserved prefix `lnet_`"
     end
-    echo "registered Callback<#{name}> for #{type}"
+    #echo "registered Callback<#{name}> for #{type}"
     @@callbacks[type] ||= Callbacks.new
     @@callbacks[type].add(name, block)
     self
@@ -434,10 +434,7 @@ class LNet
   def LNet.dispatch_callback(type, data)
     from = data["from"]
     type, *params = type.split(":")
-
-    unless params.empty?
-      params = Marshal.load(params.join(":").unpack('m').first)
-    end
+    params = []
     
     if !callbacks.keys.include?(type)
       echo "rejecting unknown request (#{type}) from #{from}..."
@@ -449,7 +446,7 @@ class LNet
       end
       LNet.send_data(attr={'type'=>type, 'to'=>from},
         # prefer default callbacks 
-        results.shift)
+        nil)
     else
       echo "rejecting request from #{from} for #{type} info..."
       LNet.send_data(attr={'type'=>type, 'to'=>from}, nil)
@@ -551,7 +548,7 @@ class LNet
         end
       elsif (@active_tags.last == 'data')
         begin
-          data = Marshal.load(text.unpack('m').first)
+          data = nil
         rescue
           return
         end


### PR DESCRIPTION
[source](https://ruby-doc.org/core-2.6.3/Marshal.html#load)
> By design, ::load can deserialize almost any class loaded into the Ruby process. In many cases this can lead to remote code execution if the Marshal data is loaded from an untrusted source.

There is almost no source more untrusted than an lnet message, so we should **never** use Marshal data here.

This is unfortunately a break change as it makes `send_data` a `noop` for now, but it must be done for safety concerns.  I have reported this vulnerability to Tillmen and he has implemented some mitigations on the lnet server for regular `lnet.lic` users, but any use of `Marshal` in this manner is inherently insecure.