### PR TITLE
 Request For Comment (Bigshot)

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,12 +8,14 @@
   contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias
           game: Gemstone
           tags: hunting
-       version: 3.91
+       version: 3.92
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
   Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
   
+  v3.92 (2020-07-08)
+    -Added LTE support for followers, overkill support for followers, & fried hunting commands for followers
   v3.91 (2020-06-16)
     -Added longterm boost usage option
   v3.90 (2020-05-19)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -84,7 +84,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '3.91'
+BIGSHOT_VERSION = '3.92'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -212,7 +212,8 @@ before_dying { $bigshot.gather_ammo }
 class Event
   attr_accessor :type, :created_at, :room_id
   @@RECOGNIZED = [ :HUNTING_PREP_COMMANDS, :HUNTING_SCRIPTS_START, :CAST_SIGNS, :ATTACK, :PREP_REST, 
-                   :HUNTING_SCRIPTS_STOP, :RESTING_SCRIPTS_START, :RESTING_PREP_COMMANDS, :DISPLAY_WATCH ]
+                   :HUNTING_SCRIPTS_STOP, :RESTING_SCRIPTS_START, :RESTING_PREP_COMMANDS, :DISPLAY_WATCH, 
+                   :FOLLOWER_OVERKILL ]
 
   def initialize( type, time_stamp, room_id )
     raise "Event type not recognized" unless @@RECOGNIZED.include?(type)
@@ -269,6 +270,17 @@ class Group
       rescue
         @leader.message("Error adding #{type.to_s} event to members stack: #{$!}")
         @leader.message($!.backtrace.join("\n"))
+      end
+    }
+  end
+
+  def group_assist( should_attack )
+    @members.each_pair { |k,v|
+      begin
+        v.set_help_group( should_attack )
+      rescue
+        @leader.message("Error polling member. Removing!")
+        @members.delete(k)
       end
     }
   end
@@ -349,14 +361,19 @@ class Bigshot
     :MSTRIKE_QUICKSTRIKE, :MSTRIKE_STAMINA_QUICKSTRIKE,
     :UAC_MSTRIKE, :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY,
     :QUICKHUNT_TARGETS, :UAC_SMITE, :FOG_RETURN, :LOOT_STANCE,
-    :DELAY_LOOT, :PULL, :OVERKILL, :LTE_BOOST
+    :DELAY_LOOT, :PULL, :OVERKILL, :LTE_BOOST, :help_group_kill
 
   PRONE = /sleeping|webbed|stunned|kneeling|sitting|^lying|prone|frozen|held in place/
 
   def add_event( type, time_stamp, room_id )
     echo "add_event" if $bigshot_debug
     unless( @event_stack.size > 5 && type == :ATTACK )
-      @event_stack.push( Event.new( type, time_stamp, room_id ) )
+      if( type == :FOLLOWER_OVERKILL )
+        add_overkill()
+        @event_stack.push( Event.new( type, time_stamp, room_id ) ) unless( @event_stack.any? { |a| a.type == type} )
+      else  
+        @event_stack.push( Event.new( type, time_stamp, room_id ) )
+      end  
     end
   end
 
@@ -373,6 +390,7 @@ class Bigshot
   def initialize(bounty_mode=nil)
     echo "initialize" if $bigshot_debug
     $bigshot = self
+    @help_group_kill = true
     if bounty_mode
       @BOUNTY_MODE = true
     end
@@ -1442,7 +1460,7 @@ class Bigshot
 
   def find_routine(target)
     echo "find_routine" if $bigshot_debug
-    if( !solo? && fried? )
+    if( !solo? && fried? && !@DISABLE_COMMANDS.size == 0 )
       return @DISABLE_COMMANDS
     else
       key = @TARGETS.keys.find { |k| target.name =~ /^#{k}$/i or target.noun =~ /^#{k}$/i }
@@ -1668,6 +1686,10 @@ class Bigshot
       echo "Need a blessing on weapon to continue hunting"
       Script.self.kill
     end
+
+    if (!solo? && leading?)
+      @followers.group_assist( true )
+    end  
     # loop
     until(should_hunt?)
       @followers.add_event(:DISPLAY_WATCH)
@@ -1923,11 +1945,15 @@ class Bigshot
   end
 
   def overkill?()
-    if( $bigshot_overkill_counter >= @OVERKILL )
+    if( $bigshot_overkill_counter >= @OVERKILL && lte_boost? )
       return true
     else
       return false
     end
+  end
+
+  def set_help_group( keep_attacking )
+    @help_group_kill = keep_attacking
   end
 
   def lte_boost?()
@@ -1939,14 +1965,18 @@ class Bigshot
   end
 
   def use_lte_boost()
-    boost_attempt = dothistimeout "boost longterm", 3, /You do not have any Long-Term Experience Boosts to redeem.|You have deducted 500 experience points from your field experience/
-    if boost_attempt =~ /You do not have any Long-Term Experience Boosts to redeem./
-      message("No more LTE boosts available - Skipping")
-      $bigshot_lte_boost_counter = @LTE_BOOST
-    elsif boost_attempt =~ /You have deducted 500 experience points from your field experience/
-      $bigshot_lte_boost_counter += 1
-      message("Used LTE Boost: #{$bigshot_lte_boost_counter} of #{@LTE_BOOST}")
-    end
+    if(fried? && !lte_boost?) #Need the check because of the race condition caused if you are a follower in RT when called
+      boost_attempt = dothistimeout "boost longterm", 3, /You do not have any Long-Term Experience Boosts to redeem.|You have deducted 500 experience points from your field experience/
+        if boost_attempt =~ /You do not have any Long-Term Experience Boosts to redeem./
+          message("No more LTE boosts available - Skipping")
+          $bigshot_lte_boost_counter = @LTE_BOOST
+          add_overkill()
+        elsif boost_attempt =~ /You have deducted 500 experience points from your field experience/
+          $bigshot_lte_boost_counter += 1
+          message("Used LTE Boost: #{$bigshot_lte_boost_counter} of #{@LTE_BOOST}")
+          $bigshot_overkill_counter = 0 
+        end
+    end  
   end
 
   def ammo_on_ground(ammo)
@@ -2085,6 +2115,12 @@ class Bigshot
       $rest_reason = "emergency rest."
       $bigshot_status = :resting
       return true
+    elsif ( !solo? && !leading? && $bigshot_status != :resting && @help_group_kill )
+      return false if !oom?  
+    end
+
+    if (leading? && !solo? && fried? && overkill? && lte_boost? )
+      @followers.group_assist( false )
     end
 
     followers_fried = (leading? && !solo?) ? ( @followers.should_rest? && overkill? && lte_boost? ) : true
@@ -2107,6 +2143,17 @@ class Bigshot
     $rest_reason = "none."
     return false
   end
+
+  def add_overkill()
+    if (fried? && lte_boost?)
+      $bigshot_overkill_counter += 1
+      message("Extra Kills currently at: #{$bigshot_overkill_counter} of #{@OVERKILL}")
+    end
+    
+    if (!solo? && leading?)
+      @followers.add_event(:FOLLOWER_OVERKILL)
+    end  
+  end  
 
   def cast_signs(single_cast = false)
     echo "cast_signs?" if $bigshot_debug
@@ -2150,11 +2197,8 @@ class Bigshot
         elsif $last_loot <= Time.now
           dead_npcs.each { |i|
             $last_loot = nil
-            use_lte_boost if (!lte_boost? && fried?)
-            if (fried?)
-              $bigshot_overkill_counter += 1
-              message("Extra Kills currently at: #{$bigshot_overkill_counter} of #{@OVERKILL}")
-            end
+            use_lte_boost()
+            add_overkill()
             change_stance('defensive') if GameObjNpcCheck() > 0 && @LOOT_STANCE
             if(@LOOT_SCRIPT)
               run_script( @LOOT_SCRIPT, true )
@@ -2167,11 +2211,8 @@ class Bigshot
       else
         dead_npcs.each { |i|
           $last_loot = nil
-          use_lte_boost if (!lte_boost? && fried?)
-          if (fried?)
-            $bigshot_overkill_counter += 1
-            message("Extra Kills currently at: #{$bigshot_overkill_counter} of #{@OVERKILL}")
-          end
+          use_lte_boost()
+          add_overkill()
           change_stance('defensive') if GameObjNpcCheck() > 0 && @LOOT_STANCE
           if(@LOOT_SCRIPT)
             run_script( @LOOT_SCRIPT, true )
@@ -2606,9 +2647,10 @@ class Bigshot
       $OP_TABLE1.attach(align, 1, 2, 8, 9)
 
       commands_tip =  "Example 1: 413 target, 903 target\nExample 2: 903 target(x2)\nExample 3: 903 target(xx)\nExample 4: 910 target(m50), 903 target\nExample 5: unarmed punch, wait 30\nExample 1 will cast 413 then 903 on the target. Example 2 will cast 903 on the target twice. Example 3 will cast 903 on the target until the fight is over. Example 4 will cast 910 if mana is at least 50, otherwise it will cast 903. Example 5 will start the unarmed routine with punch as the main attack. It will attack once, then wait 30 seconds for another attack to happen before attacking again.\nSeparate all commands with commas.\n\nNew feature: 'and'.\nFor example: stance def and 1615 target, kill target(xx)"
+      disable_tip = "If left blank and this character is in a bigshot group, character will continue to use standard hunting commands after mind is fried and overkill limit is reached\nIf row populated, and character is in a bigshot group, these commands will be used instead of standard hunting commands once fried and overkill limit reached\nSee hunting commands tooltip for examples on what commands to use."
       $OP_TOOLTIPS.set_tip($OP_ENTRY['hunting_commands'], commands_tip, "")
       $OP_TOOLTIPS.set_tip($OP_ENTRY['hunting_commands_g'], commands_tip, "")
-      $OP_TOOLTIPS.set_tip($OP_ENTRY['disable_commands'], commands_tip, "")
+      $OP_TOOLTIPS.set_tip($OP_ENTRY['disable_commands'], disable_tip, "")
 
       signs_tip = "Shadow Mastery - 9603\nSurge of Strength - 9605\n\nSigil of Contact - 9703\nSigil of Resolve - 9704\nSigil of Minor Bane - 9705\nSigil of Defense - 9707\nSigil of Offense - 9708\nSigil of Minor Protection - 9710\nSigil of Focus - 9711\nSigil of Mending - 9713\nSigil of Concentration - 9714\nSigil of Major Bane - 9715\nSigil of Major Determination - 9716\nSigil of Major Protection - 9719\n\nSign of Warding - 9903\nSign of Striking - 9904\nSign of Thought - 9906\nSign of Defending - 9907\nSign of Smiting - 9908\nSign of Staunching - 9909\nSign of Deflection - 9910\nSign of Swords - 9912\nSign of Shields - 9913\nSign of Dissipation - 9914\nSign of Madness - 9916\n\nSymbol of Courage - 9805\nSymbol of Protection - 9806"
       $OP_TOOLTIPS.set_tip($OP_ENTRY['signs'], signs_tip, "")
@@ -2823,6 +2865,7 @@ elsif( script.vars[1] =~ /tail|follow/i )
   # Participate
   bs.message("Joined group")
   leader = group.leader.name
+ $bigshot_overkill_counter = 0
 
   bs.groupcheck() if !checkpcs.nil?
   echo "Groupcheck done" if $bigshot_debug
@@ -2856,6 +2899,9 @@ elsif( script.vars[1] =~ /tail|follow/i )
           end
         }
 
+      elsif( event.type == :FOLLOWER_OVERKILL )
+        bs.use_lte_boost()
+
       elsif( event.type == :CAST_SIGNS )
         bs.cast_signs()
 
@@ -2881,6 +2927,7 @@ elsif( script.vars[1] =~ /tail|follow/i )
 
       elsif( event.type == :RESTING_PREP_COMMANDS )
         $bigshot_should_rest = nil # need to reset this
+        $bigshot_overkill_counter = 0
         bs.RESTING_COMMANDS.each { |i| fput(i) }
 
       elsif( event.type == :RESTING_SCRIPTS_START )


### PR DESCRIPTION

name: Falicor
about: Feature discussion

# 💬 RFC

Added ability for followers to use the newly added LTE boost feature and to fix issues with group hunting caused by the overkill feature.  I also modified fried hunting to be more "user friendly" and changed tool tip on the fried hunting commands to clearly spell out the choices.

## 🔦 Context

Was trying to group hunt with my characters and could not get the features to work as expected.  It ended up being a combination of user error, documentation issues and script defects/omissions.  

## 💻 Examples

Previously, if you had overkill (or, later, LTE) >0 on a follower, the hunt would only end once OOM/Encumbered/Injured.  If nothing was filled in the 'fried hunting commands' box, the character would stand there and do nothing instead of defaulting to hunting actions.  There are still edge cases where this inaction can happen when leading a larger group, but much less common.  Can add that fix in a later update, time permitting
