### PR TITLE
tears: update info regex to work with commas in numbers

### DIFF
--- a/scripts/tears.lic
+++ b/scripts/tears.lic
@@ -313,7 +313,7 @@ elsif script.vars[0] =~ /bonus/
 	put "info"
 	loop {
 	    line = get
-	    if line =~ /^Gender: (?:\w+)(?:\s+)Age: (?:\d+)(?:\s+)Expr: (?:\d+)(?:\s+)Level:(?:\s+)(\d+)$/
+	    if line =~ /^Gender: (?:\w+)(?:\s+)Age: (?:\d+)(?:\s+)Expr: (?:[\d,]+)(?:\s+)Level:(?:\s+)(\d+)$/
         	level = $1.to_i
     	elsif line =~ /^       Logic \(LOG\):(?:\s+)(?:\d+) \((?:\d+|-\d+)\)(?:\s+)\.\.\.(?:\s+)(?:\d+) \((\d+|-\d+)\)$/
 	        logic = $1.to_i


### PR DESCRIPTION
They added commas to `info` and this is one of the things that broke.