### PR TITLE
Update tfish.lic

### DIFF
--- a/scripts/tfish.lic
+++ b/scripts/tfish.lic
@@ -150,22 +150,22 @@ def fish()
 	loop {
 		waitrt?
 		if cast_counter == 1 && UserVars.tfish[:cycle_weights]
-			fput "get #{UserVars.tfish[:weight_depths]} from my #{UserVars.tfish[:supplies_pole]}"
+			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
 			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
-			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_pole]}"
-			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
+			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
+			fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
 			
 		elsif cast_counter == 2 && UserVars.tfish[:cycle_weights]
-			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_pole]}"
+			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
 			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
 			fput "get #{UserVars.tfish[:weight_depths]} from my #{UserVars.tfish[:supplies_container]}"
 			fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
 			
 		elsif cast_counter == 3 && UserVars.tfish[:cycle_weights]
-			fput "get #{UserVars.tfish[:weight_depths]} from my #{UserVars.tfish[:supplies_pole]}"
+			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
 			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
-			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
-			fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
+			#fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
+			#fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
 			cast_counter = 0
 		end
 		

--- a/scripts/tfish.lic
+++ b/scripts/tfish.lic
@@ -13,12 +13,14 @@
      author: Tysong (horibu on PC)
        name: tfish
        tags: EG, Ebon Gate, fish, fishing
-    version: 1.4
+    version: 1.5
     website: https://github.com/elanthia-online/scripts/
 
     changelog:
+        1.5 (2020-10-13)
+            Cleanup on weight cycling.
         1.4 (2020-10-13)
-	    Added some cleanup when killing script to store supplies
+            Added some cleanup when killing script to store supplies
         1.3 (2020-10-13)
             Fixes for lure descriptions and other things, credit to Ziled
         1.2 (2019-10-17)
@@ -152,8 +154,6 @@ def fish()
 		if cast_counter == 1 && UserVars.tfish[:cycle_weights]
 			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
 			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
-			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
-			fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
 			
 		elsif cast_counter == 2 && UserVars.tfish[:cycle_weights]
 			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
@@ -164,8 +164,8 @@ def fish()
 		elsif cast_counter == 3 && UserVars.tfish[:cycle_weights]
 			fput "get weight from my #{UserVars.tfish[:supplies_pole]}"
 			fput "put my weight in my #{UserVars.tfish[:supplies_container]}"
-			#fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
-			#fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
+			fput "get #{UserVars.tfish[:weight_bottom]} from my #{UserVars.tfish[:supplies_container]}"
+			fput "put my weight on my #{UserVars.tfish[:supplies_pole]}"
 			cast_counter = 0
 		end
 		


### PR DESCRIPTION
Fixes cycle_weights loop. Some container variables were incorrect. Also generalized to simply adding and removing noun "weight" - previous version assumed the a the weight_depth was on the rod to start