### PR TITLE
feat: GTK3 - signore.lic and warnings removed

### DIFF
--- a/scripts/signore.lic
+++ b/scripts/signore.lic
@@ -19,12 +19,11 @@
   
 =end
 
-HELP = "
+@help = "
 ;signore setup            launches the GUI
 ;signore room:list        lists all rooms currently tagged as anti-magic
 ;signore room:rm  <num>   the anti-magic tag from room <num>
 "
-require "gtk2"
 
 class Try
   attr_accessor :result, :task
@@ -62,7 +61,8 @@ class Try
 end
 
 module Signore
-  LIST = [
+
+  @avail_list = [
     # CoL
     Spell[9903],
     Spell[9904],
@@ -92,10 +92,10 @@ module Signore
     Spell[9719], 
   ]
 
-  MAIN       = Script.current
-  PUNISHMENT = Spell[9012]
-  ANTIMAGIC  = /^The power from your sign dissipates into the air.$/
-  SUCCESS    = Regexp.union(
+  @main       = Script.current
+  @punishment = Spell[9012]
+  @antimagic  = /^The power from your sign dissipates into the air.$/
+  @success    = Regexp.union(
       /^You flex your muscles with renewed vigor!$/,
       /^You grip your (.*?) with renewed vigor!$/,
       /^Your veins throb and your blood sings.$/,
@@ -113,7 +113,7 @@ module Signore
       /^As you concentrate on your sigil/,
       /^You feel infused with a collective knowledge on the undead and their weaknesses.$/)
 
-  BERSERK = /^You cannot do that while berserking.$/
+  @berserk = /^You cannot do that while berserking.$/
 
   ##
   ## @brief      makes the GTK thread join the Script thread
@@ -121,13 +121,13 @@ module Signore
   ##
   def self.in_main_thread
     original_thread_group = Thread.current.group
-    if original_thread_group != MAIN.thread_group
-      unless MAIN.thread_group.list.include?(Thread.current)
-        MAIN.thread_group.add Thread.current
+    if original_thread_group != @main.thread_group
+      unless @main.thread_group.list.include?(Thread.current)
+        @main.thread_group.add Thread.current
       end
     end
     res = Try.new { yield }
-    if original_thread_group != MAIN.thread_group
+    if original_thread_group != @main.thread_group
       original_thread_group.add Thread.current
     end
     res
@@ -138,11 +138,11 @@ module Signore
   end
 
   def self.punished?
-    PUNISHMENT.active?
+    @punishment.active?
   end
 
   def self.available
-    LIST.select {|spell| spell.known? }
+    @avail_list.select {|spell| spell.known? }
   end
 
   def self.save(key, state)
@@ -196,11 +196,11 @@ module Signore
 
     if power.affordable? && active?(power) && !power.active? && !antimagic_room?
       result = dothistimeout(power.to_s, 5, 
-        Regexp.union(ANTIMAGIC, SUCCESS))
+        Regexp.union(@antimagic, @success))
       case result
-      when SUCCESS   then true
-      when ANTIMAGIC then Signore.add_anti_magic_room(Room.current.id)
-      when BERSERK   then berserk_timeout!
+      when @success   then true
+      when @antimagic then Signore.add_anti_magic_room(Room.current.id)
+      when @berserk   then berserk_timeout!
       else
         until line=get do sleep(1) end
         sleep(1) # game is responsive again
@@ -217,6 +217,10 @@ module Signore
       .select { |power| !power.active? }
       .each { |power| cast power }
   end
+  
+  def self.gtk_active
+	active_gtk = Gtk::Version::STRING.chr
+  end
 end
 
 Settings[:antimagic_rooms] ||= []
@@ -229,8 +233,8 @@ module Gui
     def initialize(power, parent)
       @power = power
       super @power.to_s
-      set_active Signore.active?(@power)
-
+	  self.active = Signore.active?(@power)
+	  
       signal_connect("clicked") { 
         if on_clicked.failed?
           respond "Signore.error >> " + on_clicked.result.message
@@ -249,10 +253,10 @@ module Gui
     attr_accessor :toggles, :layout, :closed
 
     def initialize(toggleables)
-      super Gtk::Window::TOPLEVEL
+      super :toplevel
       @closed = false
-      @layout = Gtk::VBox.new(false, 0)
-
+      @layout = Gtk::Box.new(:vertical, 0) if Signore.gtk_active == '3'
+	  @layout = Gtk::VBox.new(false, 0) if Signore.gtk_active == '2'
       set_title "Signore::Setup"
       set_border_width 10
 


### PR DESCRIPTION
Changed CONSTANT to instance variable to remove ruby warning about already initialized

Added GTK version check and enabled both GTK2 and GTK3 in single script.  Version check can probably be improved grammatically.