### PR TITLE
treim: only block responses to clear checks if the rare if still alive

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -405,7 +405,7 @@ end
 
 def checkclear(bossname)
 	# GameObj.npcs.select{ |npc| npc.id == bossname.id }.count
-	while GameObj.npcs.select{ |npc| npc.id == bossname }.count > 0 do
+	while GameObj.npcs.select{ |npc| npc.id == bossname && !npc.status.include?("dead") }.count > 0 do
 		pause 0.5
 	end
 	waitrt?


### PR DESCRIPTION
It gets dumb if a clear check is requested while there is still an unlooted dead rare in the room. This updates it to only pause responding to the clear check if the rare is still alive.