### PR TITLE
fix: use empty? instead of zero? on a string, and fix an invalid variable name.

### DIFF
--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -78,7 +78,7 @@ def print_help
 end
 
 check_squelch = proc { |server_string|
-  if server_string.strip.zero?
+  if server_string.strip.empty?
     server_string
   else
     pass_line = true
@@ -110,7 +110,7 @@ loop do
   update_regex = false
   case command
   when /add/
-    Vars[@script_name][:squelches].push({ text: target, enabled: true })
+    Vars[@script_name][:squelches].push({ text: argument, enabled: true })
     respond "Added \/#{argument}\/"
     update_regex = true
   when /(?<state>en|dis)able/


### PR DESCRIPTION
This fixes two issues found by users that were caused be recent refactoring. The first is that a `string.length == 0` was changed to `.zero?` when it should have been `.empty?`, and the second was a variable renaming missing one instance.