### PR TITLE
Add StormFront importing to isquelch, and accept first command

### DIFF
--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -6,10 +6,11 @@
 # author: Ineum
 # game: Gemstone IV
 # tags: squelching, squelch
-# version: 0.0.4
+# version: 0.1.0
 #
 # changelog:
-#   0.0.4 (2020-12-02)
+#   0.1.0 (2020-12-02)
+#     Now has ability to import ignores from a StormFront XML file.
 #     Accept arguments on first run, and improve help documentation with examples.
 #   0.0.3 (2020-11-30)
 #     Defined instance variable for usage, simplified the default configuration creation.
@@ -19,6 +20,8 @@
 #     Initial release.
 
 require 'English'
+require 'rexml/document'
+require 'rexml/xpath'
 
 @script_name = Script.current.name
 
@@ -89,6 +92,7 @@ def print_help
   respond '";isquelch disable 0"                   - disable the first stored squelch'
   respond '";isquelch enable 0"                    - enable the first store squelch'
   respond '";isquelch remove 0"                    - permanently delete the first stored squelch'
+  respond '";isquelch import ../../StormFront.xml" - import squelches from file just outside lich'
   respond '";isquelch stop                         - quit isquelch'
 end
 
@@ -139,6 +143,13 @@ loop do
     update_regex = remove_squelch(index)
   when /list|ls/
     print_squelches
+  when /import/
+    import = File.open(argument)
+    document = REXML::Document.new(import)
+    REXML::XPath.each(document, '//settings/ignores/*/@text') do |elem|
+      Vars[@script_name][:squelches].push({ text: Regexp.escape(elem.to_s), enabled: true })
+    end
+    update_regex = true
   when /stop/
     break
   else

--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -99,8 +99,11 @@ rebuild_regex
 
 toggle_upstream
 
+get_next_line = false
+
 loop do
-  line = upstream_get
+  line = get_next_line ? upstream_get : "#{CMD_STRING} #{script.vars[1..-1].join(' ')}"
+  get_next_line = true
   # Exit early if the command isn't for us
   next unless line =~ /#{CMD_STRING}\s*(?<command>\w+)\s*(?<argument>.*)/
 

--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -6,9 +6,11 @@
 # author: Ineum
 # game: Gemstone IV
 # tags: squelching, squelch
-# version: 0.0.3
+# version: 0.0.4
 #
 # changelog:
+#   0.0.4 (2020-12-02)
+#     Accept arguments on first run, and improve help documentation with examples.
 #   0.0.3 (2020-11-30)
 #     Defined instance variable for usage, simplified the default configuration creation.
 #   0.0.2 (2020-10-22)
@@ -67,14 +69,27 @@ def print_squelches
 end
 
 def print_help
-  respond 'Usage: ;isquelch command [arguments]'
+  respond 'Usage: ;isquelch <command> [arguments]'
   respond ''
   respond 'Commands:'
-  respond 'add REGEX: Adds REGEX to the list of squelched expressions.'
-  respond 'enable INDEX: Enables the regular expression stored at the specified INDEX.'
-  respond 'disable INDEX: Disables the regular expression stored at the specified INDEX.'
-  respond 'remove INDEX: Removes the regular expression stored at the specified INDEX.'
-  respond 'list: Lists all regular expressions'
+  respond 'add <REGEX>:     Adds REGEX to the list of squelched expressions.'
+  respond 'enable <INDEX>:  Enables the regular expression stored at the specified INDEX.'
+  respond 'disable <INDEX>: Disables the regular expression stored at the specified INDEX.'
+  respond 'import <FILE>:   Read the specified StormFront XML file and import all squelches.'
+  respond 'remove <INDEX>:  Removes the regular expression stored at the specified INDEX.'
+  respond 'list:            Lists all regular expressions.'
+  respond 'stop:            Quit isquelch from running'
+  respond 'rm <INDEX>:      Alias for "remove INDEX"'
+  respond 'ls:              Alias for "list"'
+  respond ''
+  respond ''
+  respond 'Examples:'
+  respond ';isquelch tossing the sand aside\.$"    - squelch any line digging at Ebon Gate'
+  respond '";isquelch list"                        - list the saved squelches'
+  respond '";isquelch disable 0"                   - disable the first stored squelch'
+  respond '";isquelch enable 0"                    - enable the first store squelch'
+  respond '";isquelch remove 0"                    - permanently delete the first stored squelch'
+  respond '";isquelch stop                         - quit isquelch'
 end
 
 check_squelch = proc { |server_string|


### PR DESCRIPTION
Adds a command to import squelches from a StormFront settings XML file. Also improves the command interface so the first command is parsed, to eliminate a separate starting command. Also adds examples and improves the help statements slightly.