### PR TITLE
Add export command to isquelch

### DIFF
--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -6,9 +6,11 @@
 # author: Ineum
 # game: Gemstone IV
 # tags: squelching, squelch
-# version: 0.1.0
+# version: 0.2.0
 #
 # changelog:
+#   0.2.0 (2020-12-03)
+#     Introduced export command for exporting squelches compatible with import.
 #   0.1.0 (2020-12-02)
 #     Now has ability to import ignores from a StormFront XML file.
 #     Accept arguments on first run, and improve help documentation with examples.
@@ -75,15 +77,16 @@ def print_help
   respond 'Usage: ;isquelch <command> [arguments]'
   respond ''
   respond 'Commands:'
-  respond 'add <REGEX>:     Adds REGEX to the list of squelched expressions.'
-  respond 'enable <INDEX>:  Enables the regular expression stored at the specified INDEX.'
-  respond 'disable <INDEX>: Disables the regular expression stored at the specified INDEX.'
-  respond 'import <FILE>:   Read the specified StormFront XML file and import all squelches.'
-  respond 'remove <INDEX>:  Removes the regular expression stored at the specified INDEX.'
-  respond 'list:            Lists all regular expressions.'
-  respond 'stop:            Quit isquelch from running'
-  respond 'rm <INDEX>:      Alias for "remove INDEX"'
-  respond 'ls:              Alias for "list"'
+  respond 'add <REGEX>:            Adds REGEX to the list of squelched expressions.'
+  respond 'enable <INDEX>:         Enables the regular expression stored at the specified INDEX.'
+  respond 'disable <INDEX>:        Disables the regular expression stored at the specified INDEX.'
+  respond 'import <FILE>:          Read the specified StormFront XML file and import all squelches.'
+  respond 'export <FILE> [IDX...]: Export squelches, either all or the indexes specified'
+  respond 'remove <INDEX>:         Removes the regular expression stored at the specified INDEX.'
+  respond 'list:                   Lists all regular expressions.'
+  respond 'stop:                   Quit isquelch from running'
+  respond 'rm <INDEX>:             Alias for "remove INDEX"'
+  respond 'ls:                     Alias for "list"'
   respond ''
   respond ''
   respond 'Examples:'
@@ -93,6 +96,8 @@ def print_help
   respond '";isquelch enable 0"                    - enable the first store squelch'
   respond '";isquelch remove 0"                    - permanently delete the first stored squelch'
   respond '";isquelch import ../../StormFront.xml" - import squelches from file just outside lich'
+  respond '";isquelch export test.xml              - export all squelches to test.xml'
+  respond '";isquelch export test.xml 0 2 4        - exports squelches 0, 2, and 4 to test.xml'
   respond '";isquelch stop                         - quit isquelch'
 end
 
@@ -150,6 +155,28 @@ loop do
       Vars[@script_name][:squelches].push({ text: Regexp.escape(elem.to_s), enabled: true })
     end
     update_regex = true
+  when /export/
+    arguments = argument.split(' ')
+    if arguments.empty?
+      print_help
+      next
+    end
+    out_path = arguments.shift
+    # Build list of ignore lines from chosen set.
+    ignore_lines = []
+    if arguments.empty?
+      Vars[@script_name][:squelches].each do |squelch|
+        ignore_lines.push("<h text=\"#{squelch[:text]}\"/>")
+      end
+    else
+      arguments.each do |index|
+        text = Vars[@script_name][:squelches][index.to_i][:text]
+        ignore_lines.push("<h text=\"#{text}\"/>")
+      end
+    end
+    export = File.open(out_path, 'w')
+    REXML::Document.new("<settings><ignores>#{ignore_lines.join("\n")}</ignores></settings>").write(output: export, indent: 2)
+    export.close
   when /stop/
     break
   else


### PR DESCRIPTION
Add a command to export squelches to isquelch, so squelches can be shared between individuals. This includes both bulk export, or specified by index.