### PR TITLE
tears.lic: update for new essence numbers

### DIFF
--- a/scripts/tears.lic
+++ b/scripts/tears.lic
@@ -18,9 +18,11 @@
      author: Elanthia-Online
        name: tears
        tags: tears, essence, enchant, enchanting, 925
-    version: 1.6
+    version: 1.7
 
     changelog:
+        1.7 (2020-12-06)
+            Update for new tears values
         1.6 (2020-09-29)
             Update for commas in INFO readout for ;tears bonus
         1.5 (2020-07-27)
@@ -32,14 +34,15 @@
         1.2 (2019-05-14)
             Added material, chance, and rolls function from ;dechanter (thanks Claudaro)
         1.1 (2019-05-10)
-            Added calc function (thanks FarFigNewGut
+            Added calc function (thanks FarFigNewGut)
         1.0 (2019-05-06)
             Initial release
 
 =end
 
-tear_cost = ["0", "100", "200", "300", "400", "500", "600", "700", "800", "900", "1000", "1100", "1200", "1300", "1400", "1500", "1600", "1700", "1800", "1900", "2000", "2100", "2200", "2300", "2400", "4800", "7200", "9600", "12000", "14400", "16800", "19200", "21600", "24000", "26400", "28800", "31200", "33600", "36000", "38400", "40800", "43200", "45600", "48000", "50400", "52800", "55200", "57600", "60000", "62400"]
-WEEK = 16000.0
+tear_cost = ["0", "312", "625", "937", "1250", "1562", "1875", "2187", "2500", "2812", "3125", "3437", "3750", "4062", "4375", "4687", "5000", "5312", "5625", "5937", "6250", "6562", "6875", "7187", "7500", "15000", "22500", "30000", "37500", "45000", "52500", "60000", "67500", "75000", "82500", "90000", "97500", "105000", "112500", "120000", "127500", "135000", "142500", "150000", "157500", "165000", "172500", "180000", "187500", "195000"]
+WEEK = 50000.0
+
 PAD = 91
 
 private_workshop = ["Tysong"]
@@ -152,6 +155,27 @@ def rowout(msg_arr, mbold = false)
         end
 end
 
+def number_commas(number)
+	return number.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+end
+
+def silver_to_dollar(silvers, dollar_per)
+	return '%.2f' % ((silvers / 1000000 * dollar_per).to_f.round(2))
+end
+
+def calc_rate_row(rate, running_total_ess)
+	silver_cost = rate.to_f * running_total_ess.to_f
+	row_label = "#{rate} silver"
+	orig_rate = rate * 3.125
+	silver_cost_comma = number_commas(silver_cost)
+	output = [row_label,
+                  "#{orig_rate} silver",
+                  silver_cost_comma,
+                  silver_to_dollar(silver_cost, 4),
+                  silver_to_dollar(silver_cost, 5)]
+	return output
+end
+
 def rowout2(msg_arr, mbold = false)
         out = '| '
         msg_arr.each { |m|
@@ -208,22 +232,19 @@ def do_calc(tear_cost)
 	end
 	_respond "-" * PAD
 	_respond ""
-	_respond "-" * 77
-	headers = ['Cost per Essence', 'Total Cost', '$4/1m Silver', '$5/1m Silver']
+	_respond "-" * 96
+	headers = ['Cost per Essence', 'Old Cost per Ess', 'Total Cost', '$4/1m Silver', '$5/1m Silver']
 	rowout2(headers, true)
-	_respond "-" * 77
+	_respond "-" * 96
 	if variable[4]
-		rowout2(["#{tears_rate} Silver", "#{((tears_rate * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((tears_rate * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((tears_rate * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
+		rowout2(calc_rate_row(tears_rate, running_total_ess))
 	else
-		rowout2(['200 Silver', "#{((200 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((200 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((200 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['250 Silver', "#{((250 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((250 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((250 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['300 Silver', "#{((300 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((300 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((300 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['350 Silver', "#{((350 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((350 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((350 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['400 Silver', "#{((400 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((400 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((400 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['450 Silver', "#{((450 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((450 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((450 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
-		rowout2(['500 Silver', "#{((500 * running_total_ess).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse)}", "$#{'%.2f' % ((500 * running_total_ess.to_f) / 1000000 * 4).to_f.round(2)}", "$#{'%.2f' % ((500 * running_total_ess.to_f) / 1000000 * 5).to_f.round(2)}"])
+		(4..10).to_a.each { |rate_multi|
+			rate = 16 * rate_multi
+			rowout2(calc_rate_row(rate, running_total_ess))
+		}
 	end
-	_respond "-" * 77
+	_respond "-" * 96
 	
 end
 


### PR DESCRIPTION
- updates calculations to use new essence scheme
- dedupes some inline code to functions for the silver/dollar rate calculation table
- adds "old rate" column for the calc table so people can easily reference costs for the old numbers

example outputs:
range with no rate specified

```
>;tears calc 20 25
--- Lich: tears active.
Calculating essence needed to take an item from 20 to 25
-------------------------------------------------------------------------------------------
| Current      | New          | Cost (ess)   | Cost (wks)   | Total (ess)  | Total (wks)  |
-------------------------------------------------------------------------------------------
| 20           | 21           | 6250         | 0.13         | 6250         | 0.13         |
| 21           | 22           | 6562         | 0.13         | 12812        | 0.26         |
| 22           | 23           | 6875         | 0.14         | 19687        | 0.39         |
| 23           | 24           | 7187         | 0.14         | 26874        | 0.54         |
| 24           | 25           | 7500         | 0.15         | 34374        | 0.69         |
-------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------
| Cost per Essence | Old Cost per Ess | Total Cost       | $4/1m Silver     | $5/1m Silver     |
------------------------------------------------------------------------------------------------
| 64 silver        | 200.0 silver     | 2,199,936.0      | 8.80             | 11.00            |
| 80 silver        | 250.0 silver     | 2,749,920.0      | 11.00            | 13.75            |
| 96 silver        | 300.0 silver     | 3,299,904.0      | 13.20            | 16.50            |
| 112 silver       | 350.0 silver     | 3,849,888.0      | 15.40            | 19.25            |
| 128 silver       | 400.0 silver     | 4,399,872.0      | 17.60            | 22.00            |
| 144 silver       | 450.0 silver     | 4,949,856.0      | 19.80            | 24.75            |
| 160 silver       | 500.0 silver     | 5,499,840.0      | 22.00            | 27.50            |
------------------------------------------------------------------------------------------------
--- Lich: tears has exited.
```

example with explicit rate:

```>;tears calc 20 25 50
--- Lich: tears active.
Calculating essence needed to take an item from 20 to 25
-------------------------------------------------------------------------------------------
 Current      | New          | Cost (ess)   | Cost (wks)   | Total (ess)  | Total (wks)  |
-------------------------------------------------------------------------------------------
| 20           | 21           | 6250         | 0.13         | 6250         | 0.13         |
| 21           | 22           | 6562         | 0.13         | 12812        | 0.26         |
| 22           | 23           | 6875         | 0.14         | 19687        | 0.39         |
| 23           | 24           | 7187         | 0.14         | 26874        | 0.54         |
| 24           | 25           | 7500         | 0.15         | 34374        | 0.69         |
-------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------
| Cost per Essence | Old Cost per Ess | Total Cost       | $4/1m Silver     | $5/1m Silver     |
------------------------------------------------------------------------------------------------
| 50 silver        | 156.25 silver    | 1,718,700.0      | 6.87             | 8.59             |
------------------------------------------------------------------------------------------------
--- Lich: tears has exited.
```