### PR TITLE
puritan: loresing to orb gems if option is enabled

### DIFF
--- a/scripts/puritan.lic
+++ b/scripts/puritan.lic
@@ -536,9 +536,15 @@ module Puritan
     case outcome_of_1004(gem)
     when Outcomes::STRAIN
       return on_sung(gem, start_value || 0, verses + 1)
-    when Outcomes::MISFIRE, Outcomes::PURE
-      return on_sung(gem, start_value || 0, verses)
-    when Outcomes::MAX
+    when Outcomes::PURE
+      track_earnings(start_value, appraise_gem(gem))
+      track_verses(verses)
+      if Opts.loresing
+        return loresing(GameObj.right_hand)
+      else
+        return Puritan.add_to_bag(@orb_gems, GameObj.right_hand)
+      end
+    when Outcomes::MISFIRE, Outcomes::MAX
       # handle maybe naturally pure gem
       if round.eql?(0) and Opts.loresing
         track_earnings(start_value, appraise_gem(gem))


### PR DESCRIPTION
After a recent update, ;puritan stopped saving most orb gems for me. I figured out it was checking naturally orbbed gems but was treating sung gems the same regardless of whether they were orbs or not. This updates puritan to respect the orb bag setting and also to loresing to orb gems if the loresing option is enabled to check for mage rechargeable gems.