### PR TITLE
Make it more clear that jinx splits into two "commands"

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -513,22 +513,26 @@ module Jinx
     def self.help()
       _respond <<~HELP
         <b>jinx</b>
-        
-        a federated script repository manager
 
-        ;jinx repo
-          list                            list all currently known repositories
-          add    {repo:name} {repo:url}   add a repository from an http url
-          info   {repo:name}              show detailed info about a specific repo
-          rm     {repo:name}              remove a repository by name
+        A federated script repository manager
 
-        ;jinx script
-          list                                      list all currently known scripts
-          list    --repo={repo:name}                list all scripts available from a specific repo
-          info    {script:name}                     shows known info about a remote script
-          install {script:name}                     attempt to install a script
-          install --repo={repo:name} {script:name}  attempt to install a script
-          update  {script:name}                     attempts to update an installed script
+        Usage: ;jinx help or ;jinx (repo|script) <subcommand> [<arg1>, ...]
+
+        Repo commands:
+          repo list                                        list all currently known repositories
+          repo add    {repo:name} {repo:url}               add a repository from an http url
+          repo info   {repo:name}                          show detailed info about a specific repo
+          repo rm     {repo:name}                          remove a repository by name
+
+        Script commands:
+          script list                                      list all currently known scripts
+          script info    {script:name}                     shows known info about a remote script
+          script install {script:name}                     attempt to install a script
+          script update  {script:name}                     attempts to update an installed script
+
+        Script commands all take an optional --repo={repo:name} argument to perform the action on a
+        specified repo. Without the argument, the action will be attempted on all repos that have
+        been added.
       HELP
     end
 


### PR DESCRIPTION
...with grouped subcommands. Also, --repo seems to be applicable to all
script actions, not just install and list, so I made the doc say that.