### PR TITLE
treim: Autochill when leader says KILL THY SCIRPTS

### DIFF
--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -53,11 +53,11 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 2.21
+    version: 2.22
 
     changelog:
-			2.22 (2020-12-27)
-			Recognize "KILL THY SCRIPTS" as a "cease fire" command
+    	2.22 (2020-12-27)
+	    Recognize "KILL THY SCRIPTS" as a "cease fire" command
     	2.21 (2020-05-23)
 	    Added support for "cease fire" and "resume fire"
     	2.20 (2020-05-19)

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -56,6 +56,8 @@
     version: 2.21
 
     changelog:
+			2.22 (2020-12-27)
+			Recognize "KILL THY SCRIPTS" as a "cease fire" command
     	2.21 (2020-05-23)
 	    Added support for "cease fire" and "resume fire"
     	2.20 (2020-05-19)
@@ -682,13 +684,14 @@ loop {
 					else
 						put "whisper ooc #{whisperperson} You're not the leader, #{whisperperson}!" 
 					end
-				elsif line =~ /\(OOC\) (.*)'s player whispers to the group, "Cease fire."/
+				elsif line =~ /\(OOC\) (.*)'s player whispers to the group, "Cease fire."/ || line =~ /\(OOC\) (.*)'s player whispers to the group, ".*KILL THY SCRIPTS/i
 					whisperperson = $1.split.first
 					silence.call
 					leader, members = checkgroup
 					DownstreamHook.remove("#{script.name}_silence")
 					if whisperperson == leader
-						while line !~ /\(OOC\) (.*)#{whisperperson}'s player whispers to the group, "Resume fire."/ do
+						while line !~ /\(OOC\) (.*)#{whisperperson}'s player whispers to the group, "Resume fire."/
+							break unless AreaReim.include?(Room.current.id)
 							line = get
 						end
 					end


### PR DESCRIPTION
Extends the Cease fire command to recognize any OOC whisper from the leader that includes the phrase "KILL THY SCRIPTS". Also updates this command to break out of the loop if we leave Reim or move into the Throne Room.