### PR TITLE
The selfcast check in bigshot was ugly

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -13,7 +13,7 @@
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
   Full Changelog: https://gswiki.play.net/Script_Bigshot_Changelog
-  
+
   v3.93 (2020-12-31)
     -Update self-cast spells due to Ranger/Paladin spell review
   v3.92 (2020-07-08)
@@ -52,7 +52,7 @@
       ;bigshot profile save <name here, no spaces>
       Allows saving of bigshot profiles as YAML files, saved in your LICH\scripts\bigshot_profiles folder
 =end
-=begin  
+=begin
     To do:
       Add more messaging for ambush checks (snipe, etc.)
       Add Stun Relief (108)|Undisease (113)|Unpoison (114) option for stunned group members
@@ -121,6 +121,23 @@ $last_loot=nil
 $not_hunting_reason = nil
 $rest_reason = nil
 $room_npcs_last_check=[]
+
+def spell_is_selfcast?(spell_id)
+  [
+    106, 109, 115, 117, 120, 130, 140,
+    205, 206, 211, 213, 215, 218, 219, 220, 240,
+    303, 307, 310, 313, 314, 319, 350,
+    401, 402, 403, 404, 405, 406, 414, 418, 419, 425, 430,
+    503, 506, 507, 508, 509, 511, 513, 515, 517, 520, 535, 540,
+    601, 602, 604, 605, 606, 608, 612, 613, 617, 618, 620, 625, 630, 640, 650,
+    707, 712,
+    905, 911, 913, 916, 919,
+    1003, 1006, 1007, 1009, 1010, 1011, 1012, 1014, 1017, 1018, 1019, 1020, 1025, 1035, 1040,
+    1109, 1119, 1125, 1130, 1150,
+    1202, 1204, 1208, 1213, 1214, 1215, 1216, 1220, 1235,
+    1601, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1616, 1617, 1618, 1619, 1635
+  ].include? spell_id
+end
 
 def spam
   def waitcastrt?
@@ -215,8 +232,8 @@ before_dying { $bigshot.gather_ammo }
 
 class Event
   attr_accessor :type, :created_at, :room_id
-  @@RECOGNIZED = [ :HUNTING_PREP_COMMANDS, :HUNTING_SCRIPTS_START, :CAST_SIGNS, :ATTACK, :PREP_REST, 
-                   :HUNTING_SCRIPTS_STOP, :RESTING_SCRIPTS_START, :RESTING_PREP_COMMANDS, :DISPLAY_WATCH, 
+  @@RECOGNIZED = [ :HUNTING_PREP_COMMANDS, :HUNTING_SCRIPTS_START, :CAST_SIGNS, :ATTACK, :PREP_REST,
+                   :HUNTING_SCRIPTS_STOP, :RESTING_SCRIPTS_START, :RESTING_PREP_COMMANDS, :DISPLAY_WATCH,
                    :FOLLOWER_OVERKILL ]
 
   def initialize( type, time_stamp, room_id )
@@ -360,8 +377,8 @@ class Bigshot
     :DISABLE_COMMANDS, :HUNTING_STANCE, :HUNTING_PREP_COMMANDS,
     :MONITOR_INTERACTION, :FLEE_CLOUDS, :FLEE_VINES, :FLEE_WEBS, :WRACKING_SPIRIT,
     :REST_TILL_SPIRIT, :BOUNTY_MODE, :AMBUSH, :ARCHERY_AIM,
-    :event_stack, :followers, :BLESS, :AIM, :TIER3, 
-    :MSTRIKE_COOLDOWN, :MSTRIKE_STAMINA_COOLDOWN, :MSTRIKE_MOB, 
+    :event_stack, :followers, :BLESS, :AIM, :TIER3,
+    :MSTRIKE_COOLDOWN, :MSTRIKE_STAMINA_COOLDOWN, :MSTRIKE_MOB,
     :MSTRIKE_QUICKSTRIKE, :MSTRIKE_STAMINA_QUICKSTRIKE,
     :UAC_MSTRIKE, :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY,
     :QUICKHUNT_TARGETS, :UAC_SMITE, :FOG_RETURN, :LOOT_STANCE,
@@ -375,9 +392,9 @@ class Bigshot
       if( type == :FOLLOWER_OVERKILL )
         add_overkill()
         @event_stack.push( Event.new( type, time_stamp, room_id ) ) unless( @event_stack.any? { |a| a.type == type} )
-      else  
+      else
         @event_stack.push( Event.new( type, time_stamp, room_id ) )
-      end  
+      end
     end
   end
 
@@ -946,7 +963,8 @@ class Bigshot
 
   def cmd_spell( incant = nil, id, extra, target )
     echo "cmd_spell" if $bigshot_debug
-    selfcast = false
+    selfcast = spell_is_selfcast?(id)
+
     if ( checkprep != "None" and checkprep != Spell[id].name )
       fput 'release'
     end
@@ -970,21 +988,21 @@ class Bigshot
       $bigshot_should_rest = true
       $rest_reason = "out of mana"
     end
-    selfcast = true if id.to_s =~ /^(?:106|109|115|117|120|130|140|205|206|211|213|215|218|219|220|240|303|307|310|313|314|319|350|401|402|403|404|405|406|414|418|419|425|430|503|506|507|508|509|511|513|515|517|520|535|540|601|602|604|605|606|608|612|613|617|618|620|625|630|640|650|707|712|905|911|913|916|919|1003|1006|1007|1009|1010|1011|1012|1014|1017|1018|1019|1020|1025|1035|1040|1109|1119|1125|1130|1150|1202|1204|1208|1213|1214|1215|1216|1220|1235|1601|1605|1606|1607|1608|1609|1610|1611|1612|1613|1616|1617|1618|1619|1635)$/
+
     waitcastrt?
-    if !incant.nil?
+    if incant.nil?
+      if selfcast
+        Spell[id].cast(Char.name)
+      else
+        Spell[id].cast("##{target.id}")
+      end
+    else
       if XMLData.current_target_id != target.id && selfcast == false
         fput "target ##{target.id}"
       end
       change_stance('offensive') if Spell[id].stance || (id.to_s =~ /1700/i && extra =~ /evoke/i)
       bs_put "incant #{id} #{extra}"
       change_stance(@HUNTING_STANCE)
-    else
-      if selfcast == false
-        Spell[id].cast("##{target.id}")
-      else
-        Spell[id].cast(Char.name)
-      end
     end
   end
 
@@ -1678,7 +1696,7 @@ class Bigshot
     croak_scripts(@HUNTING_SCRIPTS)
 
     @followers.add_event(:RESTING_PREP_COMMANDS)
-    @RESTING_COMMANDS.each { |i| 
+    @RESTING_COMMANDS.each { |i|
       fput(i)
       sleep(0.3)
     }
@@ -1693,7 +1711,7 @@ class Bigshot
 
     if (!solo? && leading?)
       @followers.group_assist( true )
-    end  
+    end
     # loop
     until(should_hunt?)
       @followers.add_event(:DISPLAY_WATCH)
@@ -1800,7 +1818,7 @@ class Bigshot
     elsif(leading?)
       (checkpcs - $grouplist).each { |i| return true unless @followers.get_names.include?(i) }
       if solo? && !$bigshot_quick
-        GameObj.npcs.each { |i| return true if i.type =~ /companion/ && i.name !~ /#{$companion}/i } 
+        GameObj.npcs.each { |i| return true if i.type =~ /companion/ && i.name !~ /#{$companion}/i }
         GameObj.npcs.each { |i| return true if i.type =~ /familiar/ && i.name !~ /#{$familiar}/i }
       end
       return false
@@ -1863,14 +1881,14 @@ class Bigshot
       targets = Hash.new
       tokens = []
       if @QUICKHUNT_TARGETS.nil?
-        @QUICKHUNT_TARGETS = Hash.new 
+        @QUICKHUNT_TARGETS = Hash.new
         @QUICKHUNT_TARGETS["ZZTestZZ"]="ZZTestZZ"
       end
       npcs = GameObj.npcs.find_all { |i| i.status !~ /dead/ }
       npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
       npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
       npcs.each {|i| tokens.push(i.name)}
-      tokens.uniq.each {|i| 
+      tokens.uniq.each {|i|
         if i =~ /#{@QUICKHUNT_TARGETS.keys.join('|')}/i
           next
         else
@@ -1978,9 +1996,9 @@ class Bigshot
         elsif boost_attempt =~ /You have deducted 500 experience points from your field experience/
           $bigshot_lte_boost_counter += 1
           message("Used LTE Boost: #{$bigshot_lte_boost_counter} of #{@LTE_BOOST}")
-          $bigshot_overkill_counter = 0 
+          $bigshot_overkill_counter = 0
         end
-    end  
+    end
   end
 
   def ammo_on_ground(ammo)
@@ -2120,7 +2138,7 @@ class Bigshot
       $bigshot_status = :resting
       return true
     elsif ( !solo? && !leading? && $bigshot_status != :resting && @help_group_kill )
-      return false if !oom?  
+      return false if !oom?
     end
 
     if (leading? && !solo? && fried? && overkill? && lte_boost? )
@@ -2153,11 +2171,11 @@ class Bigshot
       $bigshot_overkill_counter += 1
       message("Extra Kills currently at: #{$bigshot_overkill_counter} of #{@OVERKILL}")
     end
-    
+
     if (!solo? && leading?)
       @followers.add_event(:FOLLOWER_OVERKILL)
-    end  
-  end  
+    end
+  end
 
   def cast_signs(single_cast = false)
     echo "cast_signs?" if $bigshot_debug
@@ -2283,10 +2301,10 @@ class Bigshot
     end
   end
 
-  def CompanionCheck() 
+  def CompanionCheck()
     if ( Char.prof =~ /Ranger/i && Spell[630].known? && GameObj.npcs.any?{|i| i.type =~ /companion/} && $companion == nil )
       npcs = GameObj.npcs.find_all { |i| i.type =~ /companion/i }
-      npcs.each {|i| 
+      npcs.each {|i|
         res = dothistimeout "lean ##{i.id}", 1, /your direction in acknowledgement|rubbing.*gently|while it is flying|You lean toward/i
         if res =~ /rubbing.*gently/i
           $companion = i.name
@@ -2337,11 +2355,11 @@ class Bigshot
     script.want_downstream_xml = restore_want_downstream_xml
     clear
     find_all_containers_var = container_ids.collect { |id| GameObj[id] }
-    find_all_containers_var.each{|i| 
+    find_all_containers_var.each{|i|
       if i.contents.nil?
         fput "look in ##{i.id}"
       end
-      i.contents.each{|s| 
+      i.contents.each{|s|
         if s.name =~ /alfange|basilard|bodkin|cinquedea|dagger|dirk|knife|kozuka|ice pick|misericord|parazonium|pavade|poignard|pugio|scramasax|sgian achlais|spike|stiletto|tanto|sidearm-of-Onar/i
           fput "_drag ##{s.id} right"
           while !checkroom("The Belly of the Beast").nil?


### PR DESCRIPTION
Unnecessary cast to string, unecessary regex, massive one-liner, etc. Also includes Nidal's fix from [here](https://discord.com/channels/226045346399256576/387286877327065108/794212531518308413) but that could use a double-check for accuracy since it's actual functionality.

I haven't tested this.