### PR TITLE
 Add interaction monitor options to specify expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .bundle
 Gemfile.lock
+temp/

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,10 @@
   Version Control:
     Major_change.feature_addition.bugfix
 
+  v4.2.0 (2021-01-03)
+    -Removed 1617 from forced stance change
+    -Added customizable interaction monitoring panel
+
   v4.1.1 (2020-12-31)
     -Added cleanup from selfcast check in bigshot PR #374
     -Included v3.93 updates
@@ -2724,6 +2728,13 @@ class Bigshot
   # gui
   def self.setup
     Gtk.queue do
+      @get_vBox = proc {
+        if Gtk::Version::STRING.chr == '3'
+          Gtk::Box.new(:vertical)
+        else
+          Gtk::VBox.new(false, 0)
+        end
+      }
       @OP_WINDOW = Gtk::Window.new
       @OP_WINDOW.title = "Big Shot: v#{BIGSHOT_VERSION}"
       @OP_WINDOW.set_icon(@default_icon)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.1.1
+       version: 4.2.0
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -109,7 +109,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.1.1' # updated for GTK2 and GTK3
+BIGSHOT_VERSION = '4.2.0' # updated for GTK2 and GTK3
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -1542,7 +1542,7 @@ class Bigshot
   end
 
   def change_stance(new_stance, force = true)
-    return if Spell[1617].active? || Spell[216].active? || dead?
+    return if Spell[216].active? || dead?
 
     if (stance() =~ /#{new_stance}/)
       return

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1483,8 +1483,8 @@ class Bigshot
                         end;
                     end;
                 end;
-                        eos
-                       )
+      eos
+      )
     end
   end
 
@@ -2706,15 +2706,7 @@ class Bigshot
 
   # gui
   def self.setup
-    Gtk.queue {
-      @get_vBox = proc {
-        if Gtk::Version::STRING.chr == '3'
-          Gtk::Box.new(:vertical)
-        else
-          Gtk::VBox.new(false, 0)
-        end
-      }
-
+    Gtk.queue do
       @OP_WINDOW = Gtk::Window.new
       @OP_WINDOW.title = "Big Shot: v#{BIGSHOT_VERSION}"
       @OP_WINDOW.set_icon(@default_icon)
@@ -2728,79 +2720,53 @@ class Bigshot
       @OP_BOX.set_border_width(5)
       @OP_WINDOW.add(@OP_BOX)
 
-      vbox_iter = [*'1'..'11']
-      vbox_iter.each { |val|
-        instance_variable_set("@OP_VERTICAL_BOX#{val}", @get_vBox.call)
-      }
-
       @OP_NOTEBOOK = Gtk::Notebook.new
       @OP_NOTEBOOK.set_show_border(true)
       @OP_NOTEBOOK.override_background_color(:normal, grey) if Gtk::Version::STRING.chr == '3'
       @OP_BOX.add(@OP_NOTEBOOK)
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX1,  Gtk::Label.new('General'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX2,  Gtk::Label.new('Resting'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX3,  Gtk::Label.new('Hunting Map'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX4,  Gtk::Label.new('Hunting'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX5,  Gtk::Label.new('Attacking'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX6,  Gtk::Label.new('Commands'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX7,  Gtk::Label.new('UAC'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX8,  Gtk::Label.new('MSTRIKE'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX9,  Gtk::Label.new('Should_hunt?'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX10, Gtk::Label.new('Should_rest?'))
-      @OP_NOTEBOOK.append_page(@OP_VERTICAL_BOX11, Gtk::Label.new('Ammo/Wands'))
-
       @OP_ENTRY = Hash.new # For mapping entries to variables
       @OP_TABLE_SIZE = Hash.new # For mapping table sizes
-    }
+    end
 
-    Gtk.queue {
-      @get_Table = proc {
-        test = Gtk::Table.new(6, 3, false)
-      }
+    Gtk.queue do
+      tab_names = %w[
+        General
+        Resting
+        Hunting\ Map
+        Hunting
+        Attacking
+        Commands
+        UAC
+        MSTRIKE
+        Should_hunt?
+        Should_rest?
+        Ammo/Wands
+      ]
 
-      table_iter = [*'1'..'11']
-      table_iter.each { |val|
-        instance_variable_set("@OP_TABLE#{val}", @get_Table.call)
-      }
+      tab_names.each.with_index(1) do |name, val|
+        new_table = Gtk::Table.new(6, 3, false).tap do |table|
+          table.row_spacings = 3
+          table.column_spacings = 3
+        end
 
-      @OP_TABLE1.row_spacings = 3  ; @OP_TABLE1.column_spacings = 3
-      @OP_TABLE2.row_spacings = 3  ; @OP_TABLE2.column_spacings = 3
-      @OP_TABLE3.row_spacings = 3  ; @OP_TABLE3.column_spacings = 3
-      @OP_TABLE4.row_spacings = 3  ; @OP_TABLE4.column_spacings = 3
-      @OP_TABLE5.row_spacings = 3  ; @OP_TABLE5.column_spacings = 3
-      @OP_TABLE6.row_spacings = 1  ; @OP_TABLE6.column_spacings = 1
-      @OP_TABLE7.row_spacings = 3  ; @OP_TABLE7.column_spacings = 3
-      @OP_TABLE8.row_spacings = 3  ; @OP_TABLE8.column_spacings = 3
-      @OP_TABLE9.row_spacings = 3  ; @OP_TABLE9.column_spacings = 3
-      @OP_TABLE10.row_spacings = 3 ; @OP_TABLE10.column_spacings = 3
-      @OP_TABLE11.row_spacings = 3 ; @OP_TABLE11.column_spacings = 3
+        new_box = if Gtk::Version::STRING.chr == '3'
+          Gtk::Box.new(:vertical)
+        else
+          Gtk::VBox.new(false, 0)
+        end
 
-      if Gtk::Version::STRING.chr == '3'
-        @OP_VERTICAL_BOX1.pack_start(@OP_TABLE1, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX2.pack_start(@OP_TABLE2, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX3.pack_start(@OP_TABLE3, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX4.pack_start(@OP_TABLE4, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX5.pack_start(@OP_TABLE5, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX6.pack_start(@OP_TABLE6, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX7.pack_start(@OP_TABLE7, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX8.pack_start(@OP_TABLE8, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX9.pack_start(@OP_TABLE9, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX10.pack_start(@OP_TABLE10, :expand => false, :fill => false, :padding => 0)
-        @OP_VERTICAL_BOX11.pack_start(@OP_TABLE11, :expand => false, :fill => false, :padding => 0)
-      else
-        @OP_VERTICAL_BOX1.pack_start(@OP_TABLE1, false, false, 0)
-        @OP_VERTICAL_BOX2.pack_start(@OP_TABLE2, false, false, 0)
-        @OP_VERTICAL_BOX3.pack_start(@OP_TABLE3, false, false, 0)
-        @OP_VERTICAL_BOX4.pack_start(@OP_TABLE4, false, false, 0)
-        @OP_VERTICAL_BOX5.pack_start(@OP_TABLE5, false, false, 0)
-        @OP_VERTICAL_BOX6.pack_start(@OP_TABLE6, false, false, 0)
-        @OP_VERTICAL_BOX7.pack_start(@OP_TABLE7, false, false, 0)
-        @OP_VERTICAL_BOX8.pack_start(@OP_TABLE8, false, false, 0)
-        @OP_VERTICAL_BOX9.pack_start(@OP_TABLE9, false, false, 0)
-        @OP_VERTICAL_BOX10.pack_start(@OP_TABLE10, false, false, 0)
-        @OP_VERTICAL_BOX11.pack_start(@OP_TABLE11, false, false, 0)
+          if Gtk::Version::STRING.chr == '3'
+          new_box.pack_start(new_table, expand: false, fill: false, padding: 0)
+          else
+          new_box.pack_start(new_table, false, false, 0)
+        end
+
+        @OP_NOTEBOOK.append_page(new_box, Gtk::Label.new(name))
+
+        instance_variable_set("@OP_TABLE#{val}", new_table)
+        instance_variable_set("@OP_VERTICAL_BOX#{val}", new_box)
       end
-    }
+    end
 
     def self.add_label_entry(table, label, variable)
       size = @OP_TABLE_SIZE[table] || 0
@@ -2821,21 +2787,17 @@ class Bigshot
     end
 
     def self.add_dropdown(table, dropdown, variable, options)
-      get_cBox = proc {
-        if Gtk::Version::STRING.chr == '3'
-          Gtk::ComboBoxText.new
-        else
-          Gtk::ComboBox.new
-        end
-      }
-
       size = @OP_TABLE_SIZE[table] || 0
       i = 0
+
       label = Gtk::Label.new(dropdown)
-      dropdown = get_cBox.call
-      options.split(',').each { |s|
-        dropdown.append_text(s)
-      }
+      dropdown = if Gtk::Version::STRING.chr == '3'
+        Gtk::ComboBoxText.new
+      else
+        Gtk::ComboBox.new
+      end
+
+      options.split(',').each { |s| dropdown.append_text(s) }
       if UserVars.op[variable].nil?
         dropdown.set_active(0)
       else
@@ -2856,7 +2818,7 @@ class Bigshot
       @OP_TABLE_SIZE[table] += 1
     end
 
-    Gtk.queue {
+    Gtk.queue do
       @OP_ENTRY = Hash.new
       add_label_entry(@OP_TABLE2, "*room id:", 'resting_room_id')
       add_label_entry(@OP_TABLE2, "pre-rest commands:", 'resting_commands')
@@ -2910,7 +2872,7 @@ class Bigshot
       add_label_entry(@OP_TABLE11, "fresh wand container:", 'fresh_wand_container')
       add_label_entry(@OP_TABLE11, "dead wand container:", 'dead_wand_container')
       add_label_entry(@OP_TABLE11, "use this wand type:", 'wand')
-    }
+    end
 
     def self.add_checkbox(table, x_pos, label, variable, default = false)
       size = @OP_TABLE_SIZE[table] || 0
@@ -2922,7 +2884,7 @@ class Bigshot
       @OP_TABLE_SIZE[table] += 1 if x_pos == 1
     end
 
-    Gtk.queue {
+    Gtk.queue do
       add_checkbox(@OP_TABLE1,  0, "Engage deadmans switch", 'dead_man_switch')
       add_checkbox(@OP_TABLE1,  1, "Monitor interaction", 'monitor_interaction')
       add_checkbox(@OP_TABLE1,  0, "Depart/rerun if dead", 'depart_switch')
@@ -2943,15 +2905,15 @@ class Bigshot
       add_checkbox(@OP_TABLE8,  1, "Use QUICKSTRIKE for MSTRIKE", 'mstrike_quickstrike', false)
       add_checkbox(@OP_TABLE11, 1, "Hide while waiting to pick up ammo", 'hide_for_ammo')
       add_checkbox(@OP_TABLE11, 1, "Use wands when out of mana", 'wand_if_oom')
-    }
+    end
 
-    Gtk.queue {
-      @OP_WINDOW.signal_connect("delete_event") {
+    Gtk.queue do
+      @OP_WINDOW.signal_connect("delete_event") do
         @OP_SETUP_COMPLETED = true
-      }
-    }
+      end
+    end
 
-    Gtk.queue {
+    Gtk.queue do
       #      @OP_TOOLTIPS = Gtk::Tooltips.new.enable
 
       label = Gtk::Label.new
@@ -3039,7 +3001,7 @@ class Bigshot
       @OP_TABLE8.attach(align, 1, 2, size, size + 1)
 
       @OP_WINDOW.show_all
-    }
+    end
 
     @OP_SETUP_COMPLETED = false
     until (@OP_SETUP_COMPLETED)
@@ -3047,7 +3009,7 @@ class Bigshot
     end
 
     UserVars.op ||= Hash.new
-    @OP_ENTRY.keys.each { |key|
+    @OP_ENTRY.keys.each do |key|
       echo "#{key} - #{@OP_ENTRY[key].class.to_s}" if $bigshot_debug
       if (@OP_ENTRY[key].class.to_s =~ /CheckButton/)
         value = @OP_ENTRY[key].active?
@@ -3061,12 +3023,12 @@ class Bigshot
           UserVars.op[key] = @OP_ENTRY[key].text.strip.downcase
         end
       end
-    }
+    end
     UserVars.save()
 
-    Gtk.queue {
+    Gtk.queue do
       @OP_WINDOW.destroy
-    }
+    end
   end
 
   def self.profile(vars)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -91,6 +91,19 @@ unless Script.exists?('GameObjAdd')
   sleep(0.5)
 end
 
+if UserVars
+  # First time running a version with monitor strings that can be specified, set up default values
+  if UserVars.op["monitor_strings"].nil?
+    UserVars.op["monitor_strings"] = "SEND||POLICY||[Rr](\s)*[Ee](\s)*[Pp](\s)*[Oo](\s)*[Rr](\s)*[Tt]||speaking to you||unresponsive||taps you||nods to you||lease respond||not in control||violation||lease speak||peak out loud||Y U SHOU D||whispers,||speaking to you||smiles at you||waves to you||grins at you||hugs you||takes hold your hand||grabs your hand||clasps your hand||trying to drag you"
+  end
+
+  if UserVars.op["monitor_safe_strings"].nil?
+    UserVars.op["monitor_safe_strings"] = "\[(?!Private)\w*\]-GS(?:T|IV):||We've noted a troubling increase in bandit activity recently||inviting you to join||Dreavening"
+  end
+
+  UserVars.save
+end
+
 # All Requirements
 require 'yaml'
 require 'drb'
@@ -587,6 +600,8 @@ class Bigshot
     set_value('quickhunt_targets',            'targets',   nil)
     set_value('dead_man_switch',              '',          false)
     set_value('monitor_interaction',          '',          false)
+    set_value('monitor_strings',              'split',     Array.new)
+    set_value('monitor_safe_strings',         'split',     Array.new)
     set_value('depart_switch',                '',          false)
     set_value('encumbered',                   'to_i',      200)
     set_value('signs',                        'split',     Array.new)
@@ -1463,26 +1478,28 @@ class Bigshot
     echo "monitor_interaction" if $bigshot_debug
     if @MONITOR_INTERACTION
       start_exec_script(<<-eos
-                def show_window(line);
-                    window_title = Char.name + ':' + line;
-                    Gtk.queue {
-                        $myWindow = Gtk::Window.new;
-                        $myWindow.title = "Autobot Alert!";
-                        $myWindow.set_size_request(450, 25);
-                        label = Gtk::Label.new window_title;
-                        $myWindow.add(label);
-                        $myWindow.show_all;
-                    };
-                end;
-                while(line = get);
-                    break unless running?($current_script_name);
-                    if(line =~ /SEND|POLICY|[Rr](\s)*[Ee](\s)*[Pp](\s)*[Oo](\s)*[Rr](\s)*[Tt]|peaking to you|unresponsive|taps you|nods to you|lease respond|not in control|character|violation|lease speak|peak out loud|Y U SHOU D|whispers,|speaking to you|smiles at you|waves to you|grins at you|hugs you|takes hold your hand|grabs your hand|clasps your hand|trying to drag you/);
-                        unless(line =~ /LNet/);
-                            show_window(line);
-                            echo "AUTOBOT ALERT: " + line;
-                        end;
-                    end;
-                end;
+        watch_list = /#{@monitor_strings.gsub("||","|")}/io
+        safe_strings = /#{@monitor_safe_strings.gsub("||","|")}/io
+
+        def show_window(line)
+          window_title = Char.name + ':' + line
+          Gtk.queue do
+            $myWindow = Gtk::Window.new
+            $myWindow.title = "Autobot Alert!"
+            $myWindow.set_size_request(450, 25)
+            label = Gtk::Label.new window_title
+            $myWindow.add(label)
+            $myWindow.show_all
+          end
+        end
+
+        while(line = get)
+          break unless running?($current_script_name)
+          if watch_list.match?(line) && !safe_strings.match?(line)
+            show_window(line)
+            echo "AUTOBOT ALERT: " + line
+          end
+        end
       eos
       )
     end
@@ -2741,6 +2758,7 @@ class Bigshot
         Should_hunt?
         Should_rest?
         Ammo/Wands
+        Monitoring
       ]
 
       tab_names.each.with_index(1) do |name, val|
@@ -2755,9 +2773,9 @@ class Bigshot
           Gtk::VBox.new(false, 0)
         end
 
-          if Gtk::Version::STRING.chr == '3'
+        if Gtk::Version::STRING.chr == '3'
           new_box.pack_start(new_table, expand: false, fill: false, padding: 0)
-          else
+        else
           new_box.pack_start(new_table, false, false, 0)
         end
 
@@ -2818,14 +2836,37 @@ class Bigshot
       @OP_TABLE_SIZE[table] += 1
     end
 
+    def self.add_text_area(vbox, label, variable)
+      # Grab value for a manual check since we can't rely on a version of Ruby with safe operators
+      current_value = UserVars.op[variable]
+
+      entry = Gtk::TextView.new
+      entry.buffer.text = current_value ? current_value.gsub("||","\n") : ""
+
+      swin = Gtk::ScrolledWindow.new
+      swin.border_width = 5
+      swin.add(entry)
+      swin.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS)
+
+      frame = Gtk::Frame.new(label)
+      frame.add(swin)
+
+      vbox.pack_start_defaults(frame)
+
+      @OP_ENTRY[variable] = entry
+    end
+
     Gtk.queue do
       @OP_ENTRY = Hash.new
+      # Resting
       add_label_entry(@OP_TABLE2, "*room id:", 'resting_room_id')
       add_label_entry(@OP_TABLE2, "pre-rest commands:", 'resting_commands')
       add_label_entry(@OP_TABLE2, "active resting scripts:", 'resting_scripts')
       add_dropdown(@OP_TABLE2, "Fog Options:", 'fog_return', 'None,Spirit Guide(130),Voln Symbol of Return,Traveler\'s Song(1020)')
+      # Hunting Map
       add_label_entry(@OP_TABLE3, "*starting room ID:", 'hunting_room_id')
       add_label_entry(@OP_TABLE3, "*boundary rooms:", 'hunting_boundaries')
+      # Hunting
       add_label_entry(@OP_TABLE4, "valid targets:", 'targets')
       add_label_entry(@OP_TABLE4, "quickhunt targets:", 'quickhunt_targets')
       add_label_entry(@OP_TABLE4, "attack stance:", 'hunting_stance')
@@ -2834,6 +2875,7 @@ class Bigshot
       add_label_entry(@OP_TABLE4, "society abilities/spells/cmans:", 'signs')
       add_label_entry(@OP_TABLE4, "loot script:", 'loot_script')
       add_label_entry(@OP_TABLE4, "wracking spirit >=", 'wracking_spirit')
+      # Attacking
       add_label_entry(@OP_TABLE5, "Ambush aiming locations (head, etc):", 'ambush')
       add_label_entry(@OP_TABLE5, "Archery aiming locations (head, etc):", 'archery_aim')
       add_label_entry(@OP_TABLE5, "flee if enemy count is >", 'flee_count')
@@ -2841,6 +2883,7 @@ class Bigshot
       add_label_entry(@OP_TABLE5, "...and always flee from:", 'always_flee_from')
       add_label_entry(@OP_TABLE5, "flee from environment message:", 'flee_message')
       add_label_entry(@OP_TABLE5, "Wait before wandering to another room:", 'wander_wait')
+      # Commands
       add_label_entry(@OP_TABLE6, "hunting commands(a):", 'hunting_commands')
       add_label_entry(@OP_TABLE6, "hunting commands(b):", 'hunting_commands_b')
       add_label_entry(@OP_TABLE6, "hunting commands(c):", 'hunting_commands_c')
@@ -2853,31 +2896,40 @@ class Bigshot
       add_label_entry(@OP_TABLE6, "hunting commands(j):", 'hunting_commands_j')
       add_label_entry(@OP_TABLE6, "fried hunting commands:", 'disable_commands')
       add_label_entry(@OP_TABLE6, "quick hunting commands:", 'quick_commands')
+      # UAC
       add_label_entry(@OP_TABLE7, "Tier 3 Attack", 'tier3')
       add_label_entry(@OP_TABLE7, "Aim at location (head, etc)", 'aim')
+      # MStrike
       add_label_entry(@OP_TABLE8, "MSTRIKE during cooldown stamina requirement", 'mstrike_stamina_cooldown')
       add_label_entry(@OP_TABLE8, "QUICKSTRIKE stamina requirement", 'mstrike_stamina_quickstrike')
       add_label_entry(@OP_TABLE8, "Unfocused MSTRIKE when creatures equal or greater", 'mstrike_mob')
+      # Should Hunt?
       add_label_entry(@OP_TABLE9, "*when percentmind <=", 'rest_till_exp')
       add_label_entry(@OP_TABLE9, "...*and percentmana >=", 'rest_till_mana')
       add_label_entry(@OP_TABLE9, "...and CHECKspirit >=", 'rest_till_spirit')
+      # Should Rest?
       add_label_entry(@OP_TABLE10, "*when percentmind >=", 'fried')
       add_label_entry(@OP_TABLE10, "...and extra kills >=", 'overkill')
       add_label_entry(@OP_TABLE10, "...and used lte boosts >=", 'lte_boost')
       add_label_entry(@OP_TABLE10, "...*or percentmana <=", 'oom')
       add_label_entry(@OP_TABLE10, "...or percentencumbrance >=", 'encumbered')
       add_label_entry(@OP_TABLE10, "...or wounded eval:", 'wounded_eval')
+      # Ammo/Wands
       add_label_entry(@OP_TABLE11, "find ammo in this container:", 'ammo_container')
       add_label_entry(@OP_TABLE11, "use this ammo type:", 'ammo')
       add_label_entry(@OP_TABLE11, "fresh wand container:", 'fresh_wand_container')
       add_label_entry(@OP_TABLE11, "dead wand container:", 'dead_wand_container')
       add_label_entry(@OP_TABLE11, "use this wand type:", 'wand')
+      # Monitoring
+      add_text_area(@OP_VERTICAL_BOX12, 'Watch for strings (or regexes) that contain', 'monitor_strings')
+      add_text_area(@OP_VERTICAL_BOX12, '..except if they also contain', 'monitor_safe_strings')
     end
 
     def self.add_checkbox(table, x_pos, label, variable, default = false)
       size = @OP_TABLE_SIZE[table] || 0
+
       checkbox = Gtk::CheckButton.new label
-      value = UserVars.op[variable].nil? ? default : UserVars.op[variable]
+      value = UserVars.op[variable] || default
       checkbox.active = value
       table.attach(checkbox, x_pos, x_pos + 1, size, size + 1)
       @OP_ENTRY[variable] = checkbox
@@ -2885,26 +2937,33 @@ class Bigshot
     end
 
     Gtk.queue do
+      # General
       add_checkbox(@OP_TABLE1,  0, "Engage deadmans switch", 'dead_man_switch')
-      add_checkbox(@OP_TABLE1,  1, "Monitor interaction", 'monitor_interaction')
-      add_checkbox(@OP_TABLE1,  0, "Depart/rerun if dead", 'depart_switch')
       add_checkbox(@OP_TABLE1,  1, "Flee from clouds", 'flee_clouds')
-      add_checkbox(@OP_TABLE1,  0, "Quiet followers", 'quiet_followers', true)
+      add_checkbox(@OP_TABLE1,  0, "Depart/rerun if dead", 'depart_switch')
       add_checkbox(@OP_TABLE1,  1, "Flee from vines", 'flee_vines')
+      add_checkbox(@OP_TABLE1,  0, "Quiet followers", 'quiet_followers', true)
       add_checkbox(@OP_TABLE1,  1, "Flee from webs", 'flee_webs')
+      # Hunting
       add_checkbox(@OP_TABLE4,  0, "Priority hunt", 'priority')
       add_checkbox(@OP_TABLE4,  1, "Use sign of wracking/sigil of power/symbol of mana", 'use_wracking')
       add_checkbox(@OP_TABLE4,  0, "Delay looting", 'delay_loot')
       add_checkbox(@OP_TABLE4,  1, "Defensive stance before looting", 'loot_stance')
       add_checkbox(@OP_TABLE4,  1, "Pull players to feet", 'pull', true)
+      # Attacking
       add_checkbox(@OP_TABLE5,  1, "Spam attacks (recommended)", 'spam', true)
       add_checkbox(@OP_TABLE5,  1, "Approach lone targets only", 'lone_targets_only', false)
       add_checkbox(@OP_TABLE5,  1, "Bless weapon?", 'bless', false)
+      # UAC
       add_checkbox(@OP_TABLE7,  1, "Use Voln SMITE?", 'uac_smite', false)
+      # MStrike
       add_checkbox(@OP_TABLE8,  1, "MSTRIKE during cooldown", 'mstrike_cooldown', false)
       add_checkbox(@OP_TABLE8,  1, "Use QUICKSTRIKE for MSTRIKE", 'mstrike_quickstrike', false)
+      # Ammo/Wands
       add_checkbox(@OP_TABLE11, 1, "Hide while waiting to pick up ammo", 'hide_for_ammo')
       add_checkbox(@OP_TABLE11, 1, "Use wands when out of mana", 'wand_if_oom')
+      # Monitoring
+      add_checkbox(@OP_TABLE12,  0, "Monitor interaction", 'monitor_interaction')
     end
 
     Gtk.queue do
@@ -3011,20 +3070,23 @@ class Bigshot
     UserVars.op ||= Hash.new
     @OP_ENTRY.keys.each do |key|
       echo "#{key} - #{@OP_ENTRY[key].class.to_s}" if $bigshot_debug
-      if (@OP_ENTRY[key].class.to_s =~ /CheckButton/)
+      if @OP_ENTRY[key].class.to_s =~ /CheckButton/
         value = @OP_ENTRY[key].active?
         UserVars.op[key] = @OP_ENTRY[key].active?
-      elsif (@OP_ENTRY[key].class.to_s =~ /ComboBox/)
+      elsif @OP_ENTRY[key].class.to_s =~ /ComboBox/
         UserVars.op[key] = @OP_ENTRY[key].active
+      elsif @OP_ENTRY[key].class.to_s =~ /TextView/
+        # Store these with double pipes so we don't mess up any supplied expressions
+        UserVars.op[key] = @OP_ENTRY[key].buffer.text.gsub("\n","||")
       else
-        if (key == 'wounded_eval')
+        if key == 'wounded_eval'
           UserVars.op[key] = @OP_ENTRY[key].text
         else
           UserVars.op[key] = @OP_ENTRY[key].text.strip.downcase
         end
       end
     end
-    UserVars.save()
+    UserVars.save
 
     Gtk.queue do
       @OP_WINDOW.destroy


### PR DESCRIPTION
I got tired of having the Dreavening line "There is nothing to report at this time, chief." cause an interaction window to pop up.  When I went to add something to the interaction monitor to ignore that, I realized that both the expressions to watch for and the expressions to ignore should be configurable, so I wrote this.

I've moved the options for the interaction monitor to their own settings tab named "Monitoring", and created text areas there for easy editing of multiple expressions.  The joined expressions are split for the text areas but stored as single string.

![new_bigshot_monitor_options](https://user-images.githubusercontent.com/6668113/103472743-d2d21e80-4d45-11eb-9d5d-a98b394a17fa.PNG)

I also did some drying up of the code that creates the settings window to make adding a window easier, and to make the code a little more compliant with the general Ruby community style.