### PR TITLE
bigshot v4.1.2

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.1.1
+       version: 4.1.2
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -96,7 +96,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.1.1' # updated for GTK2 and GTK3
+BIGSHOT_VERSION = '4.1.2' # updated for GTK2 and GTK3
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -1525,7 +1525,7 @@ class Bigshot
   end
 
   def change_stance(new_stance, force = true)
-    return if Spell[1617].active? || Spell[216].active? || dead?
+    return if Spell[216].active? || dead?
 
     if (stance() =~ /#{new_stance}/)
       return


### PR DESCRIPTION
update change_stance routine to not return if zealot is up due to recent spell change.