### PR TITLE
New option to look in boxes before looting and error handling for already unlocked boxes

### DIFF
--- a/scripts/oleani-lib.lic
+++ b/scripts/oleani-lib.lic
@@ -18,9 +18,11 @@ require "forwardable"
      author: elanthia-online
        game: Gemstone
        tags: library
-    version: 0.0.10
+    version: 0.0.11
 
    changelog:
+      0.0.11:
+        Add method for looking in boxes
       0.0.10:
         Fixed invalid method signature to quiet_command and anon_hook
       0.0.9:
@@ -52,7 +54,7 @@ require "forwardable"
 
 =end
 module Oleani
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 
   def self.version
     Gem::Version.new(VERSION)
@@ -1626,6 +1628,10 @@ module Oleani
       def open
         fput "#{@open_verb} ##{@item.id}"
         waitrt?
+      end
+
+      def look_in
+        fput "look in ##{@item.id}"
       end
 
       def loot_coins

--- a/scripts/poolparty.lic
+++ b/scripts/poolparty.lic
@@ -70,6 +70,7 @@
         Added code to better handle looting unknown boxes
         Fixed non-recognized boxes not being moved to your lootsack
  2.11 - Added the option to look into each box before dumping it
+        Fixed error when attempting to hand in an already unlocked box
 
  Use ;version to verify you are not running ruby 2.0 - You need 2.4+
  Seriously, if your ruby is asking you to trust scripts its too old and this wont work.
@@ -132,6 +133,7 @@ module PoolParty
     error :BoxNotEmpty, "Box does not appear to be empty."
     error :NoTrashBin, "Could not find a trashbin"
     error :Overloaded, "You are overloaded."
+    error :AlreadyOpenBox, "Box to hand in is already unlocked"
     error :NoBoxes
 
 
@@ -158,6 +160,7 @@ module PoolParty
 
         cmd.success /^You want a locksmith to open/
         cmd.failure /doesn't appear to be a box\./, NotaBox
+        cmd.failure /is already open/, AlreadyOpenBox
         cmd.failure /we're already holding as many boxes for you as we can/, FullPool
         cmd.nomatch "Something has gone wrong that we can not process.  Please retry poolparty"
       end
@@ -398,12 +401,12 @@ module PoolParty
 
       if current_silvers < (@config.withdraw_amount)
 
-        msg = <<-MSG
-!! [NOTICE]  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [NOTICE] !!
-You do not have the minimum withdraw amount of `#{@config.withdraw_amount}` available.
-You do currently have `#{current_silvers}` on you.
-If you wish to proceed anyways then type: @@;unpause poolparty@@
-Else type: @@;kill poolparty@@
+        msg = <<~MSG
+          !! [NOTICE]  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [NOTICE] !!
+          You do not have the minimum withdraw amount of `#{@config.withdraw_amount}` available.
+          You do currently have `#{current_silvers}` on you.
+          If you wish to proceed anyways then type: @@;unpause poolparty@@
+          Else type: @@;kill poolparty@@
         MSG
 
         Oleani::IO.send(msg)
@@ -420,7 +423,14 @@ Else type: @@;kill poolparty@@
       Oleani::Helpers.deposit_silver(current_silvers) if current_silvers > 0
 
     ensure
-      Oleani::IO.send("**  You deposited #{deposit.count} box(es) into the system. **")
+      Oleani::IO.send("**  You deposited #{deposit.success_count} box(es) into the system. **")
+      if deposit.failed_boxes.length.positive?
+        Oleani::IO.send("@@  Unable to deposit #{deposit.failed_boxes.length} box(es) into the system. @@")
+        Oleani::IO.send("@@  List of boxes you couldn't deposit: @@")
+        deposit.failed_boxes.each do |box|
+          Oleani::IO.send("@@    #{box} @@")
+        end
+      end
       Oleani::IO.send("** [Ending Deposit] **")
     end
   end
@@ -515,20 +525,21 @@ module PoolParty
   end
 
   class Deposit
-    attr_reader :count
+    attr_reader :success_count, :failed_boxes
 
     def initialize(script, tip)
       @script = script
       @tip = tip
       @pool = LocksmithPool.new
-      @count = 0
+      @success_count = 0
+      @failed_boxes = []
       @config = PoolParty.config
     end
 
     def get_box(box)
       Timeout::timeout(4) {
         fput "get ##{box.id}"
-        wait_until {!GameObj.right_hand.id.nil?}
+        wait_until { GameObj.right_hand&.id == box.id }
       }
 
       GameObj.right_hand
@@ -552,6 +563,17 @@ module PoolParty
         }
         attempts += 1
         retry if attempts < 2
+
+        false
+      rescue LocksmithPool::AlreadyOpenBox
+        @failed_boxes << GameObj.right_hand.full_name
+
+        Oleani::IO.send("**This box is already open.**")
+        Oleani::IO.send("**Putting it away for now.**")
+
+        Oleani::Objects::Box.wrap(GameObj.right_hand).move_to(Oleani::Helpers.find_sack)
+
+        false
       end
     end
 
@@ -574,8 +596,7 @@ module PoolParty
 
           next if get_box(box).nil?
 
-          deposit_box
-          @count += 1
+          @success_count += 1 if deposit_box
         }
       }
     end

--- a/scripts/poolparty.lic
+++ b/scripts/poolparty.lic
@@ -69,6 +69,7 @@
         Fixed a typo in the root rescue
         Added code to better handle looting unknown boxes
         Fixed non-recognized boxes not being moved to your lootsack
+ 2.11 - Added the option to look into each box before dumping it
 
  Use ;version to verify you are not running ruby 2.0 - You need 2.4+
  Seriously, if your ruby is asking you to trust scripts its too old and this wont work.
@@ -269,7 +270,7 @@ module PoolParty
 end
 
 module PoolParty
-  VERSION = "2.0.10"
+  VERSION = "2.0.11"
 
   def self.version
     Gem::Version.new(VERSION)
@@ -278,7 +279,8 @@ module PoolParty
   class Config
     #include Oleani::Record
 
-    attr_reader :tip_type, :withdraw_amount, :start_room, :deposit_all, :skip_disk_wait, :tip_amount, :loot_command, :options
+    attr_reader :tip_type, :withdraw_amount, :start_room, :deposit_all, :skip_disk_wait,
+                :tip_amount, :loot_command, :options, :look_in_box
 
     def self.assertbool(value, msg)
       raise ArgumentError.new(msg) if value.downcase.strip != ~/true|false/
@@ -296,6 +298,12 @@ module PoolParty
       @deposit_all = CharSettings['deposit_all']
     end
 
+    def toggle_look_in_box
+      CharSettings['look_in_box'] = !@look_in_box
+
+      @look_in_box = CharSettings['look_in_box']
+    end
+
     def toggle_loot_commamd
       CharSettings['loot_command'] = !@loot_command
 
@@ -305,6 +313,7 @@ module PoolParty
 
     def initialize(start_room)
       @start_room = start_room
+      @look_in_box = CharSettings['look_in_box'] ||= false
       @loot_command = CharSettings['loot_command'] ||= false
       @tip_amount = CharSettings['tip_amount'] ||= "25"
       @tip_type = CharSettings['tip_type'] ||= "percent"
@@ -442,6 +451,7 @@ module PoolParty
       @lootsack = lootsack
       @max = max
       @count = 0
+      @config = PoolParty.config
     end
 
     def loot_box(box, override = false)
@@ -453,6 +463,8 @@ module PoolParty
       end
 
       box.loot_coins
+
+      box.look_in if @config.look_in_box
 
       box.loot if @config.loot_command
 
@@ -510,6 +522,7 @@ module PoolParty
       @tip = tip
       @pool = LocksmithPool.new
       @count = 0
+      @config = PoolParty.config
     end
 
     def get_box(box)
@@ -535,7 +548,7 @@ module PoolParty
 
         Oleani::Transit.return_after {
           current_silvers = Oleani::Helpers.check_silvers
-          Oleani::Helpers.withdraw(PoolParty.config.withdraw_amount - current_silvers) if current_silvers < PoolParty.config.withdraw_amount.withdraw_amount
+          Oleani::Helpers.withdraw(@config.withdraw_amount - current_silvers) if current_silvers < @config.withdraw_amount.withdraw_amount
         }
         attempts += 1
         retry if attempts < 2
@@ -617,6 +630,16 @@ optsx = Slop.new strict: true do
       Oleani::IO.send("**You have chosen to deposit all silvers when finished.**")
     else
       Oleani::IO.send("**You have chosen to** !!NOT!! **deposit all silvers when finished.**")
+    end
+  end
+
+  on 'look-in-box', "Look in boxes prior to dumping them into containers,\n#{' ' * 34}**Currently:**[`#{PoolParty.config.look_in_box.to_s.upcase}`]" do |opt, args|
+    PoolParty.config.toggle_look_in_box
+
+    if PoolParty.config.look_in_box
+      Oleani::IO.send("**You have chosen to look in boxes before dumping their contents.**")
+    else
+      Oleani::IO.send("**You have chosen to** !!NOT!! **look in boxes before dumping their contents.**")
     end
   end
 

--- a/scripts/poolparty.lic
+++ b/scripts/poolparty.lic
@@ -84,7 +84,7 @@
 begin
   raise "Oleani is missing" unless Script.exists? "oleani-lib.lic"
   load 'scripts/oleani-lib.lic'
-  raise "Oleani version is out of date" if Oleani::version < Gem::Version.new('0.0.10')
+  raise "Oleani version is out of date" if Oleani::version < Gem::Version.new('0.0.11')
 rescue => error
   echo error.message
   echo "Downloading Oleani-lib.lic"

--- a/scripts/poolparty.lic
+++ b/scripts/poolparty.lic
@@ -10,7 +10,7 @@
  author: elanthia-online
 
  tags: locksmith, picker, pool, locksmith pool, picking, boxes, loot, locksmith, locksmithing, rogue
- version: 2.10
+ version: 2.11
 
  Original work done by Glaves, but now maintained via elanthia-online
 


### PR DESCRIPTION
I added a new option flag to toggle looking in each box prior to looting it (--look-in-box), which is set to false by default to maintain the current behavior.  
Fixes #355 

![poolparty_look_in_box_option](https://user-images.githubusercontent.com/6668113/103592827-ef3a9c00-4ea8-11eb-8d97-0e43b0f8ee64.PNG)

Additionally, added a new error and handling code for attempting to deposit a box which is already unlocked.  If this happens, the box is placed back in the loot sack and additional information is printed at the end of the deposit step.  If no such failures occur the print out at the end of the step is the same as before.

![poolparty_failed_boxes_printout](https://user-images.githubusercontent.com/6668113/103592835-f366b980-4ea8-11eb-93c8-56f5494364cf.PNG)
