### PR TITLE
chore: set up GitHub action to run build and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build and Test
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '20'
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Setup bundler cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+      - name: Install ruby gem dependencies with bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run type data migrations to create gameobj-data.xml
+        run: bin/migrate
+      - name: Run RSpec tests
+        run: bundle exec rspec
+      - name: Release updates to Tillmen's Lich repository
+        if: github.ref == 'refs/heads/master'
+        env:
+          AUTHOR: ${{ secrets.repo_author }}
+          PASSWORD: ${{ secrets.repo_password }}
+          TRAVIS_COMMIT: ${{ github.sha }}
+          TRAVIS_COMMIT_RANGE: ${{ github.event.before }}..${{ github.sha }}
+        run: bin/repo


### PR DESCRIPTION
Sets up a workflow to run tests and push releases to Tillmen's repo. Right now both this and Travis will run but I plan on disabling Travis soon if the GH version seems like its working.