### PR TITLE
jinx: enable specs to run with and without mocked external API

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,0 +1,30 @@
+name: smoke_test
+on:
+  schedule:
+    - cron: '*/37 * * * *'
+
+jobs:
+  jinx:
+    name: Jinx Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Setup bundler cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install ruby gem dependencies with bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run Jinx spec against live servers
+        run: bundle exec rspec spec/jinx/jinx_spec.rb
+        env:
+          ENABLE_EXTERNAL_NETWORKING: true

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ group :development do
   gem "rspec"
   gem "guard"
   gem "guard-rspec"
+  gem "webmock"
+  gem "rack"
 end

--- a/spec/jinx/repos/archive/assets/noop.lic
+++ b/spec/jinx/repos/archive/assets/noop.lic
@@ -1,0 +1,13 @@
+=begin
+        A simple script to allow for learning elanthia-online integration
+        with Github + CI environments.
+ 
+              author: elanthia-online
+                game: Gemstone
+                tags: testing
+             version: 1.0
+ 
+		To help contribute: https://github.com/elanthia-online/scripts
+=end
+
+exit

--- a/spec/jinx/repos/archive/headers/noop.header
+++ b/spec/jinx/repos/archive/headers/noop.header
@@ -1,0 +1,9 @@
+        A simple script to allow for learning elanthia-online integration
+        with Github + CI environments.
+ 
+              author: elanthia-online
+                game: Gemstone
+                tags: testing
+             version: 1.0
+ 
+		To help contribute: https://github.com/elanthia-online/scripts

--- a/spec/jinx/repos/archive/manifest.json
+++ b/spec/jinx/repos/archive/manifest.json
@@ -1,0 +1,11067 @@
+{
+    "available": [
+        {
+            "file": "/assets/salert.lic",
+            "type": "script",
+            "md5": "Gus16lCa3k0sP/7kJGYyl1zykFc=",
+            "last_commit": 1607807382,
+            "header": "/headers/salert.header",
+            "tags": [
+                "scripting",
+                "alert"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/Anchor_1020.lic",
+            "type": "script",
+            "md5": "ALFaqttUVLvr7nSy2lY/fJ4IHzY=",
+            "last_commit": 1607807382,
+            "header": "/headers/Anchor_1020.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rnum.lic",
+            "type": "script",
+            "md5": "PX+17fRKF3AD1y4nmhe+qTzSeLM=",
+            "last_commit": 1607807382,
+            "header": "/headers/rnum.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lockdown.lic",
+            "type": "script",
+            "md5": "I3U3YvLkK3J/KwTcRWvp2/v23qc=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockdown.header",
+            "tags": [
+                "lockers"
+            ],
+            "version": "1.0",
+            "author": "m444w"
+        },
+        {
+            "file": "/assets/alias.lic",
+            "type": "script",
+            "md5": "cSs8bt8/fj+r6kp1c/x8tc1rT1g=",
+            "last_commit": 1607807382,
+            "header": "/headers/alias.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.8",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/look.lic",
+            "type": "script",
+            "md5": "HWqz30/Lsz3OefpV3c3PgjU+kbs=",
+            "last_commit": 1607807382,
+            "header": "/headers/look.header",
+            "tags": [
+                "look"
+            ],
+            "version": "0.3",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/xraffle.lic",
+            "type": "script",
+            "md5": "Gf+noaGk92zQkZFIgyeL9QvV7B4=",
+            "last_commit": 1607807382,
+            "header": "/headers/xraffle.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1.1 (2019-10-20)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/drjunk.lic",
+            "type": "script",
+            "md5": "0dIpXSn4hgZ6feBA7hIjACEN6AE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/inactivespells.lic",
+            "type": "script",
+            "md5": "fP8t1QPwxB7DyR/2EiI1U0gOBHA=",
+            "last_commit": 1607807382,
+            "header": "/headers/inactivespells.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/dechanter.lic",
+            "type": "script",
+            "md5": "FILpaDnW1PYanovsAYT2eGba1HY=",
+            "last_commit": 1607807382,
+            "header": "/headers/dechanter.header",
+            "tags": [
+                "enchant",
+                "enchanting",
+                "QRT",
+                "reference",
+                "tool",
+                "calculate",
+                "925",
+                "potion",
+                "temper",
+                "water lore",
+                "wizard"
+            ],
+            "version": "1.0.1",
+            "author": "Claudaro"
+        },
+        {
+            "file": "/assets/biggus.lic",
+            "type": "script",
+            "md5": "/nkqu8le3JXX5JQvBoPcfpGVYKM=",
+            "last_commit": 1607807382,
+            "header": "/headers/biggus.header",
+            "tags": [
+                "hunting",
+                "bigshot"
+            ],
+            "version": "1.1",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/whisperbuffs.lic",
+            "type": "script",
+            "md5": "jpBYl16045oFx5pGNiPI9I2WxKc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/deathlocation.lic",
+            "type": "script",
+            "md5": "ok36C/2OvidnZ78O7SsFGa69sJg=",
+            "last_commit": 1607807382,
+            "header": "/headers/deathlocation.header",
+            "tags": [
+                "death"
+            ],
+            "version": "0.4",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/spitfirequest2015.lic",
+            "type": "script",
+            "md5": "VoqlXlNrlzP1q8KCm1jK9dxiXPI=",
+            "last_commit": 1607807382,
+            "header": "/headers/spitfirequest2015.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/get_deeds.lic",
+            "type": "script",
+            "md5": "0MibRpde7GNx51iuy7mXHb9mZw8=",
+            "last_commit": 1607807382,
+            "header": "/headers/get_deeds.header",
+            "tags": [],
+            "version": "0.9b",
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/ctt_win.lic",
+            "type": "script",
+            "md5": "N4s7rTARJi62cl0hAjrzswG3kuE=",
+            "last_commit": 1607807382,
+            "header": "/headers/ctt_win.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/enchantnotes.lic",
+            "type": "script",
+            "md5": "C5VA3/3MV2CJ0mQF1Bg2lHrGJkk=",
+            "last_commit": 1607807382,
+            "header": "/headers/enchantnotes.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/allnpcs.lic",
+            "type": "script",
+            "md5": "ERy23uGcBXpy3eKEKwOTDCL9gT0=",
+            "last_commit": 1607807382,
+            "header": "/headers/allnpcs.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rest.lic",
+            "type": "script",
+            "md5": "BydAiYw9ZzW8NnOHtLhNJeoF390=",
+            "last_commit": 1607807382,
+            "header": "/headers/rest.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/famgo2.lic",
+            "type": "script",
+            "md5": "tFl3hIOyB3tlal5xMdNhefNqUjo=",
+            "last_commit": 1607807382,
+            "header": "/headers/famgo2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/calc-td-offset.lic",
+            "type": "script",
+            "md5": "HmEkRlCDWJC7R7DR0jBaxL5YJ5Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/calc-td-offset.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/yakloot.lic",
+            "type": "script",
+            "md5": "FbplFA84IuKq7w6vmdP3gbxaRKk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/Melgorehn.lic",
+            "type": "script",
+            "md5": "wG1/oAe5vfkxOa/9l5IGBsIl6/Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/Melgorehn.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/sniper.lic",
+            "type": "script",
+            "md5": "QzIGFs0Hj4zbPXPBp/TqiFyu+Yc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/recover_item.lic",
+            "type": "script",
+            "md5": "Cn85g/oC7Aj5jC69PBpknCF/fl0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/queue.lic",
+            "type": "script",
+            "md5": "l328KTNdzRo2YQO+X+7FDc/xbs4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xfletch.lic",
+            "type": "script",
+            "md5": "zJ8XurRKAN3TPi4PNPE/xokGKLQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/colmaster.lic",
+            "type": "script",
+            "md5": "g7stv07NzLwCZlBhYe+VIkKHZVQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/colmaster.header",
+            "tags": [],
+            "version": "14",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/UBW-Theme-Dude.lic",
+            "type": "script",
+            "md5": "XsdpkFAMg1KbZ6AacBOkvaAMBP0=",
+            "last_commit": 1607807382,
+            "header": "/headers/UBW-Theme-Dude.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/jarserve_set_jarsacks.lic",
+            "type": "script",
+            "md5": "d8xSJgBT16DlCp8aaJz4ApOU8N4=",
+            "last_commit": 1607807382,
+            "header": "/headers/jarserve_set_jarsacks.header",
+            "tags": [
+                "jarserve"
+            ],
+            "version": "1",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/pause.lic",
+            "type": "script",
+            "md5": "vv52T8y88Buh3CeIjaTZBCqoR1A=",
+            "last_commit": 1607807382,
+            "header": "/headers/pause.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/celerity.lic",
+            "type": "script",
+            "md5": "u1md6bFl+k8lJPd1UGcHsoFSqWs=",
+            "last_commit": 1607807382,
+            "header": "/headers/celerity.header",
+            "tags": [
+                "wizard",
+                "506",
+                "haste"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/dead_keepalive.lic",
+            "type": "script",
+            "md5": "3QpzWRg3oA3N7bQfV+9df6ej6Fc=",
+            "last_commit": 1607807382,
+            "header": "/headers/dead_keepalive.header",
+            "tags": [
+                "dead",
+                "keepalive"
+            ],
+            "version": "3",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/powersong.lic",
+            "type": "script",
+            "md5": "1qiXEJNYyk36A0dsvkpN37/WNgE=",
+            "last_commit": 1607807382,
+            "header": "/headers/powersong.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/slats.lic",
+            "type": "script",
+            "md5": "NlhK8+4m0Ziz+ksXIWAviwxfjKM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/surge.lic",
+            "type": "script",
+            "md5": "DuRRISnXpA/5AY5jkS6+VWDDxBY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hotpot.lic",
+            "type": "script",
+            "md5": "Wsa/krkBBcVh6l82ZsemimlFWhQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/nerve.lic",
+            "type": "script",
+            "md5": "KoT3HB1N88R5CGenNxxBOVMp/Qo=",
+            "last_commit": 1607807382,
+            "header": "/headers/nerve.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/polish.cmd",
+            "type": "data",
+            "md5": "I+EJB/fcyLTI4J0vpK8oR4vAeWg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/menuid.lic",
+            "type": "script",
+            "md5": "qXpaC3gF/R5J5ffaM390xIhkSN0=",
+            "last_commit": 1607807382,
+            "header": "/headers/menuid.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-05-24)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/rogue-lmas-clasp.lic",
+            "type": "script",
+            "md5": "NWrr9DxQcock6QwdhXWfnQJ7fxs=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-clasp.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/shake.lic",
+            "type": "script",
+            "md5": "uuH4Olz9cw8i5bABi6zlIMwmspo=",
+            "last_commit": 1607807382,
+            "header": "/headers/shake.header",
+            "tags": [
+                "utility",
+                "jar"
+            ],
+            "version": "0.4 (2019-06-27)",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/swaysout.lic",
+            "type": "script",
+            "md5": "6y/He0u8yt1wOx0H41sfJ0/gYK0=",
+            "last_commit": 1607807382,
+            "header": "/headers/swaysout.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/wutang.lic",
+            "type": "script",
+            "md5": "3uURXVzA30iTHagcze7zomZe9+Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tpick.lic",
+            "type": "script",
+            "md5": "hhSm8AxkmeWMujbh8R4eEiUSYBA=",
+            "last_commit": 1608008291,
+            "header": "/headers/tpick.header",
+            "tags": [],
+            "version": "277",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/cantrips.lic",
+            "type": "script",
+            "md5": "v5loGehm3v7EqvjENJgEIXoZaVs=",
+            "last_commit": 1607807382,
+            "header": "/headers/cantrips.header",
+            "tags": [],
+            "version": "2015.05.27.01",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/auto_sort.lic",
+            "type": "script",
+            "md5": "aRtcqYRsZT1JEHPzaeuFaNxdC1A=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/raging_thrak.lic",
+            "type": "script",
+            "md5": "Si5RSu8MGoayaXvRfa6ZEFTT5WU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/symmanaloop.lic",
+            "type": "script",
+            "md5": "n9MePKkU+PRIJUf3P8VlFE9EQaE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/watch-locker.lic",
+            "type": "script",
+            "md5": "VUl1AaDO9DRCWRYlk9v6MEipwN4=",
+            "last_commit": 1607807382,
+            "header": "/headers/watch-locker.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Tillmen"
+        },
+        {
+            "file": "/assets/ph_timer.lic",
+            "type": "script",
+            "md5": "YODmqCIAnT1giriSfy1T1czXeEc=",
+            "last_commit": 1607807382,
+            "header": "/headers/ph_timer.header",
+            "tags": [
+                "duskruin",
+                "assassin",
+                "timer"
+            ],
+            "version": "1.1",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/archaeologist.lic",
+            "type": "script",
+            "md5": "a9BqN+saAqN94KJ8Z4EjupR7wu0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/petalbless.lic",
+            "type": "script",
+            "md5": "NJef20E5ef16NzgffH3RXEjjCEo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/markchargable.lic",
+            "type": "script",
+            "md5": "He7eCwKTri71df53/AL4G+HTJa8=",
+            "last_commit": 1607807382,
+            "header": "/headers/markchargable.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/qverb.lic",
+            "type": "script",
+            "md5": "bhkYFudJ9d4XLWjYNYVTsRuHUn0=",
+            "last_commit": 1607807382,
+            "header": "/headers/qverb.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-05-28)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/lajespur.lic",
+            "type": "script",
+            "md5": "gLdmI8hRfAdXQK6UCEqIygMByd4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/herbheal.lic",
+            "type": "script",
+            "md5": "3vvnICKsrZatYoCfN1ND73nnNkE=",
+            "last_commit": 1607807382,
+            "header": "/headers/herbheal.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/posthunt.lic",
+            "type": "script",
+            "md5": "x0lOWf420KtM/hGdTrz4T/eGbLk=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/ldnotebundle.lic",
+            "type": "script",
+            "md5": "bGQRu5J2OqABA3cS5PNHfUhHx68=",
+            "last_commit": 1607807382,
+            "header": "/headers/ldnotebundle.header",
+            "tags": [
+                "notes",
+                "lighten",
+                "deepen",
+                "bundle"
+            ],
+            "version": "1.0",
+            "author": "Claudaro"
+        },
+        {
+            "file": "/assets/uberspells_no_lumnis.lic",
+            "type": "script",
+            "md5": "2yoTo1gunSddudiPcRVzA5BGXAw=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberspells_no_lumnis.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/grgvars.lic",
+            "type": "script",
+            "md5": "Rx67a3JANJ9aAmf4IoE6sbRCiQI=",
+            "last_commit": 1607807382,
+            "header": "/headers/grgvars.header",
+            "tags": [
+                "rogue",
+                "utility",
+                "guild",
+                "awesome"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/bloodrunes.lic",
+            "type": "script",
+            "md5": "9DcRDn6awk3MGsrHLICGLPSqb2I=",
+            "last_commit": 1607807382,
+            "header": "/headers/bloodrunes.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/forge_loop.lic",
+            "type": "script",
+            "md5": "G3CUOsuHrw+Lp0bI7uPkEeMMASE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/medwaggle.lic",
+            "type": "script",
+            "md5": "dLJ3EXL9A0RTx8106N8J/d9iLoY=",
+            "last_commit": 1607807382,
+            "header": "/headers/medwaggle.header",
+            "tags": [
+                "spells",
+                "utility",
+                "empath",
+                "cleric",
+                "waggle"
+            ],
+            "version": "3",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/twarrior.lic",
+            "type": "script",
+            "md5": "Qx7SYiHDZHrsGtCqkaGrUpD1bd4=",
+            "last_commit": 1607807382,
+            "header": "/headers/twarrior.header",
+            "tags": [],
+            "version": "87",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/zealous.lic",
+            "type": "script",
+            "md5": "ijPcDOl5sRh0/gSF0NaDAwcvPSQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/zealous.header",
+            "tags": [
+                "Zeal",
+                "1650",
+                "Paladin"
+            ],
+            "version": "1.0b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/test.lic",
+            "type": "script",
+            "md5": "CHkHVon6TcjNqLNjQ3uC0/PNakY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/capacityall.lic",
+            "type": "script",
+            "md5": "Hr2noGsQgBdkzt6hKQE9MKpni5o=",
+            "last_commit": 1607807382,
+            "header": "/headers/capacityall.header",
+            "tags": [
+                "capacity",
+                "container",
+                "lighten",
+                "deepen",
+                "note",
+                "max"
+            ],
+            "version": "1.0",
+            "author": "Soliere"
+        },
+        {
+            "file": "/assets/gemsort2.lic",
+            "type": "script",
+            "md5": "HXxt/yWySrGEFCHLmr/deqRPf4M=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemsort2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/cleric325.lic",
+            "type": "script",
+            "md5": "ESgoKr8S/t02ATgcZDtcqNjoHW8=",
+            "last_commit": 1607807382,
+            "header": "/headers/cleric325.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/trollspeak.lic",
+            "type": "script",
+            "md5": "UFL1g30Bmmsu5vMAtdSAc9NuS5I=",
+            "last_commit": 1607807382,
+            "header": "/headers/trollspeak.header",
+            "tags": [
+                "speech"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/raging_thrak",
+            "type": "data",
+            "md5": "Si5RSu8MGoayaXvRfa6ZEFTT5WU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/find_open_locker.lic",
+            "type": "script",
+            "md5": "d7HSFtr7STRo9fpDb37wRX7vrHA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tfortress.lic",
+            "type": "script",
+            "md5": "MWkno91zuVGM1uPokZfs79zRbJ8=",
+            "last_commit": 1607807382,
+            "header": "/headers/tfortress.header",
+            "tags": [
+                "reim",
+                "rfd",
+                "fortress",
+                "fortress defense"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/findsal.lic",
+            "type": "script",
+            "md5": "bp7nSNp2RMetm+tCTrUl2ohKtDs=",
+            "last_commit": 1607807382,
+            "header": "/headers/findsal.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/tethereal.lic",
+            "type": "script",
+            "md5": "7Ps7H3JhTaYJrE9ICKnTI8+t3S4=",
+            "last_commit": 1607807382,
+            "header": "/headers/tethereal.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/escape_voln_hermit.lic",
+            "type": "script",
+            "md5": "3+IW9pAAQhjpFN9fl/dO/7tt7K8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/702deolinda.lic",
+            "type": "script",
+            "md5": "z1v7h/YqkFeMmEsYQBXPIVsf9Sk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/vaalor_document.lic",
+            "type": "script",
+            "md5": "VEnx0ocqm4axUKhGmE+0HNUpjU0=",
+            "last_commit": 1607807382,
+            "header": "/headers/vaalor_document.header",
+            "tags": [
+                "Utility",
+                "Ta'Vaalor",
+                "document"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/fletching.lic",
+            "type": "script",
+            "md5": "x5sJS1wIZQRRnxsX1wubBno5re4=",
+            "last_commit": 1607807382,
+            "header": "/headers/fletching.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/unlock.lic",
+            "type": "script",
+            "md5": "+KKT+QPPZH4MOcyvVw83qcHooik=",
+            "last_commit": 1607807382,
+            "header": "/headers/unlock.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/weaponsaver.lic",
+            "type": "script",
+            "md5": "5WcGskYf7Ss2LmEiGS4WFjCoOSQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/totalsolution.lic",
+            "type": "script",
+            "md5": "gJl9Pb1VCAVOTg+AQ+RESO//rGE=",
+            "last_commit": 1607807382,
+            "header": "/headers/totalsolution.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Old_UberBarWiz.lic",
+            "type": "script",
+            "md5": "9Stph/nubxY44D+htJ4pyA2PHnI=",
+            "last_commit": 1607807382,
+            "header": "/headers/Old_UberBarWiz.header",
+            "tags": [],
+            "author": "Deathravin"
+        },
+        {
+            "file": "/assets/celeryme.lic",
+            "type": "script",
+            "md5": "ST/tu508H03NBPKU/2dbi0Ur0yc=",
+            "last_commit": 1607807382,
+            "header": "/headers/celeryme.header",
+            "tags": [
+                "hunting",
+                "combat",
+                "magic",
+                "utility",
+                "506",
+                "celerity"
+            ],
+            "version": "1",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/postcapgoal.lic",
+            "type": "script",
+            "md5": "z8CjgWcDb5sOm8EFBCL4/dQZnXI=",
+            "last_commit": 1607807382,
+            "header": "/headers/postcapgoal.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/foliod.lic",
+            "type": "script",
+            "md5": "PoSApHd8fgKKjNZ8asiOpngq734=",
+            "last_commit": 1607807382,
+            "header": "/headers/foliod.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.1",
+            "author": "Steworaeus"
+        },
+        {
+            "file": "/assets/sebp.lic",
+            "type": "script",
+            "md5": "UJtzXI5+h9Xp26HK7lGwwWgk1uM=",
+            "last_commit": 1607807382,
+            "header": "/headers/sebp.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "2.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/picking_exp.lic",
+            "type": "script",
+            "md5": "ALte7XKVgSFclkeM8iBodsNNd/c=",
+            "last_commit": 1607807382,
+            "header": "/headers/picking_exp.header",
+            "tags": [
+                "lockpicking",
+                "rogue",
+                "stats",
+                "utility"
+            ],
+            "version": "2",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/restring.lic",
+            "type": "script",
+            "md5": "aHnzbh1Va4Xov3DDrIHGd1XCMUo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/flaskbundle.lic",
+            "type": "script",
+            "md5": "PXr+1y8ZdHvoZvpMTJfazmQvuZU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/volnstep.lic",
+            "type": "script",
+            "md5": "dh3AOxtpv0x5i3MRoFF78+K35JA=",
+            "last_commit": 1607807382,
+            "header": "/headers/volnstep.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/duskclean.lic",
+            "type": "script",
+            "md5": "J/oYwZHa5n3lkf9uaCEA/mmZjf8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/uberspells.lic",
+            "type": "script",
+            "md5": "X4ateelcS0yOgiu2k5BjoxpGb+s=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberspells.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wizbot.lic",
+            "type": "script",
+            "md5": "oQTPUynKpCH5DdO9eVd/y7y/oCs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/burst.lic",
+            "type": "script",
+            "md5": "FReBqNNDvIm7jnxpFa5vAyg47bM=",
+            "last_commit": 1607807382,
+            "header": "/headers/burst.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/inquisition.lic",
+            "type": "script",
+            "md5": "ioKc21IJ56g9wejibiMF/U18EOY=",
+            "last_commit": 1607807382,
+            "header": "/headers/inquisition.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autosort.lic",
+            "type": "script",
+            "md5": "9xN9DGHMFweYytFWK9sGN5BzpNU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rrherbs.lic",
+            "type": "script",
+            "md5": "J8Fh/H1agD3X4+8CX331FkTLkzA=",
+            "last_commit": 1607807382,
+            "header": "/headers/rrherbs.header",
+            "tags": [
+                "river's rest",
+                "herbs"
+            ],
+            "version": "0.2",
+            "author": "Xanthras"
+        },
+        {
+            "file": "/assets/ruby-deed.lic",
+            "type": "script",
+            "md5": "sAmySb3yRPIayr0mTXphDdVt1Co=",
+            "last_commit": 1607807382,
+            "header": "/headers/ruby-deed.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Tillmen"
+        },
+        {
+            "file": "/assets/mapnav.lic",
+            "type": "script",
+            "md5": "zFR6CWU/stCDHhcMK2CUPEUU79Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/mapnav.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.1.1",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/essence.lic",
+            "type": "script",
+            "md5": "nEvTNiKzcvXEH9wdPzdd7flF/h4=",
+            "last_commit": 1607807382,
+            "header": "/headers/essence.header",
+            "tags": [
+                "925"
+            ],
+            "version": "2019.05.07.04",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/dr_sewers3.lic",
+            "type": "script",
+            "md5": "jj8EAHy97v0LY0H3g3eRc37WdOk=",
+            "last_commit": 1607807382,
+            "header": "/headers/dr_sewers3.header",
+            "tags": [],
+            "author": "Brav"
+        },
+        {
+            "file": "/assets/crumbly.lic",
+            "type": "script",
+            "md5": "oGUKw0MbzZMNhaG9Gl7yz0Lo9OA=",
+            "last_commit": 1607807382,
+            "header": "/headers/crumbly.header",
+            "tags": [
+                "enhancive",
+                "items"
+            ],
+            "version": "1.2",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/uberbarv.lic",
+            "type": "script",
+            "md5": "tZgCf1WVOBmSneaJ2CgBbqgrqM0=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberbarv.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pure.lic",
+            "type": "script",
+            "md5": "krmG5zTbENbhqJWt6b0rqyZsYDo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/beaker.lic",
+            "type": "script",
+            "md5": "FHaPj79ZFXLLnLnlagoGrSUapIg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/invdb.lic",
+            "type": "script",
+            "md5": "GRMoQUc1a/rTeR+sQ44h78F8iUo=",
+            "last_commit": 1607807382,
+            "header": "/headers/invdb.header",
+            "tags": [
+                "inventory",
+                "utility",
+                "database"
+            ],
+            "version": "0.3.1.3",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/burge.lic",
+            "type": "script",
+            "md5": "L0CaRbTRUIekX3K/gsxDExBT7Sc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/teartracker.lic",
+            "type": "script",
+            "md5": "iodejLxSKowv35KHiVQanDZ+JLg=",
+            "last_commit": 1607807382,
+            "header": "/headers/teartracker.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/spellcaster.lic",
+            "type": "script",
+            "md5": "YTU7aLEzjEUPV4wNyBSxao5eZ/s=",
+            "last_commit": 1607807382,
+            "header": "/headers/spellcaster.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/deeds.lic",
+            "type": "script",
+            "md5": "ImviJ4lCmZtd17spKgcP60VkNBg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/complete-char-info.lic",
+            "type": "script",
+            "md5": "GY6NdmFFm2ja3fSj2fRw9kQ2pKs=",
+            "last_commit": 1607807382,
+            "header": "/headers/complete-char-info.header",
+            "tags": [],
+            "version": "7",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/no-pronoun-links.lic",
+            "type": "script",
+            "md5": "CJNbIm7SCeECEXT1E/JJNyJg2GA=",
+            "last_commit": 1607807382,
+            "header": "/headers/no-pronoun-links.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-07-21)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/cure.lic",
+            "type": "script",
+            "md5": "oyX2rLb9FRN9oe00HIjCyiQdcm4=",
+            "last_commit": 1607807382,
+            "header": "/headers/cure.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/burst_calc.lic",
+            "type": "script",
+            "md5": "xA16dwmgfhzf0VMsEyRjnDy/8xQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/burst_calc.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autostay.lic",
+            "type": "script",
+            "md5": "hGF99nv8M8NdvxPx/zIFlAzCAe4=",
+            "last_commit": 1607807382,
+            "header": "/headers/autostay.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/PurifyL.lic",
+            "type": "script",
+            "md5": "PM1k24a+b2ELOZahJGU8Cu7Wlgk=",
+            "last_commit": 1607807382,
+            "header": "/headers/PurifyL.header",
+            "tags": [],
+            "author": "Leafiara; previous versions by Aethor, Gibreficul, Shaelun"
+        },
+        {
+            "file": "/assets/mechfire.lic",
+            "type": "script",
+            "md5": "OFLoi8F38TnqvRDN1onkFME67XM=",
+            "last_commit": 1607807382,
+            "header": "/headers/mechfire.header",
+            "tags": [
+                "ranged crossbow mechanical combat"
+            ],
+            "version": "3.1",
+            "author": "Nisugi"
+        },
+        {
+            "file": "/assets/health-tracker.lic",
+            "type": "script",
+            "md5": "cmHRUJy/B5xumdC28RaiJih2v4E=",
+            "last_commit": 1607807382,
+            "header": "/headers/health-tracker.header",
+            "tags": [],
+            "version": "13",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/autolook.lic",
+            "type": "script",
+            "md5": "z1GuniXrv75ycmTEuqdjNJKsdhc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/fuck_forging.lic",
+            "type": "script",
+            "md5": "WJTFgT+pA50OFFPURy6VqVGiXzk=",
+            "last_commit": 1607807382,
+            "header": "/headers/fuck_forging.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/crosscharcom2.lic",
+            "type": "script",
+            "md5": "5esq5GkJ3hZLskOJREIDHPuYb/o=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/findwarcamp.lic",
+            "type": "script",
+            "md5": "rdv7yOKJEo+2bQCzFG1kX6Rz2K0=",
+            "last_commit": 1607807382,
+            "header": "/headers/findwarcamp.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.1",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/wukong.lic",
+            "type": "script",
+            "md5": "8MIZPyxN/0IlqiMrfj7DW31/bpU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/trackbless.lic",
+            "type": "script",
+            "md5": "681geVd03u95gImpMz6BrhH2hFA=",
+            "last_commit": 1607807382,
+            "header": "/headers/trackbless.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Pick.lic",
+            "type": "script",
+            "md5": "4WSre25djzgpHwiAA05V+X5Oqf4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/familiarkeeper.lic",
+            "type": "script",
+            "md5": "P5TWTUh21R4IzNojwWtd9nXwkSo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/eat-right.lic",
+            "type": "script",
+            "md5": "RmkJAtThagJDk1b1s4EergfwPHs=",
+            "last_commit": 1607807382,
+            "header": "/headers/eat-right.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/eyeswitch.lic",
+            "type": "script",
+            "md5": "Dt9TD+f3qpZ4IqHW9gnxhnQVI4w=",
+            "last_commit": 1607807382,
+            "header": "/headers/eyeswitch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autoinvite.lic",
+            "type": "script",
+            "md5": "X7SPo9fPYInMorAk+yHZE4zQUjU=",
+            "last_commit": 1607807382,
+            "header": "/headers/autoinvite.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/random-verb.lic",
+            "type": "script",
+            "md5": "o5fTDwoeUqDs56N0Jnnx2fOjvyY=",
+            "last_commit": 1607807382,
+            "header": "/headers/random-verb.header",
+            "tags": [],
+            "version": "1",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/volnxpbar.lic",
+            "type": "script",
+            "md5": "fBcpeKiOsX/1ePH+nN1t4o3qd5o=",
+            "last_commit": 1607807382,
+            "header": "/headers/volnxpbar.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/COVID-19.lic",
+            "type": "script",
+            "md5": "TXSu7qetuWrZeZtik7Jxb4nGN9E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gem-jars.lic",
+            "type": "script",
+            "md5": "v0Fe8juUPEamGy7fHAqdn7r3q7I=",
+            "last_commit": 1607807382,
+            "header": "/headers/gem-jars.header",
+            "tags": [],
+            "version": "1.0.3",
+            "author": "Nisch"
+        },
+        {
+            "file": "/assets/shlooter.lic",
+            "type": "script",
+            "md5": "gw7fiKWj5SALYNnMyriK9oYBkTE=",
+            "last_commit": 1607807382,
+            "header": "/headers/shlooter.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/instrumentrest.lic",
+            "type": "script",
+            "md5": "+3+UcpcUOqmD/cdBRhPDdo2M0gY=",
+            "last_commit": 1607807382,
+            "header": "/headers/instrumentrest.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/t.lic",
+            "type": "script",
+            "md5": "0aTF5DUKedMdiIyFqbnwTqY32mY=",
+            "last_commit": 1607807382,
+            "header": "/headers/t.header",
+            "tags": [],
+            "author": "JFTActual"
+        },
+        {
+            "file": "/assets/metamap.lic",
+            "type": "script",
+            "md5": "8ELkEjzYzYgeQjIQsDVCx0fprDc=",
+            "last_commit": 1607807382,
+            "header": "/headers/metamap.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "version": "0.1 (2019-08-14)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/bless.lic",
+            "type": "script",
+            "md5": "QjCIjej5W7c8NjX5Ak+40kw7+Jo=",
+            "last_commit": 1607807382,
+            "header": "/headers/bless.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/scrollbuff.lic",
+            "type": "script",
+            "md5": "uWJZ8oa/7quS2xIbVazWeJKjxdw=",
+            "last_commit": 1607807382,
+            "header": "/headers/scrollbuff.header",
+            "tags": [
+                "invoke",
+                "scroll",
+                "scrolls",
+                "hunting"
+            ],
+            "version": "0.0.1",
+            "author": "Sulien (SulienWaggles on PC, sulieneq@gmail.com)"
+        },
+        {
+            "file": "/assets/route2.lic",
+            "type": "script",
+            "md5": "3/0kMB2l7VwxBOjTJ9gRLAR85IA=",
+            "last_commit": 1607807382,
+            "header": "/headers/route2.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/wanddupe.lic",
+            "type": "script",
+            "md5": "8w7mbKnJnGLsraLEe9WC3jVFn88=",
+            "last_commit": 1607807382,
+            "header": "/headers/wanddupe.header",
+            "tags": [],
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/capacity.lic",
+            "type": "script",
+            "md5": "VBAI1groqDdx2VZ9WkDyso3fX5g=",
+            "last_commit": 1607807382,
+            "header": "/headers/capacity.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Calipers.lic",
+            "type": "script",
+            "md5": "UpzEM7eLchGeuQrROi9ZWa9hzAk=",
+            "last_commit": 1607807382,
+            "header": "/headers/Calipers.header",
+            "tags": [],
+            "author": "Deathravin"
+        },
+        {
+            "file": "/assets/webkill.lic",
+            "type": "script",
+            "md5": "Gb+Dp+cknW2ocnsL8WH1RC0Pipg=",
+            "last_commit": 1607807382,
+            "header": "/headers/webkill.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/chrismmake.lic",
+            "type": "script",
+            "md5": "4tNcg1N66qHBHvj3nDY8IGjmZ24=",
+            "last_commit": 1607807382,
+            "header": "/headers/chrismmake.header",
+            "tags": [],
+            "author": "Daedeus"
+        },
+        {
+            "file": "/assets/xnarostbeta.lic",
+            "type": "script",
+            "md5": "AjcPmuk2lVavf6R/9Re9IDo0H30=",
+            "last_commit": 1607807382,
+            "header": "/headers/xnarostbeta.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "version": "0.6 (2019-08-13) based on narost.lic from 2014-08-24",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/speechbox.lic",
+            "type": "script",
+            "md5": "9hrUwt6GEa7TKaFfEKj5MW6BER4=",
+            "last_commit": 1607807382,
+            "header": "/headers/speechbox.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/enlake.lic",
+            "type": "script",
+            "md5": "jhwdaiZbTWjsRyTXuCIBFeO2Nic=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/vaalorwater2.lic",
+            "type": "script",
+            "md5": "9bdthNe6jtU6fVdh6L/1I8Vs3Sc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sonezz.lic",
+            "type": "script",
+            "md5": "UlUOFoZ0gl/v9j0I7TU+1Owsts8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/iSigns.lic",
+            "type": "script",
+            "md5": "9rVpNhTRP3P65PGhXbeLgmMKyjY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/735_w_energy.lic",
+            "type": "script",
+            "md5": "+cwi0a8r+4iVI9eCAU/VgzNyvAI=",
+            "last_commit": 1607807382,
+            "header": "/headers/735_w_energy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sspell.lic",
+            "type": "script",
+            "md5": "TN+8B1yhzPXHRAebfOjyp40Rj3E=",
+            "last_commit": 1607807382,
+            "header": "/headers/sspell.header",
+            "tags": [
+                "spells"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/shopnotes.lic",
+            "type": "script",
+            "md5": "/ea337WRpgx0mPnmdjrgN577CqU=",
+            "last_commit": 1607807382,
+            "header": "/headers/shopnotes.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/purifyjars.lic",
+            "type": "script",
+            "md5": "5NXjJOjOeS+1VbOixasI3wDJ9qI=",
+            "last_commit": 1607807382,
+            "header": "/headers/purifyjars.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/joinup.lic",
+            "type": "script",
+            "md5": "b6qzkmgkkN1+wtN7gYhTlD+MT6k=",
+            "last_commit": 1607807382,
+            "header": "/headers/joinup.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/sewer.lic",
+            "type": "script",
+            "md5": "anuMpqpAC4jVd8/aqtvE/AJ54NA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ball.lic",
+            "type": "script",
+            "md5": "cvl2/uh4U1HdbHc+xJ852Zi12II=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/speechrandomizer.lic",
+            "type": "script",
+            "md5": "rRHDYGf4YCMJ0x6Z0cYH3JJZHxg=",
+            "last_commit": 1607807382,
+            "header": "/headers/speechrandomizer.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/cleangear.lic",
+            "type": "script",
+            "md5": "99V6RNH3FNmA5DNSHOFDD/Z1KmI=",
+            "last_commit": 1607807382,
+            "header": "/headers/cleangear.header",
+            "tags": [],
+            "version": "2016.12.12.01",
+            "author": "Akono (lordakono@gmail.com)"
+        },
+        {
+            "file": "/assets/dm.lic",
+            "type": "script",
+            "md5": "HRxCflROZx3PsJEa+J15e7BvFM0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/bounty.lic",
+            "type": "script",
+            "md5": "hz5yzGEc5kaq19oC3YEMibNtlNA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/manna.lic",
+            "type": "script",
+            "md5": "TrKtrlw0vC8Ql2dVlX+T4p+BJ+8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/autotone.lic",
+            "type": "script",
+            "md5": "z4ebJ6qmoonZWHbPoq+u90p/JCY=",
+            "last_commit": 1607807382,
+            "header": "/headers/autotone.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/maxlock2.lic",
+            "type": "script",
+            "md5": "9eOhVWmAfOp7mZPcGtXw59rcBgA=",
+            "last_commit": 1607807382,
+            "header": "/headers/maxlock2.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.4 (2020-03-11)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/pupper.lic",
+            "type": "script",
+            "md5": "jcdvNlgwQkBtU3sXmZMm+JfJ6Bw=",
+            "last_commit": 1607807382,
+            "header": "/headers/pupper.header",
+            "tags": [
+                "puppy",
+                "pupper",
+                "pup",
+                "dog",
+                "doggie",
+                "towncrier",
+                "pet",
+                "invisible",
+                "ambients"
+            ]
+        },
+        {
+            "file": "/assets/manashare.lic",
+            "type": "script",
+            "md5": "sqAeraDCY9Szzcr0atNouToynh4=",
+            "last_commit": 1607807382,
+            "header": "/headers/manashare.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bountyhunter-explorer.lic",
+            "type": "script",
+            "md5": "qM4dU5fS1keZ3KQhA97LmEiw8I0=",
+            "last_commit": 1607807382,
+            "header": "/headers/bountyhunter-explorer.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/gbount.lic",
+            "type": "script",
+            "md5": "JR/rMAZ/fdS7aikDXks1K2Fkuxs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/death_potions.lic",
+            "type": "script",
+            "md5": "b/tThQTET4YtdQrb9OMAt/2jU3g=",
+            "last_commit": 1607807382,
+            "header": "/headers/death_potions.header",
+            "tags": [
+                "death",
+                "recovery",
+                "potions",
+                "utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/arshreim.lic",
+            "type": "script",
+            "md5": "qi8QuLTHg3dOuwWwrppRKH3kqGM=",
+            "last_commit": 1607807382,
+            "header": "/headers/arshreim.header",
+            "tags": [
+                "reim"
+            ],
+            "version": "2.3",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/locker.lic",
+            "type": "script",
+            "md5": "5UzaeKkkIQrcVDmjyPai45JdMHU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/login.lic",
+            "type": "script",
+            "md5": "S5qn/9wPaYsnmctM2pEuGjXKlOY=",
+            "last_commit": 1607807382,
+            "header": "/headers/login.header",
+            "tags": [],
+            "author": "Phalen33"
+        },
+        {
+            "file": "/assets/tagsearch.lic",
+            "type": "script",
+            "md5": "QICt5qVO0Ki4ED+t05p1X5oXqMs=",
+            "last_commit": 1607807382,
+            "header": "/headers/tagsearch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/alch_buy.lic",
+            "type": "script",
+            "md5": "vU5qoWTQu6F4nB6QVEQZsILK5n4=",
+            "last_commit": 1607807382,
+            "header": "/headers/alch_buy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/epop.lic",
+            "type": "script",
+            "md5": "3cm9g4tHxy9zGitxgyfcMGUxCbU=",
+            "last_commit": 1607807382,
+            "header": "/headers/epop.header",
+            "tags": [
+                "loot",
+                "magic"
+            ],
+            "version": "1.9",
+            "author": "Essio"
+        },
+        {
+            "file": "/assets/posthunt_notasorcerer.lic",
+            "type": "script",
+            "md5": "9BndgJDZI61A4WHQfTUWI4/YRP8=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt_notasorcerer.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/dgrab.lic",
+            "type": "script",
+            "md5": "XrakWZz1pEsTNc3vC94QK6zPZoY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/follow.lic",
+            "type": "script",
+            "md5": "UTP19CoT/YN97D6D4A6qhPIBOaY=",
+            "last_commit": 1607807382,
+            "header": "/headers/follow.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/rrclean.lic",
+            "type": "script",
+            "md5": "/JowzgEGzcCzTsWb4UXKycHV3uA=",
+            "last_commit": 1607807382,
+            "header": "/headers/rrclean.header",
+            "tags": [
+                "RR"
+            ],
+            "version": "1.3",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/mg.lic",
+            "type": "script",
+            "md5": "mk6bfzAHczMJIRZNZnB8WAweolI=",
+            "last_commit": 1607807382,
+            "header": "/headers/mg.header",
+            "tags": [
+                "silly"
+            ],
+            "version": "0.1",
+            "author": "Caels (caelscaldanhai@gmail.com)"
+        },
+        {
+            "file": "/assets/xxx306.lic",
+            "type": "script",
+            "md5": "G3GmHpZDGITfzn8Yy8+mSYTdbrs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/onstart.lic",
+            "type": "script",
+            "md5": "H3w1jQDMoVXPMBDLtL9L7eDYkbo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/col.lic",
+            "type": "script",
+            "md5": "98cGooj47y6pYEVSI20rLpO9uFI=",
+            "last_commit": 1607807382,
+            "header": "/headers/col.header",
+            "tags": [
+                "society"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/deathlog.lic",
+            "type": "script",
+            "md5": "iYmfEd6jkvvagUrVczxuOl776k0=",
+            "last_commit": 1607807382,
+            "header": "/headers/deathlog.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/waggleroom.lic",
+            "type": "script",
+            "md5": "2oeOU7kO1fHxC4k+oCTXA2C2Yus=",
+            "last_commit": 1607807382,
+            "header": "/headers/waggleroom.header",
+            "tags": [
+                "waggle",
+                "spellup",
+                "room",
+                "everyone",
+                "mini dreavening"
+            ],
+            "version": "1.0",
+            "author": "Luxelle"
+        },
+        {
+            "file": "/assets/211.lic",
+            "type": "script",
+            "md5": "ga3xzMqtO2pRoqGf2tbOn/QKcIM=",
+            "last_commit": 1607807382,
+            "header": "/headers/211.header",
+            "tags": [
+                "211",
+                "bravery",
+                "group"
+            ],
+            "version": "1.1b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/dusk_sell.lic",
+            "type": "script",
+            "md5": "t2SFEIJ0mk7t6C5L9/WNIeUtpB0=",
+            "last_commit": 1607807382,
+            "header": "/headers/dusk_sell.header",
+            "tags": [],
+            "version": "1",
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/keepbless.lic",
+            "type": "script",
+            "md5": "miLPkK6XGL2v3eSIj1t3jKd5oDY=",
+            "last_commit": 1607807382,
+            "header": "/headers/keepbless.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/IFW_teleporter.lic",
+            "type": "script",
+            "md5": "QtRnzKiaaM5NsRIED9FohCDQunQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/IFW_teleporter.header",
+            "tags": [
+                "Mist Harbor",
+                "IFW",
+                "FWI",
+                "preme",
+                "teleporter"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/gibs_pickpocket_helper.lic",
+            "type": "script",
+            "md5": "H9eFGg0qnflDtDWKhN9fa/B4E/c=",
+            "last_commit": 1607807382,
+            "header": "/headers/gibs_pickpocket_helper.header",
+            "tags": [
+                "pickpocket",
+                "utility",
+                "information"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/illusions.lic",
+            "type": "script",
+            "md5": "DUqgxFjuq1S7GlcSWVFdmDa4VJY=",
+            "last_commit": 1607807382,
+            "header": "/headers/illusions.header",
+            "tags": [
+                "sorcerer",
+                "illusions"
+            ],
+            "version": "2.20",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/shunt-loop.lic",
+            "type": "script",
+            "md5": "+sY4SeYGda7AVxAnnNHuWG3Z584=",
+            "last_commit": 1607807382,
+            "header": "/headers/shunt-loop.header",
+            "tags": [
+                "hunting"
+            ],
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/keepsigns.lic",
+            "type": "script",
+            "md5": "2tzT9IaQy4CBF/CF2t/lI0O+UL8=",
+            "last_commit": 1607807382,
+            "header": "/headers/keepsigns.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dont-lose-it.lic",
+            "type": "script",
+            "md5": "jB8ci6yMyS1Y81QVCq9TOSzF+4c=",
+            "last_commit": 1607807382,
+            "header": "/headers/dont-lose-it.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/925.lic",
+            "type": "script",
+            "md5": "Ijq4muS+s3WkRPM/1t9ktdQynvE=",
+            "last_commit": 1607807382,
+            "header": "/headers/925.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/lootpackage.lic",
+            "type": "script",
+            "md5": "MbtVb9/SmxJ9QqTIAkS4b+ASbto=",
+            "last_commit": 1607807382,
+            "header": "/headers/lootpackage.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/societypowers.lic",
+            "type": "script",
+            "md5": "2h7LuXzoz7NyI1eFsozUmRL0EB4=",
+            "last_commit": 1607807382,
+            "header": "/headers/societypowers.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/sguild.lic",
+            "type": "script",
+            "md5": "AYewuTcUcDzcrjiQQ1kWhWe09PE=",
+            "last_commit": 1607807382,
+            "header": "/headers/sguild.header",
+            "tags": [
+                "guild rogue warrior"
+            ],
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/nexushealbot.lic",
+            "type": "script",
+            "md5": "ecGMhGtST4nbkOupqaiUjtCtfWU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/name.lic",
+            "type": "script",
+            "md5": "J80Xpgways5ZEDpANBqKNSOdf7o=",
+            "last_commit": 1607807382,
+            "header": "/headers/name.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/sbounty-2017.lic",
+            "type": "script",
+            "md5": "3W4En738EvLkf7DOp2faCdJl93I=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbounty-2017.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/fofgames.lic",
+            "type": "script",
+            "md5": "irQIoHxHOnYyMtH8x8xBmCRexjA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/917.lic",
+            "type": "script",
+            "md5": "0VYmcO0FD94eXVFjD6T8Vn9Zuhg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sfillherbs.lic",
+            "type": "script",
+            "md5": "bZHnZmLFTiRk1QPp2EOAwokS1gY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/madwarrior.lic",
+            "type": "script",
+            "md5": "dnGR/ZXfDoqKJxmtnD8y6bN3I6g=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/circle3.lic",
+            "type": "script",
+            "md5": "ywgB61TzsiTVdOgcG7JtfMMoWxk=",
+            "last_commit": 1607807382,
+            "header": "/headers/circle3.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lockpickget.lic",
+            "type": "script",
+            "md5": "4C+BolzXvziDN1MROx1ISMp+uHk=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockpickget.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/containers.lic",
+            "type": "script",
+            "md5": "oO642JcQlF1E9tPn6/kd6AncV0Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/containers.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pulse.lic",
+            "type": "script",
+            "md5": "JVlz0V+fPsCEPCxJtAEYPPLgSzg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/herb.lic",
+            "type": "script",
+            "md5": "D/7yHH2z+OSC+WA1CI7ZQ7dxKtU=",
+            "last_commit": 1607807382,
+            "header": "/headers/herb.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/plat_updater.lic",
+            "type": "script",
+            "md5": "WVmJqOo41Z2qPweAZo3doUug6Y8=",
+            "last_commit": 1607807382,
+            "header": "/headers/plat_updater.header",
+            "tags": [],
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/VolnStep24-RuneSolver.lic",
+            "type": "script",
+            "md5": "JiIzMpF1xZxBrEth0R+FdHR+xXQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/VolnStep24-RuneSolver.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/generic_checkbox_menu.lic",
+            "type": "script",
+            "md5": "ZMw/o6IP39SEz2+UpcTDTJO9Vps=",
+            "last_commit": 1607807382,
+            "header": "/headers/generic_checkbox_menu.header",
+            "tags": [
+                "GTK2",
+                "GUI",
+                "menu"
+            ],
+            "version": "0.1"
+        },
+        {
+            "file": "/assets/censer.lic",
+            "type": "script",
+            "md5": "GaysvPr4BXxFspJX1tzN4K+CCoM=",
+            "last_commit": 1607807382,
+            "header": "/headers/censer.header",
+            "tags": [
+                "censer",
+                "chrism"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/ddigmac.lic",
+            "type": "script",
+            "md5": "z7F7WM0neBHYyOilm7oqxRG1OV8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/smash.lic",
+            "type": "script",
+            "md5": "5iGChJN82/TDy0d6Qo/NIWyJ8e8=",
+            "last_commit": 1607807382,
+            "header": "/headers/smash.header",
+            "tags": [
+                "hunting"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/child2.lic",
+            "type": "script",
+            "md5": "P9azmiAYN+xJfq6A+O8OA1r456k=",
+            "last_commit": 1607807382,
+            "header": "/headers/child2.header",
+            "tags": [
+                "escort"
+            ],
+            "version": "1.8",
+            "author": "Drafix"
+        },
+        {
+            "file": "/assets/listcapacity.lic",
+            "type": "script",
+            "md5": "CFNmQuBLNdi0nA1hBr9LOQphMxk=",
+            "last_commit": 1607807382,
+            "header": "/headers/listcapacity.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Autobundle.lic",
+            "type": "script",
+            "md5": "qTAYBTFFY5hEfbXZ4cihpImrWVQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/Autobundle.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sense.lic",
+            "type": "script",
+            "md5": "3zxldjSGsvt4MQl+f3x0ThQegEs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/slocation.lic",
+            "type": "script",
+            "md5": "x9vyDcoW6ydpCkt6bre+baekU7w=",
+            "last_commit": 1607807382,
+            "header": "/headers/slocation.header",
+            "tags": [
+                "utility"
+            ]
+        },
+        {
+            "file": "/assets/pure2.lic",
+            "type": "script",
+            "md5": "DUU9KwyUmc6bTvULGONU8kQnG/s=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/mybounty.lic",
+            "type": "script",
+            "md5": "r2kHzrq0mr7rVe+ShfEPigG+UBA=",
+            "last_commit": 1607807382,
+            "header": "/headers/mybounty.header",
+            "tags": [
+                "bounty",
+                "gems",
+                "herbs",
+                "specific",
+                "lumnis",
+                "contest",
+                "boost bounty",
+                "bounty boost",
+                "exclude bounties",
+                "bounties",
+                "skins",
+                "limit"
+            ],
+            "version": "2.1 - cleaned up testing errors from 2.0  oops!",
+            "author": "Luxelle"
+        },
+        {
+            "file": "/assets/attendance.lic",
+            "type": "script",
+            "md5": "LwW7ycrBvdvpQgMoHrAB4bC3lSY=",
+            "last_commit": 1607807382,
+            "header": "/headers/attendance.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/whatlevel2.lic",
+            "type": "script",
+            "md5": "gCO1OYx2wzuxoBdUWfs5Cc+1NeU=",
+            "last_commit": 1607807382,
+            "header": "/headers/whatlevel2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/gibs_purify.lic",
+            "type": "script",
+            "md5": "dPxxEZeSe1GN6BSQOARZFqb30X4=",
+            "last_commit": 1607807382,
+            "header": "/headers/gibs_purify.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ringleader.lic",
+            "type": "script",
+            "md5": "LdSUP+H1I3StWklDc3SfxcFiVuE=",
+            "last_commit": 1607807382,
+            "header": "/headers/ringleader.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/raise.lic",
+            "type": "script",
+            "md5": "YpFodLTCGHZXdjNJfr/mHJptlGw=",
+            "last_commit": 1607807382,
+            "header": "/headers/raise.header",
+            "tags": [],
+            "version": "0.2",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/music.lic",
+            "type": "script",
+            "md5": "KxnpOjonsrinsMaXbkTHVaA+8X0=",
+            "last_commit": 1607807382,
+            "header": "/headers/music.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/add-map-metadata.lic",
+            "type": "script",
+            "md5": "vWzw2K53bYEpt77gnl42jHi210o=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/iherbalist.lic",
+            "type": "script",
+            "md5": "cG67798qPyi6NzldHrO8YLlXDCM=",
+            "last_commit": 1607807382,
+            "header": "/headers/iherbalist.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/grimcount.lic",
+            "type": "script",
+            "md5": "YfhD4MC70Ob/+YIya9hb1yQrF1Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/grimcount.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dr_dismiss.lic",
+            "type": "script",
+            "md5": "Cq/T7E488uYQ33AcDJ1F2YU4QSw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/buyarrows2.lic",
+            "type": "script",
+            "md5": "Be7tvCnpFTE8HHLLVJMpnCZzCcw=",
+            "last_commit": 1607807382,
+            "header": "/headers/buyarrows2.header",
+            "tags": [],
+            "author": "Daedeus"
+        },
+        {
+            "file": "/assets/service_queue.lic",
+            "type": "script",
+            "md5": "+73CFyxCkccw6HJHEc1dqwzhUys=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/shaggle.lic",
+            "type": "script",
+            "md5": "0RYoSGa5ypGGyhCgMzJIbR6wbnA=",
+            "last_commit": 1607807382,
+            "header": "/headers/shaggle.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.90",
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/xrogue_teach.lic",
+            "type": "script",
+            "md5": "hWfAZj4sgP9hWZs85xerdaikgYA=",
+            "last_commit": 1607807382,
+            "header": "/headers/xrogue_teach.header",
+            "tags": [],
+            "version": "50",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/SitNPick.lic",
+            "type": "script",
+            "md5": "pzmTfKydyXeurQhvYszXJ5TlKk4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/porcupine.lic",
+            "type": "script",
+            "md5": "ZwIXpPQeA/V77dfXteQKN1kNqQE=",
+            "last_commit": 1607807382,
+            "header": "/headers/porcupine.header",
+            "tags": [
+                "spells"
+            ],
+            "version": "1.0",
+            "author": "Maodan"
+        },
+        {
+            "file": "/assets/1202check.lic",
+            "type": "script",
+            "md5": "20A2rdbv+dgayGX692vJx5bMMf0=",
+            "last_commit": 1607807382,
+            "header": "/headers/1202check.header",
+            "tags": [
+                "spell"
+            ],
+            "version": "0.3",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/shealwatch.lic",
+            "type": "script",
+            "md5": "1+qkap6+thPSjom3yfuRco9btJQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/shealwatch.header",
+            "tags": [
+                "empath"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/swho.lic",
+            "type": "script",
+            "md5": "yowJKTxyJZUFX+MRNt2z0PUORnQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/HealBot.lic",
+            "type": "script",
+            "md5": "bRHTWnlLEPCVaWOTsVZyxbUqL1E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/majorgeneral.lic",
+            "type": "script",
+            "md5": "ZecBEJQHHrgNJszGbjThhs7LOnQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/majorgeneral.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/beseech.lic",
+            "type": "script",
+            "md5": "pxB0kZoxaVPxRfYS7HMkMxxfDSQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/warp.lic",
+            "type": "script",
+            "md5": "KE2tvcXsau37bVGG+VI/GyA8QGU=",
+            "last_commit": 1607807382,
+            "header": "/headers/warp.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/group2.lic",
+            "type": "script",
+            "md5": "4Gbm7GjFu9gI6dKGmGr7VK8X7lE=",
+            "last_commit": 1607807382,
+            "header": "/headers/group2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wracksafe.lic",
+            "type": "script",
+            "md5": "dG2tAnLJ6mWS4UDoXDrPts4OlXw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/spiritservantgiverunestaff.lic",
+            "type": "script",
+            "md5": "dYSDh3RnfkM9X8Cr6EFyLEsAWjM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/universalkill-nylis2.lic",
+            "type": "script",
+            "md5": "bguK/xnup4nT2BLjb1TnGtn6Xas=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rcast.lic",
+            "type": "script",
+            "md5": "RtdtfZsXfJc4ODjVL3ZONXkGHiM=",
+            "last_commit": 1607807382,
+            "header": "/headers/rcast.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bardcombo.lic",
+            "type": "script",
+            "md5": "12VgkXA0m5RDNANkQJRxho7Lbt4=",
+            "last_commit": 1607807382,
+            "header": "/headers/bardcombo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/DSD.lic",
+            "type": "script",
+            "md5": "FicVWii1bMQsKWB8AMuuvl80iJo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/mural.lic",
+            "type": "script",
+            "md5": "8DF37TnbuDjKRMJyotRqnI8LeOY=",
+            "last_commit": 1607807382,
+            "header": "/headers/mural.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/roomlinks.lic",
+            "type": "script",
+            "md5": "p9yIRxSWYZ4EZ0hkgpB6LvqrIWM=",
+            "last_commit": 1607807382,
+            "header": "/headers/roomlinks.header",
+            "tags": [
+                "utility",
+                "profanity",
+                "wizard",
+                "avalon"
+            ],
+            "version": "1.3",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/noodling.lic",
+            "type": "script",
+            "md5": "D8+cnvb2UEw0sDmi1NYVPLQmyKk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/SitNSing.lic",
+            "type": "script",
+            "md5": "Sqoh0K7V0KwkRlumS500O/x6urg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/manabattery.lic",
+            "type": "script",
+            "md5": "ZULpz4lzsp3BPBcZEOEYQvmHJQQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/manabattery.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/note.lic",
+            "type": "script",
+            "md5": "sb2RP8FOj2ZhrYMnb2ud1PLFVj8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/taptoheal.lic",
+            "type": "script",
+            "md5": "9x4kyq5Msb09+qXDhxqVFojh7zs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/vyrsh_heist.lic",
+            "type": "script",
+            "md5": "hFqUJ6irQlmRPDWu07atGCnD0aE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue-lmas-makelock.lic",
+            "type": "script",
+            "md5": "uik0dQWcqI1ZQ4MAzCFh6vBGRwc=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-makelock.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/itemnotes.lic",
+            "type": "script",
+            "md5": "bHl2rL4ov+qzMiVO/QVbLBzaGdg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/houselocker.lic",
+            "type": "script",
+            "md5": "/dbrO3p1MP1K1+uxlsdM5Hosnao=",
+            "last_commit": 1607807382,
+            "header": "/headers/houselocker.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/DRDIG.lic",
+            "type": "script",
+            "md5": "YgluITGPilR+U0NICcDwWSe/CZs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/funexp.lic",
+            "type": "script",
+            "md5": "Lhi/9vYDBdMV7eZe4DU70ww5XBM=",
+            "last_commit": 1607807382,
+            "header": "/headers/funexp.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/narost2.lic",
+            "type": "script",
+            "md5": "xpePL/Xe/qDl1mFRrucH1o7iYCU=",
+            "last_commit": 1607807382,
+            "header": "/headers/narost2.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/update-playershops.lic",
+            "type": "script",
+            "md5": "xKXDNFX+iahfoG/LGv43Kmihsaw=",
+            "last_commit": 1607807382,
+            "header": "/headers/update-playershops.header",
+            "tags": [
+                "data"
+            ],
+            "version": "0.23",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/midnightarena.lic",
+            "type": "script",
+            "md5": "DUW9biS+s8ieVELLBn8OXZ/0jZ0=",
+            "last_commit": 1607807382,
+            "header": "/headers/midnightarena.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/get-locker-id.lic",
+            "type": "script",
+            "md5": "LTpGhVpYMeHUNvRx1xjXCTjjJnE=",
+            "last_commit": 1607807382,
+            "header": "/headers/get-locker-id.header",
+            "tags": [],
+            "version": "1.0"
+        },
+        {
+            "file": "/assets/withdraw.lic",
+            "type": "script",
+            "md5": "7RowKGwKCMGdy3MiJ6oY2neH6lY=",
+            "last_commit": 1607807382,
+            "header": "/headers/withdraw.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/finvale_crystal.lic",
+            "type": "script",
+            "md5": "rLZSzXduxK/DTT/d+sGyg6mUwZ8=",
+            "last_commit": 1607807382,
+            "header": "/headers/finvale_crystal.header",
+            "tags": [],
+            "author": "Azerik"
+        },
+        {
+            "file": "/assets/inspect.lic",
+            "type": "script",
+            "md5": "YE0FSloVFNQ3SNcPoAS+T12+8hQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/inspect.header",
+            "tags": [
+                "inspect"
+            ],
+            "version": "0.7 (2019-10-23)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/215.lic",
+            "type": "script",
+            "md5": "Qe49UhxU/rQqrgTbxLBs2Exdj9A=",
+            "last_commit": 1607807382,
+            "header": "/headers/215.header",
+            "tags": [
+                "215",
+                "heroisam",
+                "group"
+            ],
+            "version": "1.0b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/bundleall.lic",
+            "type": "script",
+            "md5": "OprMwwU3rwnqfkHdIZIaWUOgq4o=",
+            "last_commit": 1607807382,
+            "header": "/headers/bundleall.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bardmana.lic",
+            "type": "script",
+            "md5": "ZbMUYZ5Le3NLww92ZzRfDa/DH2Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/bardmana.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/loresing.lic",
+            "type": "script",
+            "md5": "ocDHtSjNBL2Pby74ZATkB93P798=",
+            "last_commit": 1607807382,
+            "header": "/headers/loresing.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/noarrow.lic",
+            "type": "script",
+            "md5": "SqH5YirJBqIG39ZATx27Znf6zFk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/clean.cmd",
+            "type": "data",
+            "md5": "HKziaDz8ziL+KPP2WXYzmxFcE1Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tran.lic",
+            "type": "script",
+            "md5": "9iXK5Zq93Zf2QKpkIB5wn0dkAFo=",
+            "last_commit": 1607807382,
+            "header": "/headers/tran.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/exchange.lic",
+            "type": "script",
+            "md5": "Y+Y2cSbUIJ8HferL/o0G/NdRT1E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/drgemsell.lic",
+            "type": "script",
+            "md5": "lKl0b0Q56TzvImUWks8Vv5ydMG4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ghoul.lic",
+            "type": "script",
+            "md5": "3byJqzfjv1k7WDckTwcYleawELQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/ghoul.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lockerswap.lic",
+            "type": "script",
+            "md5": "4USgw7KM7kD3d+N5MaH65uQ1dLI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/miutwo.lic",
+            "type": "script",
+            "md5": "njqV/zcR+IT7af/a9qRnZBq7UOE=",
+            "last_commit": 1607807382,
+            "header": "/headers/miutwo.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/react.lic",
+            "type": "script",
+            "md5": "PGkuL/3rI4IW5mv6wEeV3p58hOg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/healself.lic",
+            "type": "script",
+            "md5": "nEaHnePhDA3bev+80hK8DeGHZPk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/arena-nylis2.lic",
+            "type": "script",
+            "md5": "zAQcVzqu07GdbnqEBPc9QlgxsMc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/UberBarWiz.lic",
+            "type": "script",
+            "md5": "wz6IMD0J7YIpqJwtqRcyHOexj68=",
+            "last_commit": 1607807382,
+            "header": "/headers/UberBarWiz.header",
+            "tags": [],
+            "author": "Deathravin"
+        },
+        {
+            "file": "/assets/dump-spell-data.lic",
+            "type": "script",
+            "md5": "fIYlfMM8lzoSzUO5a36OJZRYn7g=",
+            "last_commit": 1607807382,
+            "header": "/headers/dump-spell-data.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-05-19)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/servant.lic",
+            "type": "script",
+            "md5": "+PqqbvJJOltgZlfOkrcy15dDzbM=",
+            "last_commit": 1607807382,
+            "header": "/headers/servant.header",
+            "tags": [
+                "servant",
+                "spirit servant",
+                "spirit",
+                "218",
+                "empath",
+                "cleric"
+            ],
+            "version": "1.1",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/1615isdope.lic",
+            "type": "script",
+            "md5": "o8JTS1P8+8YEcGjZASXx8ktTMoA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/iza.lic",
+            "type": "script",
+            "md5": "9srOiu53Y0SX6x7sEmpNRaC49Ik=",
+            "last_commit": 1607807382,
+            "header": "/headers/iza.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ego2.lic",
+            "type": "script",
+            "md5": "/0l3wu/EWK2frpaR1R7Xft49Kbc=",
+            "last_commit": 1608258576,
+            "header": "/headers/ego2.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "0.6",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/bankdrop.lic",
+            "type": "script",
+            "md5": "E5eRRQ8//36ueto3YKUQJv0oP5Q=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/follow2.lic",
+            "type": "script",
+            "md5": "3kxNTS4b8dQETIsFsK9URwkeqAM=",
+            "last_commit": 1607807382,
+            "header": "/headers/follow2.header",
+            "tags": [
+                "Stalking"
+            ],
+            "version": "2.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/jconvert.lic",
+            "type": "script",
+            "md5": "IQnSAyjbuBS84sPHtnv11lJRJiw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/findcreature.lic",
+            "type": "script",
+            "md5": "944bOLbonrLfjtyrAdsPKtH7cck=",
+            "last_commit": 1607807382,
+            "header": "/headers/findcreature.header",
+            "tags": [
+                "Creature finding tool"
+            ],
+            "version": "0.5 beta",
+            "author": "Nugt"
+        },
+        {
+            "file": "/assets/play.lic",
+            "type": "script",
+            "md5": "85QFWM7XTJFUuU17MUyig730+ac=",
+            "last_commit": 1607807382,
+            "header": "/headers/play.header",
+            "tags": [],
+            "author": "Air"
+        },
+        {
+            "file": "/assets/703.lic",
+            "type": "script",
+            "md5": "FNuyWtTCuRQfSmHYiMjVqe3D4M4=",
+            "last_commit": 1607807382,
+            "header": "/headers/703.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/path.lic",
+            "type": "script",
+            "md5": "WQLK+pjlEn1t34F4BfG5VyySnfg=",
+            "last_commit": 1607807382,
+            "header": "/headers/path.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/volnrestore.lic",
+            "type": "script",
+            "md5": "RJkhZzmQAQo3X1sfJ7YXN8L1CkI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/roomorder.lic",
+            "type": "script",
+            "md5": "OKKe8D0tcIjuwZKYx3XwPy/g12w=",
+            "last_commit": 1607807382,
+            "header": "/headers/roomorder.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/deathvambraces.lic",
+            "type": "script",
+            "md5": "T+ly7pHbs30DZDsgpFc1IlgsrGs=",
+            "last_commit": 1607807382,
+            "header": "/headers/deathvambraces.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/getalltype.lic",
+            "type": "script",
+            "md5": "qiM8NVGAMzHdAPJzIXXnhI+CZ8I=",
+            "last_commit": 1607807382,
+            "header": "/headers/getalltype.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/arena-daiyon.lic",
+            "type": "script",
+            "md5": "i4W28G4NOSHsIF83a2J2jys9Qas=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/level2.lic",
+            "type": "script",
+            "md5": "VQ/6MNagLHmynoSNsfAHR/lBUFc=",
+            "last_commit": 1607807382,
+            "header": "/headers/level2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dlocate.lic",
+            "type": "script",
+            "md5": "lyfiSkbRKt8Op7wnch46s9I+Pos=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/checkbox.lic",
+            "type": "script",
+            "md5": "YmlL7cm9nBzazqHI5SdYp0AQ70Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/checkbox.header",
+            "tags": [
+                "lock picking",
+                "magic",
+                "popping"
+            ],
+            "version": "1.1",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/high_ds.lic",
+            "type": "script",
+            "md5": "hWnjeQGbs/3WcfwH5HqYpvkKEj4=",
+            "last_commit": 1607807382,
+            "header": "/headers/high_ds.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ebladeall.lic",
+            "type": "script",
+            "md5": "4B6ptNDubfbvNwpFEg+qS/Bwjtc=",
+            "last_commit": 1607807382,
+            "header": "/headers/ebladeall.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/herbs.lic",
+            "type": "script",
+            "md5": "xaia7iA3FKNNOxsY68pPa3OLT8Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/keepalive.lic",
+            "type": "script",
+            "md5": "DwaS4iLMOrw5/nibO2aj+lC/2FI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rep.lic",
+            "type": "script",
+            "md5": "I2Tp6G9ClZPPudTKuDm6aMrcDUs=",
+            "last_commit": 1607807382,
+            "header": "/headers/rep.header",
+            "tags": [
+                "repeat",
+                "utility",
+                "helper",
+                "auto"
+            ],
+            "version": "0.1",
+            "author": "Nomada"
+        },
+        {
+            "file": "/assets/mechbowreload.lic",
+            "type": "script",
+            "md5": "SHliuKEmmGVyxJXkSue5+5ZKbrI=",
+            "last_commit": 1607807382,
+            "header": "/headers/mechbowreload.header",
+            "tags": [
+                "hunting",
+                "mechanical-crossbow"
+            ],
+            "version": "0.1",
+            "author": "Aramund"
+        },
+        {
+            "file": "/assets/facehugger.lic",
+            "type": "script",
+            "md5": "ysd3IAJ/GAboO0pJW0DOf+c6ZEg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dr.lic",
+            "type": "script",
+            "md5": "rMbicGxWrrHxvFJwYliYV7flQwY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xday.lic",
+            "type": "script",
+            "md5": "cCCKsn5gdHI14mHHBR4oCgSEUZg=",
+            "last_commit": 1607807382,
+            "header": "/headers/xday.header",
+            "tags": [
+                "loot",
+                "magic",
+                "miu",
+                "duskruin"
+            ],
+            "version": "1.0",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/scriptcheck.lic",
+            "type": "script",
+            "md5": "wYx1qEb5uVjpFVGL+xtgnUAYnEg=",
+            "last_commit": 1607807382,
+            "header": "/headers/scriptcheck.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/buyallherbs.lic",
+            "type": "script",
+            "md5": "NnW2RRt+6PWlHk3JEYMabuJ4nTA=",
+            "last_commit": 1607807382,
+            "header": "/headers/buyallherbs.header",
+            "tags": [],
+            "version": "1.0.1",
+            "author": "Yasutoshi"
+        },
+        {
+            "file": "/assets/giveaway.lic",
+            "type": "script",
+            "md5": "LXT/SXkiiKlnS8RbxZ1auehKZ2s=",
+            "last_commit": 1607807382,
+            "header": "/headers/giveaway.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/kpop.lic",
+            "type": "script",
+            "md5": "dWq9i91RN5Wh3HrtdWTY9O/2vik=",
+            "last_commit": 1607807382,
+            "header": "/headers/kpop.header",
+            "tags": [
+                "lock picking",
+                "utility"
+            ],
+            "version": "1.5",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/show.lic",
+            "type": "script",
+            "md5": "5XpFoj5z25IMhzsnaUipzMO/rEE=",
+            "last_commit": 1607807382,
+            "header": "/headers/show.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/askgenie.lic",
+            "type": "script",
+            "md5": "2Vh7KgMYZ2iHs0EsKWrHiyUu4ck=",
+            "last_commit": 1607807382,
+            "header": "/headers/askgenie.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/gswiki.lic",
+            "type": "script",
+            "md5": "/eaVWNgS0bDqHWYHYKwkVV6eNJ8=",
+            "last_commit": 1607807382,
+            "header": "/headers/gswiki.header",
+            "tags": [
+                "information"
+            ],
+            "version": "2.0.1",
+            "author": "spiffyjr and friends!"
+        },
+        {
+            "file": "/assets/fragment.lic",
+            "type": "script",
+            "md5": "3nnwvWzmp9jZ2KGmimylxURVGsU=",
+            "last_commit": 1607807382,
+            "header": "/headers/fragment.header",
+            "tags": [
+                "EG",
+                "fragment",
+                "EG fragment"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC), original Nylis"
+        },
+        {
+            "file": "/assets/rapid-fire.lic",
+            "type": "script",
+            "md5": "zEES+oeu4U7iDznopRxRo2W7vmE=",
+            "last_commit": 1607807382,
+            "header": "/headers/rapid-fire.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/break-up.lic",
+            "type": "script",
+            "md5": "NeVIgo4KjzWZj5qtre8Ax7kat6A=",
+            "last_commit": 1607807382,
+            "header": "/headers/break-up.header",
+            "tags": [],
+            "author": "Olemac"
+        },
+        {
+            "file": "/assets/mechfire_orig.lic",
+            "type": "script",
+            "md5": "Lqj6V2MUeIXpOicKd1TKE/wL7ks=",
+            "last_commit": 1607807382,
+            "header": "/headers/mechfire_orig.header",
+            "tags": [
+                "ranged crossbow mechanical combat"
+            ],
+            "version": "1.1",
+            "author": "Getho"
+        },
+        {
+            "file": "/assets/wander.lic",
+            "type": "script",
+            "md5": "9ALkE/eWg3K8chkyDwnlZtRrSpk=",
+            "last_commit": 1607807382,
+            "header": "/headers/wander.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.6",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/adrenalin.lic",
+            "type": "script",
+            "md5": "I8w40opaTQNWx4GNloS5Xibqr+A=",
+            "last_commit": 1607807382,
+            "header": "/headers/adrenalin.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dr_counter.lic",
+            "type": "script",
+            "md5": "HoBsYo3vDUK1O8CYrqRh+aBl/uQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/dr_counter.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/uberbounty.lic",
+            "type": "script",
+            "md5": "sJDSOHwjcaDXI/iqThgRN2sbLdg=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberbounty.header",
+            "tags": [
+                "utility",
+                "stormfront"
+            ],
+            "version": "6.93",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/forge-perfects-fixed.lic",
+            "type": "script",
+            "md5": "d3UGE5fXPyYKvXPmOsPXWgUCv5E=",
+            "last_commit": 1607807382,
+            "header": "/headers/forge-perfects-fixed.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "perfect"
+            ]
+        },
+        {
+            "file": "/assets/scalcmm.lic",
+            "type": "script",
+            "md5": "g1BY3AiGllVb6SJxIpQEgmj1ZhU=",
+            "last_commit": 1607807382,
+            "header": "/headers/scalcmm.header",
+            "tags": [
+                "mechanics"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/itchy.lic",
+            "type": "script",
+            "md5": "CpFLQGdvSxcT1EGcI0hIX5MXM5Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/adventurer.lic",
+            "type": "script",
+            "md5": "1TdqHWzlwrB6jcXalgmeTzwPseA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/blursbot.lic",
+            "type": "script",
+            "md5": "9rksFBJ9XKanDsQyHNq6NvhtGaw=",
+            "last_commit": 1607807382,
+            "header": "/headers/blursbot.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/redux.lic",
+            "type": "script",
+            "md5": "YBvQC/VtH3K/Q2w69Aczen/iXLQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/cobble.lic",
+            "type": "script",
+            "md5": "PGS2NDS/vOD26oEzJ7Xcs+WYisQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/cobble.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/si_timer.lic",
+            "type": "script",
+            "md5": "SHewF/ohmcNbXiHXk6ZAO6hWi+M=",
+            "last_commit": 1607807382,
+            "header": "/headers/si_timer.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/zap.lic",
+            "type": "script",
+            "md5": "166Jy8U10/9eHzARin9EbEf9WZ8=",
+            "last_commit": 1607807382,
+            "header": "/headers/zap.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/watch4new.lic",
+            "type": "script",
+            "md5": "Gv8TzspZhfZMhrhXnfOm2tM3R/I=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/704monitor.lic",
+            "type": "script",
+            "md5": "bDqjvKmR8+3a6kYfqh9Kpzn6T6Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/704monitor.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/healdown.lic",
+            "type": "script",
+            "md5": "rpQ/vJcToKWAPpMdXBBOl9G7zvc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lootroom.lic",
+            "type": "script",
+            "md5": "34OnjUslP5xhMEEzgy/+Dqip0KY=",
+            "last_commit": 1607807382,
+            "header": "/headers/lootroom.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/ai.lic",
+            "type": "script",
+            "md5": "m9Y7cg5dBFOSmK7XdxGRFCzTRnY=",
+            "last_commit": 1607807382,
+            "header": "/headers/ai.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/forge-perfects.lic",
+            "type": "script",
+            "md5": "8AZghyW51e6oJ4BsjRVzXoibjGo=",
+            "last_commit": 1607807382,
+            "header": "/headers/forge-perfects.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "perfect"
+            ]
+        },
+        {
+            "file": "/assets/squelch.lic",
+            "type": "script",
+            "md5": "lOEw9M1RJHpYWcOzDHw5K4toOUs=",
+            "last_commit": 1607807382,
+            "header": "/headers/squelch.header",
+            "tags": [],
+            "version": "2",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/selldmjunk.lic",
+            "type": "script",
+            "md5": "/2uWNw6lysvfFy/8UsBuVToKqYM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/go2name-2.lic",
+            "type": "script",
+            "md5": "20KpfJ8yvWuGFYiv5h+EXnBoW3A=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2name-2.header",
+            "tags": [
+                "movement",
+                "utility",
+                "rescue"
+            ]
+        },
+        {
+            "file": "/assets/waggle.lic",
+            "type": "script",
+            "md5": "Xrq5FUWNgFzVO73gOslJ8t2ori4=",
+            "last_commit": 1607807382,
+            "header": "/headers/waggle.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.14",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/speak.lic",
+            "type": "script",
+            "md5": "HWIddTKofb7h/6itofq3968medc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/scrit.lic",
+            "type": "script",
+            "md5": "YMOOfARpT/MHWKMjhzYr6JtJ4qs=",
+            "last_commit": 1607807382,
+            "header": "/headers/scrit.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/bread2.lic",
+            "type": "script",
+            "md5": "8ZBQz2URokOiLMK7ZTP7jCLopMg=",
+            "last_commit": 1607807382,
+            "header": "/headers/bread2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/getall.lic",
+            "type": "script",
+            "md5": "o8nzAemGkFfbGF8Szn2eTNVknTE=",
+            "last_commit": 1607807382,
+            "header": "/headers/getall.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dr_sewers.lic",
+            "type": "script",
+            "md5": "3nGewIa4Jdt6tfM3z7Wj3MQEPOk=",
+            "last_commit": 1607807382,
+            "header": "/headers/dr_sewers.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/rrbundle.lic",
+            "type": "script",
+            "md5": "nYaxs9am2YeEzW0rcPdW1hWT8Vg=",
+            "last_commit": 1607807382,
+            "header": "/headers/rrbundle.header",
+            "tags": [
+                "river's rest",
+                "herbs",
+                "bundle"
+            ],
+            "version": "0.2",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/masscolors.lic",
+            "type": "script",
+            "md5": "casm/jogHqO8qEw2Tavr4yFX/dU=",
+            "last_commit": 1607807382,
+            "header": "/headers/masscolors.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Wiz-Meteor.lic",
+            "type": "script",
+            "md5": "nb66+mAAuzgQ7zZ47uIfxKGfdLw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/weightcalc.lic",
+            "type": "script",
+            "md5": "HuvPCtST2mWZnfNAYsQIy+7YXog=",
+            "last_commit": 1607807382,
+            "header": "/headers/weightcalc.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/foreach.lic",
+            "type": "script",
+            "md5": "CYb80W0SAhi6fBz6I24gzTzqI+s=",
+            "last_commit": 1607807382,
+            "header": "/headers/foreach.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0.3 (2020-03-10)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/xp.lic",
+            "type": "script",
+            "md5": "GCwQhevMX+L0CVaKP41rG0oKgT8=",
+            "last_commit": 1608258646,
+            "header": "/headers/xp.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.7",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/spellmerge.lic",
+            "type": "script",
+            "md5": "L9twnJisXdJ71pNPNpLSivgBE4I=",
+            "last_commit": 1607807382,
+            "header": "/headers/spellmerge.header",
+            "tags": [
+                "Magic",
+                "QOL"
+            ],
+            "version": "0.6 (2019-11-30)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/spriteWL.lic",
+            "type": "script",
+            "md5": "5SI+LMetqC2mPIQZP+Bcxwdqg1M=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/autoaccept.lic",
+            "type": "script",
+            "md5": "dkO86sOaFErZC3cm0msllb2Vq3M=",
+            "last_commit": 1607807382,
+            "header": "/headers/autoaccept.header",
+            "tags": [
+                "util"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/rol_new.lic",
+            "type": "script",
+            "md5": "7PYuq4xh4vN9qnoHo5/PXrnmCSU=",
+            "last_commit": 1607807382,
+            "header": "/headers/rol_new.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sanctumwatch.lic",
+            "type": "script",
+            "md5": "Tc1P0/8Mo/cmmx7TxY4mLATbQsc=",
+            "last_commit": 1607807382,
+            "header": "/headers/sanctumwatch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sell_shells.lic",
+            "type": "script",
+            "md5": "IcyE76J7otExtDm8hDOWIHtI6f0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/carousel.lic",
+            "type": "script",
+            "md5": "watSiOFQevF/klmrZ/vzVWvGfV8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/purify.lic",
+            "type": "script",
+            "md5": "B5+bseiVLPGkkvZAVwrHNivB8js=",
+            "last_commit": 1607807382,
+            "header": "/headers/purify.header",
+            "tags": [
+                "bard",
+                "gems",
+                "1004"
+            ],
+            "version": "2015.05.27.01",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/staminamina.lic",
+            "type": "script",
+            "md5": "oVLzZvV2G8pOmNLNJcuHPlPcEso=",
+            "last_commit": 1607807382,
+            "header": "/headers/staminamina.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/activespells.lic",
+            "type": "script",
+            "md5": "nSVqewOufmZZNXxXSrgcmPokUe8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/encumbrancebar.lic",
+            "type": "script",
+            "md5": "cB/bccpNWbRum9oBWsXH/LRJ1sk=",
+            "last_commit": 1607807382,
+            "header": "/headers/encumbrancebar.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dispel_tracker.lic",
+            "type": "script",
+            "md5": "5jEQMDEX9sC/aIbsTYj+LJtYqIs=",
+            "last_commit": 1607807382,
+            "header": "/headers/dispel_tracker.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/time.lic",
+            "type": "script",
+            "md5": "ti8gRJ0GDqw+AajU+BgdWq4ai1g=",
+            "last_commit": 1607807382,
+            "header": "/headers/time.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/1640rant.lic",
+            "type": "script",
+            "md5": "OdyUAdxBy86b5fD2hoY8nT3K3Z4=",
+            "last_commit": 1607807382,
+            "header": "/headers/1640rant.header",
+            "tags": [
+                "Paladins"
+            ],
+            "version": "1.2",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/203_rest.lic",
+            "type": "script",
+            "md5": "5hP4iooHJ1ZUbEDpll6Cn0XTYGM=",
+            "last_commit": 1607807382,
+            "header": "/headers/203_rest.header",
+            "tags": [],
+            "version": "1",
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/gaze.lic",
+            "type": "script",
+            "md5": "Nl1JljvRugyJD+kJkfwPCvGJNbU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ltb.lic",
+            "type": "script",
+            "md5": "xvYGOddMS1LRiMA+jw5OxrMdrSA=",
+            "last_commit": 1607807382,
+            "header": "/headers/ltb.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/smart_spellup.lic",
+            "type": "script",
+            "md5": "LSzQxschZVwEcyqZ+Uud0zkpBDY=",
+            "last_commit": 1607807382,
+            "header": "/headers/smart_spellup.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/group_ajar.lic",
+            "type": "script",
+            "md5": "cLNXgi4tc9JgTgg9PgbF7rtTm7U=",
+            "last_commit": 1607807382,
+            "header": "/headers/group_ajar.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/rally.lic",
+            "type": "script",
+            "md5": "xmuooCyKdixWH7tTjiX45uPSyzU=",
+            "last_commit": 1607807382,
+            "header": "/headers/rally.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/startvaalorsprite.lic",
+            "type": "script",
+            "md5": "Vy8N/FpRG7FuRqVGr+kYl9t/XM8=",
+            "last_commit": 1607807382,
+            "header": "/headers/startvaalorsprite.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/Temple_Drop.lic",
+            "type": "script",
+            "md5": "XSo9xmf4CaL/PbKTkJYFjIi59vs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/uberbarmagic.lic",
+            "type": "script",
+            "md5": "VhrwFbgrXU0BJepP6wIhXNr2CME=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberbarmagic.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/shaste.lic",
+            "type": "script",
+            "md5": "DMV0hJcLnClsZNWwbjuPJIxQT5k=",
+            "last_commit": 1607807382,
+            "header": "/headers/shaste.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ddig.lic",
+            "type": "script",
+            "md5": "xxUl8J2+0XXDHO1p0ZJPKx3Tm8Q=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/shunt.lic",
+            "type": "script",
+            "md5": "pJqqnS2c6R09g3Rtz4Q+dSpYKXk=",
+            "last_commit": 1607807382,
+            "header": "/headers/shunt.header",
+            "tags": [
+                "hunting"
+            ],
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/climatewear.lic",
+            "type": "script",
+            "md5": "q7inw8TzMhIlGYXuoY3N8Kn4snw=",
+            "last_commit": 1607807382,
+            "header": "/headers/climatewear.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/scotch.lic",
+            "type": "script",
+            "md5": "cmK9l9l6rPP/9T2fMgc53U0G+98=",
+            "last_commit": 1607807382,
+            "header": "/headers/scotch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/loud-exp-pulse.lic",
+            "type": "script",
+            "md5": "QT68RSu0Pq9lKUSGbP+RZCWPSIA=",
+            "last_commit": 1607807382,
+            "header": "/headers/loud-exp-pulse.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/loot.lic",
+            "type": "script",
+            "md5": "IIMgB6hgCm3mB9iIOES0hD8yzIU=",
+            "last_commit": 1607807382,
+            "header": "/headers/loot.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "0.26",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/skins.json",
+            "type": "data",
+            "md5": "GWJAeI/tVVJ7mmTh+O6g7tMXT38=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lore_perm_bonus.lic",
+            "type": "script",
+            "md5": "HmACiQcOcCNTFWm9MuYiIFlDqkc=",
+            "last_commit": 1607807382,
+            "header": "/headers/lore_perm_bonus.header",
+            "tags": [
+                "bard",
+                "loresinging"
+            ],
+            "version": "2",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/armoires-are-stupid.lic",
+            "type": "script",
+            "md5": "Q0/b5nLRD/IDv9+Ec83zW60Srvc=",
+            "last_commit": 1607807382,
+            "header": "/headers/armoires-are-stupid.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Takoa"
+        },
+        {
+            "file": "/assets/begforshit.lic",
+            "type": "script",
+            "md5": "gtnVo6fzyns4K9+w3awuqeBCuXU=",
+            "last_commit": 1607807382,
+            "header": "/headers/begforshit.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/chanterguide.lic",
+            "type": "script",
+            "md5": "NTEgN75Ii2buj61Lr/Kn3y/KQcc=",
+            "last_commit": 1607807382,
+            "header": "/headers/chanterguide.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wizshield.lic",
+            "type": "script",
+            "md5": "sW3kXco8SF3ShiKrCAOKKvE24iE=",
+            "last_commit": 1607807382,
+            "header": "/headers/wizshield.header",
+            "tags": [
+                "919",
+                "utility",
+                "spells",
+                "recast",
+                "helper",
+                "auto"
+            ],
+            "version": "0.1",
+            "author": "Nomada"
+        },
+        {
+            "file": "/assets/invloc.lic",
+            "type": "script",
+            "md5": "JpgIurbFgbxZsDF2tAEH0ut9XLk=",
+            "last_commit": 1607807382,
+            "header": "/headers/invloc.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/fletchit.lic",
+            "type": "script",
+            "md5": "1JmGsFSJO/lX4hz65rb7cUkrT9Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/fletchit.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/xegdig.lic",
+            "type": "script",
+            "md5": "1Uf4sO+MV77bHGJnlVZAs0lN0LQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/xegdig.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "3.6.2.4",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/ReplaceLinksWithMyName.lic",
+            "type": "script",
+            "md5": "b4FxbONnwuHf9RqxQ8tJmMQ7VM8=",
+            "last_commit": 1607807382,
+            "header": "/headers/ReplaceLinksWithMyName.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/gemscounter.lic",
+            "type": "script",
+            "md5": "Q67f0m97I2Yayln4QWvybw2cppo=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemscounter.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Nisch"
+        },
+        {
+            "file": "/assets/deeds_landing.lic",
+            "type": "script",
+            "md5": "2dQE+snyuXT/dGSaH6yQtlbarbs=",
+            "last_commit": 1607807382,
+            "header": "/headers/deeds_landing.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/provoke.lic",
+            "type": "script",
+            "md5": "dK78135x9xf7aMSHuS/i7aLynsI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/amunet.lic",
+            "type": "script",
+            "md5": "y80elA+i9Q6JYh4YeLIxzGCDekM=",
+            "last_commit": 1607807382,
+            "header": "/headers/amunet.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/trashtag.lic",
+            "type": "script",
+            "md5": "TN1AnhBpjt5Y+PfWBWYVo8N1h9o=",
+            "last_commit": 1607807382,
+            "header": "/headers/trashtag.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2020-03-16)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/UBW-Theme-Sexy.lic",
+            "type": "script",
+            "md5": "Hq1XO5IV5aa5pvxAl3gAD9XcHUk=",
+            "last_commit": 1607807382,
+            "header": "/headers/UBW-Theme-Sexy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/arena-ryjex.lic",
+            "type": "script",
+            "md5": "loaBF0wQktsB4kVEZnUCfc8uaBE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/fun-with-dreaven-video-1.lic",
+            "type": "script",
+            "md5": "D3/iTtpwEmn25iCMdNjaeNRtajk=",
+            "last_commit": 1607807382,
+            "header": "/headers/fun-with-dreaven-video-1.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/xcalipers.lic",
+            "type": "script",
+            "md5": "pSH8U362DMXkC/WzFEVIbK7+E34=",
+            "last_commit": 1607807382,
+            "header": "/headers/xcalipers.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2-PREVIEW (2020-03-17)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/qrs.lic",
+            "type": "script",
+            "md5": "muqYiB63mQeBoO4/nCZ0W7CfxIk=",
+            "last_commit": 1607807382,
+            "header": "/headers/qrs.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/expandedview.lic",
+            "type": "script",
+            "md5": "Q5qIJ4GwMYFUc363Mwf5Du+PZGQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/expandedview.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.3 (2019-07-02)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/atlas_data.db3",
+            "type": "data",
+            "md5": "qvXGHZswxF672ovbqZ3tG0ul5wA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/betazzherb.lic",
+            "type": "script",
+            "md5": "BWodDHTMHLXKHlD9Iz2izbeUv6Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/betazzherb.header",
+            "tags": [
+                "foraging",
+                "herbs"
+            ],
+            "version": "5",
+            "author": "Zzentar"
+        },
+        {
+            "file": "/assets/sing.lic",
+            "type": "script",
+            "md5": "+MrNOMVUnSZws2QHrczfnpbqABQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/sing.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/xready.lic",
+            "type": "script",
+            "md5": "GfERqJdH9AOW8OnJ4hgjZevEcD4=",
+            "last_commit": 1607807382,
+            "header": "/headers/xready.header",
+            "tags": [
+                "utility",
+                "bounty"
+            ],
+            "version": "0.1",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/waypoint.lic",
+            "type": "script",
+            "md5": "j5v5jffbvDZRrVQv7JVL0hZ1MqA=",
+            "last_commit": 1607807382,
+            "header": "/headers/waypoint.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bingo.lic",
+            "type": "script",
+            "md5": "QKh77qvA45Zh9sKT+e7zrogeQ8U=",
+            "last_commit": 1607807382,
+            "header": "/headers/bingo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/aoeleech.lic",
+            "type": "script",
+            "md5": "tRTXduKfGotZaBf6zW6UAiJf4zA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/reimtraps.lic",
+            "type": "script",
+            "md5": "61PiHEjBS98w4xpNwvK6+wb2brQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/reimtraps.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/drarch.lic",
+            "type": "script",
+            "md5": "fbncVmL8Az7YbosRX4ONT9IzPe8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gemseller.lic",
+            "type": "script",
+            "md5": "f8oxzaoMz+v6mu1liKCF4O7U2tc=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemseller.header",
+            "tags": [],
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/smartmonk2.lic",
+            "type": "script",
+            "md5": "8HxgaKtRgTpcRcOFhuPwntRor6w=",
+            "last_commit": 1607807382,
+            "header": "/headers/smartmonk2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/max_lock.lic",
+            "type": "script",
+            "md5": "VujdgntW/pRMNA72yzTnsHFDaoY=",
+            "last_commit": 1607807382,
+            "header": "/headers/max_lock.header",
+            "tags": [
+                "utility",
+                "information",
+                "lockpicking"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/vyrsh_heist_debug.lic",
+            "type": "script",
+            "md5": "x6LGs5lrJgpIKHNfV8Wo3gmXSzw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lcheck.lic",
+            "type": "script",
+            "md5": "2MRJfOpMM3xZJSPCrkGpKR9bYEw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/kstwatch.lic",
+            "type": "script",
+            "md5": "gzhM0XckAI6YOxa1k3/94R65SGc=",
+            "last_commit": 1607807382,
+            "header": "/headers/kstwatch.header",
+            "tags": [
+                "KST",
+                "RP",
+                "Stormfront",
+                "speechwindow",
+                "monsterbold",
+                "GMs",
+                "QST",
+                "WizardFE",
+                "Profanity"
+            ],
+            "version": "1.1.1",
+            "author": "Claudaro (With contributions from Tysong)"
+        },
+        {
+            "file": "/assets/givebread.lic",
+            "type": "script",
+            "md5": "X+gTsZrkSSU6XgvAJE/mykDys8w=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/banditcounter.lic",
+            "type": "script",
+            "md5": "OmZ+pEkVF33ewYc1kKOKYGC6iz8=",
+            "last_commit": 1607807382,
+            "header": "/headers/banditcounter.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/wbread.lic",
+            "type": "script",
+            "md5": "uLdEPMaj04Sv/+KGoAhV1aIsM24=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/maxcap.lic",
+            "type": "script",
+            "md5": "Gv1UUjNDb5Fz92BjANHJL8wm1iA=",
+            "last_commit": 1607807382,
+            "header": "/headers/maxcap.header",
+            "tags": [],
+            "version": "3",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/universalkill-daiyon.lic",
+            "type": "script",
+            "md5": "za/hPNlEKCR2U1GcGUfbOeColNY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/pain.lic",
+            "type": "script",
+            "md5": "Ry9GjQ8gWpiC8rtEvEo09D1F1u8=",
+            "last_commit": 1607807382,
+            "header": "/headers/pain.header",
+            "tags": [
+                "pain",
+                "711"
+            ],
+            "version": "1",
+            "author": "Zegres"
+        },
+        {
+            "file": "/assets/mana-tracking.lic",
+            "type": "script",
+            "md5": "f1Cqz3/4iSMcJ0RN/PGVwpY9kuI=",
+            "last_commit": 1607807382,
+            "header": "/headers/mana-tracking.header",
+            "tags": [],
+            "version": "7",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/mana2.lic",
+            "type": "script",
+            "md5": "Jsj2fXnNITHtIhvV75o3fKu/7dY=",
+            "last_commit": 1607807382,
+            "header": "/headers/mana2.header",
+            "tags": [
+                "guild",
+                "illusions",
+                "spellups"
+            ],
+            "version": "1.2",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/sdeath.lic",
+            "type": "script",
+            "md5": "dTbb+AA+Js1fDumsgaQBo8nGgok=",
+            "last_commit": 1607807382,
+            "header": "/headers/sdeath.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/stones.lic",
+            "type": "script",
+            "md5": "bYvPPccCDuIHwRgDwmPEv6J+9xs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dreavquit.lic",
+            "type": "script",
+            "md5": "KV6XrG+msxEGe9aYon/kCt0xzLg=",
+            "last_commit": 1607807382,
+            "header": "/headers/dreavquit.header",
+            "tags": [],
+            "author": "Demmit"
+        },
+        {
+            "file": "/assets/506.lic",
+            "type": "script",
+            "md5": "q8RPR6ZGEGq7PP8BR5eV5nuRY5M=",
+            "last_commit": 1607807382,
+            "header": "/headers/506.header",
+            "tags": [],
+            "author": "Rumbletum"
+        },
+        {
+            "file": "/assets/settings.lic",
+            "type": "script",
+            "md5": "GI/mCJ+ltww0sS7O7IuCy9r6EO8=",
+            "last_commit": 1607807382,
+            "header": "/headers/settings.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/beldig.lic",
+            "type": "script",
+            "md5": "X5ynRjLcZD8M79QNHT6mUuaZqt0=",
+            "last_commit": 1607807382,
+            "header": "/headers/beldig.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/set.lic",
+            "type": "script",
+            "md5": "PvbhUXLM/UXR5yyTOJrivKXsL3g=",
+            "last_commit": 1607807382,
+            "header": "/headers/set.header",
+            "tags": [
+                "utility",
+                "settings"
+            ],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/autoforage.lic",
+            "type": "script",
+            "md5": "gUJW67n7cFQth44BSzzcD5OmJlc=",
+            "last_commit": 1607807382,
+            "header": "/headers/autoforage.header",
+            "tags": [
+                "herbs"
+            ],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/armoire.lic",
+            "type": "script",
+            "md5": "o68FoZZ0aQlZyxVgZPqaDblQhKw=",
+            "last_commit": 1607807382,
+            "header": "/headers/armoire.header",
+            "tags": [
+                "loot",
+                "armoire"
+            ],
+            "version": "1.1",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/xfer.lic",
+            "type": "script",
+            "md5": "XUhN9obFVcfC57PhKCbVr8I39lk=",
+            "last_commit": 1607807382,
+            "header": "/headers/xfer.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/skin.lic",
+            "type": "script",
+            "md5": "do3YLtu8+9cHKiuOXJViLEnv0d4=",
+            "last_commit": 1607807382,
+            "header": "/headers/skin.header",
+            "tags": [
+                "hunting",
+                "skinning",
+                "skin",
+                "pelt"
+            ],
+            "version": "1.3",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/backroom.lic",
+            "type": "script",
+            "md5": "IuFEh9zDOjhXNjfuzdBhQfaO+HU=",
+            "last_commit": 1607807382,
+            "header": "/headers/backroom.header",
+            "tags": [
+                "backroom",
+                "utility",
+                "purchase"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/easykill.lic",
+            "type": "script",
+            "md5": "SqdH3CTf6RPgAV/qJgQ/c5PeuxQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lockpicks.lic",
+            "type": "script",
+            "md5": "OvejE8EVu24hZM4QbNh+8dXQUn0=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockpicks.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/1b2b3b.lic",
+            "type": "script",
+            "md5": "uEUTCFEDeF9wgvOIx5TuiClRuN0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/huntmaster.lic",
+            "type": "script",
+            "md5": "L0Me1AT5SnbfibEH51V6VvZqoj0=",
+            "last_commit": 1607807382,
+            "header": "/headers/huntmaster.header",
+            "tags": [
+                "hunting",
+                "combat",
+                "bigshot",
+                "placeholder"
+            ],
+            "version": "0",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/murderverses.lic",
+            "type": "script",
+            "md5": "AccRi7rThZo2RUbVlkuCNHuae4Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/murderverses.header",
+            "tags": [
+                "bard",
+                "lkp",
+                "loresong",
+                "permanent",
+                "murderverse",
+                "kill points",
+                "points",
+                "utility",
+                "translate",
+                "recall",
+                "lore knowledge point",
+                "knowledge",
+                "point"
+            ],
+            "version": "1.2 (never use a version that ends in 0)",
+            "author": "Luxelle"
+        },
+        {
+            "file": "/assets/dropbox.lic",
+            "type": "script",
+            "md5": "+YAobrOUKaK7pYsVLWvGjYmOVSo=",
+            "last_commit": 1607807382,
+            "header": "/headers/dropbox.header",
+            "tags": [
+                "loot",
+                "dropper",
+                "boxes",
+                "chests",
+                "utility",
+                "helper"
+            ],
+            "version": "0.1 alpha",
+            "author": "Nomada"
+        },
+        {
+            "file": "/assets/sunfist-health.lic",
+            "type": "script",
+            "md5": "3NGCtG0S8Y6ageIl2Wxx+zW4owE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/jailboxthatworks.lic",
+            "type": "script",
+            "md5": "CKQf8V7FG/j+GvJ/Hdom/YMsZ2k=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/SaveBountyGems.lic",
+            "type": "script",
+            "md5": "lQ42A78DVK1ScDKKvAnfOCKdKUs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/IbboIsRetarded.lic",
+            "type": "script",
+            "md5": "VOD4+Qkq2YfWDnpFL97UaJ9AAL4=",
+            "last_commit": 1607807382,
+            "header": "/headers/IbboIsRetarded.header",
+            "tags": [
+                "idiot",
+                "idiots"
+            ],
+            "version": "1.1",
+            "author": "Shimmerain"
+        },
+        {
+            "file": "/assets/log.lic",
+            "type": "script",
+            "md5": "ayVJwQ2iwZrvBKh6dqYYo1+vxYU=",
+            "last_commit": 1607807382,
+            "header": "/headers/log.header",
+            "tags": [],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/ttap.lic",
+            "type": "script",
+            "md5": "mS4Vn0kkNRZQs117eVxF9ZMz7y0=",
+            "last_commit": 1607807382,
+            "header": "/headers/ttap.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lnet.lic",
+            "type": "script",
+            "md5": "Vq61/4gTY5QPb461f28qqF6eQos=",
+            "last_commit": 1607807382,
+            "header": "/headers/lnet.header",
+            "tags": [
+                "core"
+            ],
+            "version": "1.6",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/BlackRose.lic",
+            "type": "script",
+            "md5": "B0Lo4qF6uzpEXSiSz4k9mH3XnQo=",
+            "last_commit": 1607807382,
+            "header": "/headers/BlackRose.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/uberbar.lic",
+            "type": "script",
+            "md5": "Jskijjq5Audald+MuvweEky6lk0=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberbar.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/eat-left.lic",
+            "type": "script",
+            "md5": "KbQdasWoLhVkfBgYcVGq1qoXOFY=",
+            "last_commit": 1607807382,
+            "header": "/headers/eat-left.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/qskin.lic",
+            "type": "script",
+            "md5": "lD63g/KtuDnd1eV6snw7YKFu4nU=",
+            "last_commit": 1607807382,
+            "header": "/headers/qskin.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/uberfletch.lic",
+            "type": "script",
+            "md5": "aIhxSeMnZ8wwG78Cc1g0pzc0rd4=",
+            "last_commit": 1607807382,
+            "header": "/headers/uberfletch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/buns.lic",
+            "type": "script",
+            "md5": "at5v5VwarhoTI84aIZ3MDTZh8cE=",
+            "last_commit": 1607807382,
+            "header": "/headers/buns.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/jfloo.lic",
+            "type": "script",
+            "md5": "ZfhXuxpYi2jhd+ifCdDElRJa/cA=",
+            "last_commit": 1607807382,
+            "header": "/headers/jfloo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bloot.lic",
+            "type": "script",
+            "md5": "cHPPo6nZfC5uxDA5JxnC6B91dTU=",
+            "last_commit": 1607807382,
+            "header": "/headers/bloot.header",
+            "tags": [],
+            "version": "2016.10.10.01",
+            "author": "Akono (lordakono@gmail.com)"
+        },
+        {
+            "file": "/assets/alfred-chrism.lic",
+            "type": "script",
+            "md5": "da1umaarghbczCsUUMNXlKWWOgU=",
+            "last_commit": 1607807382,
+            "header": "/headers/alfred-chrism.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pulse_do.lic",
+            "type": "script",
+            "md5": "ERat/MXhwfMW8/cPbJ+fD4j1NMI=",
+            "last_commit": 1607807382,
+            "header": "/headers/pulse_do.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/mapmap.lic",
+            "type": "script",
+            "md5": "B5TE+i/LuhHrlQ/tpTUqp48KZiY=",
+            "last_commit": 1607807382,
+            "header": "/headers/mapmap.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.3",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/502slow.lic",
+            "type": "script",
+            "md5": "GwpAbjoOgcmH4nQccScibiWiOTg=",
+            "last_commit": 1607807382,
+            "header": "/headers/502slow.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wood.lic",
+            "type": "script",
+            "md5": "Mqw04diRDcwdVnHq83vNay1La5w=",
+            "last_commit": 1607807382,
+            "header": "/headers/wood.header",
+            "tags": [],
+            "author": "Pukk"
+        },
+        {
+            "file": "/assets/restfull.lic",
+            "type": "script",
+            "md5": "Bfvl2JB3ZkF8cBg4wqm2SGuXL6Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/restfull.header",
+            "tags": [],
+            "version": "1",
+            "author": "Eldra"
+        },
+        {
+            "file": "/assets/kdisarm.lic",
+            "type": "script",
+            "md5": "Qgp0ICMatEKWUwusS8W46rV5JUA=",
+            "last_commit": 1607807382,
+            "header": "/headers/kdisarm.header",
+            "tags": [
+                "lock picking"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/sammu.lic",
+            "type": "script",
+            "md5": "kw9UlqaMcYm+T4VDXo2n/NHThow=",
+            "last_commit": 1607807382,
+            "header": "/headers/sammu.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/deathbot_ignore.lic",
+            "type": "script",
+            "md5": "stzxEm1BOYWuMGckSPfuZUtcc1o=",
+            "last_commit": 1607807382,
+            "header": "/headers/deathbot_ignore.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/guild_tasks.cmd",
+            "type": "data",
+            "md5": "tzbJeXw5AGrHfJE4b/4w87kPkkM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/highlight_links.lic",
+            "type": "script",
+            "md5": "2qcXyHf80b+DvlK0Q7MnjOqrjPc=",
+            "last_commit": 1607807382,
+            "header": "/headers/highlight_links.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lore.lic",
+            "type": "script",
+            "md5": "yuvODEBz156RCdr1dIWn71lw0vI=",
+            "last_commit": 1607807382,
+            "header": "/headers/lore.header",
+            "tags": [],
+            "version": "2.4",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/instant.lic",
+            "type": "script",
+            "md5": "+Q8IeXMbd7CMpvX5Z3Kkr6CzX9g=",
+            "last_commit": 1607807382,
+            "header": "/headers/instant.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/rogue-lmas-contest.lic",
+            "type": "script",
+            "md5": "3OksIjqktYIQ9lilqnokIaYbUGM=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-contest.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/tangleweed.lic",
+            "type": "script",
+            "md5": "KdsvgOyEPWiTkQjsBX+/zI+EPgY=",
+            "last_commit": 1607807382,
+            "header": "/headers/tangleweed.header",
+            "tags": [
+                "tangle weed",
+                "610",
+                "ranger"
+            ],
+            "version": "1.1",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/lumnis_average.lic",
+            "type": "script",
+            "md5": "VT3A5TJkRO9R81zaYFexwvklTlY=",
+            "last_commit": 1607807382,
+            "header": "/headers/lumnis_average.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "3",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/quest_sell.lic",
+            "type": "script",
+            "md5": "b812VgW6uy3MSI//6FX1m1yKJJE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/prisoners.lic",
+            "type": "script",
+            "md5": "6i2lEbG+nX5A1J+neRJ75FuMtpU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lootlist.lic",
+            "type": "script",
+            "md5": "wN5mrfFt9aLm1X08pk24ue7+sdc=",
+            "last_commit": 1607807382,
+            "header": "/headers/lootlist.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/wait-one.lic",
+            "type": "script",
+            "md5": "57nEl58Y2U/jPViitMsYWFd2dao=",
+            "last_commit": 1607807382,
+            "header": "/headers/wait-one.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/zzherb.lic",
+            "type": "script",
+            "md5": "dvWx8h6d/Xnr9o0TATwaAJcppi0=",
+            "last_commit": 1607807382,
+            "header": "/headers/zzherb.header",
+            "tags": [
+                "foraging",
+                "herbs"
+            ],
+            "author": "Zzentar"
+        },
+        {
+            "file": "/assets/bountyhunter.lic",
+            "type": "script",
+            "md5": "m3/sLFRNBZOB0PN3N+BmdTE3ZK0=",
+            "last_commit": 1607807382,
+            "header": "/headers/bountyhunter.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/untrammel.lic",
+            "type": "script",
+            "md5": "Yke66Iu2yVJU0rdfpFD4jk0onY4=",
+            "last_commit": 1607807382,
+            "header": "/headers/untrammel.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/brooch.lic",
+            "type": "script",
+            "md5": "P1O0OluX08IYxXSj/lisr7VK1WA=",
+            "last_commit": 1607807382,
+            "header": "/headers/brooch.header",
+            "tags": [],
+            "version": "2",
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/specialization.lic",
+            "type": "script",
+            "md5": "DRm7JW4WUiETqxnQ61A4mxUh/WI=",
+            "last_commit": 1607807382,
+            "header": "/headers/specialization.header",
+            "tags": [
+                "armor",
+                "utility",
+                "information"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/tradingbonus.lic",
+            "type": "script",
+            "md5": "vOBleN+k94/ycS5HevmnL6fv4Ls=",
+            "last_commit": 1607807382,
+            "header": "/headers/tradingbonus.header",
+            "tags": [
+                "trading",
+                "utility",
+                "information"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/campy.lic",
+            "type": "script",
+            "md5": "gRX5w95zU2UZmuNFhFIybmKJDGU=",
+            "last_commit": 1607807382,
+            "header": "/headers/campy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/125.lic",
+            "type": "script",
+            "md5": "KaxtuYCkEHiyAyZiaeFnBTRDnR4=",
+            "last_commit": 1607807382,
+            "header": "/headers/125.header",
+            "tags": [],
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/paths.lic",
+            "type": "script",
+            "md5": "2+89LZfXT31esu0///RxSayN+dI=",
+            "last_commit": 1607807382,
+            "header": "/headers/paths.header",
+            "tags": [],
+            "version": "1.1",
+            "author": "Essio"
+        },
+        {
+            "file": "/assets/stupid-deed.lic",
+            "type": "script",
+            "md5": "xGVZDhdv3sZ7Yy4GQ+PoHx4pCog=",
+            "last_commit": 1607807382,
+            "header": "/headers/stupid-deed.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/herball.lic",
+            "type": "script",
+            "md5": "HvuSHJ0U+/7L68F7oVCv0mBxSw4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xmlpatch.lic",
+            "type": "script",
+            "md5": "eaVhIoEVaRbsJAY1SZpiycqMzIo=",
+            "last_commit": 1607807382,
+            "header": "/headers/xmlpatch.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.3.2 (2019-10-12)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/myklian.lic",
+            "type": "script",
+            "md5": "Ny15AI8SOkqWDasrM3YC4p8DmYo=",
+            "last_commit": 1607807382,
+            "header": "/headers/myklian.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bundling.lic",
+            "type": "script",
+            "md5": "y3UfvtbocduCxz+JDzJ98FsPf4Q=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/meditate.lic",
+            "type": "script",
+            "md5": "caF5W2rAfbi/CDvNCJS0OhLDvZc=",
+            "last_commit": 1607807382,
+            "header": "/headers/meditate.header",
+            "tags": [
+                "monk",
+                "cleric",
+                "empath",
+                "resting"
+            ],
+            "version": "1.2",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/unsaturated_do.lic",
+            "type": "script",
+            "md5": "rG9swxIDYawK/JvYaUEpO+v/cmc=",
+            "last_commit": 1607807382,
+            "header": "/headers/unsaturated_do.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/checkannounce.lic",
+            "type": "script",
+            "md5": "NC7YZ+eQJxhab+Pt9exuimyuEkg=",
+            "last_commit": 1607807382,
+            "header": "/headers/checkannounce.header",
+            "tags": [
+                "info",
+                "play.net",
+                "news",
+                "announcements"
+            ],
+            "version": "1.0",
+            "author": "someone?"
+        },
+        {
+            "file": "/assets/defense_calc.lic",
+            "type": "script",
+            "md5": "VzItqEOv+w7p4wRGFL0JRImF0Cg=",
+            "last_commit": 1607807382,
+            "header": "/headers/defense_calc.header",
+            "tags": [
+                "utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/BanditPatrol.lic",
+            "type": "script",
+            "md5": "jRhlkpssf20ntUhNMSInjDm+hZ0=",
+            "last_commit": 1607807382,
+            "header": "/headers/BanditPatrol.header",
+            "tags": [
+                "bandit",
+                "bandits",
+                "bounty",
+                "utility",
+                "stormfront"
+            ],
+            "version": "1.2",
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/rnum2.lic",
+            "type": "script",
+            "md5": "te5Ugaio/S9G5gkwObv4Q0xHaCE=",
+            "last_commit": 1607807382,
+            "header": "/headers/rnum2.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1",
+            "author": "Xanlin (original author: Geldan)"
+        },
+        {
+            "file": "/assets/locksmith.lic",
+            "type": "script",
+            "md5": "OJtDoITK3K3zb8Qge45iXmkpBYY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tickets.lic",
+            "type": "script",
+            "md5": "2+9mMajfUiWpX8ZL94am7863iOM=",
+            "last_commit": 1607807382,
+            "header": "/headers/tickets.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/zesttest.lic",
+            "type": "script",
+            "md5": "kwllcxLWG5BWHkOWNFUJa2jC7MU=",
+            "last_commit": 1607807382,
+            "header": "/headers/zesttest.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dart_squelch.lic",
+            "type": "script",
+            "md5": "hpQpG+yLdP++PYES6YHC5LH9vs8=",
+            "last_commit": 1607807382,
+            "header": "/headers/dart_squelch.header",
+            "tags": [
+                "darts",
+                "games",
+                "utility",
+                "squelch"
+            ],
+            "version": "0",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/gemsell.lic",
+            "type": "script",
+            "md5": "LOC/CszpX9uTP0eB0tiI5mAvIRw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hands_and_room.lic",
+            "type": "script",
+            "md5": "pwOBGHB7wTH+4IK8NsKU2rR063M=",
+            "last_commit": 1607807382,
+            "header": "/headers/hands_and_room.header",
+            "tags": [
+                "items",
+                "hands",
+                "window"
+            ],
+            "version": "0.1",
+            "author": "Deatrys"
+        },
+        {
+            "file": "/assets/idle.lic",
+            "type": "script",
+            "md5": "1fvqojy93z1GjPqvrH9FKJnzUh0=",
+            "last_commit": 1607807382,
+            "header": "/headers/idle.header",
+            "tags": [
+                "death",
+                "afk"
+            ],
+            "version": "2.1",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/resay.lic",
+            "type": "script",
+            "md5": "q9BrDz4ZFCPWp+RX09X5s+CAVT4=",
+            "last_commit": 1607807382,
+            "header": "/headers/resay.header",
+            "tags": [
+                "utility",
+                "verb",
+                "verbs",
+                "autocorrect",
+                "roleplay",
+                "speech"
+            ],
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/conditiononce.lic",
+            "type": "script",
+            "md5": "Ptta32hKgDL+2cs4mzleipSx6eE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/pooled-essence.lic",
+            "type": "script",
+            "md5": "GgSwbqB+9G/8ihJ3gx2bc42PA2M=",
+            "last_commit": 1607807382,
+            "header": "/headers/pooled-essence.header",
+            "tags": [
+                "spells",
+                "wizard",
+                "enchanting"
+            ],
+            "version": "1.0",
+            "author": "Maodan"
+        },
+        {
+            "file": "/assets/watchdog.lic",
+            "type": "script",
+            "md5": "OdRs4SI68jMcoLeiS4TtsJBYL0k=",
+            "last_commit": 1607807382,
+            "header": "/headers/watchdog.header",
+            "tags": [],
+            "version": "0.3",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/speaklikeacat.lic",
+            "type": "script",
+            "md5": "bt/6Pf1P+VTSqZIR3Nwsw/NMZ6A=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/keepthoughts.lic",
+            "type": "script",
+            "md5": "kFOzZvQwsl3KTAekP/wCyrNU6iY=",
+            "last_commit": 1607807382,
+            "header": "/headers/keepthoughts.header",
+            "tags": [
+                "amunet",
+                "utility",
+                "background"
+            ],
+            "version": "0.0.3",
+            "author": "Sulien (SulienWaggles on PC, sulieneq@gmail.com)"
+        },
+        {
+            "file": "/assets/date-translator.lic",
+            "type": "script",
+            "md5": "SJcsuy/6tToibOv1aRAaA89Nwdg=",
+            "last_commit": 1607807382,
+            "header": "/headers/date-translator.header",
+            "tags": [
+                "language"
+            ],
+            "version": "1.0",
+            "author": "Maodan"
+        },
+        {
+            "file": "/assets/buy.cmd",
+            "type": "data",
+            "md5": "78bRddf7RH/WQpHTRKT84vQIPTM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/deed.lic",
+            "type": "script",
+            "md5": "FdQCeyQolJ7WWa22ASrUUovOUE0=",
+            "last_commit": 1607807382,
+            "header": "/headers/deed.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue-lmas-makekey.lic",
+            "type": "script",
+            "md5": "3zyuQyCecHIpKeTw1EzJT6f4wTo=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-makekey.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/eblade-gsf.lic",
+            "type": "script",
+            "md5": "nEYVUEihoLEYyKpumc2ayVXIE/8=",
+            "last_commit": 1607807382,
+            "header": "/headers/eblade-gsf.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/homefix.lic",
+            "type": "script",
+            "md5": "Z5wK5OIfJiFBtXxL3ZjHT+pshZ0=",
+            "last_commit": 1607807382,
+            "header": "/headers/homefix.header",
+            "tags": [
+                "premium",
+                "player homes",
+                "homes",
+                "wizard fe",
+                "wfe"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/eat-right-wait.lic",
+            "type": "script",
+            "md5": "BrAUf2SAYH1rvYV8eE4d6l7twFU=",
+            "last_commit": 1607807382,
+            "header": "/headers/eat-right-wait.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/locks.lic",
+            "type": "script",
+            "md5": "eZEdYcm2CTUWpZyNONYbRjkmP+Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/locks.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/backroom-auto.lic",
+            "type": "script",
+            "md5": "/CUQFe60PfkazINtBPa0W45pEZI=",
+            "last_commit": 1607807382,
+            "header": "/headers/backroom-auto.header",
+            "tags": [],
+            "version": "5",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/weapons.lic",
+            "type": "script",
+            "md5": "dMvHL/naZhY9eOFtJukkOTTAb8E=",
+            "last_commit": 1607807382,
+            "header": "/headers/weapons.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/fixit.lic",
+            "type": "script",
+            "md5": "VyZ74tuMisE7IzUGqDsTo+eg6Lw=",
+            "last_commit": 1607807382,
+            "header": "/headers/fixit.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2 (2019-11-19)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/title.lic",
+            "type": "script",
+            "md5": "xSczLnQN/JsYYUaA0Dv5VG3LrTI=",
+            "last_commit": 1607807382,
+            "header": "/headers/title.header",
+            "tags": [],
+            "version": "14",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/collect_buy.lic",
+            "type": "script",
+            "md5": "GGMJX/Pj2Q2VhAMFXSNnBbjTUKs=",
+            "last_commit": 1607807382,
+            "header": "/headers/collect_buy.header",
+            "tags": [
+                "collectibles",
+                "collections",
+                "consignment"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/emptylocker.lic",
+            "type": "script",
+            "md5": "KUNsiUl8OjP7S6m0ILtURQsfH6k=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dollsell.lic",
+            "type": "script",
+            "md5": "tFb73BP+5HbkbutWVxaopR/zV/Q=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/walk.lic",
+            "type": "script",
+            "md5": "WSCq9J4J5VskLxuHB5ytOsCeZt8=",
+            "last_commit": 1607807382,
+            "header": "/headers/walk.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.3",
+            "author": "Tillmen"
+        },
+        {
+            "file": "/assets/bundle.lic",
+            "type": "script",
+            "md5": "UGDs7spbrdgabbu2vGSG0pY5WSg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/forgery.lic",
+            "type": "script",
+            "md5": "mp8eANQ/0/2l1t88jhOjFWb2tRQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/forgery.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "perfect"
+            ],
+            "version": "17"
+        },
+        {
+            "file": "/assets/reagenthoarder.lic",
+            "type": "script",
+            "md5": "0uR/ydkxagixtKI2qwwDQlGPfSU=",
+            "last_commit": 1607807382,
+            "header": "/headers/reagenthoarder.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/imt-WhiteHaven2.png",
+            "type": "data",
+            "md5": "fHP2FRC1T2qmyL1P7if3OO6ynR4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xboxempty.lic",
+            "type": "script",
+            "md5": "KWbU1nTXHoTX0Ov8BG7YkVfa3hY=",
+            "last_commit": 1607807382,
+            "header": "/headers/xboxempty.header",
+            "tags": [
+                "loot",
+                "boxes",
+                "rogue",
+                "utility"
+            ],
+            "version": "16",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/upickbot4.lic",
+            "type": "script",
+            "md5": "RrzDHKbVt6wDJ/bTSlUyXS9TI20=",
+            "last_commit": 1607807382,
+            "header": "/headers/upickbot4.header",
+            "tags": [
+                "shattered",
+                "pickbot",
+                "auto",
+                "utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/sweep.cmd",
+            "type": "data",
+            "md5": "tmY5/9bwKFwvGhGxZESCLJfQH5g=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/digger.lic",
+            "type": "script",
+            "md5": "dq81GwWj6N4eHRShHFYPLh67guo=",
+            "last_commit": 1607807382,
+            "header": "/headers/digger.header",
+            "tags": [
+                "digging",
+                "EG",
+                "Ebon Gate"
+            ],
+            "version": "1.2",
+            "author": "Tysong"
+        },
+        {
+            "file": "/assets/wol.lic",
+            "type": "script",
+            "md5": "p3DYByF/iEmWWi/mcmFbzg5bnLM=",
+            "last_commit": 1607807382,
+            "header": "/headers/wol.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/mapcopy.lic",
+            "type": "script",
+            "md5": "PkCofPGkeZRPIf2aw3ZaUbqboW4=",
+            "last_commit": 1607807382,
+            "header": "/headers/mapcopy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/scancritters.lic",
+            "type": "script",
+            "md5": "d3i8szXZcNhb/KLwmc301SZQ3nc=",
+            "last_commit": 1607807382,
+            "header": "/headers/scancritters.header",
+            "tags": [
+                "utility",
+                "hunting",
+                "critter"
+            ],
+            "version": "1.0",
+            "author": "Kynilir"
+        },
+        {
+            "file": "/assets/collectcheck.lic",
+            "type": "script",
+            "md5": "R/+qt06XpZMXc6Er284g58c9xKU=",
+            "last_commit": 1607807382,
+            "header": "/headers/collectcheck.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/whatstats.lic",
+            "type": "script",
+            "md5": "XMKkMpDsJZHA8ZY3ufMJwEV+h3s=",
+            "last_commit": 1607807382,
+            "header": "/headers/whatstats.header",
+            "tags": [
+                "information",
+                "utility",
+                "stats",
+                "GI"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/obamacare.lic",
+            "type": "script",
+            "md5": "uvB3O42bXkyFCvDNRss8FRaudEk=",
+            "last_commit": 1607807382,
+            "header": "/headers/obamacare.header",
+            "tags": [
+                "Poison",
+                "Disease",
+                "Unpoison",
+                "Undisease",
+                "113",
+                "114"
+            ],
+            "version": "1.0",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/bigshit.lic",
+            "type": "script",
+            "md5": "phV8MZFkW6M0iV4d4mRn6KB/Y3E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tap.lic",
+            "type": "script",
+            "md5": "15NJlWiFWiyVyPzFFCSNaKiCml4=",
+            "last_commit": 1607807382,
+            "header": "/headers/tap.header",
+            "tags": [],
+            "version": "0",
+            "author": "Trysalis"
+        },
+        {
+            "file": "/assets/zzherb2.lic",
+            "type": "script",
+            "md5": "KSDUSrgk6raDnGu9dLju/AuFPtI=",
+            "last_commit": 1607807382,
+            "header": "/headers/zzherb2.header",
+            "tags": [
+                "foraging",
+                "herbs"
+            ],
+            "author": "Cidven"
+        },
+        {
+            "file": "/assets/203_info.lic",
+            "type": "script",
+            "md5": "4uwVbEbe78Usd/Awth5Ufa1gUOQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/203_info.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ai-unstun.lic",
+            "type": "script",
+            "md5": "dl525r9uBLRxi+1WfrAexLhrPew=",
+            "last_commit": 1607807382,
+            "header": "/headers/ai-unstun.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/purr.lic",
+            "type": "script",
+            "md5": "APaMGAyIVt4OMJJ6ljZbuoE3eNM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/massies.lic",
+            "type": "script",
+            "md5": "krtdufEQysdls88rT2zp59ompSs=",
+            "last_commit": 1607807382,
+            "header": "/headers/massies.header",
+            "tags": [
+                "spellup",
+                "mass",
+                "massies",
+                "blur",
+                "guard",
+                "color",
+                "spell"
+            ]
+        },
+        {
+            "file": "/assets/arkati.lic",
+            "type": "script",
+            "md5": "vJGnfC34hTlBtj/LG3qsxQlQiDY=",
+            "last_commit": 1607807382,
+            "header": "/headers/arkati.header",
+            "tags": [],
+            "author": "Pukk"
+        },
+        {
+            "file": "/assets/skintracker.lic",
+            "type": "script",
+            "md5": "sUHTOXu1nwMmxxnYPZUUsgh+O/w=",
+            "last_commit": 1607807382,
+            "header": "/headers/skintracker.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/fire.lic",
+            "type": "script",
+            "md5": "FcrWJ0Rurqwh6TTDaaZnPt0EcbE=",
+            "last_commit": 1607807382,
+            "header": "/headers/fire.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/agidex.lic",
+            "type": "script",
+            "md5": "XBrAWiXl1yHKSqmouahJ8q+BswQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/agidex.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/spellactive.lic",
+            "type": "script",
+            "md5": "4sLm7imk0SYR3qAcAxFXW3Kf68M=",
+            "last_commit": 1607807382,
+            "header": "/headers/spellactive.header",
+            "tags": [
+                "spells"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/ForgeMaster.lic",
+            "type": "script",
+            "md5": "qelqzUqMU88MG2B08QlwYRGXn6A=",
+            "last_commit": 1607807382,
+            "header": "/headers/ForgeMaster.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/posthunt_notathias.lic",
+            "type": "script",
+            "md5": "gVgS5p8/W4TcFd/2UaXuu4ptthk=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt_notathias.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/stylebold.lic",
+            "type": "script",
+            "md5": "cmQEky4sffztYR1yQi0DwZ2P7bE=",
+            "last_commit": 1607807382,
+            "header": "/headers/stylebold.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pool_squelch.lic",
+            "type": "script",
+            "md5": "yJ/lOVbmNPkVCtI9SMnIlxK4P4I=",
+            "last_commit": 1607807382,
+            "header": "/headers/pool_squelch.header",
+            "tags": [
+                "squelch",
+                "locksmith",
+                "picking",
+                "boxpool",
+                "worker"
+            ],
+            "version": "0.2",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/torb.lic",
+            "type": "script",
+            "md5": "Cy0roV+idBVJsjnLmhmTlNyreOk=",
+            "last_commit": 1607807382,
+            "header": "/headers/torb.header",
+            "tags": [
+                "reim",
+                "reorb"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/bank.lic",
+            "type": "script",
+            "md5": "IX94Q/ySGd3fHMAjEpg22eq2TWM=",
+            "last_commit": 1607807382,
+            "header": "/headers/bank.header",
+            "tags": [],
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/sloot.lic",
+            "type": "script",
+            "md5": "0e82JKYOHvzlKPwgDXm3R7lie4M=",
+            "last_commit": 1608042510,
+            "header": "/headers/sloot.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "3.6",
+            "author": "SpiffyJr"
+        },
+        {
+            "file": "/assets/electrocute.lic",
+            "type": "script",
+            "md5": "D1yNarwRABjDCn4BsYHvCni0VCw=",
+            "last_commit": 1607807382,
+            "header": "/headers/electrocute.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/readscrolls2.lic",
+            "type": "script",
+            "md5": "OCO0r1mfinV/kZdFyLRt0APqt9I=",
+            "last_commit": 1607807382,
+            "header": "/headers/readscrolls2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/summation_seed.lic",
+            "type": "script",
+            "md5": "auRey+JVdKdeKaDzQnV0aVXQ3PM=",
+            "last_commit": 1607807382,
+            "header": "/headers/summation_seed.header",
+            "tags": [
+                "information",
+                "utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/findnpc.lic",
+            "type": "script",
+            "md5": "0DzFQpAGdWhvPqsuM5xcd1wSAaI=",
+            "last_commit": 1607807382,
+            "header": "/headers/findnpc.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/showids.lic",
+            "type": "script",
+            "md5": "D5r7uJHib9wE6UrtLsWGvLWX4hU=",
+            "last_commit": 1607807382,
+            "header": "/headers/showids.header",
+            "tags": [],
+            "version": "2018.01.21.02",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/autonode.lic",
+            "type": "script",
+            "md5": "brENUgnEXmaoJO/98TJD0OYWXgE=",
+            "last_commit": 1607807382,
+            "header": "/headers/autonode.header",
+            "tags": [
+                "node",
+                "418",
+                "mana pulse",
+                "mana focus"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/no-speech-window.lic",
+            "type": "script",
+            "md5": "kZuWrJYyFqDNx898zzjVe2oXcTA=",
+            "last_commit": 1607807382,
+            "header": "/headers/no-speech-window.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/enhancive_watch.lic",
+            "type": "script",
+            "md5": "0H8S9khw1qHBgWShlFLNEqr5p10=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/unstunwand.lic",
+            "type": "script",
+            "md5": "9evRZ6uQi5wSpfFBcMGWdwdAboY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lessershroud.lic",
+            "type": "script",
+            "md5": "QUU1zD7Y52u6hJYpGDn5rAb0J8g=",
+            "last_commit": 1607807382,
+            "header": "/headers/lessershroud.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/duskruin_find_rat.lic",
+            "type": "script",
+            "md5": "fQdF5N6BxWfcrx/0ULkjOKJc7hM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/mycombat.lic",
+            "type": "script",
+            "md5": "PAfaCtrDGtkwqZw9Qsgt6hZu1Ss=",
+            "last_commit": 1607807382,
+            "header": "/headers/mycombat.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Kilded (kilded.gs4@gmail.com)"
+        },
+        {
+            "file": "/assets/crosscharcom.lic",
+            "type": "script",
+            "md5": "2sWPJhy1sg0J9IIPLtZ97QVRpQ8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ac-wizard.lic",
+            "type": "script",
+            "md5": "etlqX/SOtLMh5o4LXM/YCXlDWg8=",
+            "last_commit": 1607807382,
+            "header": "/headers/ac-wizard.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/grind.lic",
+            "type": "script",
+            "md5": "INzxFBACbr1J857q4V+r1i1Rm24=",
+            "last_commit": 1607807382,
+            "header": "/headers/grind.header",
+            "tags": [
+                "alchemy"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/dsdprime.lic",
+            "type": "script",
+            "md5": "t8SdSNF0INJVo3dKFC8Vs33klbI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hforge.lic",
+            "type": "script",
+            "md5": "DV8pRM84fM18XEAy6mDWQbZABy4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue-lmas-makepick.lic",
+            "type": "script",
+            "md5": "jQAjj601hveMs6GmNVYeUsMp9fU=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-makepick.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/suntil.lic",
+            "type": "script",
+            "md5": "xIrZQZ3UhIaLz3DZrAgecAdT3vc=",
+            "last_commit": 1607807382,
+            "header": "/headers/suntil.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/Celerity2.lic",
+            "type": "script",
+            "md5": "sW2yVubXm/iXZLjH+koEsISUyWQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/Celerity2.header",
+            "tags": [
+                "506",
+                "Celerity",
+                "wizard",
+                "haste"
+            ],
+            "version": "1.2b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/GameObjAddMore.lic",
+            "type": "script",
+            "md5": "+uLXVZ7EkBPZ278x5aHnM/PgPaM=",
+            "last_commit": 1607807382,
+            "header": "/headers/GameObjAddMore.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2 (2017-07-24)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/loot-be-gone.lic",
+            "type": "script",
+            "md5": "fS/UA4KhTQx3ycqBDwHy6LoWMXY=",
+            "last_commit": 1608258604,
+            "header": "/headers/loot-be-gone.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "0.15",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/getemup.lic",
+            "type": "script",
+            "md5": "sfQDi8r9QR1is/fewuCAFnAxSQA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/egdigger.lic",
+            "type": "script",
+            "md5": "dZr/hc/0XTRN6svG+fZQfJw2Gy4=",
+            "last_commit": 1607807382,
+            "header": "/headers/egdigger.header",
+            "tags": [
+                "digging",
+                "EG",
+                "Ebon Gate"
+            ],
+            "version": "1.3",
+            "author": "Shorthammer"
+        },
+        {
+            "file": "/assets/smithy.lic",
+            "type": "script",
+            "md5": "3PRUgQKBxix07zhiUnRV4cUksCI=",
+            "last_commit": 1607807382,
+            "header": "/headers/smithy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/then.lic",
+            "type": "script",
+            "md5": "zbHm+1AEvEJK1Oj4nMD41pyw/2I=",
+            "last_commit": 1607807382,
+            "header": "/headers/then.header",
+            "tags": [],
+            "author": "Daedeus"
+        },
+        {
+            "file": "/assets/wiz_to_lich.lic",
+            "type": "script",
+            "md5": "kQxFRoijTxEFt2lq+AVNTv1PdBc=",
+            "last_commit": 1607807382,
+            "header": "/headers/wiz_to_lich.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/confluence_sort.lic",
+            "type": "script",
+            "md5": "YSm1QPQhUWvhPuedrnIsM5WfmuY=",
+            "last_commit": 1607807382,
+            "header": "/headers/confluence_sort.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/heal.lic",
+            "type": "script",
+            "md5": "1gZGNvGQNaQ71QmtdJyF7yJ2k54=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/swapbounty.lic",
+            "type": "script",
+            "md5": "Pohe/4QWFMnGSnnoLgx/8QyAxfc=",
+            "last_commit": 1607807382,
+            "header": "/headers/swapbounty.header",
+            "tags": [
+                "bounties",
+                "utility"
+            ],
+            "version": "3.0",
+            "author": "Selema"
+        },
+        {
+            "file": "/assets/autolockranges.lic",
+            "type": "script",
+            "md5": "a8SILUptxR5hfjIlF4+qveJaWiY=",
+            "last_commit": 1607807382,
+            "header": "/headers/autolockranges.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/warrior.lic",
+            "type": "script",
+            "md5": "efVUI8RBiwJq9+8VPbBNCAIIC4A=",
+            "last_commit": 1607807382,
+            "header": "/headers/warrior.header",
+            "tags": [],
+            "version": "113",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/staminabar.lic",
+            "type": "script",
+            "md5": "u/So6XOCb68Vn9Ym2LL4auFn3YQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/staminabar.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/consolidateherbs.lic",
+            "type": "script",
+            "md5": "/DgDp9vS6tLKllr/qWhD5fwia3Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/consolidateherbs.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/maxlock.lic",
+            "type": "script",
+            "md5": "LXXi4UhD7JR2YPAivo/waX5sAMg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/enhance.lic",
+            "type": "script",
+            "md5": "4ygKtJ8vLoXeuWJzUlok2vs3COM=",
+            "last_commit": 1607807382,
+            "header": "/headers/enhance.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/boon.lic",
+            "type": "script",
+            "md5": "HG9wQaGQ/+DfJvV+eCTw23r8UuY=",
+            "last_commit": 1607807382,
+            "header": "/headers/boon.header",
+            "tags": [
+                "personal"
+            ],
+            "version": "3.4",
+            "author": "Steworaeus"
+        },
+        {
+            "file": "/assets/tracker.lic",
+            "type": "script",
+            "md5": "Ju0Avq6GJ1yt4b2ImwV2cCYfA7g=",
+            "last_commit": 1607807382,
+            "header": "/headers/tracker.header",
+            "tags": [
+                "tracking"
+            ],
+            "version": "1.0.0",
+            "author": "Tristes"
+        },
+        {
+            "file": "/assets/AUTOGROUP.lic",
+            "type": "script",
+            "md5": "wsfQYCHZ2Bbyox7WCkadocMDgi8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/deedgemappraise.lic",
+            "type": "script",
+            "md5": "0OkZroTEOKYG+GuIM+NBnmJIx7k=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/level1.lic",
+            "type": "script",
+            "md5": "wCIx7yf+NkkBPuJwYdb1N8rBTLw=",
+            "last_commit": 1607807382,
+            "header": "/headers/level1.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/explorer.lic",
+            "type": "script",
+            "md5": "TRmA3cxm3PRfLP7mKbQKSuFwcDU=",
+            "last_commit": 1607807382,
+            "header": "/headers/explorer.header",
+            "tags": [
+                "hunting"
+            ],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/readpawnscrolls.lic",
+            "type": "script",
+            "md5": "fZ3v9ZCWq60T9MyhzT4TkVSG9mQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/readpawnscrolls.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/table.lic",
+            "type": "script",
+            "md5": "RPv65TjbUOrcuYazQKjt51vLBA8=",
+            "last_commit": 1607807382,
+            "header": "/headers/table.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/smell-all.lic",
+            "type": "script",
+            "md5": "HjfnUVQXguMNyv3w3mz5u2pfT5g=",
+            "last_commit": 1607807382,
+            "header": "/headers/smell-all.header",
+            "tags": [
+                "util"
+            ],
+            "version": "0.1",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/jarserve2.lic",
+            "type": "script",
+            "md5": "MSqnyi2bH0rWmka0w1x/fSekKB0=",
+            "last_commit": 1607807382,
+            "header": "/headers/jarserve2.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2.3 (2019-06-12)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/signature.lic",
+            "type": "script",
+            "md5": "E6mb89BR3yIuj/Tkb1LEuqXCniI=",
+            "last_commit": 1607807382,
+            "header": "/headers/signature.header",
+            "tags": [
+                "verb",
+                "verbs",
+                "EG",
+                "ebon gate",
+                "RP",
+                "roleplay",
+                "act",
+                "signature",
+                "swear"
+            ],
+            "version": "0.2",
+            "author": "nobody"
+        },
+        {
+            "file": "/assets/vdig.lic",
+            "type": "script",
+            "md5": "Y+wyYUs+UCoQY653uieYzMMOHOc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dreavening.lic",
+            "type": "script",
+            "md5": "N50NU78NWjpJaLJ6OH6MQA/TGi8=",
+            "last_commit": 1607807382,
+            "header": "/headers/dreavening.header",
+            "tags": [],
+            "version": "137",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/otf_suppress.lic",
+            "type": "script",
+            "md5": "QLcymDzX9mxUCCfD3tzuorr4fK4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/fuck_you_water_tunnels.lic",
+            "type": "script",
+            "md5": "HxXNwAuES5iGrl7CwbMUbTybgDM=",
+            "last_commit": 1607807382,
+            "header": "/headers/fuck_you_water_tunnels.header",
+            "tags": [
+                "movement",
+                "utility",
+                "Melgorehn",
+                "water",
+                "tunnels",
+                "water tunnels"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/duskruin_sewer2.lic",
+            "type": "script",
+            "md5": "/qDaMeDrKnJGQu7pTccnUJmETPQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/camptown.lic",
+            "type": "script",
+            "md5": "nAUq+RlZTpWwiDyMDxYsZuFJABs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/archa.lic",
+            "type": "script",
+            "md5": "2DIuCA1o2lVHnnMRvpgYlpNnlJM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tsell.lic",
+            "type": "script",
+            "md5": "nF5HMEWUcd2sInY6LMGNDTR3vA4=",
+            "last_commit": 1607807382,
+            "header": "/headers/tsell.header",
+            "tags": [
+                "foreach",
+                "selling"
+            ],
+            "version": "1.2",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/xrogue_alpha.lic",
+            "type": "script",
+            "md5": "lT+aG4sFsVyKyke6trLkd3LgXH8=",
+            "last_commit": 1607807382,
+            "header": "/headers/xrogue_alpha.header",
+            "tags": [],
+            "version": "50",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/determination.lic",
+            "type": "script",
+            "md5": "5qtRgMDSZu/H1iHIu05eEmYjIhk=",
+            "last_commit": 1607807382,
+            "header": "/headers/determination.header",
+            "tags": [
+                "Determination",
+                "sigils",
+                "GoS",
+                "Sunfist",
+                "Combat"
+            ],
+            "version": "1.0",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/auto_spells.lic",
+            "type": "script",
+            "md5": "gKS/5W3uBHSUSJqTTTXtagm4j2A=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ls.lic",
+            "type": "script",
+            "md5": "GqNawwenn8b2nQqmgD8vK/60eDE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/shutup.lic",
+            "type": "script",
+            "md5": "swaHd0JiNCWFr75OZ4Tj2cxbrlg=",
+            "last_commit": 1607807382,
+            "header": "/headers/shutup.header",
+            "tags": [],
+            "version": "0.5",
+            "author": "Selema"
+        },
+        {
+            "file": "/assets/percentcapped.lic",
+            "type": "script",
+            "md5": "VH6r0CHz9MJAKpbThtH/cuLCh+k=",
+            "last_commit": 1607807382,
+            "header": "/headers/percentcapped.header",
+            "tags": [
+                "exp",
+                "experience cap",
+                "calc",
+                "level"
+            ],
+            "version": "1.0",
+            "author": "Claudaro"
+        },
+        {
+            "file": "/assets/ph_heist.lic",
+            "type": "script",
+            "md5": "CNybSAmcVTKLSFgRdZGvGt8Jz/g=",
+            "last_commit": 1607807382,
+            "header": "/headers/ph_heist.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/getnote.lic",
+            "type": "script",
+            "md5": "tT4nw2pjrFVljhuiMkThnDD7M8Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/getnote.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/companion-mana-tracking.lic",
+            "type": "script",
+            "md5": "PBcO5qPqJn/X7DAOKHZyswDs0bU=",
+            "last_commit": 1607807382,
+            "header": "/headers/companion-mana-tracking.header",
+            "tags": [],
+            "version": "6",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/sgrip.lic",
+            "type": "script",
+            "md5": "0u38Dgav1BJIMllASj7gGC2Io84=",
+            "last_commit": 1607807382,
+            "header": "/headers/sgrip.header",
+            "tags": [
+                "combat"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/orbsort.lic",
+            "type": "script",
+            "md5": "FVmhAN4jRBHQIBlLhMtD9eWSog4=",
+            "last_commit": 1607807382,
+            "header": "/headers/orbsort.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/dragstop.lic",
+            "type": "script",
+            "md5": "fgqxSw7h5+MOn/bVfcqOLvcSjcI=",
+            "last_commit": 1607807382,
+            "header": "/headers/dragstop.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-07-26)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/sizematters.lic",
+            "type": "script",
+            "md5": "ypeB4X5GpBDSJNKjyT6EYs/SJ1I=",
+            "last_commit": 1607807382,
+            "header": "/headers/sizematters.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/krakii.lic",
+            "type": "script",
+            "md5": "2arIRPK/VkOBxc3C00pttQQrj3g=",
+            "last_commit": 1607807382,
+            "header": "/headers/krakii.header",
+            "tags": [
+                "information"
+            ],
+            "version": "1.1.1",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/ship.lic",
+            "type": "script",
+            "md5": "mPls9yNu2oY7s9kzEwsoXp5oqso=",
+            "last_commit": 1607807382,
+            "header": "/headers/ship.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/keepmealive.lic",
+            "type": "script",
+            "md5": "GbS8CdevsuCSH4DJA7Hbt+g7s6g=",
+            "last_commit": 1607807382,
+            "header": "/headers/keepmealive.header",
+            "tags": [],
+            "author": "Nisch"
+        },
+        {
+            "file": "/assets/badjuju.lic",
+            "type": "script",
+            "md5": "l/WKsjlTri0GUN43I3jCONIQr54=",
+            "last_commit": 1607807382,
+            "header": "/headers/badjuju.header",
+            "tags": [
+                "cloud",
+                "vine",
+                "dispell",
+                "tempest",
+                "void",
+                "swarm",
+                "web"
+            ],
+            "version": "2.0b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/whatsold.lic",
+            "type": "script",
+            "md5": "dbOkm2op9tKOlREMTAsefAksE2M=",
+            "last_commit": 1607807382,
+            "header": "/headers/whatsold.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/rpverbs.lic",
+            "type": "script",
+            "md5": "F0HQmABV1a+UbAUFaovphGfciaA=",
+            "last_commit": 1607807382,
+            "header": "/headers/rpverbs.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/illisorcguild.lic",
+            "type": "script",
+            "md5": "JwCla0Z6CYvJdqA6yXrJenkuwyM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dm_sellacc.lic",
+            "type": "script",
+            "md5": "iAxZY8HPgKaQ5JCrtcJzlIdVMHA=",
+            "last_commit": 1607807382,
+            "header": "/headers/dm_sellacc.header",
+            "tags": [
+                "dm",
+                "Delirium",
+                "Manor"
+            ]
+        },
+        {
+            "file": "/assets/remote.lic",
+            "type": "script",
+            "md5": "1iwcKHdbGORQ+oaYxXzu1C/NhD8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/pickupweapon.lic",
+            "type": "script",
+            "md5": "grtdNLfC8RwpxbThDCixI9ccpoM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/slich.lic",
+            "type": "script",
+            "md5": "ZT0bwTX5IxyA//A5c8tOQWnim3U=",
+            "last_commit": 1607807382,
+            "header": "/headers/slich.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "1.0",
+            "author": "SpiffyLich"
+        },
+        {
+            "file": "/assets/coltv.lic",
+            "type": "script",
+            "md5": "j6UTdxJxL3/+B+aUtTEA2L7U9J8=",
+            "last_commit": 1607807382,
+            "header": "/headers/coltv.header",
+            "tags": [
+                "council of light",
+                "col",
+                "council"
+            ],
+            "version": "0.2",
+            "author": "Fib"
+        },
+        {
+            "file": "/assets/pt.lic",
+            "type": "script",
+            "md5": "X/DiAYOgyM/dbgA+vlaKd/Pq2QI=",
+            "last_commit": 1607807382,
+            "header": "/headers/pt.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pool.lic",
+            "type": "script",
+            "md5": "YdqmCA3DbyrWjLqXeYfEh1pdhiM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/grguild.lic",
+            "type": "script",
+            "md5": "n/J2SJ5EWWt5HI305M12tMPS5Mk=",
+            "last_commit": 1607807382,
+            "header": "/headers/grguild.header",
+            "tags": [
+                "rogue"
+            ],
+            "version": "0.4",
+            "author": "Kalros"
+        },
+        {
+            "file": "/assets/makemoons.lic",
+            "type": "script",
+            "md5": "sN7yLJV3sIHsmMX91FfBm+s4U6o=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/avalanche.lic",
+            "type": "script",
+            "md5": "u5z3k+frQ844NMlODXR0XUfQyck=",
+            "last_commit": 1607807382,
+            "header": "/headers/avalanche.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sammo.lic",
+            "type": "script",
+            "md5": "sAgoYuKTw4Ueu1wcjaFiRd0EBpw=",
+            "last_commit": 1607807382,
+            "header": "/headers/sammo.header",
+            "tags": [
+                "scripting",
+                "alert"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/clench.lic",
+            "type": "script",
+            "md5": "nvnEpTwKoTkPbEY2QUD+h7mbLgI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/tapheals.lic",
+            "type": "script",
+            "md5": "awVAOXFdrtM0FSqIYgiXxIU7EmM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/combo.lic",
+            "type": "script",
+            "md5": "CLQSaMw/pPpkiOIK/6wojvkewR8=",
+            "last_commit": 1607807382,
+            "header": "/headers/combo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/aura.lic",
+            "type": "script",
+            "md5": "gaaZSS5rEuUyE0HISdf3d5QqWR8=",
+            "last_commit": 1607807382,
+            "header": "/headers/aura.header",
+            "tags": [
+                "405",
+                "925",
+                "enchant",
+                "utility"
+            ],
+            "version": "2019.05.23.01",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/draccorscript.lic",
+            "type": "script",
+            "md5": "ilRWK+zMToPIWVP5nV/VkDLe/Bk=",
+            "last_commit": 1607807382,
+            "header": "/headers/draccorscript.header",
+            "tags": [],
+            "version": "2",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/repository.lic",
+            "type": "script",
+            "md5": "9RNjyJbq7y+HVEyhj0Ah3HYx1cg=",
+            "last_commit": 1607807382,
+            "header": "/headers/repository.header",
+            "tags": [
+                "core"
+            ],
+            "version": "2.34",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/badgezero.lic",
+            "type": "script",
+            "md5": "50bzxqT477uRmd8oEGIS91x8wYY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/alfred-deserves-gems.lic",
+            "type": "script",
+            "md5": "kdY1N+LTlKZETXZPZswMvERvwIM=",
+            "last_commit": 1607807382,
+            "header": "/headers/alfred-deserves-gems.header",
+            "tags": [
+                "death",
+                "loot"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/rogue-lmas-measure.lic",
+            "type": "script",
+            "md5": "0OZfVeHgD3XGUaMUyEHvq3p5Z5o=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-measure.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/shadowdeath.lic",
+            "type": "script",
+            "md5": "a2s0DI06xxuSyWBHFcChQalx8nM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/fly.lic",
+            "type": "script",
+            "md5": "rHVCiBu8MW8/mQxfZldRjGNE5Bg=",
+            "last_commit": 1607807382,
+            "header": "/headers/fly.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/answeringmachine.lic",
+            "type": "script",
+            "md5": "p28yxZHxqsnRriwMtkf8v1SYLAM=",
+            "last_commit": 1607807382,
+            "header": "/headers/answeringmachine.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ci_support_fishing.lic",
+            "type": "script",
+            "md5": "7EqmfWNM0puHhjbGxTwIdlQWqcw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/Nexus_healer.lic",
+            "type": "script",
+            "md5": "yLXBJgsPbsRFPS0a+ZsxAFbOjXg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/diss.lic",
+            "type": "script",
+            "md5": "6qLbm8giiWsk6tJZ0/5bxm7T1uc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/short-haste-message.lic",
+            "type": "script",
+            "md5": "KQCmOe9A5dAuQWtnZCQJanvWXvM=",
+            "last_commit": 1607807382,
+            "header": "/headers/short-haste-message.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org"
+        },
+        {
+            "file": "/assets/Tysong-duskattack.lic",
+            "type": "script",
+            "md5": "ej0PJoplGZ3sNnOaUli1zDRNK5Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/Tysong-duskattack.header",
+            "tags": [
+                "duskruin",
+                "arena",
+                "dusk ruin",
+                "tdusk"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC), original Nylis"
+        },
+        {
+            "file": "/assets/saladbar.lic",
+            "type": "script",
+            "md5": "dsbyI+UCj6zDeqP+UmL9l7haEZM=",
+            "last_commit": 1607807382,
+            "header": "/headers/saladbar.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/saimtest.lic",
+            "type": "script",
+            "md5": "uQHa+hYO+dR5njkCqluazwHN9YQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/saimtest.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/egsell.lic",
+            "type": "script",
+            "md5": "xpgOE0h/uf4+9LET/wxunbsoxcE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/leech.lic",
+            "type": "script",
+            "md5": "+uu3eUtmXA8N3ZAqugWQi9sWFDQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue.lic",
+            "type": "script",
+            "md5": "NuX73TX2S5cWeJuglTFBEsruwTI=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue.header",
+            "tags": [],
+            "version": "40",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/raffle.lic",
+            "type": "script",
+            "md5": "xB0m0F3t5h5d7cj6qOAkleTKmg4=",
+            "last_commit": 1607807382,
+            "header": "/headers/raffle.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/comp2.lic",
+            "type": "script",
+            "md5": "ZXrLkHf9SQyWoEaSmWA5MZcgVC4=",
+            "last_commit": 1607807382,
+            "header": "/headers/comp2.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.1",
+            "author": "Velana"
+        },
+        {
+            "file": "/assets/spit2015plat.lic",
+            "type": "script",
+            "md5": "9kK+zFrkQQe2hL3ukHpfAT1DB88=",
+            "last_commit": 1607807382,
+            "header": "/headers/spit2015plat.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/1030_loop.lic",
+            "type": "script",
+            "md5": "4M3ObF1uKJSfLNI0NWFN1CbO+SE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/disking.lic",
+            "type": "script",
+            "md5": "C01j4pAX5xpmUfZ09nOucDBiKqU=",
+            "last_commit": 1607807382,
+            "header": "/headers/disking.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/no-spirit-death.lic",
+            "type": "script",
+            "md5": "88xcqTVUARMP8YX5ocruCs3OlEM=",
+            "last_commit": 1607807382,
+            "header": "/headers/no-spirit-death.header",
+            "tags": [],
+            "version": "1",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/sdig.lic",
+            "type": "script",
+            "md5": "Mk6YDPIVdeIlBgl5r/5MiEpd0H0=",
+            "last_commit": 1607807382,
+            "header": "/headers/sdig.header",
+            "tags": [
+                "torture"
+            ],
+            "author": "SpiffyJr"
+        },
+        {
+            "file": "/assets/trollhear.lic",
+            "type": "script",
+            "md5": "5eyldC2/U/gz7CjR8a73Tm9aYmo=",
+            "last_commit": 1607807382,
+            "header": "/headers/trollhear.header",
+            "tags": [
+                "speech"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/eget.lic",
+            "type": "script",
+            "md5": "VL6q9+jjbhJGFItHHPjWHjwo2zU=",
+            "last_commit": 1607807382,
+            "header": "/headers/eget.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-05-27)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/judgement.lic",
+            "type": "script",
+            "md5": "cKVSCJ+7KVvqF0qehH4B9pXnmNk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/stand.lic",
+            "type": "script",
+            "md5": "cm74aa8pagn3cNWHF8G0Xt1qrYk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/DRselling.lic",
+            "type": "script",
+            "md5": "FzgCs6mYW3ZivyiL5YHbRqoli9E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/appraiser.lic",
+            "type": "script",
+            "md5": "O/Pc8vh6AP999DtOQg6EhQmnMNQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/appraiser.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bard_squelch.lic",
+            "type": "script",
+            "md5": "sTPmX3NLB/DrE8wm+FDlY0MAA0M=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/realkgate.lic",
+            "type": "script",
+            "md5": "jXMe3enL6Ig/5/GX87m9FWBRDAc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ewave.lic",
+            "type": "script",
+            "md5": "HqKQT0dh6CDRyltkIF2Buu+OW1Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/locker2.lic",
+            "type": "script",
+            "md5": "QGF0Xn+x0gWB/nc5NYS+rK8JsHE=",
+            "last_commit": 1607807382,
+            "header": "/headers/locker2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/whatis.lic",
+            "type": "script",
+            "md5": "0DSzLzKiAIqMO20k99NzvGtnl3k=",
+            "last_commit": 1607807382,
+            "header": "/headers/whatis.header",
+            "tags": [
+                "dictionary",
+                "encyclopedia",
+                "Lingo",
+                "Jargon",
+                "abbreviations",
+                "initialisms",
+                "acronyms",
+                "terms",
+                "terminology",
+                "whatis",
+                "lookup",
+                "meaning",
+                "mean",
+                "words",
+                "meanings"
+            ],
+            "version": "1.6b",
+            "author": "Luxelle"
+        },
+        {
+            "file": "/assets/forage.lic",
+            "type": "script",
+            "md5": "BrGbKLejAG1K9QNUSCnCR80NCsM=",
+            "last_commit": 1607807382,
+            "header": "/headers/forage.header",
+            "tags": [
+                "bounty",
+                "foraging"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/giveall.lic",
+            "type": "script",
+            "md5": "JEnzccMJiXWJoel7wkbwuJaSynk=",
+            "last_commit": 1607807382,
+            "header": "/headers/giveall.header",
+            "tags": [],
+            "author": "Soliere"
+        },
+        {
+            "file": "/assets/10deeds.lic",
+            "type": "script",
+            "md5": "ERThYZFyCOzyRkcJD/cXPhZNzQ0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/dm_runner.lic",
+            "type": "script",
+            "md5": "tIUTmAw7XPnADRoOeTkUJii3YB4=",
+            "last_commit": 1607807382,
+            "header": "/headers/dm_runner.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/townsmith.lic",
+            "type": "script",
+            "md5": "cXq3PCFqas/3rbb5xgVWIpl/oFI=",
+            "last_commit": 1607807382,
+            "header": "/headers/townsmith.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/DR_DIG.lic",
+            "type": "script",
+            "md5": "b3dBViztD9wVHhifimDvlEuB/xc=",
+            "last_commit": 1607807382,
+            "header": "/headers/DR_DIG.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/waitloot.lic",
+            "type": "script",
+            "md5": "U/BSG8BNq+yaAeoxyvXOPkFAhdI=",
+            "last_commit": 1607807382,
+            "header": "/headers/waitloot.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/burst_calc_no_trust.lic",
+            "type": "script",
+            "md5": "S4VEj9kO5oxmDUN3T80g9wSgFhE=",
+            "last_commit": 1607807382,
+            "header": "/headers/burst_calc_no_trust.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/disarm-no-more.lic",
+            "type": "script",
+            "md5": "j6U9drbBYV7QU2zzcsopTZR2c5Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/disarm-no-more.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/draffle.lic",
+            "type": "script",
+            "md5": "YIUraKi13cCJ9NjBkQbPXdoAu1U=",
+            "last_commit": 1607807382,
+            "header": "/headers/draffle.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/gospaladin2.lic",
+            "type": "script",
+            "md5": "UC3Umj3v5XAyoklb3Wplvvn0QOQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/app.lic",
+            "type": "script",
+            "md5": "PDuSFtm1EoXNoT/fR4UgIFMn1oE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/windowsorter.lic",
+            "type": "script",
+            "md5": "MT88RT4CqCK/FJO7QVkOMFVh70Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/windowsorter.header",
+            "tags": [
+                "sorter",
+                "inventory",
+                "windows"
+            ],
+            "version": "3.01",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/song-timer.lic",
+            "type": "script",
+            "md5": "OwySKXiNlN9l/97tjUq+/EcC8ys=",
+            "last_commit": 1607807382,
+            "header": "/headers/song-timer.header",
+            "tags": [
+                "bard"
+            ],
+            "version": "0.01 (2017-07-24)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/autonet.lic",
+            "type": "script",
+            "md5": "eQdjnm/j1soCS01Oo7TvLKS63AQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/autonet.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/joust.lic",
+            "type": "script",
+            "md5": "B/ZoIWlzUQ11ra1tS/IWorjJnb4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/crystal.lic",
+            "type": "script",
+            "md5": "Pqyj1NYrKO/japGh9enBEae6ssw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/easy_pull.lic",
+            "type": "script",
+            "md5": "AmaO0JriX6ZRiIw/uDRlpQUJJUk=",
+            "last_commit": 1607807382,
+            "header": "/headers/easy_pull.header",
+            "tags": [
+                "hunting utility"
+            ],
+            "version": "0.10",
+            "author": "Suprie"
+        },
+        {
+            "file": "/assets/lovedirvy.lic",
+            "type": "script",
+            "md5": "AbzQs1sJDwb9H54LTZsPwX4V+X8=",
+            "last_commit": 1607807382,
+            "header": "/headers/lovedirvy.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/repeat.lic",
+            "type": "script",
+            "md5": "vTd3mV5SL8VgfciwHhC3r0nR004=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/bagofholding.lic",
+            "type": "script",
+            "md5": "yqt1LpdeASrg4XnybGeorMpreuQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/bagofholding.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/findshop.lic",
+            "type": "script",
+            "md5": "bsAIhBgMw7lMOhFWWtAi/O5pWDQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/findshop.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.3 (2019-09-29)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/berserk.lic",
+            "type": "script",
+            "md5": "S38I5vIWBJSZp8Pqq9Fb9SGOAjA=",
+            "last_commit": 1607807382,
+            "header": "/headers/berserk.header",
+            "tags": [],
+            "author": "Eklectic"
+        },
+        {
+            "file": "/assets/seedpouch.lic",
+            "type": "script",
+            "md5": "FiQEYHhPwC2zWQ4ndxUj2binhug=",
+            "last_commit": 1607807382,
+            "header": "/headers/seedpouch.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/searchrepo.lic",
+            "type": "script",
+            "md5": "xKaeNAmgh0Rp7G/xw3kOxhJsRA0=",
+            "last_commit": 1607807382,
+            "header": "/headers/searchrepo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/webgoals.lic",
+            "type": "script",
+            "md5": "5RX9OCsAdjpjeCqBiXMV2dpqgpM=",
+            "last_commit": 1607807382,
+            "header": "/headers/webgoals.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/metal.lic",
+            "type": "script",
+            "md5": "5I6NQVmdv44K7cHhxwd6Y5wziKs=",
+            "last_commit": 1607807382,
+            "header": "/headers/metal.header",
+            "tags": [],
+            "author": "Pukk"
+        },
+        {
+            "file": "/assets/515.lic",
+            "type": "script",
+            "md5": "hM/AUpgUH62xcsB2p5hzCpZYsqI=",
+            "last_commit": 1607807382,
+            "header": "/headers/515.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ao-combat.lic",
+            "type": "script",
+            "md5": "Wj1XAaHkA0VqQ+4btn1KIXbzsN0=",
+            "last_commit": 1607807382,
+            "header": "/headers/ao-combat.header",
+            "tags": [],
+            "author": "Daedeus"
+        },
+        {
+            "file": "/assets/chrism.lic",
+            "type": "script",
+            "md5": "8jnNTJkemBjT7CdOaBa6prX6kHA=",
+            "last_commit": 1607807382,
+            "header": "/headers/chrism.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/enhsaver.lic",
+            "type": "script",
+            "md5": "qDR2g9nigrVwJaUJWxuoc44fjXs=",
+            "last_commit": 1607807382,
+            "header": "/headers/enhsaver.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sigilpower.lic",
+            "type": "script",
+            "md5": "NpTQI87CJYdr7PfwGse2IX9XrU0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/survey.lic",
+            "type": "script",
+            "md5": "TUHxmbV4Vyv4ZXwB4z/tHxkVpdA=",
+            "last_commit": 1607807382,
+            "header": "/headers/survey.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.4 (2019-10-21)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/lumnis_stat_boost.lic",
+            "type": "script",
+            "md5": "k6RzTnpv2lTTwQR0B6Px7+/QtlA=",
+            "last_commit": 1607807382,
+            "header": "/headers/lumnis_stat_boost.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/armor.lic",
+            "type": "script",
+            "md5": "xGnceSDG9CKF5o30D7EAhxYUK44=",
+            "last_commit": 1607807382,
+            "header": "/headers/armor.header",
+            "tags": [
+                "repository",
+                "gui",
+                "pukk"
+            ],
+            "version": "1.0",
+            "author": "Pukk"
+        },
+        {
+            "file": "/assets/alias2.lic",
+            "type": "script",
+            "md5": "cSs8bt8/fj+r6kp1c/x8tc1rT1g=",
+            "last_commit": 1607807382,
+            "header": "/headers/alias2.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.8",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/showxml.lic",
+            "type": "script",
+            "md5": "E/BVcpH8kq300I2peMI7tb4yeDk=",
+            "last_commit": 1607807382,
+            "header": "/headers/showxml.header",
+            "tags": [],
+            "version": "0.3 (2020-03-08)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/makeherbs.lic",
+            "type": "script",
+            "md5": "3xaNC73sLS2tQrkgXf+IYLZEE+I=",
+            "last_commit": 1607807382,
+            "header": "/headers/makeherbs.header",
+            "tags": [],
+            "author": "Tayre"
+        },
+        {
+            "file": "/assets/320.lic",
+            "type": "script",
+            "md5": "DT7uizxsNDRAk/zTIaQcvRkGwgY=",
+            "last_commit": 1607807382,
+            "header": "/headers/320.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/empheal.lic",
+            "type": "script",
+            "md5": "uH0JLsmN9nNg6P00vmlpQsEz/0Y=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/shoot.lic",
+            "type": "script",
+            "md5": "nThnvcuCA003KxIgrk1kkevgwP8=",
+            "last_commit": 1607807382,
+            "header": "/headers/shoot.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bacon.lic",
+            "type": "script",
+            "md5": "0WhCSevwCbjwilpYoHBw8k6Z50I=",
+            "last_commit": 1607807382,
+            "header": "/headers/bacon.header",
+            "tags": [
+                "pork",
+                "definitely not vegan"
+            ],
+            "version": "0.1 (2017-07-31)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/nodrop.lic",
+            "type": "script",
+            "md5": "8Vt4wfKAlQ8vo7FP3hLoHN/MJUQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/nodrop.header",
+            "tags": [
+                "items"
+            ],
+            "version": "1.0",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/collectible_type_data.lic",
+            "type": "script",
+            "md5": "43mOo8LKgpWqkWHyEQ9v1BYUBMQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/collectible_type_data.header",
+            "tags": [
+                "inventory",
+                "sort"
+            ],
+            "version": "1.0.0",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/go2table.lic",
+            "type": "script",
+            "md5": "khEGxAx0GNDqzXb1VnKG83zpEmI=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2table.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1.1 (2019-10-17)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/alchemy-recipes.lic",
+            "type": "script",
+            "md5": "HVhm2SWPt4gbLTchoF7w5Oib62Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/alchemy-recipes.header",
+            "tags": [
+                "alchemy",
+                "guild"
+            ],
+            "version": "0.11",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/ci_games.lic",
+            "type": "script",
+            "md5": "qhqjsqiK/bjRu3bPPgkqFZoB26Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/ci_games.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/adrop.lic",
+            "type": "script",
+            "md5": "kUofoYP+WmmMaI6npGjBfqKi59s=",
+            "last_commit": 1607807382,
+            "header": "/headers/adrop.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/numbercomma.lic",
+            "type": "script",
+            "md5": "0PwGc0i3PxHiyhBHkJxXV7kUjHI=",
+            "last_commit": 1607807382,
+            "header": "/headers/numbercomma.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bigshot-bless.lic",
+            "type": "script",
+            "md5": "Zqcl47nBR3jz/mOPYo6SCSlydVo=",
+            "last_commit": 1607807382,
+            "header": "/headers/bigshot-bless.header",
+            "tags": [],
+            "author": "Veska"
+        },
+        {
+            "file": "/assets/auto-level2.lic",
+            "type": "script",
+            "md5": "V4BdB1J3qIE31f1EmxIjJQuRVFo=",
+            "last_commit": 1607807382,
+            "header": "/headers/auto-level2.header",
+            "tags": [],
+            "version": "41",
+            "author": "RJ"
+        },
+        {
+            "file": "/assets/735.lic",
+            "type": "script",
+            "md5": "0+egGTJfjXAflQKchJeujTbhotE=",
+            "last_commit": 1607807382,
+            "header": "/headers/735.header",
+            "tags": [],
+            "version": "33",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/bardwag.lic",
+            "type": "script",
+            "md5": "hi0RNIhwHAyTBr15dholrAML73M=",
+            "last_commit": 1607807382,
+            "header": "/headers/bardwag.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sbounty-bandit-example.lic",
+            "type": "script",
+            "md5": "MmgsKxci2U2lGYy+zw2YnQMUgVE=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbounty-bandit-example.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/playcount.lic",
+            "type": "script",
+            "md5": "zOxehwDCTfUW0W3HfVcYtl2TA+Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/playcount.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/pego2.lic",
+            "type": "script",
+            "md5": "1JKbfCXmblkXF/+MWxBmGDcHffY=",
+            "last_commit": 1607807382,
+            "header": "/headers/pego2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/mana.lic",
+            "type": "script",
+            "md5": "MJhNqdc9V6K6DWL4d+7iIpZnvTk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue-lmas-sense.lic",
+            "type": "script",
+            "md5": "fnemCWMb05z4yuySZ+UQB/2MIeA=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-sense.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/502.lic",
+            "type": "script",
+            "md5": "CSAhl8fShAnnQVtnKTMXYcegHoc=",
+            "last_commit": 1607807382,
+            "header": "/headers/502.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/go2name.lic",
+            "type": "script",
+            "md5": "WLyUvL50kd9Eo70tCnXdgRbFIRs=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2name.header",
+            "tags": [
+                "movement",
+                "utility",
+                "rescue"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/slootbeta.ui",
+            "type": "data",
+            "md5": "FAJGggHGa/F8WQc5obXfwKM42w0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/redeem.lic",
+            "type": "script",
+            "md5": "Bqb5EvrIl1kt4PAQiQKQ3jtndUU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sholler.lic",
+            "type": "script",
+            "md5": "0PX1+M4YvW7gQKlVZVuVFtchZMA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/drizzleback.lic",
+            "type": "script",
+            "md5": "GPaMm2FfDoQ2QA5mzlxPdd+uiXU=",
+            "last_commit": 1607807382,
+            "header": "/headers/drizzleback.header",
+            "tags": [
+                "utility",
+                "profanity",
+                "wizad",
+                "avalon"
+            ],
+            "version": "1",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/reverb.lic",
+            "type": "script",
+            "md5": "6TAjmBuVKCaM6NdzsdWwxM2uJZo=",
+            "last_commit": 1607807382,
+            "header": "/headers/reverb.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.3 (2020-03-18)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/xnarost.lic",
+            "type": "script",
+            "md5": "DikVLJwNTSvMyBlQFnGS5F/xwI4=",
+            "last_commit": 1607807382,
+            "header": "/headers/xnarost.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "version": "0.6 (2019-08-14) based on narost.lic from 2014-08-24",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/herbs2.lic",
+            "type": "script",
+            "md5": "SCrZ17nbXNnlffU9jpeICSaaa1M=",
+            "last_commit": 1607807382,
+            "header": "/headers/herbs2.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.3",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/sammu2.lic",
+            "type": "script",
+            "md5": "uj4wehuFzRMmjlwSLfCiYPzyp3c=",
+            "last_commit": 1607807382,
+            "header": "/headers/sammu2.header",
+            "tags": [
+                "fletching"
+            ],
+            "version": "1.8",
+            "author": "Drafix"
+        },
+        {
+            "file": "/assets/symbolz.lic",
+            "type": "script",
+            "md5": "7T4AMYJqncS3rlM8poQS6Sg3hQ8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hardcore.lic",
+            "type": "script",
+            "md5": "At63idP8Iss8X+Mc285XS8HUi8I=",
+            "last_commit": 1607807382,
+            "header": "/headers/hardcore.header",
+            "tags": [
+                "hardcore",
+                "setup"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/spellactive2.lic",
+            "type": "script",
+            "md5": "UTXkcuKBtjWxoLcoEjok0tlkwSY=",
+            "last_commit": 1607807382,
+            "header": "/headers/spellactive2.header",
+            "tags": [
+                "spells"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/blessexample.lic",
+            "type": "script",
+            "md5": "+Zv+VGzLV1sUxf0fln3DPDV/3E8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ring.lic",
+            "type": "script",
+            "md5": "5Xl7IsoGYKw5wyVbmjhiaqRlEjg=",
+            "last_commit": 1607807382,
+            "header": "/headers/ring.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/favs.lic",
+            "type": "script",
+            "md5": "CD15mJ03krJ7foxgIbGu6csMYkc=",
+            "last_commit": 1607807382,
+            "header": "/headers/favs.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/rogue-lmas-appraise.lic",
+            "type": "script",
+            "md5": "svXt9vRtU8y7YoRDSiquGwZd0b4=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-appraise.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sheal.lic",
+            "type": "script",
+            "md5": "gvMII0Rl06JkqHygfLJLiHSHzX8=",
+            "last_commit": 1607807382,
+            "header": "/headers/sheal.header",
+            "tags": [
+                "empath"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/rogue-lmas-calibrate.lic",
+            "type": "script",
+            "md5": "ShFLOKhBC9VBC0QyZ3mbT7ksZhc=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-calibrate.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sfire.lic",
+            "type": "script",
+            "md5": "7DMBmk4kSW21HhiI6V6Pm08rWnA=",
+            "last_commit": 1607807382,
+            "header": "/headers/sfire.header",
+            "tags": [
+                "combat"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/getsilver.lic",
+            "type": "script",
+            "md5": "c5gfSl+5Zur1QiWhhvczVqoOslU=",
+            "last_commit": 1607807382,
+            "header": "/headers/getsilver.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ms.lic",
+            "type": "script",
+            "md5": "zQUc0Ex3q8bcCg0n8ykI8seikCY=",
+            "last_commit": 1607807382,
+            "header": "/headers/ms.header",
+            "tags": [],
+            "author": "JFTActual"
+        },
+        {
+            "file": "/assets/seawater.lic",
+            "type": "script",
+            "md5": "iAKf58yD47cqgyg4I2xnGV6fAq0=",
+            "last_commit": 1607807382,
+            "header": "/headers/seawater.header",
+            "tags": [
+                "alchemy"
+            ],
+            "version": "1.1",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/egdig2.lic",
+            "type": "script",
+            "md5": "OQwMGgHA5wGkAEVboEfkdqQ8PtI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/transfer.lic",
+            "type": "script",
+            "md5": "OOuGB0kh2I987zN/yNcDeiXVbpQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/longterm.lic",
+            "type": "script",
+            "md5": "PsO8xXMjaIJVZ2QlPYmCKPOvUvI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/whatlevel.lic",
+            "type": "script",
+            "md5": "5aQvSY9G8aPusOYZpu48CfL2jUw=",
+            "last_commit": 1607807382,
+            "header": "/headers/whatlevel.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rofl-trivia.lic",
+            "type": "script",
+            "md5": "h4ed22L1pDtaLJalCaAESPSgm0g=",
+            "last_commit": 1607807382,
+            "header": "/headers/rofl-trivia.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/wtfo.lic",
+            "type": "script",
+            "md5": "XrhcE5o9BftliTVx3oVxHhwqNWQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gemvalue.lic",
+            "type": "script",
+            "md5": "+dpBm23UboPe8AUbm4fOMHWX2Ls=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemvalue.header",
+            "tags": [],
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/epotions.lic",
+            "type": "script",
+            "md5": "lpwWaSyOu/l7ERzx0vCqcQuV054=",
+            "last_commit": 1607807382,
+            "header": "/headers/epotions.header",
+            "tags": [
+                "enchanting",
+                "reference",
+                "potions",
+                "925",
+                "wizard"
+            ],
+            "version": "0.1",
+            "author": "Felarion"
+        },
+        {
+            "file": "/assets/manapool.lic",
+            "type": "script",
+            "md5": "2ndkLbEaepNDOTXkrOqTeeG9+68=",
+            "last_commit": 1607807382,
+            "header": "/headers/manapool.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/som.lic",
+            "type": "script",
+            "md5": "uoMNHHERK5qmrg2LF8PQM2WZXe4=",
+            "last_commit": 1607807382,
+            "header": "/headers/som.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wiki.lic",
+            "type": "script",
+            "md5": "hJ5B6x+5w1yODxOZMvEW4Akgv/A=",
+            "last_commit": 1607807382,
+            "header": "/headers/wiki.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/miutest.lic",
+            "type": "script",
+            "md5": "JTJtxhzFLmpzGrGQGfviseMOZ/I=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sortforage.lic",
+            "type": "script",
+            "md5": "7fvOQA/qrqmLLLnLgzCHrH1rQx4=",
+            "last_commit": 1607807382,
+            "header": "/headers/sortforage.header",
+            "tags": [],
+            "version": "2018.04.02.02",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/deadstop.lic",
+            "type": "script",
+            "md5": "WYXarLjcMa9mgCu3ILM09/6QY1I=",
+            "last_commit": 1607807382,
+            "header": "/headers/deadstop.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/friendList.lic",
+            "type": "script",
+            "md5": "uHWoHOdDy6BPbVRwzgYsV0K0NkM=",
+            "last_commit": 1607807382,
+            "header": "/headers/friendList.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/profiler.lic",
+            "type": "script",
+            "md5": "oSVulo2s7HTJua9wtkXC9S1thWo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/pure4.lic",
+            "type": "script",
+            "md5": "+G/4bYq+NQOQmw0GVdflIW7hwt4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/CI_GHOUL.lic",
+            "type": "script",
+            "md5": "Y565zmztwKfjrJNgrsRpbcapzxM=",
+            "last_commit": 1607807382,
+            "header": "/headers/CI_GHOUL.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/slabgenerator.lic",
+            "type": "script",
+            "md5": "9JQEjp4b57EG/lKrLpF3VHnNGcQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/prettiernum.lic",
+            "type": "script",
+            "md5": "VGg3Muiar9FTXNN6LTNGMrR2rzg=",
+            "last_commit": 1607807382,
+            "header": "/headers/prettiernum.header",
+            "tags": [],
+            "version": "2",
+            "author": "Gnomad (PrettyNum by Caithris)"
+        },
+        {
+            "file": "/assets/650boost.lic",
+            "type": "script",
+            "md5": "JVTP2i0tz9FjwXDB50FYBsi46Ns=",
+            "last_commit": 1607807382,
+            "header": "/headers/650boost.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/thiefwatch.lic",
+            "type": "script",
+            "md5": "d8Q2URkQZY+IPFObI14O1jn3Hko=",
+            "last_commit": 1607807382,
+            "header": "/headers/thiefwatch.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/selling.lic",
+            "type": "script",
+            "md5": "ni7AN7PA3JSUDSCh8QJ8pG94jSI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/isigils.lic",
+            "type": "script",
+            "md5": "d8duGMbdgg8NHTXHIf3gFknRM1U=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/narost.lic",
+            "type": "script",
+            "md5": "/B7IMiwRxuDEtrIZ9ErJm8gC038=",
+            "last_commit": 1607807382,
+            "header": "/headers/narost.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/hasteme.lic",
+            "type": "script",
+            "md5": "rs8ap1H604MGIopFtaGbRglFbBE=",
+            "last_commit": 1607807382,
+            "header": "/headers/hasteme.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/link.lic",
+            "type": "script",
+            "md5": "u6JnpYa3JhyL+Pr25wdxkj1orEQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/link.header",
+            "tags": [],
+            "version": "3",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/nairreim.lic",
+            "type": "script",
+            "md5": "Yk4mlqZFGKhpOu0WEdCgCE+MBSY=",
+            "last_commit": 1607807382,
+            "header": "/headers/nairreim.header",
+            "tags": [
+                "reim"
+            ],
+            "version": "2.4",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/laraselling.lic",
+            "type": "script",
+            "md5": "yhPViia+DzdkSgk1NtZJKbYLy40=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/linktothefast.lic",
+            "type": "script",
+            "md5": "k8BGdp9izJFpAEr+tl1/9W0A4/U=",
+            "last_commit": 1607807382,
+            "header": "/headers/linktothefast.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1.4 (2019-09-27)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/autostart.lic",
+            "type": "script",
+            "md5": "q/O6QnCnnwtHCe0D5eiaR4Xf2yA=",
+            "last_commit": 1608076478,
+            "header": "/headers/autostart.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.5",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/bigtap.lic",
+            "type": "script",
+            "md5": "5WHUf4EYiZfLChdKyoZLxD4ORvY=",
+            "last_commit": 1607807382,
+            "header": "/headers/bigtap.header",
+            "tags": [
+                "hunting",
+                "wizard",
+                "bigshot"
+            ],
+            "version": "0.1",
+            "author": "nobody"
+        },
+        {
+            "file": "/assets/smarthunt.lic",
+            "type": "script",
+            "md5": "bz7OjY5spVSdZ7NRdliv9ubb0u0=",
+            "last_commit": 1607807382,
+            "header": "/headers/smarthunt.header",
+            "tags": [],
+            "author": "Aethor, Yasutoshi"
+        },
+        {
+            "file": "/assets/gemhoarder.lic",
+            "type": "script",
+            "md5": "PCYrvEEo5OHty/HM850NeHl5dg0=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemhoarder.header",
+            "tags": [],
+            "version": "0.7",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/dskin.lic",
+            "type": "script",
+            "md5": "iXSWNqUQFd9uxnqpvjO/YflhR7M=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sbinnacombo.lic",
+            "type": "script",
+            "md5": "kqZl7CFcuXUbYFHK1pxIjFO9gow=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbinnacombo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pppure.lic",
+            "type": "script",
+            "md5": "cqY36l12qj3spGwK77Pv41M88Ro=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/reprep.lic",
+            "type": "script",
+            "md5": "p3TFR8z09rHFcLW5iO9yy9/7Yew=",
+            "last_commit": 1607807382,
+            "header": "/headers/reprep.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/blacksmith.lic",
+            "type": "script",
+            "md5": "LEnWvwKkZ2sKbI696a18IGf0vA4=",
+            "last_commit": 1607807382,
+            "header": "/headers/blacksmith.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "voln"
+            ]
+        },
+        {
+            "file": "/assets/lumnis_exp_boost.lic",
+            "type": "script",
+            "md5": "WAYJwBp7G6H5aH+9/5xAe/FhD7E=",
+            "last_commit": 1607807382,
+            "header": "/headers/lumnis_exp_boost.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/arena-cleavet.lic",
+            "type": "script",
+            "md5": "7ezOUhc6VZUSoDy2AyIEaqvC2X0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/recovery.lic",
+            "type": "script",
+            "md5": "70gU+6tsEa+2rDYyVFVNk/mpxSQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/recovery.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/tour.lic",
+            "type": "script",
+            "md5": "8k+TPIhp90N4/AqLk+2lw6W2Vn4=",
+            "last_commit": 1607807382,
+            "header": "/headers/tour.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.6 (2019-10-30)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/timestop.lic",
+            "type": "script",
+            "md5": "DS1e8KryWOuaNXhfJEAdoc4u98A=",
+            "last_commit": 1607807382,
+            "header": "/headers/timestop.header",
+            "tags": [],
+            "author": "Rumbletum"
+        },
+        {
+            "file": "/assets/ezmove.lic",
+            "type": "script",
+            "md5": "SV5sv9nN1un4+QiUezKMcb8PwoM=",
+            "last_commit": 1607807382,
+            "header": "/headers/ezmove.header",
+            "tags": [
+                "reagents",
+                "Gems",
+                "Jars"
+            ],
+            "version": "0.5",
+            "author": "Steworaeus"
+        },
+        {
+            "file": "/assets/order.lic",
+            "type": "script",
+            "md5": "Wq0zVpgaet7e8D4p1MxlO3xiTvU=",
+            "last_commit": 1607807382,
+            "header": "/headers/order.header",
+            "tags": [
+                "cheatyface"
+            ],
+            "version": "0.1",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/MoonshardBundle.lic",
+            "type": "script",
+            "md5": "CSq8ZbqcKw7sgRkvy3c2L5EkTWo=",
+            "last_commit": 1607807382,
+            "header": "/headers/MoonshardBundle.header",
+            "tags": [
+                "Duskruin"
+            ],
+            "version": "1.00",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/xhouse.lic",
+            "type": "script",
+            "md5": "tv9EIq4VJwevLA+2NbTva1ZI3Q8=",
+            "last_commit": 1607807382,
+            "header": "/headers/xhouse.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/clearcheckwiz.lic",
+            "type": "script",
+            "md5": "HQh0xHam3HPE7pe8o91iTXPxYVw=",
+            "last_commit": 1607807382,
+            "header": "/headers/clearcheckwiz.header",
+            "tags": [
+                "reim"
+            ],
+            "version": "1.4",
+            "author": "Spenster"
+        },
+        {
+            "file": "/assets/permatone2.lic",
+            "type": "script",
+            "md5": "vINxnPub/tIK63eHcxkdxdVcufU=",
+            "last_commit": 1607807382,
+            "header": "/headers/permatone2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rescue-watch.lic",
+            "type": "script",
+            "md5": "9G/ECZu1o4fFYs/ynmTiBqesY4A=",
+            "last_commit": 1607807382,
+            "header": "/headers/rescue-watch.header",
+            "tags": [],
+            "version": "2016.01.28.01",
+            "author": "Akono (lordakono@gmail.com)"
+        },
+        {
+            "file": "/assets/heal2.lic",
+            "type": "script",
+            "md5": "segIo+j8/orhJL4JP01soNMT+yI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ci_fish.lic",
+            "type": "script",
+            "md5": "7EqmfWNM0puHhjbGxTwIdlQWqcw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/jlsing.lic",
+            "type": "script",
+            "md5": "knR8rT406wzzTHY9cRHHxZ656pA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gemsort.lic",
+            "type": "script",
+            "md5": "ObmHsTc+mfMvI9kxmbxSv63fz7U=",
+            "last_commit": 1607807382,
+            "header": "/headers/gemsort.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/GameObjAdd.lic",
+            "type": "script",
+            "md5": "9xKpWd6I3BQbnYaaHucB9wUgndI=",
+            "last_commit": 1607807382,
+            "header": "/headers/GameObjAdd.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/inspectweight.lic",
+            "type": "script",
+            "md5": "iEZoiVlKZkaf/fUV+9aUGHkPADs=",
+            "last_commit": 1607807382,
+            "header": "/headers/inspectweight.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rogue-lmas-repair.lic",
+            "type": "script",
+            "md5": "B8UwY7vyk2QgCmjw6n9VNQF+Djo=",
+            "last_commit": 1607807382,
+            "header": "/headers/rogue-lmas-repair.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/aspect.lic",
+            "type": "script",
+            "md5": "mrqaRNbyMN2pLwYNSzEzza3Bhyk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/fun-with-dreaven-video-2.lic",
+            "type": "script",
+            "md5": "MT1mHkBHFR5gpPfGksTfxV1yfng=",
+            "last_commit": 1607807382,
+            "header": "/headers/fun-with-dreaven-video-2.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/grabgbb.lic",
+            "type": "script",
+            "md5": "xe+bLYhUSbDheOMeqFo0DbYiagw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/appgem.lic",
+            "type": "script",
+            "md5": "WumYEnJ3YliWVQJA63Ivx/QYGag=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/logxml.lic",
+            "type": "script",
+            "md5": "PqjdSK02IAhajCE71/mTs8x11A0=",
+            "last_commit": 1607807382,
+            "header": "/headers/logxml.header",
+            "tags": [],
+            "version": "0.4.1 (2019-12-28)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/needhalp.lic",
+            "type": "script",
+            "md5": "vE0m/jP62f/TuArEOiqtCejwOCA=",
+            "last_commit": 1607807382,
+            "header": "/headers/needhalp.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autobot.lic",
+            "type": "script",
+            "md5": "01xtG4i3lnXjBKmqDZFEp3U1yd8=",
+            "last_commit": 1607807382,
+            "header": "/headers/autobot.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/feint_calc.lic",
+            "type": "script",
+            "md5": "+gyrK3eIGB/VzJOTbhrGH0TEB18=",
+            "last_commit": 1607807382,
+            "header": "/headers/feint_calc.header",
+            "tags": [
+                "hunting",
+                "information",
+                "mechanics",
+                "combat"
+            ],
+            "version": "0.5",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/helpfolks.lic",
+            "type": "script",
+            "md5": "KlVU6JaJR0KkwJ+TfMoah66Wop0=",
+            "last_commit": 1607807382,
+            "header": "/headers/helpfolks.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Cait"
+        },
+        {
+            "file": "/assets/arena-ryjex2.lic",
+            "type": "script",
+            "md5": "hL5dHaUFPWdzzfof+ymGgfg0RFw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/picklebob.lic",
+            "type": "script",
+            "md5": "a3rr0Pqh+l/EbaAFBFBVyV02XP0=",
+            "last_commit": 1607807382,
+            "header": "/headers/picklebob.header",
+            "tags": [
+                "games"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/doctorwho.lic",
+            "type": "script",
+            "md5": "fJuopWnA2/z9sZ862ntgDEqdn/E=",
+            "last_commit": 1607807382,
+            "header": "/headers/doctorwho.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2 (2019-09-17)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/pickother.lic",
+            "type": "script",
+            "md5": "h6SxBt6HId+LcrfoIJg2YUlxGP8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/partner3.lic",
+            "type": "script",
+            "md5": "SZvVeQGypYQRUjJqjSIcKSGEA1E=",
+            "last_commit": 1607807382,
+            "header": "/headers/partner3.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autolore.lic",
+            "type": "script",
+            "md5": "S7a4w3PZyWSKmEHfs726xXPEK+k=",
+            "last_commit": 1607807382,
+            "header": "/headers/autolore.header",
+            "tags": [],
+            "version": "1.2",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/aethorvars.lic",
+            "type": "script",
+            "md5": "o++bxU7X8Roib9GZZSvPGoe3bWo=",
+            "last_commit": 1607807382,
+            "header": "/headers/aethorvars.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/useimbed.lic",
+            "type": "script",
+            "md5": "DCXjo2+Tg5zkvfnjHA7AbujGo7o=",
+            "last_commit": 1607807382,
+            "header": "/headers/useimbed.header",
+            "tags": [
+                "magic"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/wrack.lic",
+            "type": "script",
+            "md5": "O5p7q+R8ZOjy25ihQty1Arb1b3c=",
+            "last_commit": 1607807382,
+            "header": "/headers/wrack.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wishlist.lic",
+            "type": "script",
+            "md5": "7Lz0pAcBRWIJkyxc9pX7okAukhc=",
+            "last_commit": 1607807382,
+            "header": "/headers/wishlist.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wait-three.lic",
+            "type": "script",
+            "md5": "MYYkM5tJQAlDwwbSfnmgLFZvaPo=",
+            "last_commit": 1607807382,
+            "header": "/headers/wait-three.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/killbigshot.lic",
+            "type": "script",
+            "md5": "0594mYDImtd0bWzqdsMHUKLiPnU=",
+            "last_commit": 1607807382,
+            "header": "/headers/killbigshot.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/trigger.lic",
+            "type": "script",
+            "md5": "9vyKSgqi0OqEdhQl0RxMckDImQk=",
+            "last_commit": 1607807382,
+            "header": "/headers/trigger.header",
+            "tags": [
+                "Utility"
+            ],
+            "version": "2",
+            "author": "Upy"
+        },
+        {
+            "file": "/assets/transcend.lic",
+            "type": "script",
+            "md5": "eYt3vKKpR3XiLdzBjGlCvspw7j4=",
+            "last_commit": 1607807382,
+            "header": "/headers/transcend.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/fragrance.lic",
+            "type": "script",
+            "md5": "HDtDfGH7jArj/NgMeLCsavXDNFU=",
+            "last_commit": 1607807382,
+            "header": "/headers/fragrance.header",
+            "tags": [
+                "cologne",
+                "perfume",
+                "utility",
+                "roleplay",
+                "rp"
+            ],
+            "version": "0.1",
+            "author": "Nomada"
+        },
+        {
+            "file": "/assets/stopbigshot.lic",
+            "type": "script",
+            "md5": "WvCEljc9/LTsCFReTUbCQy3Eqks=",
+            "last_commit": 1607807382,
+            "header": "/headers/stopbigshot.header",
+            "tags": [
+                "bigshot"
+            ],
+            "version": "1.0",
+            "author": "Zachriel"
+        },
+        {
+            "file": "/assets/npcboldspeech.lic",
+            "type": "script",
+            "md5": "VvIAxYNOrTt2MZpwNk7IATmkPSg=",
+            "last_commit": 1607807382,
+            "header": "/headers/npcboldspeech.header",
+            "tags": [],
+            "version": "0.2 (2018-10-04)",
+            "author": "MrsLostRanger (aka Aquarrist email: misara@gmail.com)"
+        },
+        {
+            "file": "/assets/song-manager.lic",
+            "type": "script",
+            "md5": "M5CoYRmGSqmzGmBswYvOsRuZnb0=",
+            "last_commit": 1607807382,
+            "header": "/headers/song-manager.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/purify2.lic",
+            "type": "script",
+            "md5": "ynjBPEy5dXYI9lxiJVJZ/bC5AL0=",
+            "last_commit": 1607807382,
+            "header": "/headers/purify2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bloodscrip.lic",
+            "type": "script",
+            "md5": "4I2ucKnU/u0uyX4uq2o2y802pRY=",
+            "last_commit": 1607807382,
+            "header": "/headers/bloodscrip.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pickerassistant.lic",
+            "type": "script",
+            "md5": "DVU5RSVJHi7VK7XvQXrPYy7X568=",
+            "last_commit": 1607807382,
+            "header": "/headers/pickerassistant.header",
+            "tags": [
+                "utility",
+                "locksmithing",
+                "lock picking"
+            ],
+            "version": "1.0.1.0",
+            "author": "Willbo"
+        },
+        {
+            "file": "/assets/tboost.lic",
+            "type": "script",
+            "md5": "5bcf0yWZ07G0uLK8HlEIOrnoVxc=",
+            "last_commit": 1607807382,
+            "header": "/headers/tboost.header",
+            "tags": [
+                "reim",
+                "reim boost",
+                "mana"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/statperfect.lic",
+            "type": "script",
+            "md5": "so53qHF5TMLzC1vVZnFEoZEDGsg=",
+            "last_commit": 1607807382,
+            "header": "/headers/statperfect.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/haste-ortar.lic",
+            "type": "script",
+            "md5": "ZpWZcHf7PjCnE2UzhxODP0NOwbU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/jur.lic",
+            "type": "script",
+            "md5": "TMDAcPS2rfI9YhXHx5vNnopmavM=",
+            "last_commit": 1607807382,
+            "header": "/headers/jur.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/zesty.lic",
+            "type": "script",
+            "md5": "KCLz97G6uefGJTDJ/SuRfEHvmCY=",
+            "last_commit": 1607807382,
+            "header": "/headers/zesty.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/tinagra.lic",
+            "type": "script",
+            "md5": "I2+VGAeWDas5N79H8yhU/JsuTzA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/donoharm.lic",
+            "type": "script",
+            "md5": "fqBgbIrHU6D0fQeyiAKpWnrqPZs=",
+            "last_commit": 1607807382,
+            "header": "/headers/donoharm.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/quest_locker.lic",
+            "type": "script",
+            "md5": "UxGuxEcn9nX1cKJbVOMk/yxtjQU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/spells.lic",
+            "type": "script",
+            "md5": "HkK3tFPEUC3+Qk8a5CO4Ld9xs60=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xforeach.lic",
+            "type": "script",
+            "md5": "G01OxLmaglI984BW7vMJUMc76UE=",
+            "last_commit": 1607807382,
+            "header": "/headers/xforeach.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.10.0-x5 (2019-06-10)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/event_support.lic",
+            "type": "script",
+            "md5": "mVOaLBa75TmOT9VootTj/eQLSA8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/twitternfl.lic",
+            "type": "script",
+            "md5": "5Gd9bYq9lCvZa6RWrhn7uVyr454=",
+            "last_commit": 1607807382,
+            "header": "/headers/twitternfl.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/lockformulae.lic",
+            "type": "script",
+            "md5": "UPBFZ3lm7pZxAQw6n0tijIoTlPc=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockformulae.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/loop.lic",
+            "type": "script",
+            "md5": "VZZ4e1tvg+LVX2ICWHJtAeH6ty0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/chargeimbed.lic",
+            "type": "script",
+            "md5": "SS6DpIQJRHrKV6buUdz4Y5JAw5A=",
+            "last_commit": 1607807382,
+            "header": "/headers/chargeimbed.header",
+            "tags": [
+                "magic"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/infuse_scroll.lic",
+            "type": "script",
+            "md5": "IFLni71iOzAJsNSZkYOhrPgCFMY=",
+            "last_commit": 1607807382,
+            "header": "/headers/infuse_scroll.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/roll-tracker.lic",
+            "type": "script",
+            "md5": "kQzvI+lHWbHiLGQBGbC7k7o5Vfs=",
+            "last_commit": 1607807382,
+            "header": "/headers/roll-tracker.header",
+            "tags": [],
+            "version": "2",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/rested.lic",
+            "type": "script",
+            "md5": "pY/OcAPZhaBetXPVlzL9CiPxa/s=",
+            "last_commit": 1607807382,
+            "header": "/headers/rested.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.4 (2019-07-31)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/lockranges.lic",
+            "type": "script",
+            "md5": "+Za1RKIQcbo0Qfd8YjKRIr1ITj8=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockranges.header",
+            "tags": [],
+            "version": "1.6",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/rephase.lic",
+            "type": "script",
+            "md5": "S20rDk92bUI1YxpxPyV3IifHwlw=",
+            "last_commit": 1607807382,
+            "header": "/headers/rephase.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/jousting.lic",
+            "type": "script",
+            "md5": "TXPCrHcmsYR+j2cll7QF9Qihi0g=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/inspectarmor.lic",
+            "type": "script",
+            "md5": "fSvo9J9pUggeDnmYw0OxIZsqQp4=",
+            "last_commit": 1607807382,
+            "header": "/headers/inspectarmor.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bountyhunter-support.lic",
+            "type": "script",
+            "md5": "9+j53kcit2WapwnVTPkn2HIFfWU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/distill.cmd",
+            "type": "data",
+            "md5": "FNGa6uvjM/gkUKtQlTkaVUzroCw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/waggle_spell_active.lic",
+            "type": "script",
+            "md5": "+M9Zem/gyZ/uuVnm5EsR3M+xgVA=",
+            "last_commit": 1608150196,
+            "header": "/headers/waggle_spell_active.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.16",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/targetwin.lic",
+            "type": "script",
+            "md5": "RqHhmnafT5aS/wjIN2Er3KKXpRE=",
+            "last_commit": 1607807382,
+            "header": "/headers/targetwin.header",
+            "tags": [],
+            "author": "Rockmontan"
+        },
+        {
+            "file": "/assets/aneya_sewers.lic",
+            "type": "script",
+            "md5": "ktC6oj/4jRsbgdCjtQ15oA5Te7Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/aneya_sewers.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/dropalltype.lic",
+            "type": "script",
+            "md5": "m/nW5P9AasZJPlEasbfSpOLrxD4=",
+            "last_commit": 1607807382,
+            "header": "/headers/dropalltype.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/targetid.lic",
+            "type": "script",
+            "md5": "ycUOet6VWjh9WAYPVimTvPx5+bo=",
+            "last_commit": 1607807382,
+            "header": "/headers/targetid.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1.2 (2019-06-18)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/uacswap.lic",
+            "type": "script",
+            "md5": "02r8217SzHUO2XJnNqPjhxyN/yg=",
+            "last_commit": 1607807382,
+            "header": "/headers/uacswap.header",
+            "tags": [
+                ""
+            ]
+        },
+        {
+            "file": "/assets/step2.lic",
+            "type": "script",
+            "md5": "m1pDc0LXVDtRW6jjTteiVAp4qz0=",
+            "last_commit": 1607807382,
+            "header": "/headers/step2.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/dr_timer.lic",
+            "type": "script",
+            "md5": "B50A2uNEmXKoB+We9yvsHX+aZs4=",
+            "last_commit": 1607807382,
+            "header": "/headers/dr_timer.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/wedges.lic",
+            "type": "script",
+            "md5": "utDxHhiUuey6WyDLNpPQ30/mtfo=",
+            "last_commit": 1607807382,
+            "header": "/headers/wedges.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/alter.lic",
+            "type": "script",
+            "md5": "t0GUsYOjZAdSe4bbIVFQf7cETGg=",
+            "last_commit": 1607807382,
+            "header": "/headers/alter.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/gremwatch.lic",
+            "type": "script",
+            "md5": "z+ZW5BSN8ps+9qsWJQwAmxjhxV8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/badge2.lic",
+            "type": "script",
+            "md5": "pg9sw46Z/CXYVnlFXT0+HSL0R0o=",
+            "last_commit": 1607807382,
+            "header": "/headers/badge2.header",
+            "tags": [
+                "loot",
+                "badge",
+                "guild",
+                "aventurer"
+            ],
+            "version": "1.0",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/unstun.lic",
+            "type": "script",
+            "md5": "r/4tQxZcAwuDTr5dUo2n7X38w8g=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/boxempty.lic",
+            "type": "script",
+            "md5": "wQR6VOxIltQQ8JXTlY36pMenkKo=",
+            "last_commit": 1607807382,
+            "header": "/headers/boxempty.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/count.lic",
+            "type": "script",
+            "md5": "zurWxXTPAlt8oWRW0F+XafDt3LA=",
+            "last_commit": 1607807382,
+            "header": "/headers/count.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ifttt.lic",
+            "type": "script",
+            "md5": "LWlnZGmGyDfZzVlzR8y+EqBva4Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/ifttt.header",
+            "tags": [
+                "helper",
+                "nerdy"
+            ],
+            "version": "0.1",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/sbounty-bigshot.lic",
+            "type": "script",
+            "md5": "An5KK83qx5mgjgHjg6iUz3G3YTM=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbounty-bigshot.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/dropall.lic",
+            "type": "script",
+            "md5": "uMiOm0VApMseZHTSMRAtH6fT+Fw=",
+            "last_commit": 1607807382,
+            "header": "/headers/dropall.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/passcoinsto.lic",
+            "type": "script",
+            "md5": "UN5ry8z13gwpygbyDOf/PM1V41c=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/smart.lic",
+            "type": "script",
+            "md5": "C1ll1jfRhymXk6RtAx3uE6o5RFE=",
+            "last_commit": 1607807382,
+            "header": "/headers/smart.header",
+            "tags": [
+                "generic"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/UBW-Theme-SF.lic",
+            "type": "script",
+            "md5": "cC156r5hudLG6IPbnq8l8QCPGBE=",
+            "last_commit": 1607807382,
+            "header": "/headers/UBW-Theme-SF.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/useherbs.lic",
+            "type": "script",
+            "md5": "vsaWCG/jhshnhh6/gYAtalpJiWY=",
+            "last_commit": 1608258625,
+            "header": "/headers/useherbs.header",
+            "tags": [
+                "healing"
+            ],
+            "version": "0.12",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/dmtest.lic",
+            "type": "script",
+            "md5": "u2bXfTkXcJw6Kg03C5I+P38q8D0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/slap.lic",
+            "type": "script",
+            "md5": "pdYw4e90NiGaPdZzuXXe/z2bxm0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/shareroom.lic",
+            "type": "script",
+            "md5": "TnZv6O1FqmFHSvdJWDQROuO+YEQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/shareroom.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sstamina.lic",
+            "type": "script",
+            "md5": "76eBziZiqcEzFxngcSA3S0ti2YU=",
+            "last_commit": 1607807382,
+            "header": "/headers/sstamina.header",
+            "tags": [
+                "combat"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/tap2.lic",
+            "type": "script",
+            "md5": "YhCd6PWNqLnJsV45PN0nT52TwhI=",
+            "last_commit": 1607807382,
+            "header": "/headers/tap2.header",
+            "tags": [],
+            "version": "0",
+            "author": "Eklectic, stolen from Trysalis"
+        },
+        {
+            "file": "/assets/MyFletch.lic",
+            "type": "script",
+            "md5": "IJwqmSPP8aDuPi4yHlSUJ4pX/oI=",
+            "last_commit": 1607807382,
+            "header": "/headers/MyFletch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/alchemydistill.lic",
+            "type": "script",
+            "md5": "XHdIaH217KPUMun0mFds2K7Ld1A=",
+            "last_commit": 1607807382,
+            "header": "/headers/alchemydistill.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/constant404.lic",
+            "type": "script",
+            "md5": "QkA2uSnSALDsYpIUXs/m5nvbBQ4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/needhelp.lic",
+            "type": "script",
+            "md5": "H/pOM0M9IkXvU6qRH98tmU+N/SQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/needhelp.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sregister.lic",
+            "type": "script",
+            "md5": "GT54uafV1FR3PSaQ9Pday36jzlQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/sregister.header",
+            "tags": [
+                "game"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/roomcreature.lic",
+            "type": "script",
+            "md5": "GgO+nF62RKGNjP/2ztUh7eLoWtQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/roomcreature.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/hunt.lic",
+            "type": "script",
+            "md5": "kg/7yp2U5djlyoNsnsoHnGmSjRg=",
+            "last_commit": 1607807382,
+            "header": "/headers/hunt.header",
+            "tags": [
+                "movement"
+            ],
+            "version": "0.3",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/gearinfo.lic",
+            "type": "script",
+            "md5": "VDzaASNNlJjTBeYbycbD3QWY6WE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/moveall.lic",
+            "type": "script",
+            "md5": "na49fpd98uK8o/xPh2CsGF7vvUk=",
+            "last_commit": 1607807382,
+            "header": "/headers/moveall.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/dumplocker.lic",
+            "type": "script",
+            "md5": "LUI2Q2uIEVaEMFe6xe2zyRd7AWI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/download_all_scripts.lic",
+            "type": "script",
+            "md5": "RGLxt02m7Y1X1iHt4GDas/BO04M=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/open_group.lic",
+            "type": "script",
+            "md5": "QFsMKbkYRWvI0Put8F0uZcmqr+U=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gscrolls.lic",
+            "type": "script",
+            "md5": "TpdhGrfIilFK8dfVZ21fBM5kqXs=",
+            "last_commit": 1607807382,
+            "header": "/headers/gscrolls.header",
+            "tags": [
+                "invoke",
+                "scroll",
+                "scrolls",
+                "hunting",
+                "buff",
+                "buffs"
+            ],
+            "version": "1.0.0",
+            "author": "Glaves (Original Sulien)"
+        },
+        {
+            "file": "/assets/EgDigForOldLich.lic",
+            "type": "script",
+            "md5": "m8sYmo2Uk1on0/OXgo5ANGZry7c=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/keep213.lic",
+            "type": "script",
+            "md5": "5rDdo3I05gZWNJxxweC0+Hev6/A=",
+            "last_commit": 1607807382,
+            "header": "/headers/keep213.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/silvers.lic",
+            "type": "script",
+            "md5": "7lZAjZO0ti7oeJPmlIbt1WkrSxY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/perday.lic",
+            "type": "script",
+            "md5": "r9HM2Ul2p0DTyDYZVH7fsZbB674=",
+            "last_commit": 1607807382,
+            "header": "/headers/perday.header",
+            "tags": [
+                "loot",
+                "magic",
+                "miu",
+                "duskruin"
+            ],
+            "version": "1.6",
+            "author": "Ponclast"
+        },
+        {
+            "file": "/assets/smastery2.lic",
+            "type": "script",
+            "md5": "CuA6Ve9hxdWFM1mqUnrhbioPMpM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sancup.lic",
+            "type": "script",
+            "md5": "JS9qwrNY0X9ec5PZW5yGx+qsBTA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gsigils.lic",
+            "type": "script",
+            "md5": "kpr5ZCXTsaa/nlr+b9qUF+Ve3Pc=",
+            "last_commit": 1607807382,
+            "header": "/headers/gsigils.header",
+            "tags": [
+                "sigils",
+                "gos",
+                "isigils",
+                "power",
+                "determination",
+                "sunfist"
+            ],
+            "version": "3.1b",
+            "author": "Glaves"
+        },
+        {
+            "file": "/assets/rats-are-dumb.lic",
+            "type": "script",
+            "md5": "21ALOH8QqbLhqm5ykzPSN6PO/Pk=",
+            "last_commit": 1607807382,
+            "header": "/headers/rats-are-dumb.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/armortap.lic",
+            "type": "script",
+            "md5": "ptNFhKTg5Hn/5AY994I8pkAbBPs=",
+            "last_commit": 1607807382,
+            "header": "/headers/armortap.header",
+            "tags": [],
+            "author": "Genstealer w/ parts of code borrowed from Trysalis"
+        },
+        {
+            "file": "/assets/finish-it.lic",
+            "type": "script",
+            "md5": "COuT0x1Cw1blPuHMIp6PsGuY9UY=",
+            "last_commit": 1607807382,
+            "header": "/headers/finish-it.header",
+            "tags": [],
+            "version": "5",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/arenawatch.lic",
+            "type": "script",
+            "md5": "Oq9xnGNKXbomUGFuPWXs1OY8h+w=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sorter.lic",
+            "type": "script",
+            "md5": "LofA8uuWR1K5/FQH/lHzQQwhSSs=",
+            "last_commit": 1607807382,
+            "header": "/headers/sorter.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.9",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/spellwatch.lic",
+            "type": "script",
+            "md5": "OMjCLKNyQi8193hV6zmorcjw/qg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/manatimer.lic",
+            "type": "script",
+            "md5": "sng8x+blXdGgS+rjAEDMgFkaus8=",
+            "last_commit": 1607807382,
+            "header": "/headers/manatimer.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/script_runner.lic",
+            "type": "script",
+            "md5": "+xdph/UjSqgFiPwwmkM2eXQKmYg=",
+            "last_commit": 1607807382,
+            "header": "/headers/script_runner.header",
+            "tags": [
+                "Utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/sortwho.lic",
+            "type": "script",
+            "md5": "bWwU52TfQHxsSf+oSYpdiDw8pJo=",
+            "last_commit": 1607807382,
+            "header": "/headers/sortwho.header",
+            "tags": [],
+            "version": "2020.01.21.01",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/intown.lic",
+            "type": "script",
+            "md5": "M2rVPVyyoHaM5NXZF6mRmL2dqwo=",
+            "last_commit": 1607807382,
+            "header": "/headers/intown.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1 (2019-09-27)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/lookall.lic",
+            "type": "script",
+            "md5": "bFFAPlBX/ulHPJkj1rU3NEcyL+E=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/keep_spell_active.lic",
+            "type": "script",
+            "md5": "RakVrI7cCKzp11D4FfQ+DW1XPIs=",
+            "last_commit": 1607807382,
+            "header": "/headers/keep_spell_active.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ensorcell_tracker.lic",
+            "type": "script",
+            "md5": "T5Nez8OcatfmOb7oyeRA1tCMDec=",
+            "last_commit": 1607807382,
+            "header": "/headers/ensorcell_tracker.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/cutiepie.lic",
+            "type": "script",
+            "md5": "cLJ8u8QGftSwSV5O5jDVkbUUAw0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/water_tunnels.lic",
+            "type": "script",
+            "md5": "0haQl9NdG6n2eKeo8ztqJgrI1z8=",
+            "last_commit": 1607807382,
+            "header": "/headers/water_tunnels.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/IC_Crits.lic",
+            "type": "script",
+            "md5": "3J4z/Ehq0IiUHEXzRrW2mckb9lM=",
+            "last_commit": 1607807382,
+            "header": "/headers/IC_Crits.header",
+            "tags": [
+                "combat"
+            ],
+            "version": "0.1",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/mechq.lic",
+            "type": "script",
+            "md5": "MvEnMFAV1AKfYVMR5345C+OSzRI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hp.lic",
+            "type": "script",
+            "md5": "3zDPuwXocmY/qxooGDlCz33vzFw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/newfavortracker.lic",
+            "type": "script",
+            "md5": "UuriegfyMZ7fXMHMfC7QQwGPvPs=",
+            "last_commit": 1607807382,
+            "header": "/headers/newfavortracker.header",
+            "tags": [
+                "Voln",
+                "Favor"
+            ],
+            "version": "0.5"
+        },
+        {
+            "file": "/assets/slootbeta.lic",
+            "type": "script",
+            "md5": "5UF/B+tOLstLShCuk303J+QGscQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lich-set-login.lic",
+            "type": "script",
+            "md5": "DXhkpW6+TLEeXeSfTsvqSyq2yZk=",
+            "last_commit": 1607807382,
+            "header": "/headers/lich-set-login.header",
+            "tags": [],
+            "version": "0.1 (2019-05-16)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/MAcomm.lic",
+            "type": "script",
+            "md5": "2sWPJhy1sg0J9IIPLtZ97QVRpQ8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/universalkill-nylis.lic",
+            "type": "script",
+            "md5": "8Ee7zJ7N8gu76R4im6hFD2/wvRg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/autovine.lic",
+            "type": "script",
+            "md5": "1ziplMpPhpQCphBkKsYnpooAS4k=",
+            "last_commit": 1607807382,
+            "header": "/headers/autovine.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autosetup.lic",
+            "type": "script",
+            "md5": "w4Czx0Q1Eu4LGAwqa616N8k6R/U=",
+            "last_commit": 1607807382,
+            "header": "/headers/autosetup.header",
+            "tags": [],
+            "version": "0.2"
+        },
+        {
+            "file": "/assets/waitanddo.lic",
+            "type": "script",
+            "md5": "B7Y/mJt64Er1ebzhLdDFJsGafIU=",
+            "last_commit": 1607807382,
+            "header": "/headers/waitanddo.header",
+            "tags": [
+                "utility",
+                "action"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/whisperheal.lic",
+            "type": "script",
+            "md5": "rYgiwZS2H0VKoIX0ZG8xpQifKIE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/box.lic",
+            "type": "script",
+            "md5": "zxe180QSHE/4aZXpV9ieT0Thidg=",
+            "last_commit": 1607807382,
+            "header": "/headers/box.header",
+            "tags": [
+                "lockpicking"
+            ],
+            "version": "0.18 (2020-03-14)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/autovote.lic",
+            "type": "script",
+            "md5": "UQCcLVNmmJ5kJITjowjxlYiLyVU=",
+            "last_commit": 1607807382,
+            "header": "/headers/autovote.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/autoloot.lic",
+            "type": "script",
+            "md5": "CKeO/5w9q+xO3BuOa4xMewyUq/o=",
+            "last_commit": 1607807382,
+            "header": "/headers/autoloot.header",
+            "tags": [
+                "loot"
+            ],
+            "version": "1.0",
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/gbtest.lic",
+            "type": "script",
+            "md5": "gjZ+3EM2ZeRAQLz4x4oLMF0Vu0s=",
+            "last_commit": 1607807382,
+            "header": "/headers/gbtest.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/ezprice.lic",
+            "type": "script",
+            "md5": "3L4dBa9efMNLbyYBtniT8q/4KX0=",
+            "last_commit": 1607807382,
+            "header": "/headers/ezprice.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/passive-spellbot.lic",
+            "type": "script",
+            "md5": "BbQi8MkV6JiSXCynNqMSr3C+F8o=",
+            "last_commit": 1607807382,
+            "header": "/headers/passive-spellbot.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "0.2",
+            "author": "Tillmen (tillmen@lichproject.org"
+        },
+        {
+            "file": "/assets/sortedskills.lic",
+            "type": "script",
+            "md5": "m7THihP56tsmaaJpUgUOQhaQ1HQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/sortedskills.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.2 (2019-07-09)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/heal_spellup.lic",
+            "type": "script",
+            "md5": "QVOyQ7m79t7zX73kDU/KtxG56u4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/prettynum.lic",
+            "type": "script",
+            "md5": "5fMtm/YK9E7aJUzwX9qPmTKNIYM=",
+            "last_commit": 1607807382,
+            "header": "/headers/prettynum.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/quest_aicrystal.lic",
+            "type": "script",
+            "md5": "80ryXs8k5WRfFYH5j0Zv74loZVE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/imbed.lic",
+            "type": "script",
+            "md5": "LZLd+LribOjL7H5+o553O4IyrSQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/imbed.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/etchedstones.lic",
+            "type": "script",
+            "md5": "vckMYwnPhbEI4GNQcOg8etMtvYw=",
+            "last_commit": 1607807382,
+            "header": "/headers/etchedstones.header",
+            "tags": [],
+            "version": "0.03.0"
+        },
+        {
+            "file": "/assets/shift.lic",
+            "type": "script",
+            "md5": "6jyUvqb/6evJvQIbkZd/uh9176g=",
+            "last_commit": 1607807382,
+            "header": "/headers/shift.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/posthunt_nexushealbot.lic",
+            "type": "script",
+            "md5": "McXpulg4G9VEm8zQFEZeHM5oDoc=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt_nexushealbot.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/nfury.lic",
+            "type": "script",
+            "md5": "3cNX4H25mugcZUtACm8F3RN4AHU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ci_fishing.lic",
+            "type": "script",
+            "md5": "7EqmfWNM0puHhjbGxTwIdlQWqcw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ssexual-favor.lic",
+            "type": "script",
+            "md5": "PMjVw2uiYBS8Ypd1X0oil30XLrg=",
+            "last_commit": 1607807382,
+            "header": "/headers/ssexual-favor.header",
+            "tags": [
+                "voln",
+                "utility"
+            ],
+            "version": "0.5",
+            "author": "Tillmen"
+        },
+        {
+            "file": "/assets/infected.lic",
+            "type": "script",
+            "md5": "h0DcNKRY0Iz9CATkjL6gNQw4WWs=",
+            "last_commit": 1607807382,
+            "header": "/headers/infected.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Xanlin"
+        },
+        {
+            "file": "/assets/room-info.lic",
+            "type": "script",
+            "md5": "wl7ReJl/bTZepRkiEPQV9Cqfgq4=",
+            "last_commit": 1607807382,
+            "header": "/headers/room-info.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Tristes"
+        },
+        {
+            "file": "/assets/tlogin.lic",
+            "type": "script",
+            "md5": "2PZDDdWbUteIoFRo+8/o1r3AvmU=",
+            "last_commit": 1607807382,
+            "header": "/headers/tlogin.header",
+            "tags": [],
+            "author": "Lostranger"
+        },
+        {
+            "file": "/assets/phase.lic",
+            "type": "script",
+            "md5": "nWrLRer2RExmDNsqt3jnpL2G7dU=",
+            "last_commit": 1607807382,
+            "header": "/headers/phase.header",
+            "tags": [
+                "sorcerer"
+            ],
+            "version": "2.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/fix.lic",
+            "type": "script",
+            "md5": "9dvWyULg1/0G7Hh4UFCK6f0L/5c=",
+            "last_commit": 1607807382,
+            "header": "/headers/fix.header",
+            "tags": [
+                "fixes",
+                "patch"
+            ],
+            "version": "0.6",
+            "author": "Brav"
+        },
+        {
+            "file": "/assets/enhancivesorter.lic",
+            "type": "script",
+            "md5": "KPKXyH/ukPxT7Y4xWGKo5P8QBJQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/enhancivesorter.header",
+            "tags": [
+                "bandit",
+                "bandits",
+                "bounty",
+                "utility",
+                "stormfront"
+            ],
+            "version": "1.0",
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/egdig.lic",
+            "type": "script",
+            "md5": "oEEtwTWhfBKK312Kbk0Ar1rYAvY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/cscalculator.lic",
+            "type": "script",
+            "md5": "jPKQXBLCc3zgGPsKXXLUaMOjMXk=",
+            "last_commit": 1607807382,
+            "header": "/headers/cscalculator.header",
+            "tags": [
+                "information",
+                "magic",
+                "utility"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/joustsmart.lic",
+            "type": "script",
+            "md5": "3hr5j52aa7RpZMDC9aF+zwJO2vw=",
+            "last_commit": 1607807382,
+            "header": "/headers/joustsmart.header",
+            "tags": [
+                "jousting"
+            ],
+            "version": "0.4",
+            "author": "Tovklar"
+        },
+        {
+            "file": "/assets/voodoo.lic",
+            "type": "script",
+            "md5": "TojGHlpagei+ceSHaE9HiKJlA0I=",
+            "last_commit": 1607807382,
+            "header": "/headers/voodoo.header",
+            "tags": [
+                "magic"
+            ],
+            "version": "2.2",
+            "author": "Tillmen"
+        },
+        {
+            "file": "/assets/shield-size.lic",
+            "type": "script",
+            "md5": "l/GTQHw37omh9s2UT+Y+bhvckvc=",
+            "last_commit": 1607807382,
+            "header": "/headers/shield-size.header",
+            "tags": [
+                "data"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/speed2.lic",
+            "type": "script",
+            "md5": "lW6XfystfJcWybu3rIqZ90utCPQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/speed2.header",
+            "tags": [
+                "travel"
+            ],
+            "author": "SpiffyJr"
+        },
+        {
+            "file": "/assets/policy.lic",
+            "type": "script",
+            "md5": "MD1pwaXBSBxt7td+V1EM2ToFn9w=",
+            "last_commit": 1607807382,
+            "header": "/headers/policy.header",
+            "tags": [
+                "utility",
+                "scripting violation"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/manatimer-sf.lic",
+            "type": "script",
+            "md5": "x0m6HkkVsdRoFKliFQ4T4Uymw1o=",
+            "last_commit": 1607807382,
+            "header": "/headers/manatimer-sf.header",
+            "tags": [
+                "mana",
+                "timer",
+                "utility",
+                "helper",
+                "auto"
+            ],
+            "version": "0.1",
+            "author": "Nomada"
+        },
+        {
+            "file": "/assets/bigshot_beta.lic",
+            "type": "script",
+            "md5": "ydVnx3UtA/LslNrNtjbGTFScNE4=",
+            "last_commit": 1607807382,
+            "header": "/headers/bigshot_beta.header",
+            "tags": [
+                "hunting"
+            ],
+            "version": "3.87",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/pulsetimer.lic",
+            "type": "script",
+            "md5": "rY6aey1GQtyQQTfjKBehYWmcj3E=",
+            "last_commit": 1607807382,
+            "header": "/headers/pulsetimer.header",
+            "tags": [],
+            "version": "0.2",
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/flowergirl.lic",
+            "type": "script",
+            "md5": "2Twx7U0KHU18H7bYw6dnnEyaimY=",
+            "last_commit": 1607807382,
+            "header": "/headers/flowergirl.header",
+            "tags": [
+                "bless",
+                "hardcore",
+                "voln",
+                "landing",
+                "npc"
+            ],
+            "version": "0.5",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/bbtest.lic",
+            "type": "script",
+            "md5": "v+VSycHT7JliWbD3UZRtyJw1tHU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/orchear.lic",
+            "type": "script",
+            "md5": "iAsLZzl1F8RBgkMPzgkymvpezrE=",
+            "last_commit": 1607807382,
+            "header": "/headers/orchear.header",
+            "tags": [
+                "speech"
+            ],
+            "version": "0.1",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/scalcflares.lic",
+            "type": "script",
+            "md5": "+ZObVXCjYS3/4eanQtlKIuEcpww=",
+            "last_commit": 1607807382,
+            "header": "/headers/scalcflares.header",
+            "tags": [
+                "mechanics"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/champkill.lic",
+            "type": "script",
+            "md5": "NF9YcGFNjrYCLCHclO/MuTdF/vA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/hastetimer.lic",
+            "type": "script",
+            "md5": "EokBTpU8uh1fwty08WpOFSkzVmk=",
+            "last_commit": 1607807382,
+            "header": "/headers/hastetimer.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/duskruin_sewer.lic",
+            "type": "script",
+            "md5": "1ZSLmqclL9OCaTTU2Y2ihImrh7Q=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/lockmaster.lic",
+            "type": "script",
+            "md5": "V2Oj6Rfa5CfXUK1uqr5CkvApP9Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/lockmaster.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/jvice.lic",
+            "type": "script",
+            "md5": "OWPXpQUfd9fPtPDXyjTQg2F343w=",
+            "last_commit": 1607807382,
+            "header": "/headers/jvice.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/shattered_portals.lic",
+            "type": "script",
+            "md5": "ZTOoh/j/ff//KeAgNYH1S6cWWDw=",
+            "last_commit": 1607807382,
+            "header": "/headers/shattered_portals.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sunfist_world_tour.lic",
+            "type": "script",
+            "md5": "zwb01EDZePsERpaA4MOmJH3uMBk=",
+            "last_commit": 1607807382,
+            "header": "/headers/sunfist_world_tour.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/pop.lic",
+            "type": "script",
+            "md5": "oJxvcoBCRbV64eiUrtIs05vDI+M=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sexual-favors.lic",
+            "type": "script",
+            "md5": "MHMsLJ8A/3UCsQkfX7yGtWHS6ZA=",
+            "last_commit": 1607807382,
+            "header": "/headers/sexual-favors.header",
+            "tags": [
+                "voln"
+            ],
+            "version": "0.34",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/shatventure.lic",
+            "type": "script",
+            "md5": "bHUCPpEzy3wp8/IfENMulxKoiPk=",
+            "last_commit": 1607807382,
+            "header": "/headers/shatventure.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/rapid.lic",
+            "type": "script",
+            "md5": "D4NFSoQA/wLUFiwcTsYIl3OCZV4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ironmanplate.lic",
+            "type": "script",
+            "md5": "pGeEsNd+sItrLz1kZcK4NlqPhas=",
+            "last_commit": 1607807382,
+            "header": "/headers/ironmanplate.header",
+            "tags": [],
+            "version": "1",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/wingstop.lic",
+            "type": "script",
+            "md5": "IT5Ax/sq68m4zqOLVSOz6IGCpqk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/xtask.lic",
+            "type": "script",
+            "md5": "9Chuqt/LeLSm76KX6hM5lPgvhAg=",
+            "last_commit": 1607807382,
+            "header": "/headers/xtask.header",
+            "tags": [],
+            "author": "Xanlin (forked from Tgo01)"
+        },
+        {
+            "file": "/assets/shopsearch.lic",
+            "type": "script",
+            "md5": "xIACZAA7NjOBNy5rPjy2dOtALh4=",
+            "last_commit": 1607807382,
+            "header": "/headers/shopsearch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/wandersanct.lic",
+            "type": "script",
+            "md5": "e4j4GECbZO52DkK7y1HtU6rFWqg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/iron.lic",
+            "type": "script",
+            "md5": "56o3IBog4MkaAPnGLlxgaOjYq9o=",
+            "last_commit": 1607807382,
+            "header": "/headers/iron.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "voln"
+            ]
+        },
+        {
+            "file": "/assets/highlight_name.cmd",
+            "type": "data",
+            "md5": "WPL5gAGjh4FSQkPNx7iAzwnd7Z8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/wearstuff.lic",
+            "type": "script",
+            "md5": "XoWs412kS4LQYOyndBVhC9r7d/A=",
+            "last_commit": 1607807382,
+            "header": "/headers/wearstuff.header",
+            "tags": [
+                "wear"
+            ],
+            "version": "1.0",
+            "author": "Aramund"
+        },
+        {
+            "file": "/assets/oc_heist.lic",
+            "type": "script",
+            "md5": "IaIgGWrTf1X+jO/yDMPa6UVi0Zs=",
+            "last_commit": 1607807382,
+            "header": "/headers/oc_heist.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/errand.lic",
+            "type": "script",
+            "md5": "U8gGm7yYfHLAM5EAWCLC7RwIlkk=",
+            "last_commit": 1607807382,
+            "header": "/headers/errand.header",
+            "tags": [],
+            "version": "0.5",
+            "author": "Gnomad"
+        },
+        {
+            "file": "/assets/autoinvitefriends.lic",
+            "type": "script",
+            "md5": "rLzus5yCn2OO2bF+5gj+wgBQZu4=",
+            "last_commit": 1607807382,
+            "header": "/headers/autoinvitefriends.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/custom_sewers.lic",
+            "type": "script",
+            "md5": "Tg5MOSduV+34tFDHqrOuiQUEI94=",
+            "last_commit": 1607807382,
+            "header": "/headers/custom_sewers.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/fixed-forge-perfects.lic",
+            "type": "script",
+            "md5": "5jz4cc4YmIJw7NZdZYCAhAS7BKY=",
+            "last_commit": 1607807382,
+            "header": "/headers/fixed-forge-perfects.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "perfect"
+            ]
+        },
+        {
+            "file": "/assets/bestiary.lic",
+            "type": "script",
+            "md5": "0wG7uU/JCsmBG9NBaAeExKj3ONs=",
+            "last_commit": 1607807382,
+            "header": "/headers/bestiary.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/AUTOHOLD.lic",
+            "type": "script",
+            "md5": "/dDoMTcXNUluRAiIB/+ivXMCGaQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/beast.lic",
+            "type": "script",
+            "md5": "r/QecMd3sbOS16Xx7GJ8wH0ZqQI=",
+            "last_commit": 1607807382,
+            "header": "/headers/beast.header",
+            "tags": [],
+            "author": "Rumbletum"
+        },
+        {
+            "file": "/assets/plist.lic",
+            "type": "script",
+            "md5": "aE9oufKG7YsJOmDza1ozFt+4KBw=",
+            "last_commit": 1607807382,
+            "header": "/headers/plist.header",
+            "tags": [],
+            "version": "2017.01.16.01",
+            "author": "Akono (lordakono@gmail.com)"
+        },
+        {
+            "file": "/assets/noop.lic",
+            "type": "script",
+            "md5": "m2FA3a6kco6IxVjpBUF4hZi69hc=",
+            "last_commit": 1608254013,
+            "header": "/headers/noop.header",
+            "tags": [
+                "testing"
+            ],
+            "version": "1.0",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/invite.lic",
+            "type": "script",
+            "md5": "LXg4udmrZ866N2Oyx5xPzjUSeWo=",
+            "last_commit": 1607807382,
+            "header": "/headers/invite.header",
+            "tags": [
+                "town",
+                "table",
+                "spellups",
+                "friends"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/fastkill.lic",
+            "type": "script",
+            "md5": "PWcGfosZYkOMVNG/xd08n7yrNEU=",
+            "last_commit": 1607807382,
+            "header": "/headers/fastkill.header",
+            "tags": [
+                "hunting"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/timequit.lic",
+            "type": "script",
+            "md5": "ETtWEBbVt1Bm/zfdmIyHPulmtJ0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/aneya_sewers2.lic",
+            "type": "script",
+            "md5": "ELAynDwt7F/9ufvt7RbQR4UeBEY=",
+            "last_commit": 1607807382,
+            "header": "/headers/aneya_sewers2.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/answers.lic",
+            "type": "script",
+            "md5": "Y/zBZbK2jVDjU1sQ8C/DJpdtINQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/answers.header",
+            "tags": [
+                "jail",
+                "hooligan"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/posthunt_wukong.lic",
+            "type": "script",
+            "md5": "rjaA4me8L5gOclq09YcJIotQ6/M=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt_wukong.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/dye_search.lic",
+            "type": "script",
+            "md5": "Nb3ocl3eljsqyU8ymjRqw5KfbPc=",
+            "last_commit": 1607807382,
+            "header": "/headers/dye_search.header",
+            "tags": [
+                "dye",
+                "shop",
+                "shopping",
+                "search"
+            ],
+            "version": "0",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/duskdig.lic",
+            "type": "script",
+            "md5": "e3r0ZMfx7FaUgI7Ub/hRQU41c1g=",
+            "last_commit": 1607807382,
+            "header": "/headers/duskdig.header",
+            "tags": [
+                "Duskruin"
+            ],
+            "version": "1.09",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/formatfix.lic",
+            "type": "script",
+            "md5": "2z84fOjyzM74ECprVjej0ork4gE=",
+            "last_commit": 1607807382,
+            "header": "/headers/formatfix.header",
+            "tags": [
+                ""
+            ]
+        },
+        {
+            "file": "/assets/alchemy.lic",
+            "type": "script",
+            "md5": "nqpJ0+CwK9y+BEq0ueF1CTUIAms=",
+            "last_commit": 1608258537,
+            "header": "/headers/alchemy.header",
+            "tags": [
+                "alchemy",
+                "guild"
+            ],
+            "version": "0.16",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/gems_2jars.lic",
+            "type": "script",
+            "md5": "+BzZ//alhZJBBrtI7PPZ2s1y0Wo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/eatbread.lic",
+            "type": "script",
+            "md5": "o45bXcumoJi4wFe0tLdMJFPM29o=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rrbountyspool.lic",
+            "type": "script",
+            "md5": "7ZfP5pQPVSqUYhkrX3WpzmEmJLM=",
+            "last_commit": 1607807382,
+            "header": "/headers/rrbountyspool.header",
+            "tags": [
+                "RR",
+                "bounty"
+            ],
+            "version": "0.18",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/recolor.lic",
+            "type": "script",
+            "md5": "6XQWUyUvKGLAPG5W2FGLF5pPBm4=",
+            "last_commit": 1607807382,
+            "header": "/headers/recolor.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.6 (2019-07-30)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/testme.lic",
+            "type": "script",
+            "md5": "KA+iR5UvgIdAz5o5HGOmHzFcGOk=",
+            "last_commit": 1607807382,
+            "header": "/headers/testme.header",
+            "tags": [],
+            "version": "45",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/accept.lic",
+            "type": "script",
+            "md5": "DKwNayMUTd97n6T8Dnh9lE1mDBI=",
+            "last_commit": 1607807382,
+            "header": "/headers/accept.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sbountybeta.lic",
+            "type": "script",
+            "md5": "xaPloxdSY35fDAHA/VOlxjbe1DU=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbountybeta.header",
+            "tags": [
+                "bounty"
+            ],
+            "author": "SpiffyJr"
+        },
+        {
+            "file": "/assets/crit_type_tracker.lic",
+            "type": "script",
+            "md5": "k1soydOvNXsCbjVDW/5mvmMANfo=",
+            "last_commit": 1607807382,
+            "header": "/headers/crit_type_tracker.header",
+            "tags": [
+                "utility",
+                "information",
+                "hunting"
+            ],
+            "author": "Gibreficul"
+        },
+        {
+            "file": "/assets/carousel2016.lic",
+            "type": "script",
+            "md5": "+nDnVQdPXcumaAWn5jj7XJzW6do=",
+            "last_commit": 1607807382,
+            "header": "/headers/carousel2016.header",
+            "tags": [
+                "ebon gate",
+                "games",
+                "eg"
+            ],
+            "version": "2.4",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/fyreim.lic",
+            "type": "script",
+            "md5": "OsK/TGgLbiv0ucsGSJSNbtCHAuQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/fyreim.header",
+            "tags": [
+                "reim"
+            ],
+            "version": "2.3",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/deposit.lic",
+            "type": "script",
+            "md5": "OuUHs7KnrpOGhAab1rTYIZPUohc=",
+            "last_commit": 1607807382,
+            "header": "/headers/deposit.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/snakewatch.lic",
+            "type": "script",
+            "md5": "xQbRWtOU9SwmUZ3mkL9raoBOFLc=",
+            "last_commit": 1607807382,
+            "header": "/headers/snakewatch.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/calcredux.lic",
+            "type": "script",
+            "md5": "S5LGTnGwuOT28TvzDaklcjOn6YE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/prioritytargets.rb",
+            "type": "script",
+            "md5": "+Jt4GBFtlK6LCOchlegkYE1NUPQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/slurplocker.lic",
+            "type": "script",
+            "md5": "rGRUWvOSfOsRyx1LRmYlgVedWzI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ironslab.lic",
+            "type": "script",
+            "md5": "u5CrQphZSb/Uz2fHXedkL4LjRtQ=",
+            "last_commit": 1607807382,
+            "header": "/headers/ironslab.header",
+            "tags": [
+                "forging",
+                "forge",
+                "craft",
+                "artisan",
+                "voln"
+            ],
+            "version": "1.2",
+            "author": "WilliamW1979 (WilliamW1979@netscape.net)"
+        },
+        {
+            "file": "/assets/umadbro.lic",
+            "type": "script",
+            "md5": "iMg0V1plxh2Z0KlOJ0vcfJl/yLE=",
+            "last_commit": 1607807382,
+            "header": "/headers/umadbro.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/deednobank.lic",
+            "type": "script",
+            "md5": "mPMt22LrqoWfr/yil//+bXCU8m8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/warcampfind.lic",
+            "type": "script",
+            "md5": "v+HT0FHWYBvwhsGlUQQCS2hTVdk=",
+            "last_commit": 1607807382,
+            "header": "/headers/warcampfind.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/badge.lic",
+            "type": "script",
+            "md5": "jW12fXm4cAmuWiGS4itp8n6Vs5o=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/unload.lic",
+            "type": "script",
+            "md5": "jJRuXSpt9pJZDZUc1Sqaj5bxoSI=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/sellshard.lic",
+            "type": "script",
+            "md5": "XFuCUb20ti7/jHRvQCFIO/riTrc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/coinpouch.lic",
+            "type": "script",
+            "md5": "2mN7etZgLdvbF3A1MQNmzQca6t0=",
+            "last_commit": 1607807382,
+            "header": "/headers/coinpouch.header",
+            "tags": [],
+            "author": "Caithris"
+        },
+        {
+            "file": "/assets/smartsorcerer.lic",
+            "type": "script",
+            "md5": "JsAgAXpzKIN4TfOGIGLtBerkOqo=",
+            "last_commit": 1607807382,
+            "header": "/headers/smartsorcerer.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/sadamantine.lic",
+            "type": "script",
+            "md5": "49Cb50V9zOs2aGDStinT+hVcZs4=",
+            "last_commit": 1607807382,
+            "header": "/headers/sadamantine.header",
+            "tags": [
+                "mechanics"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/imbue_amulet.lic",
+            "type": "script",
+            "md5": "WLY9YoQHMlubwZ5G+bI/MfirYxc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/multi.lic",
+            "type": "script",
+            "md5": "45yYYjLrDj1JbfJ/IUoA6l9c824=",
+            "last_commit": 1607807382,
+            "header": "/headers/multi.header",
+            "tags": [
+                "multifput",
+                "input",
+                "buy",
+                "repeating",
+                "multiple command entry",
+                "empty jars",
+                "etc"
+            ],
+            "author": "Luxelle"
+        },
+        {
+            "file": "/assets/pure3.lic",
+            "type": "script",
+            "md5": "4d618AcLeSDmNXJlGcedQrN/KsM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/bandit.lic",
+            "type": "script",
+            "md5": "MSmJSaSW/2U/FhWri7um1+ZZarA=",
+            "last_commit": 1607807382,
+            "header": "/headers/bandit.header",
+            "tags": [
+                "utility",
+                "stormfront"
+            ],
+            "version": "1.0",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/condition_check.lic",
+            "type": "script",
+            "md5": "KeuYlmtWa3LCHiwG5lbxMD920Gs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/cman_calc.lic",
+            "type": "script",
+            "md5": "S7Y5gH9Fr2DUJ7MD7rc8kOs59w8=",
+            "last_commit": 1607807382,
+            "header": "/headers/cman_calc.header",
+            "tags": [
+                "hunting",
+                "information",
+                "mechanics",
+                "combat"
+            ],
+            "version": "2",
+            "author": "Gnomad (PC)"
+        },
+        {
+            "file": "/assets/dontbreakyourhead.lic",
+            "type": "script",
+            "md5": "O4DBWn8mIEc97pch6T3GMKkdlyA=",
+            "last_commit": 1607807382,
+            "header": "/headers/dontbreakyourhead.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/whereami.lic",
+            "type": "script",
+            "md5": "f92LutOKheR4mPc0aLQu6Tek02Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/whereami.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/chatfail.lic",
+            "type": "script",
+            "md5": "CQs3D25verS5TFoNzjHZUPrLOlE=",
+            "last_commit": 1607807382,
+            "header": "/headers/chatfail.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/foxhunt.lic",
+            "type": "script",
+            "md5": "dPR71ib0sck68nz6Hq0gNUKmasA=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gospaladinfinal.lic",
+            "type": "script",
+            "md5": "404gt4FV7cHATEck1De8nbxnBpg=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/profs.lic",
+            "type": "script",
+            "md5": "hVQqETDpXU06E8ATcycNp3z93oo=",
+            "last_commit": 1607807382,
+            "header": "/headers/profs.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/medwag.lic",
+            "type": "script",
+            "md5": "9A4lJNayT/TDNqn6rlS3OYbuX84=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/iamannpc.lic",
+            "type": "script",
+            "md5": "iqgbOsQckglE87bH/9X9bIhM0rU=",
+            "last_commit": 1607807382,
+            "header": "/headers/iamannpc.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/nextbounty.lic",
+            "type": "script",
+            "md5": "5/EQjKVP1q2LXNfLOzYn323BmBM=",
+            "last_commit": 1607807382,
+            "header": "/headers/nextbounty.header",
+            "tags": [
+                "bounties",
+                "utility"
+            ],
+            "version": "1.0",
+            "author": "Genstealer"
+        },
+        {
+            "file": "/assets/sbounty-shunt.lic",
+            "type": "script",
+            "md5": "ywTPydXtdXOKteiqi8X7Q2Cl5TA=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbounty-shunt.header",
+            "tags": [
+                "bounty"
+            ],
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/atlas.lic",
+            "type": "script",
+            "md5": "0n2DBKdtyctGHjNgtkTFt2INs6s=",
+            "last_commit": 1607807382,
+            "header": "/headers/atlas.header",
+            "tags": [
+                "creature",
+                "critter",
+                "hunting"
+            ],
+            "version": "2017.06.28.01 - Fixed adding new creatures",
+            "author": "Jymamon (gs4-jymamon@hotmail.com)"
+        },
+        {
+            "file": "/assets/lk.lic",
+            "type": "script",
+            "md5": "JhqkepHRooLY7huoHpYrehs5BPk=",
+            "last_commit": 1607807382,
+            "header": "/headers/lk.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/childtower.lic",
+            "type": "script",
+            "md5": "LQCCMWYjbAXc0F9EwjaBU34LpTM=",
+            "last_commit": 1607807382,
+            "header": "/headers/childtower.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/arena-stats.lic",
+            "type": "script",
+            "md5": "rTm5uH5rgXQzjOGm+hPuUjSTzhk=",
+            "last_commit": 1607807382,
+            "header": "/headers/arena-stats.header",
+            "tags": [
+                "duskruin",
+                "arena",
+                "stats"
+            ],
+            "version": "0.0.2",
+            "author": "Sulien (sulieneq@gmail.com)"
+        },
+        {
+            "file": "/assets/eat-left-wait.lic",
+            "type": "script",
+            "md5": "dLz0ZzIDjUqy24PKj2MmkKT+33s=",
+            "last_commit": 1607807382,
+            "header": "/headers/eat-left-wait.header",
+            "tags": [],
+            "version": "1.0.0",
+            "author": "Zagert"
+        },
+        {
+            "file": "/assets/zombie.lic",
+            "type": "script",
+            "md5": "6nusUwvWycVwM02dceRFf8PNkgE=",
+            "last_commit": 1608258667,
+            "header": "/headers/zombie.header",
+            "tags": [
+                "death"
+            ],
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/imbed_rods.lic",
+            "type": "script",
+            "md5": "NaXPBeiT+bhko4BeQrSNe2rqiq0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/race.lic",
+            "type": "script",
+            "md5": "QG1tiCFwgdyRyHJ3NxLrYAtue0g=",
+            "last_commit": 1607807382,
+            "header": "/headers/race.header",
+            "tags": [],
+            "version": "1.14",
+            "author": "Jennora"
+        },
+        {
+            "file": "/assets/sbounty.lic",
+            "type": "script",
+            "md5": "rFJ4dL4P+RpAp3vgUf7eKeLfFwU=",
+            "last_commit": 1607807382,
+            "header": "/headers/sbounty.header",
+            "tags": [
+                "bounty"
+            ],
+            "version": "1.0",
+            "author": "spiffyjr"
+        },
+        {
+            "file": "/assets/dothis.lic",
+            "type": "script",
+            "md5": "bydNkxjq3FxN7/tCFC66qHg+Cmk=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/jailbox.lic",
+            "type": "script",
+            "md5": "VrwEEQ5F29TpTfwTlwlj8HK7h1s=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/killcounter.lic",
+            "type": "script",
+            "md5": "H9dCKe1FOPrV8TS3FArqqrrsiEc=",
+            "last_commit": 1607807382,
+            "header": "/headers/killcounter.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/bigshot-child.lic",
+            "type": "script",
+            "md5": "y9g63QkibOgdMf/xO/ieZgD4G0M=",
+            "last_commit": 1607807382,
+            "header": "/headers/bigshot-child.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/shat_sewers.lic",
+            "type": "script",
+            "md5": "GMprziZ3uJWfH/hjBrANHi9lhVs=",
+            "last_commit": 1607807382,
+            "header": "/headers/shat_sewers.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/blessme.lic",
+            "type": "script",
+            "md5": "wLasbeUdvCALNW2QXFYtAfwZNrs=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ssing.lic",
+            "type": "script",
+            "md5": "4aKH9l4AhiaLLyXIrEa0w88/gs0=",
+            "last_commit": 1607807382,
+            "header": "/headers/ssing.header",
+            "tags": [
+                "utility",
+                "bard"
+            ],
+            "version": "1.0",
+            "author": "SpiffyJr"
+        },
+        {
+            "file": "/assets/manifest.lic",
+            "type": "script",
+            "md5": "hUCb08oRDluzSpnoOFlWmjJJKY4=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/gs3level.lic",
+            "type": "script",
+            "md5": "7zkBzsR/3URcPWrsv13qr95utVc=",
+            "last_commit": 1607807382,
+            "header": "/headers/gs3level.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Xorus"
+        },
+        {
+            "file": "/assets/loglore.lic",
+            "type": "script",
+            "md5": "5Mw0+nUPDRBwOabD4+d2Gimp3OE=",
+            "last_commit": 1607807382,
+            "header": "/headers/loglore.header",
+            "tags": [],
+            "version": "0.3.1 (2017-06-19)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/go2fam.lic",
+            "type": "script",
+            "md5": "X3te8sWFNrJPqkrrifVkZZmngR8=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2fam.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/reset_vaalor_timeto.lic",
+            "type": "script",
+            "md5": "5kzAqFPJsEa7TXpRe9TeYXoaJ/s=",
+            "last_commit": 1607807382,
+            "header": "/headers/reset_vaalor_timeto.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/officialescort.lic",
+            "type": "script",
+            "md5": "ItBtseDHXTIyDkwqS1fAEIuMFc0=",
+            "last_commit": 1607807382,
+            "header": "/headers/officialescort.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/CIDig.lic",
+            "type": "script",
+            "md5": "glOiREJlL43MAQi0PtybwH9OPcY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/checkstaff.lic",
+            "type": "script",
+            "md5": "TmGoTXc7fec7DXT/wBfcIFGRDdk=",
+            "last_commit": 1607807382,
+            "header": "/headers/checkstaff.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/crit-tracking.lic",
+            "type": "script",
+            "md5": "THFUVvG0l7MwOt3SugAGr+VtW48=",
+            "last_commit": 1607807382,
+            "header": "/headers/crit-tracking.header",
+            "tags": [],
+            "version": "11",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/version.lic",
+            "type": "script",
+            "md5": "eUbJCcMsD2K9Sr/t4BBNzI5B+EI=",
+            "last_commit": 1607807382,
+            "header": "/headers/version.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.5 (2020-03-19)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/fox.lic",
+            "type": "script",
+            "md5": "0ctX9fAvegwA43ovIG85NKRFslc=",
+            "last_commit": 1607807382,
+            "header": "/headers/fox.header",
+            "tags": [],
+            "author": "Ryjex"
+        },
+        {
+            "file": "/assets/posthunt_notaneya.lic",
+            "type": "script",
+            "md5": "LiIvRTHbeSn7809bXIApqj6aV+I=",
+            "last_commit": 1607807382,
+            "header": "/headers/posthunt_notaneya.header",
+            "tags": [],
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/monastery.lic",
+            "type": "script",
+            "md5": "RiDkSdrbGDZxsaKC4SBpeGxdR7Y=",
+            "last_commit": 1607807382,
+            "header": "/headers/monastery.header",
+            "tags": [
+                "go2",
+                "travel",
+                "Voln"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/heal_tracker.lic",
+            "type": "script",
+            "md5": "79pctZvOJIVxm8z8Tt0oNjazeFg=",
+            "last_commit": 1607807382,
+            "header": "/headers/heal_tracker.header",
+            "tags": [
+                "empath",
+                "heal",
+                "healing"
+            ],
+            "version": "1.5.0",
+            "author": "Xanlin (Xanlin#4407 on discord)"
+        },
+        {
+            "file": "/assets/disk_protector.lic",
+            "type": "script",
+            "md5": "DwHm5khED2t71s5Q/9mG+f103S8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/rescue-sunfist.lic",
+            "type": "script",
+            "md5": "l3ZZPjbj25DcVlO0EnXnHbxy2kY=",
+            "last_commit": 1607807382,
+            "header": "/headers/rescue-sunfist.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/XPMonitor.lic",
+            "type": "script",
+            "md5": "fcIsPK2+HGalWyufJD8ZSVlu/uU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/chrism2.lic",
+            "type": "script",
+            "md5": "H4K/RsEH6Lo5Q6R3Tct2jyq7mzI=",
+            "last_commit": 1607807382,
+            "header": "/headers/chrism2.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/StartVaalor.lic",
+            "type": "script",
+            "md5": "D2kmmwPK99qKeFcnj75bDBj9UAc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/huntingareas.lic",
+            "type": "script",
+            "md5": "puPmOWp0K6xPqi6OONAee4P668Q=",
+            "last_commit": 1607807382,
+            "header": "/headers/huntingareas.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/madtarget.lic",
+            "type": "script",
+            "md5": "3hWx933zYiwmueHqwCh2I/wzxyE=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/joinup2.lic",
+            "type": "script",
+            "md5": "yHtvyeMg/X/bclrXzGBiWPFqs94=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/citrove.lic",
+            "type": "script",
+            "md5": "mNWkYbFikanX3FH4by7qLmEO+Dw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/ising.lic",
+            "type": "script",
+            "md5": "vqKGaHPO8+Ql8s9ql88suTBm7QM=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/spelltap.lic",
+            "type": "script",
+            "md5": "FQyigOWlQBK7tWxjygxksnhq1fo=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/arena-nylis.lic",
+            "type": "script",
+            "md5": "OjJEulS9ZfhbZ8urxhYXhWGnhDc=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/duskdigbin.lic",
+            "type": "script",
+            "md5": "JkVXS7p2B/ScjKQiYAWBf5dxzGo=",
+            "last_commit": 1607807382,
+            "header": "/headers/duskdigbin.header",
+            "tags": [
+                "Duskruin"
+            ],
+            "version": "1.09",
+            "author": "Hazado"
+        },
+        {
+            "file": "/assets/Society.lic",
+            "type": "script",
+            "md5": "CKsnNKbLyN1WJ+AZV0s7GwufT8A=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/go2shop.lic",
+            "type": "script",
+            "md5": "0gEdvWO7XvOXz44Pm+0cmJ+5tnY=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2shop.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.3 (2019-09-29)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/register-all.lic",
+            "type": "script",
+            "md5": "cfZmBHZyA7Flcu4asP/6NeIcCxY=",
+            "last_commit": 1607807382,
+            "header": "/headers/register-all.header",
+            "tags": [],
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/parasite.lic",
+            "type": "script",
+            "md5": "Gi3t8IQeYFMgO4Aqq3uAxyFCtc4=",
+            "last_commit": 1607807382,
+            "header": "/headers/parasite.header",
+            "tags": [],
+            "version": "1",
+            "author": "Dantax"
+        },
+        {
+            "file": "/assets/remoteheal.lic",
+            "type": "script",
+            "md5": "CiT2jj5aWSd1BKFkYP9fd8OKrmY=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/go2locate.lic",
+            "type": "script",
+            "md5": "Sy7a3COm7jC1+7lInUjD3Bvru94=",
+            "last_commit": 1607807382,
+            "header": "/headers/go2locate.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/universalkill-champ.lic",
+            "type": "script",
+            "md5": "6p5/vAq4xb97G3hNlfIPPvs/EAw=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/prettybounty.lic",
+            "type": "script",
+            "md5": "pxEKBz3LSLDKDbQ6Sl2txrI/MNE=",
+            "last_commit": 1607807382,
+            "header": "/headers/prettybounty.header",
+            "tags": [
+                "cosmetic"
+            ],
+            "version": "0.1",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/dforge.lic",
+            "type": "script",
+            "md5": "NnvWQAZcmkqS5oLsQOqWuIfDXGU=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/colorsbot.lic",
+            "type": "script",
+            "md5": "kMr+u7iCwrn7hU1k+l7nICNdKZc=",
+            "last_commit": 1607807382,
+            "header": "/headers/colorsbot.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/smarthunt2.lic",
+            "type": "script",
+            "md5": "/RQvUShaWhGKNVvot72WuezvWvA=",
+            "last_commit": 1607807382,
+            "header": "/headers/smarthunt2.header",
+            "tags": [],
+            "author": "Yasutoshi, Monk"
+        },
+        {
+            "file": "/assets/fletchmaster.lic",
+            "type": "script",
+            "md5": "TtDSBlCjEj/NaWcjFPG7c0q5boM=",
+            "last_commit": 1607807382,
+            "header": "/headers/fletchmaster.header",
+            "tags": [
+                "fletching",
+                "artisan",
+                "guild",
+                "hardcore"
+            ],
+            "version": "1.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/rubmeforabless.lic",
+            "type": "script",
+            "md5": "d1VZ2X+zqNARVQrcYBJtuafVOuw=",
+            "last_commit": 1607807382,
+            "header": "/headers/rubmeforabless.header",
+            "tags": [],
+            "author": "Licel"
+        },
+        {
+            "file": "/assets/partner2.lic",
+            "type": "script",
+            "md5": "E1xu6IV/sjeSGRaqydMJBPFX4i8=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/cluster-rc.lic",
+            "type": "script",
+            "md5": "W7TCKBGZDNSdISnlYpBKAqEE8n0=",
+            "last_commit": 1607807382,
+            "header": "/headers/cluster-rc.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/oc_timer.lic",
+            "type": "script",
+            "md5": "3ufVQBU3J+1VjgTlk4Wj/LVsc48=",
+            "last_commit": 1607807382,
+            "header": "/headers/oc_timer.header",
+            "tags": [],
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/itemnote.lic",
+            "type": "script",
+            "md5": "AxZyN47tqZz+JHlZvMMATSw3k08=",
+            "last_commit": 1607807382,
+            "header": "/headers/itemnote.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/auto_containers.lic",
+            "type": "script",
+            "md5": "o7T6dJwubfe4ddfV1jXbi7xXNjM=",
+            "last_commit": 1607807382,
+            "header": "/headers/auto_containers.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/srogue.lic",
+            "type": "script",
+            "md5": "egy3KZunPzzXDbcEoBiy/TWC6MY=",
+            "last_commit": 1607807382,
+            "header": "/headers/srogue.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/jsort.lic",
+            "type": "script",
+            "md5": "vORS2qxD/BhG/V8LODeSD/WDk9c=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/illusion_tutor.lic",
+            "type": "script",
+            "md5": "8170GuFIJ0SrBD4jkQfQytw0cOg=",
+            "last_commit": 1607807382,
+            "header": "/headers/illusion_tutor.header",
+            "tags": [
+                "illusions",
+                "sorcerer",
+                "guild"
+            ],
+            "version": "2.02",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/triage.lic",
+            "type": "script",
+            "md5": "pfWzSi7qjaV8cesxm6RYY7i5tFA=",
+            "last_commit": 1607807382,
+            "header": "/headers/triage.header",
+            "tags": [
+                "utility"
+            ],
+            "version": "0.1.3 (2020-03-07)",
+            "author": "LostRanger (thisgenericname@gmail.com)"
+        },
+        {
+            "file": "/assets/www.lic",
+            "type": "script",
+            "md5": "qkjqTTteTc+V1PgekTcgWechdTo=",
+            "last_commit": 1607807382,
+            "header": "/headers/www.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/official2.lic",
+            "type": "script",
+            "md5": "CLGVsmpUArQhTFZpX58NrBZLf40=",
+            "last_commit": 1607807382,
+            "header": "/headers/official2.header",
+            "tags": [
+                "gos"
+            ],
+            "version": "2.0",
+            "author": "Kaldonis"
+        },
+        {
+            "file": "/assets/si_heist.lic",
+            "type": "script",
+            "md5": "Bg8FJ547wLeUdfXZdTDWCSaLJVU=",
+            "last_commit": 1607807382,
+            "header": "/headers/si_heist.header",
+            "tags": [],
+            "version": "1.0",
+            "author": "Alastir"
+        },
+        {
+            "file": "/assets/1601room.lic",
+            "type": "script",
+            "md5": "MYRlq/rLUj7FL44rRouX++BM/3A=",
+            "last_commit": 1607807382,
+            "header": "/headers/1601room.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/invmanager.lic",
+            "type": "script",
+            "md5": "fNTHjqPJfxy41fwqtDJwsmfkE+0=",
+            "last_commit": 1607807382,
+            "header": "/headers/invmanager.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/auto-level.lic",
+            "type": "script",
+            "md5": "x1txOYSxRZP3Kg0KtSR7H/sJLGk=",
+            "last_commit": 1607807382,
+            "header": "/headers/auto-level.header",
+            "tags": [],
+            "version": "41",
+            "author": "Tgo01"
+        },
+        {
+            "file": "/assets/bigdisarm.lic",
+            "type": "script",
+            "md5": "6/zWjsuZOZN/gnNFZWBjzV0KiVQ=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/curseditemhandler.lic",
+            "type": "script",
+            "md5": "ysPOIucIIhDfKKYGMGTpAnS4m8g=",
+            "last_commit": 1607807382,
+            "header": "/headers/curseditemhandler.header",
+            "tags": [],
+            "author": "Aethor Whiteaxe"
+        },
+        {
+            "file": "/assets/taparmor.lic",
+            "type": "script",
+            "md5": "GbhDT37IVVPTkqd28xJCYua20P0=",
+            "last_commit": 1607807382,
+            "tags": []
+        },
+        {
+            "file": "/assets/power.lic",
+            "type": "script",
+            "md5": "0cXLuvVq/SE7UlEY4cdhxhQwVoM=",
+            "last_commit": 1607807382,
+            "header": "/headers/power.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/hud_bounty.lic",
+            "type": "script",
+            "md5": "lPpWyKWkSfx/8QPyqU54aBymc24=",
+            "last_commit": 1607807382,
+            "header": "/headers/hud_bounty.header",
+            "tags": [
+                "cosmetic",
+                "bounty"
+            ],
+            "version": "0.2",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/diskus_shat.lic",
+            "type": "script",
+            "md5": "9yEpWN7otp2eZGBP2uwW+iPI63A=",
+            "last_commit": 1607807382,
+            "header": "/headers/diskus_shat.header",
+            "tags": [
+                "magic",
+                "disk"
+            ],
+            "version": "0.10",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/volndeath.lic",
+            "type": "script",
+            "md5": "QWoL5WiMeobMX3ht/x2BXqacJJg=",
+            "last_commit": 1607807382,
+            "tags": []
+        }
+    ],
+    "last_updated": 1610246456
+}

--- a/spec/jinx/repos/core/assets/alias.lic
+++ b/spec/jinx/repos/core/assets/alias.lic
@@ -1,0 +1,491 @@
+#quiet
+=begin
+
+   Implements aliases for Lich.
+
+   Start the script and type ;alias help
+
+   author: Tillmen (tillmen@lichproject.org)
+   game: any
+   tags: core
+   required: Lich >= 4.6.0
+   version: 0.8
+
+   changelog:
+      0.8 (2018-08-29):
+         fixes for compatibility with Ruby >= 2.3
+      0.7 (2015-08-31):
+         make triggers case-insensitive
+      0.6 (2015-03-10):
+         don't allow the script to run as trusted
+         update trigger regex after deleting a trigger
+
+=end
+=begin
+
+      0.5 (2015-02-01):
+         add gui
+      0.4 (2014-11-13):
+         remove leading spaces before sending the alias target
+      0.3 (2014-11-07):
+         sort ;alias list
+      0.2 (2014-10-05):
+         don't crash from recursive aliases 
+
+=end
+
+$SAFE = 3 if ($SAFE < 3) and (RUBY_VERSION =~ /^2\.[012]\./)
+
+if script.vars[1] =~ /^stop/i
+   if UpstreamHook.list.include('alias-service')
+      UpstreamHook.remove('alias-service')
+      respond "\n--- Lich: alias service stopped\n\n"
+   else
+      respond "\n--- Lich: alias service is not running\n\n"
+   end
+   exit
+end
+
+db = Script.open_file('db3')
+character = "#{XMLData.game.downcase}_#{XMLData.name.downcase}".gsub(/[^a-z_]/, '').encode('UTF-8')
+
+db.execute("CREATE TABLE IF NOT EXISTS global (trigger TEXT NOT NULL, target TEXT NOT NULL, UNIQUE(trigger));")
+db.execute("CREATE TABLE IF NOT EXISTS #{character} (trigger TEXT NOT NULL, target TEXT NOT NULL, UNIQUE(trigger));")
+
+character_regex = nil
+global_regex = nil
+
+update_regex = proc {
+   global_regex = Array.new
+   db.execute("SELECT trigger FROM global;") do |row|
+      global_regex.push(Regexp.escape(row[0]))
+   end
+   if global_regex.empty?
+      global_regex = nil
+   else
+      global_regex = /^(?:<c>)?(#{global_regex.join('|')})(?:\s+|$)(.*)/i
+   end
+
+   character_regex = Array.new
+   db.execute("SELECT trigger FROM #{character};") do |row|
+      character_regex.push(Regexp.escape(row[0]))
+   end
+   if character_regex.empty?
+      character_regex = nil
+   else
+      character_regex = /^(?:<c>)?(#{character_regex.join('|')})(?:\s+|$)(.*)/i
+   end
+   true
+}
+
+update_regex.call
+
+hook_proc = proc { |client_string|
+   if client_string =~ /^(?:<c>)?#{$lich_char}alias\s+(.*)/
+      args = $1
+      if (args == 'setup') and defined?(Gtk)
+         if defined?($alias_setup_window) and not $alias_setup_window.nil?
+            $alias_setup_window.present # fixme: show window
+         else
+            Thread.new {
+               done = false
+               Gtk.queue {
+                  character     = "#{XMLData.game.downcase}_#{XMLData.name.downcase}".gsub(/[^a-z_]/, '').encode('UTF-8')
+                  char_aliases  = Array.new
+                  db.execute("SELECT trigger,target FROM #{character};") do |row|
+                     char_aliases.push [ row[0], row[1] ]
+                  end
+                  char_aliases.sort! { |a,b| a[0].to_s <=> b[0].to_s }
+                  char_table     = Gtk::Table.new((char_aliases.length + 1), 3)
+                  char_textboxes = Array.new
+                  char_aliases.each_index { |i|
+                     label = Gtk::Label.new(char_aliases[i][0].to_s)
+                     box   = Gtk::HBox.new
+                     box.pack_end(label, false, false, 0)
+                     char_table.attach(box, 0, 1, i, (i + 1), Gtk::FILL, Gtk::FILL, 3, 3)
+                     textbox      = Gtk::Entry.new
+                     textbox.text = char_aliases[i][1]
+                     char_table.attach(textbox, 1, 2, i, (i + 1), (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+                     char_textboxes[i] = textbox
+                     delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+                     char_table.attach(delete_button, 2, 3, i, (i + 1), Gtk::SHRINK, Gtk::FILL, 3, 3)
+                     delete_button.signal_connect('clicked') {
+                        report_errors {
+                           label.sensitive = false
+                           textbox.sensitive = false
+                           delete_button.sensitive = false
+                           char_textboxes[i] = nil
+                        }
+                     }
+                  }
+                  new_char_aliases = Array.new
+                  char_sw = nil
+                  add_new_char_row = proc {
+                     i = new_char_aliases.length
+                     char_table.n_rows = char_table.n_rows + 1
+                     label = Gtk::Entry.new
+                     label.text = "(new alias trigger)"
+                     char_table.attach(label, 0, 1, (char_table.n_rows - 1), char_table.n_rows, Gtk::FILL, Gtk::FILL, 3, 3)
+                     textbox = Gtk::Entry.new
+                     textbox.text = "(new alias target)"
+                     textbox.sensitive = false
+                     char_table.attach(textbox, 1, 2, (char_table.n_rows - 1), char_table.n_rows, (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+                     new_char_aliases[i] = [ label, textbox ]
+                     delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+                     delete_button.sensitive = false
+                     char_table.attach(delete_button, 2, 3, (char_table.n_rows - 1), char_table.n_rows, Gtk::SHRINK, Gtk::FILL, 3, 3)
+                     label.show
+                     textbox.show
+                     delete_button.show
+                     label.signal_connect('focus-in-event') {
+                        report_errors {
+                           if label.text == "(new alias trigger)"
+                              label.text = ''
+                           end
+                           unless textbox.sensitive?
+                              textbox.sensitive = true
+                              delete_button.sensitive = true
+                              add_new_char_row.call
+                              Thread.new {
+                                 sleep 0.05
+                                 inc = (char_sw.vadjustment.upper - char_sw.vadjustment.value - char_sw.vadjustment.page_size) / 10.0
+                                 10.times { char_sw.vadjustment.value = char_sw.vadjustment.value + inc; sleep 0.02 }
+                                 char_sw.vadjustment.value = (char_sw.vadjustment.upper - char_sw.vadjustment.page_size)
+                              }
+                           end
+                        }
+                     }
+                     textbox.signal_connect('focus-in-event') {
+                        report_errors {
+                           if textbox.text == "(new alias target)"
+                              textbox.text = ''
+                           end
+                        }
+                     }
+                     delete_button.signal_connect('clicked') {
+                        report_errors {
+                           label.sensitive = false
+                           textbox.sensitive = false
+                           delete_button.sensitive = false
+                           new_char_aliases[i][1] = nil
+                        }
+                     }
+                  }
+                  add_new_char_row.call
+
+                  char_vp = Gtk::Viewport.new(nil, nil)
+                  char_vp.add(char_table)
+                  char_sw = Gtk::ScrolledWindow.new
+                  char_sw.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS)
+                  char_sw.add(char_vp)
+
+                  global_aliases = Array.new
+                  db.execute("SELECT trigger,target FROM global;") do |row|
+                     global_aliases.push [ row[0], row[1] ]
+                  end
+                  global_aliases.sort! { |a,b| a[0].to_s <=> b[0].to_s }
+                  global_table     = Gtk::Table.new((global_aliases.length + 1), 3)
+                  global_textboxes = Array.new
+                  global_aliases.each_index { |i|
+                     label = Gtk::Label.new(global_aliases[i][0].to_s)
+                     box   = Gtk::HBox.new
+                     box.pack_end(label, false, false, 0)
+                     global_table.attach(box, 0, 1, i, (i + 1), Gtk::FILL, Gtk::FILL, 3, 3)
+                     textbox      = Gtk::Entry.new
+                     textbox.text = global_aliases[i][1]
+                     global_table.attach(textbox, 1, 2, i, (i + 1), (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+                     global_textboxes[i] = textbox
+                     delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+                     global_table.attach(delete_button, 2, 3, i, (i + 1), Gtk::SHRINK, Gtk::FILL, 3, 3)
+                     delete_button.signal_connect('clicked') {
+                        report_errors {
+                           label.sensitive = false
+                           textbox.sensitive = false
+                           delete_button.sensitive = false
+                           global_textboxes[i] = nil
+                        }
+                     }
+                  }
+                  new_global_aliases = Array.new
+                  global_sw = nil
+                  add_new_global_row = proc {
+                     i = new_global_aliases.length
+                     global_table.n_rows = global_table.n_rows + 1
+                     label = Gtk::Entry.new
+                     label.text = "(new alias trigger)"
+                     global_table.attach(label, 0, 1, (global_table.n_rows - 1), global_table.n_rows, Gtk::FILL, Gtk::FILL, 3, 3)
+                     textbox = Gtk::Entry.new
+                     textbox.text = "(new alias target)"
+                     textbox.sensitive = false
+                     global_table.attach(textbox, 1, 2, (global_table.n_rows - 1), global_table.n_rows, (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+                     new_global_aliases[i] = [ label, textbox ]
+                     delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+                     delete_button.sensitive = false
+                     global_table.attach(delete_button, 2, 3, (global_table.n_rows - 1), global_table.n_rows, Gtk::SHRINK, Gtk::FILL, 3, 3)
+                     label.show
+                     textbox.show
+                     delete_button.show
+                     label.signal_connect('focus-in-event') {
+                        report_errors {
+                           if label.text == "(new alias trigger)"
+                              label.text = ''
+                           end
+                           unless textbox.sensitive?
+                              textbox.sensitive = true
+                              delete_button.sensitive = true
+                              add_new_global_row.call
+                              Thread.new {
+                                 sleep 0.05
+                                 inc = (global_sw.vadjustment.upper - global_sw.vadjustment.value - global_sw.vadjustment.page_size) / 10.0
+                                 10.times { global_sw.vadjustment.value = global_sw.vadjustment.value + inc; sleep 0.02 }
+                                 global_sw.vadjustment.value = (global_sw.vadjustment.upper - global_sw.vadjustment.page_size)
+                              }
+                           end
+                        }
+                     }
+                     textbox.signal_connect('focus-in-event') {
+                        report_errors {
+                           if textbox.text == "(new alias target)"
+                              textbox.text = ''
+                           end
+                        }
+                     }
+                     delete_button.signal_connect('clicked') {
+                        report_errors {
+                           label.sensitive = false
+                           textbox.sensitive = false
+                           delete_button.sensitive = false
+                           new_global_aliases[i][1] = nil
+                        }
+                     }
+                  }
+                  add_new_global_row.call
+
+                  global_vp = Gtk::Viewport.new(nil, nil)
+                  global_vp.add(global_table)
+                  global_sw = Gtk::ScrolledWindow.new
+                  global_sw.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS)
+                  global_sw.add(global_vp)
+
+                  global_tab = Gtk::VBox.new
+                  notebook = Gtk::Notebook.new
+                  notebook.append_page(char_sw, Gtk::Label.new("#{Char.name}'s Aliases"))
+                  notebook.append_page(global_sw, Gtk::Label.new('Global Aliases'))
+                  $alias_setup_window = Gtk::Window.new
+                  $alias_setup_window.title = "Lich - Aliases"
+                  $alias_setup_window.add(notebook)
+                  $alias_setup_window.signal_connect('delete_event') {
+                     report_errors {
+                        modified = false
+                        char_aliases.each_index { |i| if char_textboxes[i].nil? or new_char_aliases.any? { |a| (a[1] != nil) and a[1].sensitive? } or (char_aliases[i][1] != char_textboxes[i].text); modified = true; break; end }
+                        global_aliases.each_index { |i| if global_textboxes[i].nil? or new_global_aliases.any? { |a| (a[1] != nil) and a[1].sensitive? } or (global_aliases[i][1] != global_textboxes[i].text); modified = true; break; end }
+                        if modified
+                           dialog = Gtk::MessageDialog.new(nil, Gtk::Dialog::MODAL, Gtk::MessageDialog::QUESTION, Gtk::MessageDialog::BUTTONS_YES_NO, "Save changes?")
+                           dialog.title = "Lich - #{Char.name}'s Aliases"
+                           response = nil
+                           dialog.run { |r| response = r; dialog.destroy }
+                           if response == Gtk::Dialog::RESPONSE_YES
+                              char_aliases.each_index { |i|
+                                 if char_textboxes[i].nil?
+                                    db.execute("DELETE FROM #{character} WHERE trigger=?", char_aliases[i][0].encode('UTF-8'))
+                                 elsif (char_aliases[i][1] != char_textboxes[i].text)
+                                    db.execute("INSERT OR REPLACE INTO #{character} (trigger,target) VALUES(?,?);", char_aliases[i][0].encode('UTF-8'), char_textboxes[i].text.encode('UTF-8'))
+                                 end
+                              }
+                              new_char_aliases.each { |a|
+                                 if (a[1] != nil) and a[1].sensitive?
+                                    if a[0].text.empty?
+                                       respond "[alias: warning: ignoring new alias with no trigger]"
+                                    elsif db.get_first_value("SELECT target FROM #{character} WHERE trigger=? COLLATE NOCASE;", a[0].text.encode('UTF-8'))
+                                       respond "[alias: warning: new alias #{a[0].text} already exists; ignoring]"
+                                    else
+                                       db.execute("INSERT INTO #{character} (trigger,target) VALUES(?,?);", a[0].text.encode('UTF-8'), a[1].text.encode('UTF-8'))
+                                    end
+                                 end
+                              }
+                              global_aliases.each_index { |i|
+                                 if global_textboxes[i].nil?
+                                    db.execute("DELETE FROM global WHERE trigger=?", global_aliases[i][0].encode('UTF-8'))
+                                 elsif (global_aliases[i][1] != global_textboxes[i].text)
+                                    db.execute("INSERT OR REPLACE INTO global (trigger,target) VALUES(?,?);", global_aliases[i][0].encode('UTF-8'), global_textboxes[i].text.encode('UTF-8'))
+                                 end
+                              }
+                              new_global_aliases.each { |a|
+                                 if (a[1] != nil) and a[1].sensitive?
+                                    if a[0].text.empty?
+                                       respond "[alias: warning: ignoring new alias with no trigger]"
+                                    elsif db.get_first_value("SELECT target FROM global WHERE trigger=? COLLATE NOCASE;", a[0].text.encode('UTF-8'))
+                                       respond "[alias: warning: new alias #{a[0].text} already exists; ignoring]"
+                                    else
+                                       db.execute("INSERT INTO global (trigger,target) VALUES(?,?);", a[0].text.encode('UTF-8'), a[1].text.encode('UTF-8'))
+                                    end
+                                 end
+                              }
+                              update_regex.call
+                           end
+                        end
+                        done = true
+                     }
+                  }
+                  $alias_setup_window.set_default_size((Gdk.screen_width/2), (Gdk.screen_height/2))
+                  $alias_setup_window.set_window_position(Gtk::Window::POS_CENTER)
+                  $alias_setup_window.show_all
+               }
+               begin
+                  wait_until { done }
+               ensure
+                  Gtk.queue { $alias_setup_window.destroy; $alias_setup_window = nil }
+               end
+            }
+         end
+      elsif args =~ /^(\-\-global\s+)?(?:add|set)\s+(\-\-global\s+)?([^=]+)=\s*(.+)$/i
+         if ($1 || $2)
+            table = 'global'
+         else
+            table = character
+         end
+         trigger = $3.strip
+         target = $4
+         if old_target = db.get_first_value("SELECT target FROM #{table} WHERE trigger=? COLLATE NOCASE;", trigger.encode('UTF-8'))
+            db.execute("UPDATE #{table} SET target=? WHERE trigger=?;", target.encode('UTF-8'), trigger.encode('UTF-8'))
+            respond "\n--- Alias updated.  (old alias was: #{old_target})\n\n"
+         else
+            db.execute("INSERT INTO #{table} (trigger,target) VALUES(?,?);", trigger.encode('UTF-8'), target.encode('UTF-8'))
+            respond "\n--- Alias saved\n\n"
+         end
+         update_regex.call
+      elsif args =~ /^(\-\-global\s+)?(?:rem(?:ove)?|del(?:ete)?)\s+(\-\-global\s+)?(.+)/i
+         if ($1 || $2)
+            table = 'global'
+         else
+            table = character
+         end
+         trigger = $3
+         if target = db.get_first_value("SELECT target FROM #{table} WHERE trigger=? COLLATE NOCASE;", trigger.encode('UTF-8'))
+            db.execute("DELETE FROM #{table} WHERE trigger=?", trigger.encode('UTF-8'))
+            update_regex.call
+            respond "\n--- Alias deleted (#{trigger} => #{target})\n\n"
+         else
+            respond "\n--- Alias was not found in #{if table == 'global'; 'global'; else; "#{XMLData.name}'s"; end} list\n\n"
+         end
+      elsif args =~ /^list$/i
+         output = "\nGlobal Aliases:\n\n"
+         list = Array.new
+         db.execute("SELECT trigger,target FROM global;") do |row|
+            list.push "   #{row[0]} => #{row[1]}\n"
+         end
+         if list.empty?
+            output.concat "   (none)\n"
+         else
+            output.concat list.sort.join
+         end
+         output.concat "\n#{XMLData.name}'s Aliases:\n\n"
+         list.clear
+         db.execute("SELECT trigger,target FROM #{character};") do |row|
+            list.push "   #{row[0]} => #{row[1]}\n"
+         end
+         if list.empty?
+            output.concat "   (none)\n"
+         else
+            output.concat list.sort.join
+         end
+         output.concat "\n"
+         respond output
+      elsif args =~ /^reload/i
+         update_regex.call
+         respond "\n--- Alias data reloaded\n\n"
+      elsif args =~ /^stop/i
+         UpstreamHook.remove('alias-service')
+         db.close rescue()
+         respond "\n--- Lich: alias service stopped\n\n"
+      else
+         output = "\n"
+         output.concat "Usage:\n"
+         output.concat "\n"
+         if defined?(Gtk)
+            output.concat "     #{$clean_lich_char}alias setup\n"
+            output.concat "          Opens a window to configure aliases.\n"
+         end
+         output.concat "     #{$clean_lich_char}alias add <trigger> = <target>\n"
+         output.concat "     #{$clean_lich_char}alias add --global <trigger> = <target>\n"
+         output.concat "          Creates a new alias.  When you send a command that starts with <trigger>, it will be replaced\n"
+         output.concat "          with <target>.  If --global is specified, the alias will be active for all characters.\n"
+         output.concat "          \\r and \\? in the target are treated special.\n"
+         output.concat "\n"
+         output.concat "     #{$clean_lich_char}alias remove <trigger>\n"
+         output.concat "     #{$clean_lich_char}alias remove --global <trigger>\n"
+         output.concat "          Deletes the given alias\n"
+         output.concat "\n"
+         output.concat "     #{$clean_lich_char}alias list\n"
+         output.concat "          Lists the currently active aliases\n"
+         output.concat "\n"
+         output.concat "Examples:\n"
+         output.concat "\n"
+         output.concat "     ;alias add zap = ;eq cast(901, \"\\?\")\n"
+         output.concat "     ;alias add --global ;code = ;lnet chat on code\n"
+         output.concat "     ;alias add --global ls = look\n"
+         output.concat "\n"
+         respond output
+      end
+      nil
+   elsif caller.count { |x| x =~ /do_client/ } < 2
+      if character_regex and (client_string =~ character_regex)
+         trigger, extra = $1, $2
+         if target = db.get_first_value("SELECT target FROM #{character} WHERE trigger=? COLLATE NOCASE;", trigger.encode('UTF-8'))
+            target = target.split('\\r')#.collect { |line| line.sub(/^\s+/, '') }
+            if extra.empty?
+               target.collect! { |line| line.gsub('\\?', '') }
+            elsif target.any? { |line| line.include?('\\?') }
+               target.collect! { |line|
+                  if line =~ /^;e.*"\\\?"/
+                     line.gsub('"\\?"', extra.inspect)
+                  elsif line.include?('\\?')
+                     line.gsub('\\?', extra)
+                  else
+                     line
+                  end
+               }
+            elsif target.length == 1
+               target.first.concat(" #{extra}")
+            end
+            target.each { |line| do_client("#{line.chomp}\n") }
+         else
+            respond "[alias: fixme 1]"
+         end
+         nil
+      elsif global_regex and (client_string =~ global_regex)
+         trigger, extra = $1, $2
+         if target = db.get_first_value("SELECT target FROM global WHERE trigger=? COLLATE NOCASE;", trigger.encode('UTF-8'))
+            target = target.split('\\r')#.collect { |line| line.sub(/^\s+/, '') }
+            if extra.empty?
+               target.collect! { |line| line.gsub('\\?', '') }
+            elsif target.any? { |line| line.include?('\\?') }
+               target.collect! { |line|
+                  if line =~ /^;e.*"\\\?"/
+                     line.gsub('"\\?"', extra.inspect)
+                  elsif line.include?('\\?')
+                     line.gsub('\\?', extra)
+                  else
+                     line
+                  end
+               }
+            elsif target.length == 1
+               target.first.concat(" #{extra}")
+            end
+            target.each { |line| do_client("#{line.chomp}\n") }
+         else
+            respond "[alias: fixme 2]"
+         end
+         nil
+      else
+         client_string
+      end
+   else
+      client_string
+   end
+}
+
+UpstreamHook.add('alias-service', hook_proc)
+respond "--- Lich: alias service started"
+
+# fixme: override voodoo

--- a/spec/jinx/repos/core/assets/autostart.lic
+++ b/spec/jinx/repos/core/assets/autostart.lic
@@ -1,0 +1,170 @@
+#quiet
+=begin
+
+  Automatically starts scripts when Lich starts.
+
+  ;autostart help
+
+        author: Tillmen (tillmen@lichproject.org)
+  contributors: Athias, Doug
+          game: any
+          tags: core
+       version: 0.52
+      required: Lich >= 4.6.58
+
+  changelog:
+    0.52 (2021-01-04):
+      Fix to only run ;repository download-updates if in autostart list instead of forced.
+    0.51 (2020-09-09):
+      Added LostRanger gtk_version method to detect GTK version
+      Forcing unset-lich-updatable to prevent overwriting GTK3-enabled Lich only if GTK3 detected
+      Exclude narost / alias from update list if GTK3 detected
+      The above are only intended to be used in the GTK3 distro.
+    0.5 (2020-07-05):
+      Forced infomon and repository update to run at start
+      Prevented duplicate runs of infomon
+      Fixed bug with repository update not running
+      Made go2 and narost defaults
+      Formatting changes
+    0.4 (2015-07-12):
+      start infomon before other scripts
+    0.3 (2014-11-23):
+      add default settings on first run
+    0.2 (2014-11-10):
+      auto add infomon to global autostart list
+
+=end
+
+def gtk_version
+    begin
+        return 'not installed' unless Object.const_defined?(:Gtk)
+        return 'unknown' unless Gtk.const_defined?(:Version)
+        return Gtk::Version::STRING
+    rescue
+        return 'error'
+    end
+end
+
+if Settings['scripts'].nil?
+  Settings['scripts'] = Array.new
+  Settings['scripts'].push(:name => 'lnet', :args => [])
+  Settings['scripts'].push(:name => 'go2', :args => [])
+  Settings['scripts'].push(:name => 'narost', :args => []) if gtk_version < "3"
+  Settings['scripts'].push(:name => 'alias', :args => []) if gtk_version < "3"
+end
+
+if script.vars.empty?
+  # Wait after login then unset lich updatable before any other action (GTK3 option only)
+  start_script 'repository', ['unset-lich-updatable'] if gtk_version > "3"
+  sleep 2.5
+  did_something = false
+  run_info = false
+  run_repo = false
+  for script_list in [ Settings['scripts'], CharSettings['scripts'] ]
+    if script_list.class == Array
+      if run_info == false
+        # Run infomon
+        start_script 'infomon'
+        run_info = true
+        sleep 2.5
+      end
+      if run_repo == false 
+        # Run repository
+        if script_list.find { |script| script[:name] == "repository"}
+          start_script 'repository', ['download-updates']
+          wait_while {running? 'repository'}
+        end
+        run_repo = true
+      end
+      # Loop through list
+      for script_info in script_list
+        if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
+          next
+        else
+          Script.start(script_info[:name], :args => script_info[:args])
+        end
+        did_something = true
+      end
+    end
+  end
+  unless did_something
+    echo 'nothing to do'
+  end
+elsif (script.vars[1] =~ /^add$/i) and script.vars[2] and (script.vars[3] or script.vars[2] !~ /^\-\-global$/i)
+  if script.vars[2] =~ /^\-\-global$/i
+    script_list = Settings['scripts']
+    script_list = Array.new unless script_list.class == Array
+    if not Script.exists?(script.vars[3])
+      respond "\n--- #{script.vars[3]} does not appear to be a valid script\n\n"
+    elsif script_list.any? { |s| s[:name] == script.vars[3].downcase }
+      respond "\n--- #{script.vars[3]} is already set to start at login for all characters\n\n"
+    else
+      script_list.push(:name => script.vars[3].downcase, :args => script.vars[4..-1])
+      Settings['scripts'] = script_list
+      respond "\n--- #{script.vars[3]} will now start at login for all characters\n\n"
+    end
+  else
+    script_list = CharSettings['scripts']
+    script_list = Array.new unless script_list.class == Array
+    if not Script.exists?(script.vars[2])
+      respond "\n--- #{script.vars[2]} does not appear to be a valid script\n\n"
+    elsif script_list.any? { |s| s[:name] == script.vars[2].downcase }
+      respond "\n--- #{script.vars[2]} is already set to start at login for #{Char.name}\n\n"
+    else
+      script_list.push(:name =>script.vars[2].downcase, :args => script.vars[3..-1])
+      CharSettings['scripts'] = script_list
+      respond "\n--- #{script.vars[2]} will now start at login for #{Char.name}\n\n"
+    end
+  end
+elsif script.vars[1] =~ /^rem(?:ove)?$|^del(?:ete)?$/ and script.vars[2] and (script.vars[3] or script.vars[2] !~ /^\-\-global$/i)
+  if script.vars[2] =~ /^\-\-global$/i
+    script_list = Settings['scripts']
+    if (script_list.class == Array) and (script_info = script_list.find { |s| s[:name] == script.vars[3].downcase })
+      script_list.delete(script_info)
+      Settings['scripts'] = script_list
+      respond "\n--- #{script.vars[3]} was removed from the global autostart list\n\n"
+    else
+      respond "\n--- #{script.vars[3]} was not found in the global autostart list\n\n"
+    end
+  else
+    script_list = CharSettings['scripts']
+    if (script_list.class == Array) and (script_info = script_list.find { |s| s[:name] == script.vars[2].downcase })
+      script_list.delete(script_info)
+      CharSettings['scripts'] = script_list
+      respond "\n--- #{script.vars[2]} was removed from #{XMLData.name}'s autostart list\n\n"
+    else
+      respond "\n--- #{script.vars[2]} was not found in #{XMLData.name}'s autostart list\n\n"
+    end
+  end
+elsif script.vars[1] =~ /^list$/i
+  script_list = Settings['scripts']
+  output = "\n--- Global autostart scripts: "
+  if (script_list.class == Array) and not script_list.empty?
+    output.concat script_list.collect { |script_info| if script_info[:args].empty?; script_info[:name]; else; "#{script_info[:name]} (args: #{script_info[:args].join(' ')})"; end }.join(', ')
+    output.concat "\n\n"
+  else
+    output.concat "(none)\n\n"
+  end
+  script_list = CharSettings['scripts']
+  output.concat "--- #{XMLData.name}'s autostart scripts: "
+  if (script_list.class == Array) and not script_list.empty?
+    output.concat script_list.collect { |script_info| if script_info[:args].empty?; script_info[:name]; else; "#{script_info[:name]} (args: #{script_info[:args].join(' ')})"; end }.join(', ')
+    output.concat "\n\n"
+  else
+    output.concat "(none)\n\n"
+  end
+  respond output
+else
+  output = "\n"
+  output.concat "Usage:\n"
+  output.concat "\n"
+  output.concat "     #{$clean_lich_char}autostart add <script name> <args>\n"
+  output.concat "     #{$clean_lich_char}autostart add --global <script name> <args>\n"
+  output.concat "\n"
+  output.concat "     #{$clean_lich_char}autostart remove <script name>\n"
+  output.concat "     #{$clean_lich_char}autostart remove --global <script name>\n"
+  output.concat "\n"
+  output.concat "     #{$clean_lich_char}autostart list\n"
+  output.concat "\n"
+  respond output
+end

--- a/spec/jinx/repos/core/assets/demo.lic
+++ b/spec/jinx/repos/core/assets/demo.lic
@@ -1,0 +1,15 @@
+=begin
+  Jinx repo demo
+=end
+
+module Demo
+  ##
+  # runs the jinx demo
+
+  def self.main()
+    respond :success
+  end
+
+
+  Demo.main()
+end

--- a/spec/jinx/repos/core/assets/go2.lic
+++ b/spec/jinx/repos/core/assets/go2.lic
@@ -1,0 +1,1235 @@
+=begin
+
+   attempts to find the shortest route between any two rooms in the game
+   requires a map database (;repository download-mapdb)
+
+   ;go2 help
+
+            author: Tillmen (tillmen@lichproject.org)
+   original author: Shaelun
+              game: any
+              tags: core, movement
+           version: 1.26
+          required: Lich >= 4.6.14
+
+   changelog:
+      1.26 (2020-10-08):
+        Fix silver check broken by Commageddon
+      1.25 (2019-05-11):
+        Fix DragonRealms auto drag feature (Sarvatt)
+      1.24 (2019-03-03):
+         Updated formatting for ";go2 list" in GSPlat and GSF
+=end
+=begin
+      1.23 (2019-03-03):
+         add setting for using GSPlat old portal system
+      1.22 (2019-02-10):
+         add settings for using Chronomage day passes
+      1.21 (2017-10-07):
+         don't try to stand before swimming movements
+      1.20 (2017-09-17):
+         add confluence-hot and confluence-cold targets
+      1.19 (2016-09-24):
+         fix DragonRealms auto drag feature some more
+      1.18 (2016-09-24):
+         fix DragonRealms auto drag feature somewhat
+      1.17 (2016-09-12):
+         change portal settings to be saved using UserVars
+      1.16 (2016-08-19):
+         add fwi-trinket setting
+      1.15 (2016-04-01):
+         added experimental setting to auto drag in DragonRealms
+      1.14 (2015-07-09):
+         change ice mode setting to be saved using UserVars
+      1.13 (2015-07-09):
+         don't search for the confluence if you're already there
+      1.12 (2015-07-08):
+         don't do a GS lag check in DR
+      1.11 (2015-04-13):
+         add --instability option
+         fix going to a specific room inside the confluence from outside
+      1.10 (2015-04-13):
+         add confluence and instability targets
+      1.9 (2015-02-08):
+         stop using Map.tags
+      1.8 (2015-01-16):
+         fix ";go2 save" bug
+      1.7 (2014-12-11):
+         added stop-for-dead to the help message
+      1.6 (2014-12-10):
+         added stop-for-dead option
+         add settings to list command
+      1.5 (2014-12-04):
+         remove a debug message
+      1.4 (2014-12-04):
+         added delay setting
+         fixed bug with finding silver cost of a path
+      1.3 (2014-11-09):
+         changed typeahead setting to be different for each character
+      1.2 (2014-10-16):
+         don't use typeaheads for first move: makes it easier to find problems
+      1.1 (2014-10-07):
+         only automatically reduce typeahead setting if there's a typeahead message in the buffer
+
+=end
+
+# fixme: don't do puzzles option
+
+setting_value = { 'on' => true, 'true' => true, 'yes' => true, 'off' => false, 'false' => false, 'no' => false }
+previous = shortest_distances = nil
+
+CharSettings['typeahead']        =     0 if CharSettings['typeahead'].nil?
+CharSettings['vaalor shortcut']  = false if CharSettings['vaalor shortcut'].nil?
+CharSettings['get silvers']      = false if CharSettings['get silvers'].nil?
+CharSettings['delay']            =     0 if CharSettings['delay'].nil?
+CharSettings['stop for dead']    = false if CharSettings['stop for dead'].nil?
+
+show_help = proc {
+   output = "\n"
+   output.concat "   #{$lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
+   output.concat "   #{$lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
+   output.concat "   #{''.rjust($lich_char.length + script.name.length)}                          instead of your saved options.\n"
+   output.concat "   #{$lich_char}#{script.name} <options>               Saves the given options.\n"
+   output.concat "\n"
+   output.concat "   target:\n"
+   output.concat "\n"
+   output.concat "      <target> may be a room number, a custom target, a built-in target,\n"
+   output.concat "       or part of a room title or room description.\n"
+   output.concat "\n"
+   output.concat "   options:\n"
+   output.concat "\n"
+   output.concat "     --typeahead=<#>                         Sets the number of typeahead lines to use.\n"
+   output.concat "     --delay=<#>                             Sets the delay in seconds between movements\n"
+   output.concat "                                              (disables typeahead).\n"
+   if XMLData.game =~ /^GS/
+      output.concat "     --get-silvers=<on|off>                  Sets if #{script.name} has permission to access your bank\n"
+      output.concat "                                              account.\n"
+      output.concat "     --get-return-trip-silvers=<on|off>      Sets if #{script.name} should withdraw enough silvers to\n"
+      output.concat "                                              return from your destination room to your starting room.\n"
+      output.concat "     --ice-mode=<auto|wait|run>              Sets how #{script.name} should deal with rooms that make\n"
+      output.concat "                                              you slip and fall.\n"
+      output.concat "     --stop-for-dead=<on|off>                Pauses the script if you pass a dead person.\n"
+      output.concat "     --shortcut=<on|off>                     Sets if the shortcut to Ta'Vaalor should be used.\n"
+      output.concat "                                              (climbing and/or simming needed)\n"
+      output.concat "     --use-seeking=<on|off>                  Sets if #{script.name} should use Voln symbol of seeking\n"
+      output.concat "                                              when it will shorten your trip.\n"
+      output.concat "     --use-day-pass=<on|off>                 Use a Chronomage day pass to travel between towns in the\n"
+      output.concat "                                              same zone if you have one.\n"
+      output.concat "     --buy-day-pass=<on|off|locations>       Buy a Chronomage day pass if you don't have an unexpired\n"
+      output.concat "                                              one.  get-silvers will also need to be turned on if you\n"
+      output.concat "                                              want to buy one without gold ring credits.  If you only\n"
+      output.concat "                                              want to buy passes for certain locations, specify the\n"
+      output.concat "                                              locations like so:\n"
+      output.concat "                                              ;go2 --buy-day-pass=wl,imt;imt,wl;imt,sol;ill,val;ill,cys\n" 
+      output.concat "     --day-pass-container=<container name>   Sets the container where you keep your day passes\n"
+      output.concat "     --instability=<room number>             Use the instability at the given room number to get into\n"
+      output.concat "                                              the Elementla Confluence instead of finding an attuned one.\n"
+      output.concat "     --fwi-trinket=<trinket name>            Use a FWI trinket to get to/from FWI\n"
+      output.concat "     --fwi-trinket=off                       Stop using a FWI trinket\n"
+   elsif XMLData.game =~ /^DR/
+      output.concat "     --drag=<name>                           Attempt to automatically drag someone to your destination\n"
+      output.concat "                                              (this probably won't work)\n"
+   end
+   if XMLData.game =~ /^GSPlat|^GSF/
+      output.concat "     --portals=<on|off>                      Sets if portals should be used.\n"
+   end
+   if XMLData.game =~ /^GSPlat/
+      output.concat "     --old-portals=<on|off>                  Sets if old (dangerous) portals should be used.\n"
+      output.concat "     --portal-pass=<on|off>                  Turn this on if you have a wearable portal pass and don't\n"
+      output.concat "                                              need a portal ticket.\n"
+   end
+   output.concat "\n"
+   output.concat "   other commands:\n"
+   output.concat "\n"
+   output.concat "      #{$lich_char}#{script.name} save <new name>=<target>      Saves a custom target.  <target> can be the same\n"
+   output.concat "      #{''.rjust($lich_char.length + script.name.length)}                                as before, or \"current\" for your current room\n"
+   output.concat "      #{$lich_char}#{script.name} delete <custom target>        Deletes a saved custom target.\n"
+   output.concat "      #{$lich_char}#{script.name} list                          Shows your settings and custom targets.\n"
+   output.concat "      #{$lich_char}#{script.name} targets                       Shows the built-in targets.\n"
+   output.concat "\n"
+   respond output
+}
+
+change_map_vaalor_shortcut = proc { |use_shortcut|
+   unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
+      if use_shortcut
+         Room[16745].timeto['16746'] = 15
+         Room[16746].timeto['16745'] = 15
+      else
+         Room[16745].timeto['16746'] = 15000
+         Room[16746].timeto['16745'] = 15000
+      end
+   end
+}
+
+check_silvers = proc {
+   hook_proc = proc { |server_string|
+      if server_string =~ /^\s*Name\:|^\s*Gender\:|^\s*Normal \(Bonus\)|^\s*Strength \(STR\)\:|^\s*Constitution \(CON\)\:|^\s*Dexterity \(DEX\)\:|^\s*Agility \(AGI\)\:|^\s*Discipline \(DIS\)\:|^\s*Aura \(AUR\)\:|^\s*Logic \(LOG\)\:|^\s*Intuition \(INT\)\:|^\s*Wisdom \(WIS\)\:|^\s*Influence \(INF\)\:/
+         nil
+      elsif server_string =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9,]+)/
+         DownstreamHook.remove('go2_check_silvers')
+         nil
+      else
+         server_string
+      end
+   }
+   clear
+   DownstreamHook.add('go2_check_silvers', hook_proc)
+   silence_me unless undo_silence = silence_me
+   put 'info'
+   silence_me if undo_silence
+   while (line = get)
+      if line =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9,]+)/
+         silvers = $1.gsub(',','').to_i
+         break
+      end
+   end
+   silvers
+}
+
+get_silver_cost = proc { |path|
+   cost = 0
+   path.each_index { |index|
+      Room[path[index]].tags.each { |tag|
+         if tag =~ /^silver-cost:#{path[index+1]}:(.*)$/
+            cost_string = $1
+            if cost_string =~ /^[0-9]+$/
+               cost += cost_string.to_i
+            else
+               cost += StringProc.new(cost_string).call.to_i
+            end
+         end
+      }
+   }
+   cost
+}
+
+#
+# check for general commands
+#
+if script.vars.empty? or script.vars[0].strip =~ /^help$/i
+   show_help.call
+   exit
+elsif script.vars[0] =~ /^targets$/i
+   echo 'generating list...'
+   interesting_tags = [ "alchemist", "consignment", "bank", "furrier", "gemshop", "herbalist", "locksmith", "pawnshop", "town", "advguard", "advguild", "advpickup", "armorshop", "bakery", "bardguild", "boutique", "chronomage", "clericguild", "empathguild", "forge", "general store", "npccleric", "npchealer", "movers", "smokeshop", "sorcererguild", "warriorguild", "weaponshop", "wizardguild", "advguard2", "clericshop", "fletcher", "rangerguild", "sunfist", "voln", "exchange", "inn", "exchange" ]
+   town_list = Map.list.find_all { |room| room.tags.include?('town') }
+   town_ids = town_list.collect { |room| room.id }
+   town_hash = Hash.new
+   town_ids.each { |id| town_hash[id] = Array.new }
+   for tag in interesting_tags
+      for room in Map.list.find_all { |room| room.tags.include?(tag) }
+         if nearest = Room[room.id].find_nearest(town_ids)
+            unless town_hash[nearest].any? { |line| line =~ /^ \- #{tag.ljust(17)} / }
+               town_hash[nearest].push " - #{tag.ljust(17)} #{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{room.id.to_s.rjust(5)}"
+            end
+         end
+      end
+   end
+   output = "\n"
+   town_list.each { |town_room|
+      output.concat "---------------------------------------------------------------\n"
+      output.concat " - town              #{town_room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{town_room.id.to_s.rjust(5)}\n"
+      output.concat "---------------------------------------------------------------\n"
+      town_hash[town_room.id].sort.each { |thingie|
+         output.concat thingie
+         output.concat "\n"
+      }
+      output.concat "\n"
+   }
+   respond output
+   exit
+elsif script.vars[0] =~ /^list$/i
+   output = "\n"
+   output.concat "settings:\n"
+   output.concat "\n"
+   output.concat "            typeahead: #{CharSettings['typeahead']}"
+   if (CharSettings['typeahead'] > 0) and (CharSettings['delay'] > 0)
+      output.concat " (not used because delay > 0)"
+   end
+   output.concat "\n"
+   output.concat "                delay: #{CharSettings['delay']}\n"
+   output.concat "          get silvers: #{CharSettings['get silvers'] ? 'on' : 'off'}\n"
+   output.concat "   get return silvers: #{CharSettings['get return trip silvers'] ? 'on' : 'off'}\n"
+   output.concat "             ice mode: #{UserVars.mapdb_ice_mode.nil? ? 'auto' : UserVars.mapdb_ice_mode}\n"
+   output.concat "          use seeking: #{CharSettings['use seeking'] ? 'on' : 'off'}\n"
+   output.concat "         use day pass: #{UserVars.mapdb_use_day_pass == 'yes' ? 'on' : 'off'}\n"
+   output.concat "         buy day pass: #{UserVars.mapdb_buy_day_pass.nil? ? 'off' : UserVars.mapdb_buy_day_pass}\n"
+   output.concat "   day pass container: #{UserVars.day_pass_sack.nil? ? '(not set)' : UserVars.day_pass_sack}\n"
+   if XMLData.game =~ /^GS/
+      output.concat "        stop for dead: #{CharSettings['stop for dead'] ? 'on' : 'off'}\n"
+      output.concat "      vaalor shortcut: #{CharSettings['vaalor shortcut'] ? 'on' : 'off'}\n"
+      output.concat "          FWI trinket: #{UserVars.mapdb_fwi_trinket ? UserVars.mapdb_fwi_trinket : '(not set)'}\n"
+   end
+   if XMLData.game =~ /^GSPlat|^GSF/
+      output.concat "          use portals: #{(UserVars.mapdb_use_portals == 'yes') ? 'yes' : 'no'}\n"
+   end
+   if XMLData.game =~ /^GSPlat/
+      output.concat "      use old portals: #{(UserVars.mapdb_use_old_portals == 'yes') ? 'yes' : 'no'}\n"
+   end
+   if XMLData.game =~ /^GSPlat|^GSF/
+      output.concat "     have portal pass: #{(UserVars.mapdb_have_portal_pass == 'yes') ? 'yes' : 'no'}\n"
+   end
+   output.concat "\n"
+   output.concat "custom targets:\n"
+   output.concat "\n"
+   for target_name,target_num in GameSettings['custom targets'].sort
+      output.concat "   #{target_name.ljust(20)} = #{target_num.to_s.rjust(5)}   #{Map[target_num].title.first}\n"
+   end
+   output.concat "\n"
+   respond output
+   exit
+elsif script.vars[1] =~ /^save/i
+   unless script.vars[0] =~ /^save (.+?)=(.+)$/
+      echo "error: You're doing it wrong."
+      exit
+   end
+   target_name = $1.strip
+   target = $2.strip
+   if target_name =~ /^\d+$/
+      echo "error: target name can't be just a number."
+      exit
+   end
+   if target =~ /^current$/i
+      unless target_room = Map.current
+         echo 'error: your current room was not found in the map database.'
+         exit
+      end
+   else
+      unless target =~ /^\d+$/ and (target_room = Map[target.to_i])
+         unless target_room = Map[target]
+            echo "error: could not identify the target room"
+            exit
+         end
+      end
+   end
+   custom_targets = (GameSettings['custom targets'] || Hash.new)
+   custom_targets[target_name] = target_room.id
+   GameSettings['custom targets'] = custom_targets
+   echo "custom target saved (#{target_name}->#{target_room.id})"
+   exit
+elsif script.vars[1] =~ /^delete$/i
+   delkey = script.vars[0].sub(/\s*delete\s*/i, '')
+   custom_targets = (GameSettings['custom targets'] || Hash.new)
+   if kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}$/i } or kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}/i }
+      custom_targets.delete(kilkey)
+      GameSettings['custom targets'] = custom_targets
+      echo "custom target deleted (#{kilkey})"
+      exit
+   else
+      echo "#{delkey} does not appear to be a custom target"
+      exit
+   end
+elsif script.vars[1] =~ /^reload$/i
+   Map.reload
+   echo  'map data has been reloaded'
+   exit
+end
+
+#
+# target and/or options
+#
+
+target_search_array             = Array.new
+setting_typeahead               = nil
+setting_delay                   = nil
+setting_disable_confirm         = false
+setting_use_vaalor_shortcut     = nil
+setting_ice_mode                = nil
+setting_fwi_trinket             = nil
+setting_get_silvers             = nil
+setting_use_seeking             = nil
+setting_use_day_pass            = nil
+setting_buy_day_pass            = nil
+setting_day_pass_container      = nil
+setting_stop_for_dead           = nil
+setting_get_return_trip_silvers = nil
+setting_have_portal_pass        = nil
+setting_use_portals             = nil
+setting_use_old_portals         = nil
+setting_instability             = nil
+setting_drag                    = nil
+
+for var in script.vars[1..-1]
+   if var =~ /^(?:\-\-)?typeahead=([0-9]+)$/i
+      setting_typeahead = $1.to_i
+   elsif var =~ /^(?:\-\-)?delay=([0-9\.]+)$/i
+      setting_delay = $1.to_f
+   elsif var =~ /^\-\-instability=([0-9]+)$/i
+      setting_instability = $1.to_i
+   elsif var =~ /^_disable_confirm_$|^--disable-confirm$/i
+      setting_disable_confirm = true
+   elsif var =~ /^--stop-for-dead$/i
+      setting_stop_for_dead = true
+   elsif var =~ /^--stop-for-dead=(on|true|yes|off|false|no)/i
+      setting_stop_for_dead = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and var =~ /^(?:\-\-)?shortcut=(on|true|yes|off|false|no)$/i
+      setting_use_vaalor_shortcut = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?ice\-?mode=(auto|wait|run)$/i)
+      setting_ice_mode = $1.downcase
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get[_\-]?(?:silver|coin)s?=(on|true|yes|off|false|no)$/i)
+      setting_get_silvers = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?use[_\-]?seeking=(on|true|yes|off|false|no)$/i)
+      setting_use_seeking = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-use[_\-]?day[_\-]?pass=(on|true|yes|off|false|no)$/i)
+      setting_use_day_pass = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-buy[_\-]?day[_\-]?pass=(.+)$/i)
+      if setting_value[$1]
+         setting_buy_day_pass = setting_value[$1]
+      else
+         setting_buy_day_pass = $1
+         setting_buy_day_pass.split(';').each { |location|
+            if location !~ /^\s*(?:wl,imt|imt,wl|wl,sol|sol,wl|imt,sol|ill,val|val,ill|ill,cys|cys,ill|val,cys|cys,val)\s*$/i
+               echo "warning: Location #{location} is invalid.  Using it anyway."
+            end
+         }
+      end
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-day[_\-]?pass[_\-]?(?:container|sack)=(.+)$/i)
+      setting_day_pass_container = $1
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get\-return\-trip\-silvers=(on|true|yes|off|false|no)$/i)
+      setting_get_return_trip_silvers = setting_value[$1]
+   elsif (XMLData.game =~ /^DR/) and (var =~ /^(?:\-\-)?drag=(.+)$/i)
+      setting_drag = $1
+   elsif (XMLData.game =~ /^GSF|^GSPlat/) and (var =~ /^(?:\-\-)?portals?=(on|true|yes|off|false|no)$/i)
+      setting_use_portals = setting_value[$1]
+   elsif (XMLData.game =~ /^GSPlat/) and (var =~ /^(?:\-\-)?old\-portals?=(on|true|yes|off|false|no)$/i)
+      setting_use_old_portals = setting_value[$1]
+   elsif (XMLData.game =~ /^GSPlat/) and (var =~ /^(?:\-\-)?portal\-pass=(on|true|yes|off|false|no)$/i)
+      setting_have_portal_pass = setting_value[$1]
+   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?fwi\-?trinket=(.+)$/i)
+      setting_fwi_trinket = $1.downcase
+   else
+      target_search_array.push(var)
+   end
+end
+target_search_string = target_search_array.join(' ')
+
+#
+# if only settings were given, save the settings and exit
+#
+if target_search_string.empty?
+   unless setting_delay.nil?
+      CharSettings['delay'] = setting_delay
+      echo "delay setting changed to #{setting_delay} seconds"
+   end
+   unless setting_typeahead.nil?
+      CharSettings['typeahead'] = setting_typeahead
+      echo "typeahead setting changed to #{setting_typeahead}"
+      if CharSettings['delay'].to_f > 0
+         echo "typeahead setting will not be used, because the delay setting is greater than zero"
+      end
+   end
+   if XMLData.game =~ /^GSPlat|^GSF/
+      unless setting_use_portals.nil?
+         UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
+         echo "portals will #{'not ' unless setting_use_portals}be used"
+      end
+   end
+   if XMLData.game =~ /^GSPlat/
+      unless setting_use_old_portals.nil?
+         UserVars.mapdb_use_old_portals = (setting_use_old_portals ? 'yes' : 'no')
+         echo "old portals will #{'not ' unless setting_use_old_portals}be used"
+      end
+      unless setting_have_portal_pass.nil?
+         UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
+         echo "the script will #{'not ' if setting_have_portal_pass}try to pull out a portal ticket to use portals"
+      end
+   end
+   if XMLData.game =~ /^GS/
+      unless setting_use_vaalor_shortcut.nil?
+         CharSettings['vaalor shortcut'] = setting_use_vaalor_shortcut
+         $go2_use_vaalor_shortcut = setting_use_vaalor_shortcut
+         change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
+         echo "shortcut between Ta'Vaalor and Ta'Illistim will #{'not ' unless setting_use_vaalor_shortcut}be used"
+      end
+      unless setting_get_silvers.nil?
+         CharSettings['get silvers'] = setting_get_silvers
+         echo "go2 #{ if setting_get_silvers then 'may' else 'will not' end } withdraw money from your bank account for travel expenses"
+      end
+      unless setting_use_seeking.nil?
+         CharSettings['use seeking'] = setting_use_seeking
+         $go2_use_seeking = setting_use_seeking
+         echo "go2 #{ if setting_use_seeking then 'may' else 'will not' end } use symbol of seeking for faster travel"
+      end
+      unless setting_use_day_pass.nil?
+         UserVars.mapdb_use_day_pass = setting_use_day_pass
+         echo "go2 #{ if setting_use_day_pass then 'will' else 'will not' end } use Chronomage day passes for faster travel"
+      end
+      unless setting_buy_day_pass.nil?
+         UserVars.mapdb_buy_day_pass = setting_buy_day_pass
+         echo 'setting saved' # fixme: be more descriptive
+      end
+      unless setting_day_pass_container.nil?
+         UserVars.day_pass_sack = setting_day_pass_container
+         echo 'setting saved' # fixme: be more descriptive
+      end
+      unless setting_stop_for_dead.nil?
+         CharSettings['stop for dead'] = setting_stop_for_dead
+         echo "go2 #{ if setting_stop_for_dead then 'will (probably)' else 'will not' end } stop when it sees dead people"
+      end
+      unless setting_ice_mode.nil?
+         UserVars.mapdb_ice_mode = setting_ice_mode
+         echo 'setting saved' # fixme: be more descriptive
+      end
+      unless setting_fwi_trinket.nil?
+         if setting_fwi_trinket == 'off'
+            UserVars.mapdb_fwi_trinket = nil
+         else
+            UserVars.mapdb_fwi_trinket = setting_fwi_trinket
+         end
+         echo 'setting saved' # fixme: be more descriptive
+      end
+      unless setting_get_return_trip_silvers.nil?
+         CharSettings['get return trip silvers'] = setting_get_return_trip_silvers
+         echo "silvers will #{'not ' unless setting_get_return_trip_silvers}be withdrawn in advance for return trips"
+      end
+   end
+   exit
+end
+
+unless start_room = Room.current
+   echo 'error: your current room was not found in the map database'
+   exit
+end
+
+#
+# target was given; use saved settings, override them with command line settings, but don't save them
+#
+if setting_drag
+   setting_typeahead = 0
+elsif setting_typeahead.nil?
+   setting_typeahead = CharSettings['typeahead']
+end
+
+if setting_delay.nil?
+   setting_delay = CharSettings['delay']
+end
+
+if setting_get_silvers.nil?
+   $go2_get_silvers = CharSettings['get silvers']
+else
+   before_dying { $go2_get_silvers = CharSettings['get silvers'] }
+   $go2_get_silvers = setting_get_silvers
+end
+
+if setting_use_seeking.nil?
+   $go2_use_seeking = CharSettings['use seeking']
+else
+   before_dying { $go2_use_seeking = CharSettings['use seeking'] }
+   $go2_use_seeking = setting_use_seeking
+end
+
+if setting_use_day_pass
+   previous_use_day_pass = UserVars.mapdb_use_day_pass
+   before_dying { UserVars.mapdb_use_day_pass = previous_use_day_pass }
+   UserVars.mapdb_use_day_pass = setting_use_day_pass
+end
+
+if setting_buy_day_pass
+   previous_buy_day_pass = UserVars.mapdb_buy_day_pass
+   before_dying { UserVars.mapdb_buy_day_pass = previous_buy_day_pass }
+   UserVars.mapdb_buy_day_pass = setting_buy_day_pass
+end
+
+if setting_day_pass_container
+   previous_day_pass_container = UserVars.day_pass_sack
+   before_dying { UserVars.day_pass_sack = previous_day_pass_container }
+   UserVars.day_pass_sack = setting_day_pass_container
+end
+
+if setting_stop_for_dead.nil?
+   setting_stop_for_dead = CharSettings['stop for dead']
+end
+
+if setting_ice_mode
+   previous_ice_mode = UserVars.mapdb_ice_mode
+   before_dying { UserVars.mapdb_ice_mode = previous_ice_mode }
+   UserVars.mapdb_ice_mode = setting_ice_mode
+end
+
+if setting_fwi_trinket
+   previous_fwi_trinket = UserVars.mapdb_fwi_trinket
+   before_dying { UserVars.mapdb_fwi_trinket = previous_fwi_trinket }
+   if setting_fwi_trinket == 'off'
+      UserVars.mapdb_fwi_trinket = nil
+   else
+      UserVars.mapdb_fwi_trinket = setting_fwi_trinket
+   end
+end
+
+unless setting_use_portals.nil?
+   previous_use_portals = UserVars.mapdb_use_portals
+   before_dying { UserVars.mapdb_use_portals = previous_use_portals }
+   UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
+end
+
+unless setting_use_old_portals.nil?
+   previous_use_old_portals = UserVars.mapdb_use_old_portals
+   before_dying { UserVars.mapdb_use_old_portals = previous_use_old_portals }
+   UserVars.mapdb_use_old_portals = (setting_use_old_portals ? 'yes' : 'no')
+end
+
+unless setting_have_portal_pass.nil?
+   previous_have_portal_pass = UserVars.mapdb_have_portal_pass
+   before_dying { UserVars.mapdb_have_portal_pass = previous_have_portal_pass }
+   UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
+end
+
+if setting_use_vaalor_shortcut.nil?
+   setting_use_vaalor_shortcut = CharSettings['vaalor shortcut']
+else
+   before_dying { $go2_use_vaalor_shortcut = CharSettings['vaalor shortcut'] }
+end
+$go2_use_vaalor_shortcut = setting_use_vaalor_shortcut
+
+if setting_get_return_trip_silvers.nil?
+   setting_get_return_trip_silvers = CharSettings['get return trip silvers']
+end
+
+if XMLData.game =~ /^GS/
+   change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
+end
+
+#
+# find target
+#
+if (target_search_string =~ /^[0-9]+$/) or (XMLData.game =~ /^GS/ and target_search_string =~ /^confluence(?:\-hot|\-cold)?$|^instability$/i)
+   if target_search_string =~ /^[0-9]+$/
+      unless destination = Map[target_search_string.to_i]
+         echo "error: room number (#{target_search_string}) was not found in the map database"
+         exit
+      end
+      confirm = false
+   end
+   if (target_search_string =~ /^confluence(?:\-hot|\-cold)?$|^instability$/i) or (XMLData.game =~ /^GS/ and destination.title.first == '[Elemental Confluence]' and XMLData.room_title != '[Elemental Confluence]')
+      if target_search_string =~ /^confluence$/ and XMLData.room_title == '[Elemental Confluence]'
+         echo "you're already here..."
+         exit
+      end
+      town_ids          = [ 228, 2300, 1438, 1005, 188, 1932, 3519, 10855, 3668 ]
+      found_instability = false
+      if setting_instability
+         Script.run('go2', setting_instability.to_s, :force => true)
+         if GameObj.loot.any? { |o| o.noun == 'instability' }
+            $mapdb_last_instability = Room.current.id
+            $mapdb_instability_timeto = Hash.new
+            for id in town_ids
+               path = Room[$mapdb_last_instability].path_to(id)
+               if path.nil?
+                  $mapdb_instability_timeto[id] = nil
+               else
+                  $mapdb_instability_timeto[id] = Map.estimate_time(path)
+               end
+            end
+            found_instability = true
+         end
+      else
+         if CharSettings['element'].nil?
+            r = dothistimeout 'attune', 5, /^\s*You are attuned to the Element of|^\s*ATTUNE SET/
+            if r =~ /You are attuned to the Element of (.+)\./
+               CharSettings['element'] = $1.downcase
+            elsif r =~ /ATTUNE SET/
+               echo "You're not attuned to an element, so I don't know how to find an instability."
+               exit
+            else
+               echo "error: can't get right"
+               exit
+            end
+         end
+
+         GameSettings['recent-instabilities'] ||= Array.new
+
+         good_room_ids     = Array.new
+         bad_room_ids      = Array.new
+         got_room_text     = false
+         to_element        = { 'gust of wind' => 'air', 'burst of sparks' => 'lightning', 'waft of heat' => 'fire', 'puff of rock dust' => 'earth', 'puff of mist' => 'water', }
+
+         check_instability = proc {
+            if GameObj.loot.any? { |o| o.noun == 'instability' }
+               r = dothistimeout 'look instability', 10, /^The air is oddly warped and distorted here, almost as if something unseen was trying to push through from the other side of an invisible barrier\.  Every so often a (?:gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist) (?:is|are) emitted from the anomaly, which quickly reseals itself\./
+               if r =~ /(gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist)/
+                  element = to_element[$1]
+                  unless GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == Room.current.id) and i[:element] == element }
+                     GameSettings['recent-instabilities'].push(:room_id => Room.current.id, :element => element, :first_seen => Time.now.to_i)
+                  end
+                  if (element == CharSettings['element'])
+                     $mapdb_last_instability = Room.current.id
+                     $mapdb_instability_timeto = Hash.new
+                     for id in town_ids
+                        path = Room[$mapdb_last_instability].path_to(id)
+                        if path.nil?
+                           $mapdb_instability_timeto[id] = nil
+                        else
+                           $mapdb_instability_timeto[id] = Map.estimate_time(path)
+                        end
+                     end
+                     found_instability = true
+                  end
+               else
+                  echo "error: can't get right"
+                  exit
+               end
+            else
+               GameSettings['recent-instabilities'].delete_if { |i| i[:room_id] == Room.current.id }
+               false
+            end
+         }
+
+         #
+         # go directly to nearby recently seen attuned instabilities
+         #
+         GameSettings['recent-instabilities'].delete_if { |i| i[:first_seen] < (Time.now.to_i - 21600) }
+         GameSettings['recent-instabilities'].find_all { |i| i[:element] == CharSettings['element'] }.each { |i|
+            # fixme: would one full dijkstra be faster?
+            if (path = Room.current.path_to(i[:room_id])) and (Map.estimate_time(path) <= 10.0)
+               Script.run('go2', i[:room_id].to_s, :force => true)
+               break if check_instability.call
+            end
+         }
+
+         #
+         # get room numbers from attune sense
+         #
+         unless found_instability
+            if (last_roomdesc = $_SERVERBUFFER_.reverse.find { |line| line =~ /<style id="roomDesc"\/>/ }) and (last_roomdesc =~ /<style id="roomDesc"\/></)
+               set_desc = true
+            else
+               set_desc = false
+            end
+
+            2.times {
+               put 'set description on' if set_desc
+               sense_result = dothistimeout 'attune sense', 5, /^You sense nothing unusual\.|^You sense an unusual fluctuation emanating from .+\.|^You feel your senses being pulled towards a strong fluctuation\.\.\.|^You feel a strong sense of instability surround you!/
+               put 'set description off' if set_desc
+               if sense_result =~ /^You sense an unusual fluctuation emanating from (.+)\./
+                  location = $1
+                  bad_room_ids = Room.list.find_all { |r| r.location == location }.collect { |r| r.id }
+               elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
+                  location = Room.current.location
+                  room_text = Array.new
+                  3.times { room_text.push(get) }
+                  good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
+                  if good_room_ids.empty?
+                     desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+                     good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
+                  end
+                  got_room_text = true
+                  Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
+               elsif sense_result =~ /^You feel a strong sense of instability surround you!/
+                  location = Room.current.location
+                  good_room_ids = [ Room.current.id ]
+                  Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
+               elsif sense_result =~ /^You sense nothing unusual\./
+                  echo "error: can't get right"
+                  exit
+               else
+                  echo "error: unrecognized result from \"attune sense\""
+                  exit
+               end
+
+               while (line = get?)
+                  if line =~ /^You sense an unusual fluctuation emanating from (.+)\./
+                     location = $1
+                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+                  elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
+                     location = Room.current.location
+                     room_text = Array.new
+                     3.times { room_text.push(get) }
+                     gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
+                     if gri.empty?
+                        desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+                        gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
+                     end
+                     gri.each { |i| good_room_ids.push(i) unless good_room_ids.include?(i) }
+                     got_room_text = true
+                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+                  elsif sense_result =~ /^You feel a strong sense of instability surround you!/
+                     location = Room.current.location
+                     good_room_ids.push(Room.current.id) unless good_room_ids.include?(Room.current.id)
+                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+                  else
+                     break
+                  end
+               end
+               waitrt?
+               break if got_room_text or (good_room_ids.count > 0)
+               Script.run('go2', Room.current.find_nearest(bad_room_ids).to_s, :force => true)
+            }
+
+            #
+            # go to rooms and junk
+            #
+            loop {
+               next_id = nil
+               next_id = Room.current.find_nearest(good_room_ids) unless good_room_ids.empty?
+               if next_id.nil?
+                  next_id_list = bad_room_ids.find_all { |r| GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == r) and (i[:element] == CharSettings['element']) } }
+                  next_id = Room.current.find_nearest(next_id_list) unless next_id_list.empty?
+               end
+               if next_id.nil?
+                  next_id = (Room.current.wayto.keys.find { |k| bad_room_ids.include?(k) } || Room.current.find_nearest(bad_room_ids))
+               end
+               if next_id.nil?
+                  echo 'fail'
+                  exit
+               end
+               if Room.current.wayto.keys.include?(next_id.to_s)
+                  way = Room.current.wayto[next_id.to_s]
+                  if way.class == Proc
+                     way.call
+                  elsif way.class == String
+                     move way
+                  else
+                     echo "error: map database movement is neither a Proc or a String"
+                     exit
+                  end
+               else
+                  Script.run('go2', next_id.to_s, :force => true)
+               end
+               good_room_ids.delete(next_id)
+               bad_room_ids.delete(next_id)
+               break if check_instability.call
+            }
+         end
+      end
+      if found_instability
+         if target_search_string == 'instability'
+            exit
+         elsif target_search_string == 'confluence'
+            put 'unhide' if invisible?
+            move 'push instability with my soulstone'
+            exit
+         elsif target_search_string == 'confluence-hot'
+            put 'unhide' if invisible?
+            move 'push instability with my soulstone'
+            exit if Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
+            if hot_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ } }
+               begin
+                  go_thread = Thread.new { Room.current.wayto[hot_id].call }
+                  sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
+               ensure
+                  go_thread.kill rescue nil
+               end
+            end
+            exit
+         elsif target_search_string == 'confluence-cold'
+            put 'unhide' if invisible?
+            move 'push instability with my soulstone'
+            exit if Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
+            if cold_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ } }
+               begin
+                  go_thread = Thread.new { Room.current.wayto[cold_id].call }
+                  sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
+               ensure
+                  go_thread.kill rescue nil
+               end
+            end
+            exit
+         else
+            put 'unhide' if invisible?
+            move 'push instability with my soulstone'
+            sleep 0.3
+            unless start_room = Room.current
+               echo 'error: your current room was not found in the map database'
+               exit
+            end
+         end
+      else
+         echo 'error: all hope is lost'
+         exit
+      end
+   end
+elsif (custom_targets = GameSettings['custom targets']) and (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}$/i }) or (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}/i })
+   destination_id = custom_targets[target]
+   unless destination = Map[destination_id]
+      echo "error: custom target (#{destination_id}) was not found in the map database"
+      exit
+   end
+   confirm = false
+elsif Map.list.any? { |r| r.tags.include?(target_search_string) }
+   target_list = Map.list.find_all { |room| room.tags.include?(target_search_string) }.collect { |room| room.id }
+   if target_list.empty?
+      echo 'fixme (1)'
+      exit
+   end
+   if target_list.include?(start_room.id)
+      echo "you're already here..."
+      exit
+   end
+   previous, shortest_distances = start_room.dijkstra(target_list)
+   target_list.delete_if { |room_id| shortest_distances[room_id].nil? }
+   if target_list.empty?
+      echo 'fixme (2)'
+      exit
+   end
+   target_id = target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
+   unless target_id and (destination = Map[target_id])
+      echo 'fixme (3)'
+      exit
+   end
+   if shortest_distances[destination.id] < 20
+      confirm = false
+   else
+      confirm = true
+   end
+else
+   chkre = /#{target_search_string.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
+   chk = /#{Regexp.escape(target_search_string.strip)}/i
+   room_list = Map.list.find_all { |room| room.title.find { |title| title =~ chk } or room.description.find { |desc| desc =~ chk } or room.description.find { |desc| desc =~ chkre } }
+   if room_list.nil? or room_list.empty?
+      echo 'no matching rooms found'
+      exit
+   end
+   if room_list.length == 1
+      destination = room_list.first
+      confirm = true
+   else
+      destination = nil
+      first = 1
+      show_size = 20
+      respond "#{room_list.length} matching rooms found:"
+      while first < room_list.length
+         respond
+         for which in (first)..([(first+show_size-1),room_list.length].min)
+            respond "#{(which).to_s.rjust(5)}: #{room_list[which-1].title.first.ljust(37)} (#{room_list[which-1].id})"
+         end
+         respond
+         respond "select a room (;send <#{first}-#{[first+show_size-1,room_list.length].min}>)#{ " or ';send next' for more" if (first+show_size-1) < room_list.length}"
+         respond
+         clear
+         line = nil
+         line = get until line.strip =~ /^[0-9]+$|^next$/i
+         if line =~ /^next$/
+            first += show_size
+         else
+            destination = room_list[line.to_i-1]
+            break
+         end
+      end
+      unless destination
+         echo 'no more rooms match'
+         exit
+      end
+      confirm = false
+   end
+end
+
+if setting_stop_for_dead and (setting_typeahead > 0) and (setting_delay <= 0)
+   $go2_see_dead_people = false
+   exec_string = "
+      hide_me
+      status_tags
+      parent_id = #{Script.self.object_id}
+      Thread.new { loop { sleep 3; Script.self.kill unless Script.running.any? { |s| s.object_id == parent_id } or Script.hidden.any? { |s| s.object_id == parent_id } } }
+      while (line = get)
+         if line =~ /<compDef id='room players'>Also here:.*? the body of </
+            $go2_see_dead_people = true
+         end
+      end
+   "
+   start_exec_script(exec_string, flags={ :quiet => true })
+end
+
+#
+# move
+#
+if start_room.id == destination.id
+   echo "you're already here..."
+   exit
+end
+
+start_time   = nil
+error_count  = 0
+$go2_restart = false
+first_move   = true
+
+loop {
+
+   moves_sent = $room_count
+
+   if $go2_restart
+      first_move = true
+      break if Room.current.id == destination.id
+      echo 'restarting script...'
+      if error_count > 1
+         # dothis 'help lag-check', /^No help files matching that entry were found\.|^MERCHANT HELP/
+         if XMLData.game =~ /^GS/
+            dothis 'combatant', /^That only works in the Gladiator Arenas\./
+         else
+            sleep 5
+         end
+      end
+      unless start_room = Map.current
+         echo 'error: your current room was not found in the map database'
+         exit
+      end
+      previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+   end
+
+   unless previous and shortest_distances
+      previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+   end
+   unless previous[destination.id]
+      echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
+      exit
+   end
+   path = [ destination.id ]
+   path.push(previous[path[-1]]) until previous[path[-1]].nil?
+   path.reverse!
+   est_time = shortest_distances[destination.id]
+   previous = shortest_distances = nil
+
+   if XMLData.game =~ /^GS/
+      needed_silvers = get_silver_cost.call(path)
+      if setting_get_return_trip_silvers
+         return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
+         return_path = [ start_room.id ]
+         return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
+         return_path.reverse!
+         return_previous = return_shortest_distances = nil
+         needed_silvers += get_silver_cost.call(return_path)
+         return_path = nil
+      end
+      if needed_silvers > 0
+         current_silvers = check_silvers.call
+         if needed_silvers > current_silvers
+            if $go2_get_silvers
+               unless bank_id = Room.current.find_all_nearest_by_tag('bank').find { |room_id| current_silvers >= get_silver_cost.call(Room.current.path_to(room_id)) }
+                  echo "error: You're too poor to go to the bank."
+                  exit
+               end
+               pr, s = Map.dijkstra(Room.current.id, bank_id)
+               est_time = s[bank_id]
+               pr = s = nil
+               pr, s = Map.dijkstra(bank_id, destination.id)
+               est_time += s[destination.id]
+               pr = s = nil
+               unless setting_disable_confirm or not confirm
+                  confirm = false
+                  respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} (wrong) rooms between this room (#{start_room.id}), the bank (#{bank_id}), and:"
+                  respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
+                  pause_script
+               end
+               if $go2_started_go2_bank
+                  echo "You're too poor to go to the bank."
+                  exit
+               end
+               begin
+                  $go2_started_go2_bank = true
+                  go2_count = Script.running.find_all { |s| s.name == script.name }.length
+                  force_start_script script.name, [ bank_id.to_s ]
+                  wait_until { Script.running.find_all { |s| s.name == script.name }.length <= go2_count }
+               ensure
+                  $go2_started_go2_bank = false
+               end
+               unless start_room = Room.current
+                  echo 'error: your current room was not found in the map database'
+                  exit
+               end
+               moves_sent = $room_count
+               previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+               unless previous[destination.id]
+                  echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
+                  exit
+               end
+               path = [ destination.id ]
+               path.push(previous[path[-1]]) until previous[path[-1]].nil?
+               path.reverse!
+               est_time = shortest_distances[destination.id]
+               previous = shortest_distances = nil
+               needed_silvers = get_silver_cost.call(path)
+               if setting_get_return_trip_silvers
+                  return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
+                  return_path = [ start_room.id ]
+                  return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
+                  return_path.reverse!
+                  return_previous = return_shortest_distances = nil
+                  needed_silvers += get_silver_cost.call(return_path)
+                  return_path = nil
+               end
+               fput 'unhide' if hidden? or invisible?
+               if XMLData.room_title == '[Pinefar, Depository]'
+                  fput "ask banker for #{[(needed_silvers - check_silvers.call), 20].max} silvers"
+               else
+                  fput "withdraw #{needed_silvers - check_silvers.call} silvers"
+               end
+            else
+               echo 'You are too poor to make this trip.'
+               echo 'To give go2 permission to take your monies, type ;go2 getsilvers=on'
+               echo 'Continuing anyway in 10 seconds...'
+               sleep 10
+            end
+         end
+      end
+   end
+
+   if setting_disable_confirm or $go2_restart or not confirm
+      echo "ETA: #{(est_time/60.0).as_time} (#{path.length-1} rooms to move through)"
+   else 
+      respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} rooms between this room (#{start_room.id}) and:"
+      respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
+      pause_script
+   end
+
+   start_time = Time.now.to_f unless $go2_restart
+
+   $go2_restart = false
+
+   path.each_index { |idx|
+      room = Map[path[idx]]
+      next_id = (path[idx + 1] || break).to_s
+
+      exit if dead?
+      wait_while { muckled? }
+      unless standing? or (room.wayto[next_id].inspect =~ /swim/i)
+         waitrt?
+         fput 'stand'
+      end
+      waitrt?
+
+      if room.wayto[next_id].class == Proc
+         if setting_drag
+            echo "error: drag feature can't deal with StringProc movements yet"
+            exit
+         end
+         # echo 'proc: ' + room.id.to_s + ' -> ' + next_id.to_s
+         if (setting_typeahead > 0) and (setting_delay <= 0)
+            50.times {
+               break if ($room_count >= moves_sent)
+               sleep 0.05
+            }
+            if setting_stop_for_dead and $go2_see_dead_people
+               $go2_restart = true
+               10.times {
+                  break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+                  idx -= 1
+                  break unless (way = Room.current.wayto[path[idx].to_s])
+                  if way.class == Proc
+                     way.call
+                  else
+                     move way
+                  end
+               }
+               pause_script
+               $go2_see_dead_people = false
+               break
+            end
+            unless ($room_count >= moves_sent)
+               if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
+                  echo 'reducing typeahead setting...'
+                  setting_typeahead -= 1
+               end
+               $go2_restart = true
+               break
+            end
+         end
+         begin
+            room_id_before_proc = Room.current.id
+            room.wayto[next_id].call
+            sleep setting_delay
+            pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+            # $go2_restart = true if Room.current.id == room_id_before_proc
+            break if $go2_restart
+         rescue
+            respond "--- error running mini-script: #{room.id} -> #{next_id}"
+            respond $!
+            exit
+         end
+         moves_sent = $room_count
+      else
+         if (setting_typeahead > 0) and (setting_delay <= 0) and not first_move
+            time = Time.now + 3
+            moves = moves_sent - setting_typeahead
+            loop {
+               break if ($room_count >= moves) or (Time.now > time)
+               sleep 0.02
+            }
+            if setting_stop_for_dead and $go2_see_dead_people
+               $go2_restart = true
+               50.times {
+                  break if ($room_count >= moves_sent)
+                  sleep 0.05
+               }
+               10.times {
+                  break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+                  idx -= 1
+                  break unless (way = Room.current.wayto[path[idx].to_s])
+                  if way.class == Proc
+                     way.call
+                  else
+                     move way
+                  end
+               }
+               pause_script
+               $go2_see_dead_people = false
+               break
+            end
+            unless ($room_count + setting_typeahead) >= moves_sent
+               if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
+                  echo 'reducing typeahead setting...'
+                  setting_typeahead -= 1
+               end
+               $go2_restart = true
+               break
+            end
+            put room.wayto[next_id]
+            moves_sent += 1
+         else
+            first_move = false
+            moves_sent += 1
+            if setting_drag
+               way = room.wayto[next_id]
+               if way =~ /^(north|northeast|east|southeast|south|southwest|west|northwest|n|ne|e|se|s|sw|w|nw|up|u|down|d|out)$/i
+                  way = "drag #{setting_drag} #{way}"
+                  result = move way
+               elsif way =~ /^(?:go|climb) /i
+                  way = way.sub(/^(?:go|climb) /i, "drag #{setting_drag} ")
+                  result = move way
+               else
+                  echo "error: drag feature doesn't know how to deal with this movement: #{way}"
+                  exit
+               end
+            else
+               result = move room.wayto[next_id]
+            end
+            sleep setting_delay
+            pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+            unless result
+               error_count += 1
+               if (idx == 0) and (error_count > 2) and (Room.current.id == room.id)
+                  echo "changing Room[#{room.id}].timeto['#{next_id}'] to nil"
+                  old_room = room
+                  old_next_id = next_id
+                  old_timeto = room.timeto[next_id]
+                  before_dying {
+                     echo "reverting Room[#{old_room.id}].timeto['#{old_next_id}'] back to #{old_timeto.inspect}"
+                     old_room.timeto[old_next_id] = old_timeto
+                  }
+                  room.timeto[next_id] = nil
+               end
+               $go2_restart = true
+               break
+            end
+         end
+      end
+      waitrt?
+      if $go2_cast and Spell[515].active? and (checkprep == Spell[402].name) and Spell[402].affordable?
+         Spell[402].cast
+      end
+   }
+
+   if (setting_typeahead > 0) and (setting_delay <= 0)
+      50.times {
+         break if ($room_count >= moves_sent)
+         sleep 0.05
+      }
+      unless $room_count >= moves_sent
+         $go2_restart = true
+      end
+   end
+
+   break unless $go2_restart
+}
+
+sleep 0.1
+echo "travel time: #{((Time.now.to_f - start_time) / 60.00).as_time}"

--- a/spec/jinx/repos/core/assets/infomon.lic
+++ b/spec/jinx/repos/core/assets/infomon.lic
@@ -1,0 +1,1606 @@
+=begin
+
+    This script tracks a bunch of info about your character that isn't available as XML, such as your skills and stats, the spells you have on and their duration, gift of lumis, and other random things.
+    Use   ;magic   to see what spells you have on.
+    Use   ;banks   to see how poor you are.
+
+             author: Tillmen (tillmen@lichproject.org)
+    original author: Shaelun
+               game: Gemstone
+               tags: core
+           required: Lich > 4.6.10
+            version: 1.18.2
+
+  Version Control:
+    Major_change.feature_addition.bugfix
+
+    changelog:
+      1.18.2 (2021-01-06):
+        Previous fix exposed different bug. Updated infomon to maintain bind spell
+        state in both $infomon_bound (for checkbound) and Spell[214].active?
+      1.18.1 (2021-01-05):
+        Typo for infomon_bound with envelopes should be envelop
+      1.18 (2021-01-01):
+        update stat parsing regex to handle negative enhanced bonuses
+      1.17 (2020-12-19):
+        Recorded previous commageddon fixes in change log
+        Updated formatting for viewer friendly goodness
+      1.16 (2018-07-30):
+        Rename Core Tap Recovery to match spell active
+      1.15 (2018-07-22):
+        improved tracking for Core Tap
+        fix spell active match for Cloak of Shadows
+      1.14 (2017-10-08):
+        detect Mage Armor in spell active
+=end
+=begin
+
+      1.13 (2017-01-15):
+        rapid fire recovery/penalty fixes
+        somewhat fix lumnis tracking for the new system
+      1.12 (2017-01-09):
+        fix mana leech cooldown timer (Drafix)
+      1.11 (2016-09-19):
+        added Duck and Weave cman support
+      1.10 (2016-05-15):
+        added death message for ants to the missing xml workaround
+      1.9 (2016-01-13):
+        update lumnis start time from "lumnis info"
+      1.8 (2015-07-02):
+        add support for Medatative Resistance (Takoa)
+      1.7 (2015-05-28):
+        add FoF offset to magic bonuses output
+      1.6 (2015-05-21):
+        recognize Vornavis Caravansary bank as a Vornavis bank
+      1.5 (2015-02-21):
+        remove broken ;magic save/load commands
+      1.4 (2015-02-01):
+        added minotaur magus death message for xml fail workaround
+      1.3 (2014-12-17):
+        recognize spells in "spell active" that have an "Indefinite" time left
+      1.2 (2014-11-14):
+        attempted bugfix
+      1.1 (2014-11-10):
+        don't define check(sleeping|bound|silenced|calmed|cutthroat)
+
+=end
+
+
+unless XMLData.game =~ /^(?:GSF|GSIV|GSPlat|GSTest)$/
+  echo "This script is meant for Gemstone Prime, Platinum, or Shattered.  It will likely cause problems on whatever game you're trying to run it on..."
+  exit
+end
+
+hide_me
+setpriority(1)
+
+=begin
+get_lich_server = proc {
+  begin
+    lich_server = TCPSocket.open('216.224.171.85', 7153)
+  rescue
+    lich_server.close rescue()
+    lich_server = nil
+    echo "error connecting to server: #{$!}"
+  end
+  lich_server
+}
+=end
+
+sleep(0.1) until Char.name and not Char.name.empty?
+CharSettings['active_spells'] = Hash.new unless CharSettings['active_spells'].class == Hash
+CharSettings['bank_accounts'] = Hash.new unless CharSettings['bank_accounts'].class == Hash
+CharSettings['show_circles']  = true     if CharSettings['show_circles'].nil?
+CharSettings['show_bonuses']  = false    if CharSettings['show_bonuses'].nil?
+CharSettings['show_messages'] = true     if CharSettings['show_messages'].nil?
+CharSettings['show_gift']     = true     if CharSettings['show_gift'].nil?
+
+bank_titles = {
+  "Wehnimer's Landing"          => [ '[First Elanith Bank, Teller]', '[Clenchfist Bros. Banking, Lobby]'],
+  'Kharam-Dzu'                  => [ '[The Bank of Kharam-Dzu]' ],
+  'Icemule Trace'               => [ '[Icemule Trace, Bank]' ],
+  'Vornavis'                    => [ '[Bank of Vornavis, Solhaven]', '[Mercantylers\' Banking Hall]' ],
+  "River's Rest"                => [ "[River's Rest Bank, Teller]" ],
+  "Kharag 'doth Dzulthu"        => [ '[Bank of Zul Logoth]' ],
+  'United City-States'          => [ '[United Bank of City-States]', '[The United Bank of City-States]' ],
+  'Isle of the Four Winds Bank' => [ '[Mist Harbor Bank, Bank Windows]', '[Mist Harbor Bank, Windows]' ],
+  'Cysaegir'                    => [ '[Cysaegir Bank]' ],
+}
+
+#
+# Load spell info
+#
+unless Spell.load
+  echo 'error: failed to load spell list'
+  exit
+end
+
+#
+# Load or get character information
+#
+if CharSettings['Stats'] and CharSettings['Skills'] and CharSettings['Spells'] and CharSettings['Society'] and CharSettings['citizenship'] and CharSettings['cman']
+  begin
+    Stats.load_serialized   = CharSettings['Stats']
+    Skills.load_serialized  = CharSettings['Skills']
+    Spells.load_serialized  = CharSettings['Spells']
+    Society.load_serialized = CharSettings['Society']
+    Char.citizenship        = CharSettings['citizenship']
+    begin
+      CharSettings['cman'].each_pair { |cman,rank| CMan.send("#{cman}=", rank) }
+    rescue
+      nil
+    end
+  rescue
+    echo $!
+    echo $!.backtrace[0..1]
+    exit
+  end
+else
+  silence_me
+
+  hide_lines = done = false
+  action = proc { |server_string|
+    if hide_lines
+      if server_string =~ /^\s*Mana\:|<prompt/
+        DownstreamHook.remove('infomon_info')
+        done = true
+      end
+      nil
+    elsif server_string =~ /^\s*Name\:/
+      hide_lines = true
+      nil
+    else
+      server_string
+    end
+  }
+  DownstreamHook.add('infomon_info', action)
+  echo 'checking stats...'
+  put 'info'
+  wait_until { done }
+  
+  hide_lines = done = false
+  action = proc { |server_string|
+    if hide_lines
+      if server_string =~ /<output class=""\/>|<prompt/
+        DownstreamHook.remove('infomon_skills')
+        done = true
+      end
+      nil
+    elsif server_string =~ /^\s*(?:<.*?>)?#{Char.name}(?:<\/a>)? \(at level/o
+      hide_lines = true
+      nil
+    else
+      server_string
+    end
+  }
+  DownstreamHook.add('infomon_skills', action)
+  echo 'checking skills...'
+  put 'skills'
+  wait_until { done }
+  
+  hide_lines = done = false
+  action = proc { |server_string|
+    if hide_lines
+      if server_string =~ /<prompt/
+        DownstreamHook.remove('infomon_society')
+        done = true
+      end
+      nil
+    elsif server_string == "<pushBold/>\r\n"
+      hide_lines = true
+      nil
+    else
+      server_string
+    end
+  }
+  DownstreamHook.add('infomon_society', action)
+  echo 'checking society...'
+  put 'society'
+  wait_until { done }
+
+  done = false
+  action = proc { |server_string|
+    if server_string =~ /You currently have .*? citizenship in|You don't seem to have citizenship\./
+      DownstreamHook.remove('infomon_citizenship')
+      done = true
+      nil
+    else
+      server_string
+    end
+  }
+  DownstreamHook.add('infomon_citizenship', action)
+  echo 'checking citizenship...'
+  put 'citizenship'
+  wait_until { done }
+
+  hide_lines = done = false
+  action = proc { |server_string|
+    if hide_lines
+      if server_string =~ /<output class=""\/>|<prompt/
+        DownstreamHook.remove('infomon_cman')
+        done = true
+      end
+      nil
+    else
+      if server_string =~ /You know absolutely nothing about Combat Maneuvers\./
+        DownstreamHook.remove('infomon_cman')
+        done = true
+        nil
+      elsif server_string =~ /#{Char.name}<\/a>, your Combat Maneuvers are as follows:/
+        hide_lines = true
+        nil
+      else
+        server_string
+      end
+    end
+  }
+  DownstreamHook.add('infomon_cman', action)
+  echo 'checking combat maneuvers...'
+  put 'cman info'
+  wait_until { done }
+
+  echo 'done'
+
+  silence_me
+end
+
+#
+# Load spell timers
+#
+CharSettings['active_spells'].each_pair { |spell_num,timeleft|
+  if (spell = Spell[spell_num.to_i])
+    if defined?(spell.real_time) and spell.real_time
+      timeleft = (timeleft - Time.now.to_f)/60.0
+      if timeleft > 0
+        spell.timeleft = timeleft
+        spell.active = true
+      end
+    else
+      spell.timeleft = timeleft
+      spell.active = true
+    end
+  else
+    echo "spell not loaded: #{spell_num}"
+  end
+}
+Spellsong.load_serialized = CharSettings['Spellsong'] if CharSettings['Spellsong']
+
+#
+# Register ;magic and ;banks commands
+#
+action = proc { |client_string|
+  if client_string =~ /^(?:<c>)?#{$lich_char}((?:magic|banks).*)/i
+    if scr = (Script.running + Script.hidden).find { |val| val.name == 'infomon' }
+      scr.downstream_buffer.shove("#{$clean_lich_char}#{$1}")
+    else
+      UpstreamHook.remove('infomon')
+    end
+    nil
+  else
+    client_string
+  end
+}
+UpstreamHook.add('infomon', action)
+
+$infomon_sleeping = false
+$infomon_bound = false
+$infomon_silenced = false
+$infomon_calmed = true
+$infomon_cutthroat = false
+
+#
+# Save function
+#
+save_proc = proc {
+  CharSettings['active_spells'] = Hash.new
+  Spell.active.each { |spell|
+    if defined?(spell.real_time) and spell.real_time
+      CharSettings['active_spells'][spell.num.to_s] = Time.now.to_f + (spell.timeleft * 60)
+    else
+      CharSettings['active_spells'][spell.num.to_s] = spell.timeleft
+    end
+  }
+  CharSettings['Spellsong'] = Spellsong.serialize
+  CharSettings.save
+  if not CharSettings['uploaded_spell_ranks'] and defined?(LNet.upload_spell_ranks)
+    if LNet.upload_spell_ranks
+      CharSettings['uploaded_spell_ranks'] = true
+    end
+  end
+}
+
+#
+# Save current status every five minutes in case of crash
+#
+Thread.new {
+  begin
+    loop {
+      sleep 300
+      save_proc.call
+    } 
+  rescue
+    echo $!
+    echo $!.backtrace[0..1]
+  end
+}
+
+#
+# Save current status on exit
+#
+before_dying {
+  save_proc.call
+  UpstreamHook.remove('infomon')
+}
+
+#
+# Death
+#
+Thread.new {
+  begin
+    loop {
+      wait_until { dead? }
+      Spell.list.each { |killit|
+        if defined?(killit.clear_on_death)
+          killit.putdown if killit.clear_on_death
+        else
+          killit.putdown unless [6666,9009,920,9516,9003,9011].include?(killit.num)
+        end
+      }
+      Spellsong.renewed
+      wait_while { dead? }
+      Spell[6666].putdown
+    }
+  rescue
+    echo $!
+    echo $!.backtrace[0..1]
+    sleep 0.3
+  end
+}
+
+#
+# Another workaround for Simu fail
+#
+fix_gameobj_status = proc { |server_string|
+  # false positive: shudders with sporadic convulsions as pearlescent ripples envelop .*? body
+#The earth elemental rumbles in agony as it teeters for a moment, then tumbles to the ground with a thundering crash! 
+  if server_string =~ /^(?:The fire in the|With a surprised grunt, the|A sudden blue fire bursts over the hair of a|You hear a sound like a weeping child as a white glow separates itself from the|A low gurgling sound comes from deep within the chest of the|The|A|One last prolonged bovine moan escapes from the) (?:<pushBold\/>)?<a.*?exist=["'](\-?[0-9]+)["'].*?>.*?<\/a>(?:<popBold\/>)?(?:'s)? (?:body as it rises, disappearing into the heavens|falls to the ground and dies(?:, its feelers twitching)?|falls back into a heap and dies|body goes rigid and collapses to the ground, dead|body goes rigid and collapses to the floor, dead|slowly settles to the ground and begins to dissipate|falls to the ground motionless|body goes rigid and <pushBold\/><a.*?>\w+<\/a><popBold\/> eyes roll back into <pushBold\/><a.*?>\w+<\/a><popBold\/> head as <pushBold\/><a.*?>\w+<\/a><popBold\/> dies|growls one last time, and crumples to the ground in a heap|spins backwards and collapses dead|falls to the ground as the stillness of death overtakes <pushBold\/><a.*?>(?:him|her|it)<\/a><popBold\/>|crumples to the ground motionless|howls in agony one last time and dies|howls in agony while falling to the ground motionless|moans pitifully as <pushBold\/><a.*?>(?:he|she|it)<\/a><popBold\/> is released|careens to the ground and crumples in a heap|hisses one last time and dies|flutters its wings one last time and dies|slumps to the ground with a final snarl|horn dims as (?:his|her) lifeforce fades away|blinks in astonishment, then collapses in a motionless heap|collapses in a heap, its huge girth shaking the floor around it|goes limp and .*? falls over as the fire slowly fades from .*? eyes|eyes slowly fades|sputters violently, cascading flames all around as .*? collapses in a final fiery display|falls to the ground in a clattering, motionless heap|goes limp and .*? falls over as the fire slowly fades from .*? eyes|collapses to the ground and shudders once before finally going still|crumbles into a pile of rubble|shudders once before .*? finally goes still|totters for a moment and then falls to the ground like a pillar, breaking into pieces that fly out in every direction|collapses into a pile of rubble|rumbles in agony as .*? teeters for a moment, then falls directly at you|twists and coils violently in .*? death throes, finally going still|twitches one final time before falling still upon the floor|, consuming .*? form in the space of a breath|screams one last time and dies|breathes .*? last gasp and dies|rolls over and dies|as .*? falls (?:slack|still) against the (?:floor|ground)|collapses to the ground, emits a final squeal, and dies|cries out in pain one last time and dies|crumples to a heap on the ground and dies|collapses to the ground, emits a final sigh, and dies|crumples to the ground and dies|lets out a final caterwaul and dies|screams evilly one last time and goes still|gurgles eerily and collapses into a puddle of water|shudders, then topples to the ground|shudders one last time before lying still|violently for a moment, then goes still|grumbles in pain one last time before lying still|rumbles in agony and goes still|falls to the ground dead|collapses to the ground, emits a final bleat, and dies|topples to the ground motionless|shudders violently for a moment, then goes still|rumbles in agony as .*? teeters for a moment, then tumbles to the ground with a thundering crash)[\.!]\r?\n?$/
+    npc_id = $1
+    if npc = GameObj.npcs.find { |obj| obj.id == npc_id }
+      npc.status = 'dead'
+    end
+  elsif server_string =~ /^A calm washes over <pushBold\/>(?:a|an|the) <a exist="(.*?)" noun=".*?">.*?<\/a><popBold\/>\.\r?\n?$/
+    npc_id = $1
+    if npc = GameObj.npcs.find { |obj| obj.id == npc_id }
+      npc.status = 'calm'
+    end
+  end
+  server_string
+}
+before_dying { DownstreamHook.remove('fix_gameobj_status') }
+DownstreamHook.add('fix_gameobj_status', fix_gameobj_status)
+
+#
+# Spell tracking
+#
+spell_up_msgs_re = /^#{Spell.upmsgs.join('$|^')}$/o
+spell_dn_msgs_re = /^#{Spell.dnmsgs.join('$|^')}$/o
+caster = 'self'
+multicast = false
+activator = 'cast'
+self_invoke = false
+other_invoke = LimitedArray.new
+other_invoke.max_size = 15
+servant_type = nil
+while line = get
+  begin
+    # fixme: invisible people casting at you
+    # fixme: bard renews his songs when you're in his group
+    # fixme: bard renew message shows up after spell message
+    if line =~ /^You (?:gesture|make a complex gesture|sing a melody|sing with renewed vigor|skillfully begin to weave another verse|weave another verse into your harmony)/
+      caster = 'self'
+      activator = 'cast'
+      if line =~ /^You make a complex gesture/
+        multicast = true
+      else
+        multicast = false
+      end
+      echo "caster = #{caster.inspect}; activator = #{activator.inspect}; multicast = #{multicast.inspect}" if $infomon_debug
+    elsif line =~ /^Sparks begin to fly between the .+ and your fingers.  With a sudden burst of enthusiasm, the sparks jump into your hand and a charged feeling surrounds you\.$/
+      self_invoke = true
+      multicast = false
+      echo "self_invoke = true" if $infomon_debug
+    elsif line =~ /^Your spell is ready\./
+      self_invoke = false
+      echo "self_invoke = false" if $infomon_debug
+    elsif line =~ /^You (?:narrow your eyes in concentration as you |take a )?(rub|raise|wave|tap|drink|bite|gobble)/
+      caster = 'self'
+      multicast = false
+      activator = $1
+      echo "caster = #{caster.inspect}; activator = #{activator.inspect}; multicast = #{multicast.inspect}" if $infomon_debug
+    elsif line =~ /^([A-Z][a-z]+) (?:gestures|makes a complex gesture|sings a melody|sings with renewed vigor|skillfully begins to weave another verse|weave another verse into (?:his|her) harmony)/
+      caster = $1
+      activator = 'cast'
+      if line =~ /^([A-Z][a-z]+) makes a complex gesture/
+        multicast = true
+      else
+        multicast = false
+      end
+      echo "caster = #{caster.inspect}; activator = #{activator.inspect}; multicast = #{multicast.inspect}" if $infomon_debug
+    elsif line =~ /^([A-Z][a-z]+) (?:takes a )?(rubs|raises|waves|taps|drink|bite|gobbles)/
+      caster = $1
+      activator = $2.sub(/s$/, '')
+      multicast = false
+      echo "caster = #{caster.inspect}; activator = #{activator.inspect}; multicast = #{multicast.inspect}" if $infomon_debug
+    elsif line =~ /^Sparks begin to fly between .*? and ([A-Z][a-z]+)'s fingers\./
+      other_invoke.push($1)
+      multicast = false
+      echo "other_invoke.push(#{$1.inspect}) => #{other_invoke.inspect}" if $infomon_debug
+    elsif line =~ /^([A-Z][a-z]+) (begins drawing a faint, twisting symbol as he utters an arcane invocation in hushed tones|folds his hands and deeply intones a sonorous mantra|recites a series of mystical phrases while raising his hands|traces a sign while petitioning the spirits for cognition|gestures while calling upon the lesser spirits for aid|traces a series of glowing runes while chanting an arcane phrase|makes a quick gesture while calling upon the powers of the elements)/
+      # fixme: moar messages
+      other_invoke.delete($1)
+      echo "other_invoke.delete(#{$1.inspect}) => #{other_invoke.inspect}" if $infomon_debug
+    elsif line =~ /^Your songs? renews?/
+      Spellsong.renewed
+    elsif mobj = /^#{$lich_char}magic\s?(clear|set|reset|help|circles|bonus|bonuses|messages|update|load|save|gift|cleanup)?\s?([^\s]+|#{Spell.list.collect { |spell| Regexp.escape(spell.name) }.join('|')})?\s?(\d+\.?\d?\d?)?$/oi.match(line)
+      begin
+        if mobj.captures.first.nil? or mobj.captures.first =~ /cleanup/i
+          output = String.new
+          Spell.active.each { |spell| if spell.timeleft <= 0 then spell.putdown end } if mobj.captures.first =~ /cleanup/i
+          if Spell.active.empty?
+            output.concat("\n(no active spells)\n")
+          else
+            lastcircle = nil
+            Spell.active.compact!
+            total_boltAS, total_physicalAS, total_boltDS, total_physicalDS, total_elementalCS, total_mentalCS, total_spiritCS, total_sorcererCS, total_elementalTD, total_mentalTD, total_spiritTD, total_sorcererTD, total_strength, total_dodging, total_combatmaneuvers, total_damagefactor, total_block, total_constitution, total_health, total_uaf, total_asg, total_fof_offset = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            Spell.active.sort_by { |spell| spell.num.to_i }.each { |spell|
+              if CharSettings['show_circles'] and (spell.circle != lastcircle) then output.concat("\r\n- #{spell.circlename}:\r\n") end
+              bonus_string = ' - '
+              if CharSettings['show_bonuses']
+                if spell.bolt_as != 0
+                  bonus_string.concat "#{spell.bolt_as} bAS, "
+                  total_boltAS += spell.bolt_as
+                end
+                if spell.physical_as != 0
+                  bonus_string.concat "#{spell.physical_as} pAS, "
+                  total_physicalAS += spell.physical_as
+                end
+                if spell.bolt_ds != 0
+                  bonus_string.concat "#{spell.bolt_ds} bDS, "
+                  total_boltDS += spell.bolt_ds
+                end
+                if spell.physical_ds != 0
+                  bonus_string.concat "#{spell.physical_ds} pDS, "
+                  total_physicalDS += spell.physical_ds
+                end
+                if spell.elemental_cs != 0
+                  bonus_string.concat "#{spell.elemental_cs} elemCS, "
+                  total_elementalCS += spell.elemental_cs
+                end
+#               if spell.mental_cs != 0
+#                 bonus_string.concat "#{spell.mental_cs} mentCS, "
+#                 total_mentalCS += spell.mental_cs
+#               end
+                if spell.spirit_cs != 0
+                  bonus_string.concat "#{spell.spirit_cs} spirCS, "
+                  total_spiritCS += spell.spirit_cs
+                end
+                if spell.sorcerer_cs != 0
+                  bonus_string.concat "#{spell.sorcerer_cs} sorcCS, "
+                  total_sorcererCS += spell.sorcerer_cs
+                end
+                if spell.elemental_td != 0
+                  bonus_string.concat "#{spell.elemental_td} elemTD, "
+                  total_elementalTD += spell.elemental_td
+                end
+                if spell.mental_td != 0
+                  bonus_string.concat "#{spell.mental_td} mentTD, "
+                  total_mentalTD += spell.mental_td
+                end
+                if spell.spirit_td != 0
+                  bonus_string.concat "#{spell.spirit_td} spirTD, "
+                  total_spiritTD += spell.spirit_td
+                end
+                if spell.sorcerer_td != 0
+                  bonus_string.concat "#{spell.sorcerer_td} sorcTD, "
+                  total_sorcererTD += spell.sorcerer_td
+                end
+                if spell.strength.to_i != 0
+                  bonus_string.concat "#{spell.strength} str, "
+                  total_strength += spell.strength.to_i
+                end
+                if spell.dodging.to_i != 0
+                  bonus_string.concat "#{spell.dodging} dodge, "
+                  total_dodging += spell.dodging.to_i
+                end
+                if spell.combatmaneuvers.to_i != 0
+                  bonus_string.concat "#{spell.combatmaneuvers} CM, "
+                  total_combatmaneuvers += spell.combatmaneuvers.to_i
+                end
+                if spell.damagefactor.to_i != 0
+                  bonus_string.concat "#{spell.damagefactor}% DF, "
+                  total_damagefactor += spell.damagefactor.to_i
+                end
+                if spell.block.to_i != 0
+                  bonus_string.concat "#{spell.block}% block, "
+                  total_block += spell.block.to_i
+                end
+                if spell.constitution.to_i != 0
+                  bonus_string.concat "#{spell.constitution} con, "
+                  total_constitution += spell.constitution.to_i
+                end
+                if spell.health.to_i != 0
+                  bonus_string.concat "#{spell.health} health, "
+                  total_health += spell.health.to_i
+                end
+                if spell.unarmed_af.to_i != 0
+                  bonus_string.concat "#{spell.unarmed_af} UAF, "
+                  total_uaf += spell.unarmed_af.to_i
+                end
+                if spell.asg.to_i != 0
+                  bonus_string.concat "#{spell.asg} AsG, "
+                  total_asg += spell.asg.to_i
+                end
+                begin
+                  if spell.fof_offset.to_i != 0
+                    bonus_string.concat "#{spell.fof_offset} FoF offset, "
+                    total_fof_offset += spell.fof_offset.to_i
+                  end
+                rescue
+                  nil
+                end
+              end
+              output.concat(sprintf("  %04s:  %-023s - %s%s\n", spell.num.to_s, spell.name, spell.remaining, bonus_string.chop.chop))
+              lastcircle = spell.circle
+            }
+            output.concat("\n")
+            if CharSettings['show_bonuses']
+              total_offense_string = ''
+                            total_defense_string = ''
+                            total_stat_string    = ''
+                            total_skill_string   = ''
+                            
+              total_offense_string = total_offense_string + total_boltAS.to_s + ' bAS, ' if total_boltAS != 0
+              total_offense_string = total_offense_string + total_physicalAS.to_s + ' pAS, ' if total_physicalAS != 0
+              total_offense_string = total_offense_string + total_elementalCS.to_s + ' elemCS, ' if total_elementalCS != 0
+              total_offense_string = total_offense_string + total_mentalCS.to_s + ' mentCS, ' if total_mentalCS != 0
+              total_offense_string = total_offense_string + total_spiritCS.to_s + ' spirCS, ' if total_spiritCS != 0
+              total_offense_string = total_offense_string + total_sorcererCS.to_s + ' sorcCS, ' if total_sorcererCS != 0
+                            total_offense_string = total_offense_string + total_damagefactor.to_s + '% DF ' if total_damagefactor != 0
+                            total_offense_string = total_offense_string + total_uaf.to_s + ' UAF, ' if total_uaf != 0
+                            total_offense_string.chop!.chop!
+                            
+              total_defense_string = total_defense_string + total_boltDS.to_s + ' bDS, ' if total_boltDS != 0
+              total_defense_string = total_defense_string + total_physicalDS.to_s + ' pDS, ' if total_physicalDS != 0
+              total_defense_string = total_defense_string + total_elementalTD.to_s + ' elemTD, ' if total_elementalTD != 0
+              total_defense_string = total_defense_string + total_mentalTD.to_s + ' mentTD, ' if total_mentalTD != 0
+              total_defense_string = total_defense_string + total_spiritTD.to_s + ' spirTD, ' if total_spiritTD != 0
+              total_defense_string = total_defense_string + total_sorcererTD.to_s + ' sorcTD, ' if total_sorcererTD != 0
+                            total_defense_string = total_defense_string + total_block.to_s + '% block, ' if total_block != 0
+                            total_defense_string = total_defense_string + total_asg.to_s + ' AsG, ' if total_asg != 0
+                            total_defense_string = total_defense_string + total_fof_offset.to_s + ' FoF offset, ' if total_fof_offset != 0
+                            total_defense_string.chop!.chop!
+                            
+              total_stat_string = total_stat_string + total_strength.to_s + ' str, ' if total_strength != 0
+                            total_stat_string = total_stat_string + total_constitution.to_s + ' con, ' if total_constitution != 0
+                            total_stat_string = total_stat_string + total_health.to_s + ' health, ' if total_health != 0
+                            total_stat_string.chop!.chop!
+                            
+              total_skill_string = total_skill_string + total_dodging.to_s + ' dodge, ' if total_dodging != 0
+                            total_skill_string = total_skill_string + total_combatmaneuvers.to_s + ' CM, ' if total_combatmaneuvers != 0
+                            total_skill_string.chop!.chop!
+                            
+                            output.concat("- Totals:\n")
+              output.concat("  Offense: #{total_offense_string}\n") if total_offense_string.length > 0
+                            output.concat("  Defense: #{total_defense_string}\n") if total_defense_string.length > 0
+                            output.concat("    Stats: #{total_stat_string}\n") if total_stat_string.length > 0
+                            output.concat("   Skills: #{total_skill_string}\n") if total_skill_string.length > 0
+                            output.concat("\n\n")
+            end
+          end         
+          if CharSettings['show_gift']
+            if CharSettings['lumnis start exp'] and CharSettings['lumnis 3x exp'] and CharSettings['lumnis 2x exp']
+              exp_diff = Char.exp - CharSettings['lumnis start exp']
+              if exp_diff < (CharSettings['lumnis 3x exp'] * 3)
+                exp = exp_diff / 3
+                output.concat "You have used #{exp}/#{CharSettings['lumnis 3x exp']} (#{exp*100/CharSettings['lumnis 3x exp']}%) of your 3x multiplier and 0/#{CharSettings['lumnis 3x exp']} (0%) of your 2x multiplier this week for a total of #{exp_diff} experience.\n"
+              elsif exp_diff < ((CharSettings['lumnis 3x exp'] * 3) + (CharSettings['lumnis 2x exp'] * 2))
+                exp = (exp_diff - (CharSettings['lumnis 3x exp'] * 3)) / 2
+                output.concat "You have used #{CharSettings['lumnis 3x exp']}/#{CharSettings['lumnis 3x exp']} (100%) of your 3x multiplier and #{exp}/#{CharSettings['lumnis 2x exp']} (#{exp*100/CharSettings['lumnis 2x exp']}%) of your 2x multiplier this week for a total of #{exp_diff} experience.\n"
+              elsif CharSettings['lumnis next start'] >= Time.now.to_i
+                output.concat "You have used up your Gift of Lumnis this week for a total of #{(CharSettings['lumnis 3x exp']*3)+(CharSettings['lumnis 2x exp']*2)} experience.\n"
+              end
+            end
+            if CharSettings['lumnis next start']
+              if CharSettings['lumnis next start'] < Time.now.to_i
+                output.concat "Your Gift of Lumnis cycle will start when you gain some experience.\n\n"
+              else
+                cycleminstime = ((CharSettings['lumnis next start'] - Time.now.to_i) / 60.00).as_time
+                days = cycleminstime.slice(/\d+/).to_i / 24
+                hours = cycleminstime.slice(/\d+/).to_i % 24 
+                mins, secs = cycleminstime.split(':')[-2..-1]
+                mins, secs = mins.to_i, secs.to_i
+                foo = Array.new
+                foo.push "#{days} day#{'s' if days > 1}" if days > 0
+                foo.push "#{hours} hour#{'s' if hours > 1}" if hours > 0
+                foo.push "#{mins} minute#{'s' if mins > 1}" if mins > 0
+                foo.push "#{secs} second#{'s' if secs > 1}" if (secs > 0) and (days == 0) and (hours == 0)
+                output.concat "Your Gift of Lumnis cycle will restart in #{foo.join(', ')}.\n\n"
+              end
+            end
+          end
+          respond output
+        elsif mobj.captures.first =~ /help/i
+          respond
+          respond 'Magic usage:'
+          respond '   ;magic                     - Shows your active spells and their durations.'
+          respond "   ;magic set [spell#] [mins] - Sets a spell's duration."
+          respond '   ;magic clear [spell]       - Remove a single spell.'
+          respond '   ;magic clear               - Clears the whole list.'
+          respond '   ;magic circles             - Toggles the display of spell circle labels with the active spell list.'
+          respond '   ;magic bonuses             - Toggles the display of spell bonuses with the active spell list.'
+          respond '   ;magic gift                - Toggles the display of Gift of Lumnis information with the active spell list.'
+          respond '   ;magic messages            - Toggles the display of a duration message after each cast.'
+#         respond '   ;magic save                - Saves your currently active spells and currently tracked skills/stats on the Lich server.'
+#         respond '   ;magic load                - Load your currently active spells and skills/stats from the Lich server.'
+          respond
+        elsif mobj.captures.first =~ /clear|reset/i
+          if mobj.captures[1].nil? or mobj.captures[1].empty?
+            while spell = Spell.active.first
+              spell.putdown
+            end
+            Spell.active.clear
+            respond('Active spell list cleared.')
+          else
+            if mobj.captures[1].to_i == 0
+              spell = Spell[mobj.captures[1]]
+            else
+              spell = Spell[mobj.captures[1].to_i]
+            end
+            if spell.nil?
+              respond("Could not identify spell #{$1}")
+            else
+              spell.putdown
+              respond("#{spell} has been removed from the list.")
+            end
+          end
+        elsif mobj.captures.first =~ /circle/i
+          if CharSettings['show_circles'] == false
+            CharSettings['show_circles'] = true
+            echo('Spell circle labels will be displayed in the active spell list.')
+          else
+            CharSettings['show_circles'] = false
+            echo('Spell circle labels will not be displayed in the active spell list.')
+          end
+        elsif mobj.captures.first =~ /messages/i
+          if CharSettings['show_messages'] == false
+            CharSettings['show_messages'] = true
+            echo('Showing spell duration messages after each cast is now on.')
+          else
+            CharSettings['show_messages'] = false
+            echo('Showing spell duration messages after each cast is now off.')
+          end
+        elsif mobj.captures.first =~ /bonus/i
+          if CharSettings['show_bonuses'] == false
+            CharSettings['show_bonuses'] = true
+            echo('Spell bonuses will be displayed in the active spell list.')
+          else
+            CharSettings['show_bonuses'] = false
+            echo('Spell bonuses will not be displayed in the active spell list.')
+          end
+        elsif mobj.captures.first =~ /gift/i
+          if CharSettings['show_gift'] == false
+            CharSettings['show_gift'] = true
+            echo('Gift of Lumnis will be displayed in the active spell list.')
+          else
+            CharSettings['show_gift'] = false
+            echo('Gift of Lumnis will not be displayed in the active spell list.')
+          end
+        elsif mobj.captures.first =~ /update/i
+          echo 'this setting is no longer used'
+        elsif mobj.captures.first =~ /set/i
+          if (mobj.captures[1].nil? || mobj.captures[2].nil?)
+            echo("Magic error! Type ';magic help' for usage information.")
+          else
+            if mobj.captures[1].to_i == 0
+              spell = Spell[mobj.captures[1]]
+            else
+              spell = Spell[mobj.captures[1].to_i]
+            end
+            if spell.nil?
+              echo("Magic error! Type ';magic help' for usage information.")
+            else
+              spell.putup
+              spell.timeleft = mobj.captures[2].to_i
+              echo("Spell '#{spell.to_s}' is now set as having #{spell.timeleft} minutes left.")
+            end
+          end
+        elsif mobj.captures.first =~ /save/i
+          echo 'this function no longer works'
+=begin
+          if $SAFE == 0
+            echo("Saving your current active spells on the Lich server for later use on a different computer... please be patient, it can sometimes take up to half a minute to initiate the connection...")
+            if lich_server = get_lich_server.call
+              lich_server.send('x',0)
+              lich_server.puts("#{XMLData.game}:#{XMLData.name}")
+              lich_server.binmode
+              remote_save = Hash.new
+              remote_save['active_spells'] = Hash.new
+              Spells.active.each { |spell|
+                if defined?(spell.real_time) and spell.real_time
+                  remote_save['active_spells'][spell.num.to_s] = Time.now.to_f + (spell.timeleft * 60)
+                else
+                  remote_save['active_spells'][spell.num.to_s] = spell.timeleft
+                end
+              }
+              remote_save['Spellsong'] = Spellsong.serialize
+              remote_save['Stats'] = Stats.serialize
+              remote_save['Skills'] = Skills.serialize
+              remote_save['Spells'] = Spells.serialize
+              remote_save['Gift'] = Gift.serialize
+              remote_save['Society'] = Society.serialize
+              remote_save['citizenship'] = Char.citizenship
+              lich_server.write(Marshal.dump(remote_save))
+              lich_server.close rescue()
+              echo
+              echo "Data has been cached remotely! Simply type '#{$clean_lich_char}magic load' when you wish to restore the current state of your character on the other computer."
+              echo
+            end
+          else
+            echo 'This script must be trusted to use this function. (;trust infomon)'
+          end
+=end
+        elsif mobj.captures.first =~ /load/i
+          echo 'this function no longer works'
+=begin
+          if $SAFE == 0
+            echo("Loading your current active spells from the remote cache on the Lich server... please be patient, it can sometimes take up to half a minute to initiate the connection...")
+            if lich_server = get_lich_server.call
+              lich_server.send("z",0)
+              lich_server.puts("#{XMLData.game}:#{XMLData.name}")
+              lich_server.binmode
+              begin
+                remote_load = Marshal.load(lich_server.read)
+                Stats.load_serialized   = remote_load['Stats']
+                Skills.load_serialized  = remote_load['Skills']
+                Spells.load_serialized  = remote_load['Spells']
+                Society.load_serialized = remote_load['Society']
+                Char.citizenship        = remote_load['citizenship']
+                remote_load['active_spells'].each_pair { |num,timeleft|
+                  if spell = Spell[num]
+                    if defined?(spell.real_time) and spell.real_time
+                      timeleft = (timeleft - Time.now.to_f)/60.0
+                      if timeleft > 0
+                        spell.timeleft = timeleft
+                        spell.active = true
+                      end
+                    else
+                      spell.timeleft = timeleft
+                      spell.active = true
+                    end
+                  end
+                }
+                Spellsong.load_serialized = remote_load['Spellsong'] if remote_load['Spellsong']
+                Gift.load_serialized = remote_load['Gift'] if remote_load['Gift']
+              rescue
+                echo("There was an error loading your status information from the server.  Are you certain you have status info saved on it?  Type `;magic help' for more.")
+                lich_server.close rescue()
+                next
+              end
+              lich_server.close rescue()
+              echo
+              echo 'Data has been loaded!'
+              echo
+            end
+          else
+            echo 'This script must be trusted to use this function. (;trust infomon)'
+          end
+=end
+        else
+          echo "Magic error! Type ';magic help' for usage information."
+        end
+      rescue
+        echo $!
+      end
+    elsif line =~ /^#{$lich_char}banks$/
+      if CharSettings['bank_accounts'].empty?
+        respond
+        respond 'No bank account info recorded.'
+        respond
+      elsif Char.name == 'Tillmen'
+        respond
+        subtotal = 0
+        total = 0
+        for town,amount in CharSettings['bank_accounts']
+          if town =~ /Icemule Trace|Wehnimer's Landing/
+            respond "#{town.rjust(27)}:#{amount.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+            subtotal += amount
+            total += amount
+          end
+        end
+        respond '                      -------------------'
+        respond "                   Subtotal:#{total.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+        respond
+        for town,amount in CharSettings['bank_accounts']
+          if town !~ /Icemule Trace|Wehnimer's Landing/
+            respond "#{town.rjust(27)}:#{amount.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+            total += amount
+          end
+        end
+        respond '                      -------------------'
+        respond "                      Total:#{total.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+        respond
+      else
+        respond
+        total = 0
+        for town,amount in CharSettings['bank_accounts']
+          respond "#{town.rjust(27)}:#{amount.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+          total += amount
+        end
+        respond '                      -------------------'
+        respond "                      Total:#{total.to_s.reverse.scan(/(?:\d*\.)?\d{1,3}-?/).join(',').reverse.rjust(13)}"
+        respond
+      end
+    elsif line =~ /^(?:You hand your silvers? over to the|You hand your notes to the|You hand over your notes to the|You deposit [0-9]+ silvers? into your account.  The|The) (?:teller|dwarf).*(?:balance is |balance of |balance to |balance up to |balance is currently at |New balance\: )([0-9]+)/
+      for town,titles in bank_titles
+        if titles.include?(checkroom)
+          CharSettings['bank_accounts'][town] = $1.to_i
+          break
+        end
+      end
+    elsif line =~ /^The (?:teller|dwarf) (?:carefully records the transaction,|scribbles the transaction into a book)(?: and)?(?: then)?(?: reluctantly)? hands you ([0-9]+)/
+      for town,titles in bank_titles
+        if titles.include?(checkroom)
+          CharSettings['bank_accounts'][town] = CharSettings['bank_accounts'][town].to_i - $1.to_i
+          break
+        end
+      end
+    elsif line =~ /^You deposit(?: your note worth| your chit worth)? ([0-9]+)/
+      for town,titles in bank_titles
+        if titles.include?(checkroom)
+          CharSettings['bank_accounts'][town] = CharSettings['bank_accounts'][town].to_i + $1.to_i
+          break
+        end
+      end
+    elsif line =~ /^The (?:teller|dwarf).* ([0-9]+) silver surchar?ge/
+      surcharge = $1.to_i
+      if line = $_CLIENTBUFFER_.reverse.find { |line| line =~ /^(?:\[.*?\]>)?(?:<c>)?(?:wit|with|withd|withr|withdra|withdraw)\s+[0-9]+/i }
+        amount = line.slice(/[0-9]+/).to_i
+        for town,titles in bank_titles
+          if titles.include?(checkroom)
+            CharSettings['bank_accounts'][town] = [ (CharSettings['bank_accounts'][town].to_i - amount - surcharge), 0 ].max
+            break
+          end
+        end
+      end
+    elsif line =~ /^The (?:teller|dwarf).*you don't(?: seem to)? have an (?:open )?account/
+      for town,titles in bank_titles
+        if titles.include?(checkroom)
+          CharSettings['bank_accounts'][town] = 0
+          break
+        end
+      end
+    elsif line == 'You study your current bank balances...'
+      15.times {
+        line = get
+        if line =~ /\s*(Wehnimer's Landing|Kharam-Dzu|Icemule Trace|Vornavis|River's Rest|Kharag 'doth Dzulthu|United City-States|Isle of the Four Winds Bank|Cysaegir):\s+([0-9]+)/
+          CharSettings['bank_accounts'][$1] = $2.to_i
+        elsif line =~ /Your total silvers/
+          break
+        end
+      }
+#   elsif line =~ /^You stop singing\.$|^But you are not singing any spellsongs\.$/
+#     Spell.list.each { |spell| spell.putdown if spell.circle.to_i == 10 }
+#   elsif line =~ /^The soft feeling of serenity slowly dissipates from your mind\.$/
+#     nil
+    elsif line =~ /^The global Lumnis experience boost currently multiplies your first (\d+) experience points by 3, and your next (\d+) experience points by 2, for a total bonus of/
+      CharSettings['lumnis 3x exp'] = $1.to_i
+      CharSettings['lumnis 2x exp'] = $2.to_i
+    elsif line =~ /^Your Gift of Lumnis (is currently in effect|has expired for this week)\.\s+It is scheduled to refresh in (\d+ days?, )?(\d+ hours? and )?(\d+) minutes?\./
+      days = $2
+      hours = $3
+      minutes = $4.to_i
+      days = (days ? days.slice(/\d+/).to_i : 0)
+      hours = (hours ? hours.slice(/\d+/).to_i : 0)
+      CharSettings['lumnis next start'] = Time.now.to_i + (minutes * 60) + (hours * 3600) + (days * 86400)
+    elsif line =~ /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$/
+      CharSettings['lumnis start exp'] = Char.exp
+      CharSettings['lumnis next start'] = Time.now.to_i + 604800
+      status_squelching = false
+      status_hook_name = 'infomon_lumnis_contest_status'
+      status_hook_proc = proc { |s|
+        if status_squelching
+          DownstreamHook.remove(status_hook_name) if s =~ /<prompt/
+          nil
+        elsif s =~ /^The global Lumnis/
+          status_squelching = true
+          nil
+        else
+          s
+        end
+      }
+      DownstreamHook.add(status_hook_name, status_hook_proc)
+      info_squelching = false
+      info_hook_name = 'infomon_lumnis_info'
+      info_hook_proc = proc { |s|
+        if info_squelching
+          DownstreamHook.remove(info_hook_name) if s =~ /<prompt/
+          nil
+        elsif s =~ /^Your Gift of Lumnis/
+          info_squelching = true
+          nil
+        else
+          s
+        end
+      }
+      DownstreamHook.add(info_hook_name, info_hook_proc)
+      silence_me unless undo_silence = silence_me
+      put 'lumnis contest status'
+      put 'lumnis info'
+      silence_me if undo_silence
+    elsif line == 'Repeating the sign has no effect!'
+      if spell_name = [ 'Sign of Striking', 'Sign of Smiting', 'Sign of Swords', 'Sign of Warding', 'Sign of Defending', 'Sign of Shields', 'Sign of Deflection', 'Sign of Dissipation' ].find { |name| (XMLData.active_spells[name] > Time.now) and not Spell[name].active? }
+        spell = Spell[spell_name]
+        spell.putup
+        respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+      elsif mangled_name = $_CLIENTBUFFER_.reverse.find { |cmd| cmd =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(st|str|stri|strik|striki|strikin|striking|sm|smi|smit|smiti|smitin|smiting|sw|swo|swor|sword|swords|wa|war|ward|wardi|wardin|warding|de|def|defe|defen|defend|defendi|defendin|defending|sh|shi|shie|shiel|shield|shields|defl|defle|deflec|deflect|deflecti|deflectio|deflection|di|dis|diss|dissi|dissip|dissipa|dissipat|dissipati|dissipatio|dissipation)\s*$/i }
+        mangled_name =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(st|str|stri|strik|striki|strikin|striking|sm|smi|smit|smiti|smitin|smiting|sw|swo|swor|sword|swords|wa|war|ward|wardi|wardin|warding|defl|defle|deflec|deflect|deflecti|deflectio|deflection|de|def|defe|defen|defend|defendi|defendin|defending|sh|shi|shie|shiel|shield|shields|di|dis|diss|dissi|dissip|dissipa|dissipat|dissipati|dissipatio|dissipation)\s*$/i
+        spell = Spell["Sign of #{$1}"]
+        spell.putup
+        respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+      end
+    elsif line =~ /^The High Taskmaster looks at you, consults her notes, and then announces in a loud voice\: "Congratulations, [A-Z][a-z]+!  By the power invested in me by the Grand Poohbah, I declare you to be .*? of rank ([0-9]+)!/
+      Society.status = 'Council of Light'
+      Society.rank = $1.dup
+      CharSettings['Society'] = Society.serialize
+    elsif line =~ /^The monk concludes ceremoniously,|^The Grandmaster says, "Welcome to the Order/
+      hide_lines = done = false
+      action = proc { |server_string|
+        if hide_lines
+          if server_string =~ /<prompt/
+            DownstreamHook.remove('infomon_society')
+            done = true
+          end
+          nil
+        elsif server_string == "<pushBold/>\r\n"
+          hide_lines = true
+          nil
+        else
+          server_string
+        end
+      }
+      DownstreamHook.add('infomon_society', action)
+      # echo 'checking society...'
+      silence_me unless undo_silence = silence_me
+      put 'society'
+      silence_me if undo_silence
+      wait_until { done }
+    elsif line =~ /^\s+You are a (Master|member) (?:in|of) the (Order of Voln|Council of Light|Guardians of Sunfist)( at rank [0-9]+| at step [0-9]+)?\.$/
+      Society.status = $2.dup
+      if $1 == 'Master'
+        if $2 == 'Order of Voln'
+          Society.rank = '26'
+        else
+          Society.rank = '20'
+        end
+      else
+        Society.rank = $3.dup
+      end
+      CharSettings['Society'] = Society.serialize
+    elsif line == '   You are not a member of any society at this time.'
+      Society.status = 'None'
+      Society.rank = '0'
+      CharSettings['Society'] = Society.serialize
+    elsif line =~ /^\s#{Char.name} \(at level/o
+      begin
+        before_ranks = [ Spells.minorelemental, Spells.minormental, Spells.majorelemental, Spells.minorspiritual, Spells.majorspiritual, Spells.wizard, Spells.sorcerer, Spells.ranger, Spells.paladin, Spells.empath, Spells.cleric, Spells.bard, Skills.magicitemuse, Skills.arcanesymbols ]
+        Skills.armoruse, Skills.shielduse, Skills.combatmaneuvers, Skills.edgedweapons, Skills.bluntweapons, Skills.twohandedweapons, Skills.rangedweapons, Skills.thrownweapons, Skills.polearmweapons, Skills.brawling, Skills.ambush, Skills.multiopponentcombat, Skills.combatleadership, Skills.physicalfitness, Skills.dodging, Skills.arcanesymbols, Skills.magicitemuse, Skills.spellaiming, Skills.harnesspower, Skills.emc, Skills.mmc, Skills.smc, Skills.elair, Skills.elearth, Skills.elfire, Skills.elwater, Skills.slblessings, Skills.slreligion, Skills.slsummoning, Skills.sldemonology, Skills.slnecromancy, Skills.mldivination, Skills.mlmanipulation, Skills.mltelepathy, Skills.mltransference, Skills.mltransformation, Skills.survival, Skills.disarmingtraps, Skills.pickinglocks, Skills.stalkingandhiding, Skills.perception, Skills.climbing, Skills.swimming, Skills.firstaid, Skills.trading, Skills.pickpocketing, Spells.minorelemental, Spells.minormental, Spells.majorelemental, Spells.minorspiritual, Spells.majorspiritual, Spells.wizard, Spells.sorcerer, Spells.ranger, Spells.paladin, Spells.empath, Spells.cleric, Spells.bard = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        until (line = get) =~ /\(Use |[0-9]+ days? remain|You started this migration period|Further information can be found in the FAQs./
+          if line =~ /Two Weapon Combat/
+            Skills.twoweaponcombat = $'.split[2].to_i
+          elsif line =~ /Armor Use/
+            Skills.armoruse = $'.split[2].to_i
+          elsif line =~ /Shield Use/
+            Skills.shielduse = $'.split[2].to_i
+          elsif line =~ /Combat Maneuvers/
+            Skills.combatmaneuvers = $'.split[2].to_i
+          elsif line =~ /Edged Weapons/
+            Skills.edgedweapons = $'.split[2].to_i
+          elsif line =~ /Blunt Weapons/
+            Skills.bluntweapons = $'.split[2].to_i
+          elsif line =~ /Two-Handed Weapons/
+            Skills.twohandedweapons = $'.split[2].to_i
+          elsif line =~ /Ranged Weapons/
+            Skills.rangedweapons = $'.split[2].to_i
+          elsif line =~ /Thrown Weapons/
+            Skills.thrownweapons = $'.split[2].to_i
+          elsif line =~ /Polearm Weapons/
+            Skills.polearmweapons = $'.split[2].to_i
+          elsif line =~ /Brawling/
+            Skills.brawling = $'.split[2].to_i
+          elsif line =~ /Ambush/
+            Skills.ambush = $'.split[2].to_i
+          elsif line =~ /Multi Opponent Combat/
+            Skills.multiopponentcombat = $'.split[2].to_i
+          elsif line =~ /Combat Leadership/
+            Skills.combatleadership = $'.split[2].to_i
+          elsif line =~ /Physical Fitness/
+            Skills.physicalfitness = $'.split[2].to_i
+          elsif line =~ /Dodging/
+            Skills.dodging = $'.split[2].to_i
+          elsif line =~ /Arcane Symbols/
+            Skills.arcanesymbols = $'.split[2].to_i
+          elsif line =~ /Magic Item Use/
+            Skills.magicitemuse = $'.split[2].to_i
+          elsif line =~ /Spell Aiming/
+            Skills.spellaiming = $'.split[2].to_i
+          elsif line =~ /Harness Power/
+            Skills.harnesspower = $'.split[2].to_i
+          elsif line =~ /Elemental Mana Control/
+            Skills.emc = $'.split[2].to_i
+          elsif line =~ /Mental Mana Control/
+            Skills.mmc = $'.split[2].to_i
+          elsif line =~ /Spirit Mana Control/
+            Skills.smc = $'.split[2].to_i
+          elsif line =~ /Elemental Lore - ([A-Z][a-z]+)/
+            if $1 == "Air"
+              Skills.elair = $'.split[2].to_i
+            elsif $1 == "Earth"
+              Skills.elearth = $'.split[2].to_i
+            elsif $1 == "Fire"
+              Skills.elfire = $'.split[2].to_i
+            elsif $1 == "Water"
+              Skills.elwater = $'.split[2].to_i
+            end
+          elsif line =~ /Spiritual Lore - ([A-Z][a-z]+)/
+            if $1 == "Blessings"
+              Skills.slblessings = $'.split[2].to_i
+            elsif $1 == "Religion"
+              Skills.slreligion = $'.split[2].to_i
+            elsif $1 == "Summoning"
+              Skills.slsummoning = $'.split[2].to_i
+            end
+          elsif line =~ /Sorcerous Lore - ([A-Z][a-z]+)/
+            if $1 == "Demonology"
+              Skills.sldemonology = $'.split[2].to_i
+            elsif $1 == "Necromancy"
+              Skills.slnecromancy = $'.split[2].to_i
+            end
+          elsif line =~ /Mental Lore - ([A-Z][a-z]+)/
+            if $1 == "Divination"
+              Skills.mldivination = $'.split[2].to_i
+            elsif $1 == "Manipulation"
+              Skills.mlmanipulation = $'.split[2].to_i
+            elsif $1 == "Telepathy"
+              Skills.mltelepathy = $'.split[2].to_i
+            elsif $1 == "Transference"
+              Skills.mltransference = $'.split[2].to_i
+            elsif $1 == "Transformation"
+              Skills.mltransformation = $'.split[2].to_i
+            end
+          elsif line =~ /Survival/
+            Skills.survival = $'.split[2].to_i
+          elsif line =~ /Disarming Traps/
+            Skills.disarmingtraps = $'.split[2].to_i
+          elsif line =~ /Picking Locks/
+            Skills.pickinglocks = $'.split[2].to_i
+          elsif line =~ /Stalking and Hiding/
+            Skills.stalkingandhiding = $'.split[2].to_i
+          elsif line =~ /Perception/
+            Skills.perception = $'.split[2].to_i
+          elsif line =~ /Climbing/
+            Skills.climbing = $'.split[2].to_i
+          elsif line =~ /Swimming/
+            Skills.swimming = $'.split[2].to_i
+          elsif line =~ /First Aid/
+            Skills.firstaid = $'.split[2].to_i
+          elsif line =~ /Trading/
+            Skills.trading = $'.split[2].to_i
+          elsif line =~ /Pickpocketing/
+            Skills.pickpocketing = $'.split[2].to_i
+          elsif line =~ /Minor Elemental/
+            Spells.minorelemental = $'.split[1].to_i
+          elsif line =~ /Major Elemental/
+            Spells.majorelemental = $'.split[1].to_i
+          elsif line =~ /Minor Mental/
+            Spells.minormental = $'.split[1].to_i
+          elsif line =~ /Minor Spirit/
+            Spells.minorspiritual = $'.split[1].to_i
+          elsif line =~ /Major Spirit/
+            Spells.majorspiritual = $'.split[1].to_i
+          elsif line =~ /Wizard/
+            Spells.wizard = $'.split[1].to_i
+          elsif line =~ /Sorcerer/
+            Spells.sorcerer = $'.split[1].to_i
+          elsif line =~ /Ranger/
+            Spells.ranger = $'.split[1].to_i
+          elsif line =~ /Paladin/
+            Spells.paladin = $'.split[1].to_i
+          elsif line =~ /Empath/
+            Spells.empath = $'.split[1].to_i
+          elsif line =~ /Cleric/
+            Spells.cleric = $'.split[1].to_i
+          elsif line =~ /Bard/
+            Spells.bard = $'.split[1].to_i
+          end
+        end
+        CharSettings['Skills'] = Skills.serialize
+        CharSettings['Spells'] = Spells.serialize
+        if (before_ranks != [ Spells.minorelemental, Spells.minormental, Spells.majorelemental, Spells.minorspiritual, Spells.majorspiritual, Spells.wizard, Spells.sorcerer, Spells.ranger, Spells.paladin, Spells.empath, Spells.cleric, Spells.bard, Skills.magicitemuse, Skills.arcanesymbols ])
+          if defined?(LNet.upload_spell_ranks)
+            if LNet.upload_spell_ranks
+              CharSettings['uploaded_spell_ranks'] = true
+            else
+              CharSettings['uploaded_spell_ranks'] = false
+            end
+          else
+            CharSettings['uploaded_spell_ranks'] = false
+          end
+        end
+      rescue
+          echo $!
+      end
+    elsif line =~ /^Name:\s+[-A-z\s']+Race:\s+([-A-z\s]+)\s+Profession:\s+([-A-z\s]+)/
+      Stats.race = $1.strip
+      Stats.prof = $2.strip
+      if get =~ /Gender:\s+([A-z]+)\s+Age:\s+([0-9]+)\s+Expr:\s+([0-9,]+)\s+Level:\s+([0-9]+)/
+        Stats.gender = $1
+        Stats.age = $2.to_i
+        Stats.exp = $3.to_i
+        Stats.level = $4.to_i
+        get
+        while get =~ /^\s*[A-Z][a-z]+\s\((STR|CON|DEX|AGI|DIS|AUR|LOG|INT|WIS|INF)\):\s+([0-9]+)\s\((\-?[0-9]+)\)\s+[.]{3}\s+(\d+)\s+\((-?\d+)\)/
+          Stats.send("#{$1.downcase}=", [ $2.to_i, $3.to_i])
+          Stats.send("enhanced_#{$1.downcase}=", [ $4.to_i, $5.to_i]) rescue nil # available on Lich 4.6.54+
+        end
+      end
+      CharSettings['Stats'] = Stats.serialize
+    elsif line =~ /^You are now level ([0-9]+)!$/
+      Stats.level = $1.to_i
+      get
+      while get =~ /^\s*(?:Strength|Constitution|Dexterity|Agility|Discipline|Aura|Logic|Intuition|Wisdom|Influence|Dexterity)\s+\((STR|CON|DEX|AGI|DIS|AUR|LOG|INT|WIS|INF)\)\s*\:\s+([0-9]+)\s+\+([0-9]+)\s+\.\.\.\s+(\-?[0-9]+)\s*\+?([0-9]+)\s*$/
+        Stats.send("#{$1.downcase}=", [ $2.to_i + $3.to_i, $4.to_i + $5.to_i ])
+      end
+      CharSettings['Stats'] = Stats.serialize
+    elsif (line == 'You know absolutely nothing about Combat Maneuvers.') and defined?(CMan)
+      begin
+        CharSettings['cman'].keys.each { |cman| CMan[cman] = nil }
+      rescue
+        nil
+      end
+      CharSettings['cman'] = Hash.new
+    elsif (line =~ /#{Char.name}, your Combat Maneuvers are as follows:/) and defined?(CMan)
+      begin
+        CharSettings['cman'].keys.each { |cman| CMan[cman] = nil }
+      rescue
+        nil
+      end
+      CharSettings['cman'] = Hash.new
+      get
+      while get =~ /^([A-z\s']+)\s+([a-z0-9]+)\s+([0-9])\s*$|Skill name|\-\-\-\-/
+                cman_rank = $3
+        cman_name = $1.strip.downcase.gsub(/[\s\-]/,'_').gsub("'", "")
+        
+        CharSettings['cman'][cman_name] = cman_rank.to_i
+        begin
+          CMan[cman_name] = cman_rank
+        rescue
+          nil
+        end
+      end
+    elsif (line =~ /^You have now achieved the (first|second|third|fourth|fifth) rank of (.*)\.$/)
+      fix_num = { 'first' => 1, 'second' => 2, 'third' => 3, 'fourth' => 4, 'fifth' => 5 }
+      cman_name = $2
+      cman_rank = $1
+      CharSettings['cman'][cman_name.gsub(/[\s\-]/,'_').gsub("'", "").downcase] = fix_num[cman_rank]
+      begin
+        CMan[cman_name] = fix_num[cman_rank]
+      rescue
+        nil
+      end
+    elsif (line =~ /^You decide to unlearn your (first|second|third|fourth|fifth) rank of (.*),/)
+      fix_num = { 'first' => 0, 'second' => 1, 'third' => 2, 'fourth' => 3, 'fifth' => 4 }
+      cman_name = $2
+      cman_rank = $1
+      CharSettings['cman'][cman_name.gsub(/[\s\-]/,'_').gsub("'", "").downcase] = fix_num[cman_rank]
+      begin
+        CMan[cman_name] = fix_num[cman_rank]
+      rescue
+        nil
+      end
+    elsif line =~ /^\.\.\.departing in ([0-9]+) mins\.\.\.$/
+      Spell[6666].putup
+      Spell[6666].timeleft = $1.to_i
+    elsif line =~ /^\((?:You sense that your soul has been bound to your body for|Thy soul is bound to thy body for an extra) ([0-9]+) minutes( and 30 seconds)?/
+      #The hermit gestures at you.  A web of light surrounds you then the web fades into your body.
+      time_added = $1.to_f
+      time_added += 0.5 if $2
+      time_added += Spell[6666].minsleft
+      Spell[6666].putup
+      Spell[6666].timeleft = time_added
+    elsif line =~ spell_up_msgs_re and not $timers_test
+      spell = Spell.list.find { |s| line =~ /^#{s.msgup}$/ }
+      if spell.num == 218
+        if line =~ /^You infuse your (.*?) spirit with the mana necessary to maintain its corporeal form\.$/
+          servant_type = $1
+        else
+          servant_type = nil
+        end
+      elsif spell.num == 214
+        spell.putup
+        $infomon_bound = true
+      elsif spell.num == 9812
+        if line =~ /^With difficulty, you manage to will yourself into the space between the corporeal and ethereal realms\.$/
+          $infomon_transcendance_emergency = true
+        else
+          $infomon_transcendance_emergency = false
+        end
+      elsif spell.num == 9043
+        Spell[9042].putdown
+      elsif spell.num == 9627
+        Spell[9052].timeleft = 5
+        Spell[9052].putup
+      elsif (spell.num == 515) and (recovery = Spell[599])
+        recovery.putup
+      elsif spell.num == 597
+        Spell[515].putup
+        respond "[ #{Spell[515].name}: +#{Spell[515].timeleft.as_time}, #{Spell[515].remaining} remaining. ]" if CharSettings['show_messages']
+        if recovery = Spell[599]
+          recovery.putup
+        end
+      elsif spell.name =~ /^Meditative Resistance/
+        Spell.list.each { |s| s.putdown if s.name =~ /^Meditative/ }
+      end
+      if (spell.name == 'Core Tap Recovery') and (line != 'You are too exhausted to cast Core Tap right now.')
+        thresholds = [ [210,4], [135,3], [60,2], [0,1] ]
+        max_uses = thresholds.find { |foo| Skills.elearth >= foo[0] }[1]
+        if (max_uses > 1) and not Spell['Core Tap Recovery (1 Charge)'].active?
+          spell = Spell['Core Tap Recovery (1 Charge)']
+        elsif (max_uses > 2) and not Spell['Core Tap Recovery (2 Charges)'].active?
+          spell = Spell['Core Tap Recovery (2 Charges)']
+        elsif (max_uses > 3) and not Spell['Core Tap Recovery (3 Charges)'].active?
+          spell = Spell['Core Tap Recovery (3 Charges)']
+        end
+      end
+      if (spell.circle.to_i == 10) and not Spell.active.any? { |s| s.circle.to_i == 10 }
+        Spellsong.renewed
+      end
+      if spell.nil?
+        echo "Error finding matching spell-active message!"
+      elsif line =~ /^Your punishment does not end for another ([0-9]+) minutes?\.$/
+        spell.putup
+        spell.timeleft = $1.to_f
+        respond "[ #{spell.name}: +#{$1.to_f.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+      elsif spell.name =~ /^Sign of (?:Striking|Smiting|Swords)$/
+        if spell_name = [ 'Sign of Striking', 'Sign of Smiting', 'Sign of Swords' ].find { |name| (XMLData.active_spells[name] > Time.now) and not Spell[name].active? }
+          spell = Spell[spell_name]
+          spell.putup
+          respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+        elsif mangled_name = $_CLIENTBUFFER_.reverse.find { |cmd| cmd =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(st|str|stri|strik|striki|strikin|striking|sm|smi|smit|smiti|smitin|smiting|sw|swo|swor|sword|swords)\s*$/i }
+          fix_sign = { 'st' => 'Striking', 'sm' => 'Smiting', 'sw' => 'Swords' }
+          mangled_name =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(st|str|stri|strik|striki|strikin|striking|sm|smi|smit|smiti|smitin|smiting|sw|swo|swor|sword|swords)\s*$/i
+          spell = Spell["Sign of #{fix_sign[$1[0..1].downcase]}"]
+          spell.putup
+          respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+        end
+      elsif spell.name =~ /^Sign of (?:Warding|Defending|Shields)$/
+        if spell_name = [ 'Sign of Warding', 'Sign of Defending', 'Sign of Shields' ].find { |name| (XMLData.active_spells[name] > Time.now) and not Spell[name].active? }
+          spell = Spell[spell_name]
+          spell.putup
+          respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+        elsif mangled_name = $_CLIENTBUFFER_.reverse.find { |cmd| cmd =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(wa|war|ward|wardi|wardin|warding|de|def|defe|defen|defend|defendi|defendin|defending|sh|shi|shie|shiel|shield|shields)\s*$/i }
+          fix_sign = { 'wa' => 'Warding', 'de' => 'Defending', 'sh' => 'Shields' }
+          mangled_name =~ /^(?:\[[^\]]+\])?>?(?:<c>)?(?:si|sig|sign)\s+(?:of\s+)?(wa|war|ward|wardi|wardin|warding|de|def|defe|defen|defend|defendi|defendin|defending|sh|shi|shie|shiel|shield|shields)\s*$/i
+          spell = Spell["Sign of #{fix_sign[$1[0..1].downcase]}"]
+          spell.putup
+          respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+        end
+      elsif spell.num.to_i == 9516
+        rate = maxmana / 30
+        rate += 1 if Skills.to_bonus(Skills.emc) >= 100
+        rate += [Skills.to_bonus(Skills.emc)-100, 0].max / 20
+        mana_time = total_mana_drained = mana_recovered = 0
+        mana_drained = line.slice(/[0-9]+/).to_i
+
+        if spell.active?
+          total_mana_drained = UserVars.total_mana_drained
+          mana_time = UserVars.mana_time
+        end
+
+        if mana_time >= 1 and spell.timeleft < mana_time
+          mana_recovered = (mana_time - spell.timeleft.to_i) * rate
+        end
+
+        total_mana_drained = total_mana_drained - mana_recovered + mana_drained
+
+        if spell.active?
+          spell.timeleft = (total_mana_drained/rate.to_f).ceil - (1 - spell.timeleft % 1) 
+        else
+          spell.putup
+          spell.timeleft = (total_mana_drained/rate.to_f).ceil
+        end
+
+        UserVars.total_mana_drained = total_mana_drained
+        UserVars.mana_time = spell.timeleft.to_i
+
+        respond "[ #{spell.name}: +#{spell.timeleft.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+      elsif (spell.num.to_i >= 9000 and spell.num.to_i != 9011) or (spell.num.to_i == 725)
+        spell.putup
+                respond "[ #{spell.name}: +#{spell.time_per.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+                
+                # Assume Aspect cooldowns
+                if spell.num.to_i > 9013 and spell.num.to_i < 9042
+          cooldown_spell = Spell[spell.num+1]
+          cooldown_spell.putup
+          respond "[ #{cooldown_spell.name}: +#{cooldown_spell.timeleft.as_time}, #{cooldown_spell.remaining} remaining. ]" if CharSettings['show_messages']
+        end
+      else
+        if caster == 'self'
+          if self_invoke
+            options = { :caster => 'self', :activator => 'invoke' }
+          else
+            options = { :caster => 'self', :activator => activator }
+          end
+        elsif other_invoke.include?(caster)
+          options = { :caster => caster, :activator => 'invoke' }
+          other_invoke.delete(caster)
+        else
+          options = { :caster => caster, :activator => activator }
+        end
+        options[:line] = line
+        echo "spell.putup(#{options.inspect})" if $infomon_debug
+        if spell.name == 'Curse of the Star (bonus)'
+          before_xml_end_time = XMLData.active_spells[spell.name]
+          xml_end_time = nil
+          15.times {
+            sleep 0.1
+            xml_end_time = XMLData.active_spells[spell.name]
+            unless before_xml_end_time == xml_end_time
+              echo "got spell active change" if $infomon_debug
+              break
+            end
+          }
+          if xml_end_time
+            xml_timeleft = ((xml_end_time - Time.now) / 60.0) + 1.5
+            xml_minutes_left = (xml_end_time - Time.now).to_i / 60
+            timeleft = xml_minutes_left + (spell.timeleft.to_i * 60) % 60
+            difference = (xml_minutes_left - spell.timeleft).round
+            spell.putup
+            spell.timeleft = timeleft
+            respond "[ #{spell.name}: +#{difference.as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+          else
+            spell.putup(options)
+            respond "[ #{spell.name}: +#{spell.time_per(options).as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+          end
+        elsif multicast
+          echo XMLData.active_spells[spell.name].inspect if $infomon_debug
+          before_xml_end_time = (XMLData.active_spells[spell.name] || XMLData.active_spells[spell.num.to_s])
+          xml_end_time = nil
+          15.times {
+            sleep 0.1
+            xml_end_time = (XMLData.active_spells[spell.name] || XMLData.active_spells[spell.num.to_s])
+            unless before_xml_end_time == xml_end_time
+              echo "got spell active change" if $infomon_debug
+              echo XMLData.active_spells[spell.name].inspect if $infomon_debug
+              break
+            end
+          }
+          if xml_end_time
+            xml_timeleft = ((xml_end_time - Time.now) / 60.0) + 1.5
+            multicast_num = 0
+            echo "xml_timeleft: #{xml_timeleft}" if $infomon_debug
+            echo "spell.timeleft + spell.time_per(options): #{spell.timeleft} + #{spell.time_per(options)} = #{spell.timeleft + spell.time_per(options)}" if $infomon_debug
+            19.times {
+              if spell.timeleft + spell.time_per(options) < xml_timeleft
+                echo "spell.timeleft + spell.time_per(options) < xml_timeleft" if $infomon_debug
+                multicast_num += 1
+                spell.putup(options)
+              elsif xml_timeleft > spell.max_duration(options)
+                echo "xml_timeleft > spell.max_duration(options)" if $infomon_debug
+                multicast_num += 1
+                spell.putup(options)
+                break
+              end
+            }
+            respond "[ #{spell.name}: +#{(spell.time_per(options)*multicast_num).as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+          else
+            2.times { spell.putup(options) }
+            respond "[ #{spell.name}: +#{(spell.time_per(options)*2).as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+          end
+        else
+          spell.putup(options)
+          respond "[ #{spell.name}: +#{spell.time_per(options).as_time}, #{spell.remaining} remaining. ]" if CharSettings['show_messages']
+        end
+      end
+       if spell == Spell['Core Tap Recovery']
+            Spell['Core Tap Recovery (3 Charges)'].putdown if Spell['Core Tap Recovery (3 Charges)'].active?
+            Spell['Core Tap Recovery (2 Charges)'].putdown if Spell['Core Tap Recovery (2 Charges)'].active?
+            Spell['Core Tap Recovery (1 Charge)'].putdown if Spell['Core Tap Recovery (1 Charge)'].active?
+         elsif spell == Spell['Core Tap Recovery (3 Charges)']
+            Spell['Core Tap Recovery (2 Charges)'].putdown
+         elsif spell == Spell['Core Tap Recovery (2 Charges)']
+            Spell['Core Tap Recovery (1 Charge)'].putdown
+       end
+    elsif line =~ spell_dn_msgs_re and not $timers_test
+      if spell = (Spell.active.find { |s| line =~ /^#{s.msgdn}$/ } || Spell.list.find { |s| line =~ /^#{s.msgdn}$/ })
+        if (spell.num == 218) and servant_type
+          if line =~ /(?:An?|The) #{servant_type} spirit fades into ethereal form and wafts away\.$/
+            spell.putdown
+            servant_type = nil
+          end
+        elsif spell.num == 725
+          spell.putdown
+          Spell['Illusion - Demon'].putdown
+        elsif spell.num == 9009
+          unless spell.timeleft > 50
+            spell.putdown
+          end
+        elsif (spell.num == 515) and (penalty = Spell[597])
+          penalty.putdown
+          spell.putdown
+          if (recovery = Spell[599]) and (recovery.timeleft > 0)
+            respond "[ #{recovery.name}: +#{recovery.timeleft.as_time}, #{recovery.remaining} remaining. ]" if CharSettings['show_messages']
+          end
+        elsif spell.num == 214
+          spell.putdown
+          $infomon_bound = false
+        else
+          spell.putdown
+        end
+      else
+        echo 'Error finding matching spell-melted message!'
+      end
+    elsif line =~ /^As you remove your .*?, it falls out of alignment\.$/
+      for num in 9501..9509
+        spell.putdown if (spell = Spell[num]) and spell.active?
+      end
+    elsif line =~ /^You sense that you are losing control of .+ and will need to send it back soon\.$/
+      # fixme
+    elsif line =~ /^Your mind goes completely blank\.$|^You close your eyes and slowly drift off to sleep\.$|^You slump to the ground and immediately fall asleep\.  You must have been exhausted!$/
+      $infomon_sleeping = true
+    elsif line =~ /^Your thoughts slowly come back to you as you find yourself lying on the ground\.  You must have been sleeping\.$|^You wake up from your slumber\.$|^You are awoken|^You awake/
+      $infomon_sleeping = false
+    elsif line == 'An unseen force envelops you, restricting all movement.'
+      $infomon_bound = true
+    elsif line =~ /^The restricting force that envelops you dissolves away\.|^You shake off the immobilization that was restricting your movements!/
+      $infomon_bound = false
+    elsif line =~ /^A pall of silence settles over you\.|^The pall of silence settles more heavily over you\./
+      $infomon_silenced = true
+    elsif line == 'The pall of silence leaves you.'
+      $infomon_silenced = false
+    elsif line == 'A calm washes over you.'
+      $infomon_calmed = true
+    elsif line =~ /^You are enraged by .*? attack!|^The feeling of calm leaves you\./
+      $infomon_calmed = false
+    elsif line =~ /slices deep into your vocal cords\!$|^All you manage to do is cough up some blood\.$/
+      $infomon_cutthroat = true
+    elsif line =~ /^\s*The horrible pain in your vocal cords subsides as you spit out the last of the blood clogging your throat\.$/
+      $infomon_cutthroat = false
+    elsif line == "You currently have the following active spells:"
+      while (line = get)
+        if line =~ /([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)$/
+          spell_name = $1
+          if $2 == 'Indefinite'
+            spell_time = 599.0
+          else
+            spell_time = ($3.to_i * 60) + $4.to_i + ($5.to_i / 60.0)
+          end 
+          if spell_name == 'Raise Dead Recovery'
+            # fixme
+            spell_name = 'Raise Dead Cooldown'
+          elsif spell_name =~ /^Mage Armor \- /
+            spell_name = 'Mage Armor'
+          elsif spell_name =~ /^Cloak of Shadows \- /
+            spell_name = 'Cloak of Shadows'
+          end
+          if spell = Spell.list.find { |s| s.name == spell_name or s.num.to_s == spell_name }
+            spell.active = true
+            spell.timeleft = spell_time
+          else
+            echo "no spell matches #{spell_name}" if $infomon_debug
+          end
+        elsif line
+          script.downstream_buffer.unshift(line)
+          break
+        else
+          break
+        end
+      end
+    elsif line =~ /^You currently have .*? citizenship in (.*)\.$/
+      Char.citizenship = $1
+      CharSettings['citizenship'] = Char.citizenship
+    elsif line =~ /^\s*You don't seem to have citizenship\.$/
+      Char.citizenship = 'None'
+      CharSettings['citizenship'] = Char.citizenship
+    elsif line =~ /^Leaving your room, you check back out of the .*?, wander over to the front desk and hand the room key back to the innkeeper\./
+      hide_lines = done = false
+      action = proc { |server_string|
+        if hide_lines
+          if server_string =~ /^\s*Mana\:/
+            DownstreamHook.remove('infomon_info')
+            done = true
+          end
+          nil
+        elsif server_string =~ /^\s*Name\:/
+          hide_lines = true
+          nil
+        else
+          server_string
+        end
+      }
+      DownstreamHook.add('infomon_info', action)
+      # echo 'checking stats...'
+      save_silent = script.silent
+      script.silent = true
+      put 'info'
+      script.silent = save_silent
+      wait_until { done }
+  
+      hide_lines = done = false
+      action = proc { |server_string|
+        if hide_lines
+          if server_string =~ /<output class=""\/>/
+            DownstreamHook.remove('infomon_skills')
+            done = true
+          end
+          nil
+        elsif server_string =~ /^\s*(?:<.*?>)?#{Char.name}(?:<\/a>)? \(at level/o
+          hide_lines = true
+          nil
+        else
+          server_string
+        end
+      }
+      DownstreamHook.add('infomon_skills', action)
+      # echo 'checking skills...'
+      save_silent = script.silent
+      script.silent = true
+      put 'skills'
+      script.silent = save_silent
+      wait_until { done }
+    elsif line =~ /^You sign your name into the citizenship/
+      done = false
+      action = proc { |server_string|
+        if server_string =~ /You currently have .*? citizenship in|You don't seem to have citizenship\./
+          DownstreamHook.remove('infomon_citizenship')
+          done = true
+          nil
+        else
+          server_string
+        end
+      }
+      DownstreamHook.add('infomon_citizenship', action)
+      # echo 'checking citizenship...'
+      save_silent = script.silent
+      script.silent = true
+      put 'citizenship'
+      script.silent = save_silent
+      wait_until { done }
+    end
+  rescue Exception
+    echo $!
+    echo $!.backtrace.first
+    sleep 1
+  rescue ThreadError
+    echo $!
+    echo $!.backtrace.first
+    sleep 1
+  rescue
+    echo $!
+    echo $!.backtrace.first
+    sleep 1
+  end
+end
+
+=begin
+
+  fixme: track enhanced skills and stats
+
+  You sense the link between you and your .+ begin to slowly weaken\.
+  You sense that you are losing control of .+ and will need to send it back soon\.
+
+  fixme: track group members
+    You reach out and hold Name's hand.
+
+  The Grandmaster says, "You are now a member of the Guardians of Sunfist.  Welcome.  As a member you are expected to slay our enemies whenever possible.  If this is all that you wish to do, then you are welcome to do only that."
+
+=end

--- a/spec/jinx/repos/core/assets/lnet.lic
+++ b/spec/jinx/repos/core/assets/lnet.lic
@@ -1,0 +1,1672 @@
+=begin
+
+  Chat client for Lich.
+
+  ;lnet help
+
+    author: Tillmen (tillmen@lichproject.org)
+      game: any
+      tags: core
+  required: Lich >= 4.3.12
+   version: 1.6
+
+  changelog:
+    1.6 (2016-01-10):
+      fixed room id lookup for ;locate command
+      added alias feature
+    1.5 (2015-11-25):
+      added reply command (DR:Etreu)
+    1.4 (2015-05-13):
+      move channel owners and moderators to the front of the ;who list
+
+=end
+=begin
+
+    1.3 (2015-01-21):
+      give a warning if the system date is outside the range of the CA cert date
+      disable SSLv2 and SSLv3
+    1.2 (2015-01-16):
+      new host name
+    1.1 (2014-10-25):
+      workaround to deal with the plat_updater script disabling OpenSSL::SSL::VERIFY_PEER
+
+=end
+
+if $SAFE > 0
+  echo "error: This script needs to be trusted to work. (;trust #{script.name})"
+  exit
+end
+
+# fixme: option to separate private messages to familiar window
+# fixme: scrub
+
+require 'openssl'
+
+toggle_unique
+clear
+hide_me
+
+class LNet
+
+  @@server    ||= nil
+  @@script    ||= nil
+  @@options   ||= Hash.new
+  @@waiting   ||= Array.new
+  @@last_recv ||= Time.now
+  @@last_send ||= Time.now
+  @@last_priv ||= nil
+  @@secret    ||= Array.new
+  @@version     = '1.6'
+
+  @@server_restart = false
+
+  def LNet.server;        if $SAFE==0; @@server;        else; nil; end; end
+  def LNet.server=(val);  if $SAFE==0; @@server=val;    else; nil; end; end
+  def LNet.script;        if $SAFE==0; @@script;        else; nil; end; end
+  def LNet.script=(val);  if $SAFE==0; @@script=val;    else; nil; end; end
+  def LNet.options;       if $SAFE==0; @@options;       else; nil; end; end
+  def LNet.options=(val); if $SAFE==0; @@options=val;   else; nil; end; end
+  def LNet.alias;         if $SAFE==0; @@alias;         else; nil; end; end
+  def LNet.alias=(val);   if $SAFE==0; @@alias=val;     else; nil; end; end
+
+  def LNet.server_restart;       if $SAFE==0; @@server_restart;     else; nil; end; end
+  def LNet.server_restart=(val); if $SAFE==0; @@server_restart=val; else; nil; end; end
+
+  def LNet.store_secret=(val); if $SAFE==0; @@secret=val;    else; nil; end; end
+  def LNet.secret=(val);       if $SAFE==0; @@secret[0]=val; else; nil; end; end
+
+  def LNet.last_send
+    @@last_send
+  end
+
+  def LNet.last_recv
+    @@last_recv
+  end
+
+  def LNet.last_priv
+    @@last_priv
+  end
+
+  def LNet.connect
+    begin
+      hostname = 'lnet.lichproject.org'
+      port     = 7155
+      ca_cert  = OpenSSL::X509::Certificate.new("-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAwIBAgIJAKuu65i5NsruMA0GCSqGSIb3DQEBCwUAMGExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIDAhJbGxpbm9pczESMBAGA1UECgwJTWF0dCBMb3dlMQ8w\nDQYDVQQDDAZSb290Q0ExGjAYBgkqhkiG9w0BCQEWC21hdHRAaW80LnVzMB4XDTE0\nMDYwNzE3NDUwMFoXDTI0MDYwNDE3NDUwMFowYTELMAkGA1UEBhMCVVMxETAPBgNV\nBAgMCElsbGlub2lzMRIwEAYDVQQKDAlNYXR0IExvd2UxDzANBgNVBAMMBlJvb3RD\nQTEaMBgGCSqGSIb3DQEJARYLbWF0dEBpbzQudXMwggEiMA0GCSqGSIb3DQEBAQUA\nA4IBDwAwggEKAoIBAQCcIRn0IMCNYeL5agKmkdedgJXsIyTJS8qKrY6EvQsq4tt0\nmO3Or9K8IaDl7qFdQ9nfSJ5phNgoCy9wZ9rDWv5FhY5MnnVHGr3fCa7RkMxJFR/N\nwiD4ihQlixOUly76glceyc/6QQS9bNe96evZDstERGAFfzgHY4qAlyurR6mBu9Mb\nyyCRok6xMRnjrbTMNkvvOsuG0sY9ot+SLHGgU3qT7+wVh/CbWcjeF7/Qwa//fbFk\nmq5c1FuvhU3DanSSz+VuWudPFSyZ3r5pYrLMJWsyomDa4gkL2bJ5jya2BWDMXvSS\nCpdQgPDIlClMfAFLd/Ss8ZIGa6uNFcSK6Xca51ClAgMBAAGjUDBOMB0GA1UdDgQW\nBBScbglRiGzz9yzuhgBwFYjgimeByDAfBgNVHSMEGDAWgBScbglRiGzz9yzuhgBw\nFYjgimeByDAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQA7MLZYfqam\n5aaSBqQpT6sOGDtVc9koIok59oTQmNXqe+awg2VUnAiesxtLd+FWGUMp8XzHdGWw\nH3O6kAUkPm/in001X7TRAhbgDujfTRbTzxND0XrjuEzDMALs3YpDM1pMXqC7RXWA\n7z+N0gRaUgmh1rMbk/qA3cAfC2dwf2j3NYy3bDw3lMpdyIwAfOQxiZVglYgX3dgT\nU9b//gsUyPCvlpL0mYcmhOOLt6oqQhMJaw1I6A9xMe2kO2L+8KPGK2u1B+P5/Sx0\nFE8LIp5KA3a7yRbOty19NsGR+yW7WwV7BL6c6GOKb/iKJBLYzTmNG6m16hRrxDGj\ntGu91I0ORptB\n-----END CERTIFICATE-----")
+      if ca_cert.not_before > Time.now
+        respond "\n---\n--- warning: The current date is set incorrectly on your computer. This will\n---          cause the SSL certificate verification to fail and prevent LNet\n---          from connecting to the server.  Fix it.\n---\n\n"
+        sleep 3
+      end
+      if ca_cert.not_after < Time.now
+        respond "\n---\n--- warning: Your computer thinks the date is #{Time.now.strftime("%m-%d-%Y")}.  If this is the\n---          correct date, you need an updated version of this script.  If \n---          this is not the correct date, you need to change it.  In either\n---          case, this date makes the SSL certificate in this script\n---          invalid and will prevent LNet from connecting to the server.\n---\n\n"
+        sleep 3
+      end
+      cert_store              = OpenSSL::X509::Store.new
+      ssl_context             = OpenSSL::SSL::SSLContext.new
+      ssl_context.cert_store  = cert_store
+      ssl_context.options     = (OpenSSL::SSL::OP_NO_SSLv2 + OpenSSL::SSL::OP_NO_SSLv3)
+      cert_store.add_cert(ca_cert)
+      if OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE
+        # the plat_updater script redefines OpenSSL::SSL::VERIFY_PEER, disabling it for everyone
+        ssl_context.verify_mode = 1 # probably right
+      else
+        ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
+      socket = TCPSocket.open(hostname, port)
+      ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
+      ssl_socket.sync_close = true
+      ssl_socket.connect
+         if $lnet_debug
+            echo ssl_socket.peer_cert.inspect
+         end
+      if (ssl_socket.peer_cert.subject.to_a.find { |n| n[0] == 'CN' }[1] != 'lichproject.org') and (ssl_socket.peer_cert.subject.to_a.find { |n| n[0] == 'CN' }[1] != 'LichNet')
+        echo "error: server certificate hostname mismatch"
+        ssl_socket.close
+        exit
+      end
+      LNet.server = ssl_socket
+
+      xml = REXML::Document.new
+      element = xml.add_element('login')
+      element.add_attribute('name', XMLData.name)
+      element.add_attribute('game', XMLData.game)
+      element.add_attribute('client', @@version)
+      element.add_attribute('lich', $version)
+      if @@secret[0]
+        element.add_attribute('password', @@secret[0])
+      end
+      @@server.puts(xml)
+      @@last_send = Time.now
+      xml = element = nil
+    rescue
+      echo $!
+      respond $!.backtrace[0..1]
+    end
+  end
+
+  def LNet.send_ping
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('ping')
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.send_ping."
+    end
+  end
+
+  def LNet.send_message(attributes, message)
+    return false if @@server.closed?
+    # causes errors in Ruby 1.9.2
+    #message.gsub!(/\x80|\x81|\x86|\x87|\x8D|\x8F|\x90|\x95|\x9C|\x9D/, '?')
+    #message.gsub!(/\x83/, 'f')
+    #message.gsub!(/\x84/, ',,')
+    #message.gsub!(/\x85/, '...')
+    #message.gsub!(/\x88/, '^')
+    #message.gsub!(/\x89/, '%o')
+    #message.gsub!(/\x8A/, 'S')
+    #message.gsub!(/\x8B/, '<')
+    #message.gsub!(/\x8C/, 'CE')
+    #message.gsub!(/\x8E/, 'Z')
+    #message.gsub!(/\x91|\x92/, "'")
+    #message.gsub!(/\x93|\x94/, '"')
+    #message.gsub!(/\x96|\x97|\x98/, '-')
+    #message.gsub!(/\x99/, '(tm)')
+    #message.gsub!(/\x9A/, 's')
+    #message.gsub!(/\x9B/, '>')
+    #message.gsub!(/\x9E/, 'z')
+    #message.gsub!(/\x9F/, 'Y')
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('message')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      element.text = message
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.send_message."
+    end
+  end
+
+  def LNet.send_query(attributes)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('query')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.send_query."
+    end
+  end
+
+  def LNet.send_request(attributes)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('request')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.send_request."
+    end
+  end
+
+  def LNet.send_data(attributes, data)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('data')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      element.text = [Marshal.dump(data)].pack('m').strip
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.send_data."
+    end
+  end
+
+  def LNet.tune_channel(channel)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('tune')
+      element.add_attribute('channel', channel)
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.tune_channel."
+    end
+  end
+
+  def LNet.untune_channel(channel)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('untune')
+      element.add_attribute('channel', channel)
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.untune_channel."
+    end
+  end
+
+  def LNet.moderate(attributes)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('moderate')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.moderate."
+    end
+  end
+
+  def LNet.admin(attributes)
+    return false if @@server.closed?
+    if $SAFE == 0
+      xml = REXML::Document.new
+      element = xml.add_element('admin')
+      attributes.each_pair { |name,val| element.add_attribute(name, val) }
+      @@server.puts(xml)
+      @@last_send = Time.now
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.admin."
+    end
+  end
+
+  def LNet.echo_thought(from, message, channel)
+    if $SAFE == 0
+      aliased_from = (LNet.alias[from] || from)
+      channel = "[#{channel}]-" unless from == '[server]'
+      if @@options['timestamps']
+        timestamp = "  (#{Time.now.strftime('%X')})"
+      else
+        timestamp = String.new
+      end
+      if @@options['fam_window']
+        xml_thought = "<pushStream id=\"familiar\" ifClosedStyle=\"watching\"/>#{channel}#{aliased_from}: \"#{message.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}\"#{timestamp}\n<popStream/>\n"
+      else
+#       xml_thought = "<stream id=\"thoughts\">#{channel}#{aliased_from}: \"#{message.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}\"#{timestamp}</stream>\n"
+        xml_thought = "<pushStream id=\"thoughts\"/>#{channel}#{aliased_from}: \"#{message.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}\"#{timestamp}\n<popStream/>\n"
+      end
+      unless LNet.ignored?(from)
+        if $frontend =~ /wizard|avalon/
+          if @@options['fam_window']
+            $_CLIENT_.puts("\034GSe\r\n#{channel}#{aliased_from}: \"#{message}\"#{timestamp}\r\n\034GSf\r\n")
+          else
+            $_CLIENT_.puts("You hear the faint thoughts of #{channel}#{aliased_from} echo in your mind:\n\"#{message}\"#{timestamp}\r\n")
+          end
+          Script.new_downstream("#{channel}#{aliased_from}: \"#{message}\"#{timestamp}")
+        else
+          if defined?(_respond)
+            _respond(xml_thought)
+          else
+            $_CLIENT_.puts(xml_thought)
+          end
+        end
+      end
+      $_SERVERBUFFER_.push(xml_thought)
+      Script.new_downstream_xml(xml_thought)
+      Script.new_downstream("#{channel}#{aliased_from}: \"#{message}\"#{timestamp}")
+    else
+      respond "--- Lich: Untrusted script (#{Script.self.name}) called LNet.echo_thought."
+    end
+  end
+
+  def LNet.allow?(action, name)
+    if @@options['permission'][action] == 'all'
+      true
+    elsif @@options['permission'][action] == 'friends'
+      if LNet.friend?(name)
+        true
+      else
+        false
+      end
+    elsif @@options['permission'][action] == 'enemies'
+      if LNet.enemy?(name)
+        false
+      else
+        true
+      end
+    else
+      false
+    end
+  end
+
+  def LNet.ignored?(name)
+    @@options['ignore'].include?(name) or @@options['ignore'].include?(name.slice(/[A-Z][a-z]+$/))
+  end
+
+  def LNet.friend?(name)
+    @@options['friends'].include?(name) or @@options['friends'].include?(name.slice(/[A-Z][a-z]+$/))
+  end
+
+  def LNet.enemy?(name)
+    @@options['enemies'].include?(name) or @@options['enemies'].include?(name.slice(/[A-Z][a-z]+$/))
+  end
+
+  def LNet.get_data(name, type)
+    if $SAFE == 0
+      return false if (name.class != String) or name.empty? or (type.class != String) or type.empty? or @@server.closed?
+      name.capitalize!
+      waiter = { 'type'=>type, 'name'=>name, 'data'=>:waiting }
+      @@waiting.push(waiter)
+      begin
+        LNet.send_request(attr={'type'=>type, 'to'=>name})
+        80.times { sleep 0.1; break unless waiter['data'] == :waiting }
+      ensure
+        @@waiting.delete(waiter)
+      end
+      if waiter['data'] == :waiting
+        false
+      else
+        waiter['data']
+      end
+    else
+      UNTRUSTED_LNET_GET_DATA.call(name, type)
+    end
+  end
+
+  def LNet.upload_spell_ranks
+    if $SAFE == 0
+      begin
+        return false if @@server.closed?
+        data = {
+          'minorspiritual' => Spells.minorspiritual,
+          'majorspiritual' => Spells.majorspiritual,
+          'cleric'         => Spells.cleric,
+          'minorelemental' => Spells.minorelemental,
+          'majorelemental' => Spells.majorelemental,
+          'ranger'         => Spells.ranger,
+          'sorcerer'       => Spells.sorcerer,
+          'wizard'         => Spells.wizard,
+          'bard'           => Spells.bard,
+          'empath'         => Spells.empath,
+          'paladin'        => Spells.paladin,
+          'arcanesymbols'  => Skills.arcanesymbols,
+          'magicitemuse'   => Skills.magicitemuse,
+        }
+        begin
+          data['minormental'] = Spells.minormental
+        rescue
+          nil
+        end
+        LNet.send_data(attr={'type'=>'spell-ranks'}, data)
+        return true
+      rescue
+        return false
+      end
+    else
+      UNTRUSTED_LNET_UPLOAD_SPELL_RANKS.call
+    end
+  end
+
+  def initialize
+    @active_tags = Array.new
+    @active_attributes = Array.new
+  end
+
+  def tag_start(tag_name, attributes)
+    begin
+      @@last_recv = Time.now
+      @active_tags.push(tag_name)
+      @active_attributes.push(attributes)
+      if tag_name == 'ping'
+        xml = REXML::Document.new
+        xml.add_element('pong')
+        @@server.puts(xml)
+        @@last_send = Time.now
+      elsif (tag_name == 'request') and (type = attributes['type']) and (name = attributes['from'])
+        if LNet.ignored?(name)
+          LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+        elsif type == 'spells'
+          if LNet.allow?('spells', name)
+            echo "sending spell info to #{name}..."
+            active_spells = Hash.new
+            Spell.active.each { |spell| active_spells[spell.num.to_s] = spell.timeleft }
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, active_spells)
+          else
+            echo "rejecting request from #{name} for spell info..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        elsif type == 'skills'
+          if LNet.allow?('skills', name)
+            echo "sending skills to #{name}..."
+            skills = Hash.new
+            skills['Two Weapon Combat'] = Skills.twoweaponcombat if Skills.twoweaponcombat > 0
+            skills['Armor Use'] = Skills.armoruse if Skills.armoruse > 0
+            skills['Shield Use'] = Skills.shielduse if Skills.shielduse > 0
+            skills['Combat Maneuvers'] = Skills.combatmaneuvers if Skills.combatmaneuvers > 0
+            skills['Edged Weapons'] = Skills.edgedweapons if Skills.edgedweapons > 0
+            skills['Blunt Weapons'] = Skills.bluntweapons if Skills.bluntweapons > 0
+            skills['Two-Handed Weapons'] = Skills.twohandedweapons if Skills.twohandedweapons > 0
+            skills['Ranged Weapons'] = Skills.rangedweapons if Skills.rangedweapons > 0
+            skills['Thrown Weapons'] = Skills.thrownweapons if Skills.thrownweapons > 0
+            skills['Polearm Weapons'] = Skills.polearmweapons if Skills.polearmweapons > 0
+            skills['Brawling'] = Skills.brawling if Skills.brawling > 0
+            skills['Ambush'] = Skills.ambush if Skills.ambush > 0
+            skills['Multi Opponent Combat'] = Skills.multiopponentcombat if Skills.multiopponentcombat > 0
+            skills['Combat Leadership'] = Skills.combatleadership if Skills.combatleadership > 0
+            skills['Physical Fitness'] = Skills.physicalfitness if Skills.physicalfitness > 0
+            skills['Dodging'] = Skills.dodging if Skills.dodging > 0
+            skills['Arcane Symbols'] = Skills.arcanesymbols if Skills.arcanesymbols > 0
+            skills['Magic Item Use'] = Skills.magicitemuse if Skills.magicitemuse > 0
+            skills['Spell Aiming'] = Skills.spellaiming if Skills.spellaiming > 0
+            skills['Harness Power'] = Skills.harnesspower if Skills.harnesspower > 0
+            skills['Elemental Mana Control'] = Skills.emc if Skills.emc > 0
+            skills['Mental Mana Control'] = Skills.mmc if Skills.mmc > 0
+            skills['Spirit Mana Control'] = Skills.smc if Skills.smc > 0
+            skills['Elemental Lore - Air'] = Skills.elair if Skills.elair > 0
+            skills['Elemental Lore - Earth'] = Skills.elearth if Skills.elearth > 0
+            skills['Elemental Lore - Fire'] = Skills.elfire if Skills.elfire > 0
+            skills['Elemental Lore - Water'] = Skills.elwater if Skills.elwater > 0
+            skills['Spiritual Lore - Blessings'] = Skills.slblessings if Skills.slblessings > 0
+            skills['Spiritual Lore - Religion'] = Skills.slreligion if Skills.slreligion > 0
+            skills['Spiritual Lore - Summoning'] = Skills.slsummoning if Skills.slsummoning > 0
+            skills['Sorcerous Lore - Demonology'] = Skills.sldemonology if Skills.sldemonology > 0
+            skills['Sorcerous Lore - Necromancy'] = Skills.slnecromancy if Skills.slnecromancy > 0
+            skills['Mental Lore - Divination'] = Skills.mldivination if Skills.mldivination > 0
+            skills['Mental Lore - Manipulation'] = Skills.mlmanipulation if Skills.mlmanipulation > 0
+            skills['Mental Lore - Telepathy'] = Skills.mltelepathy if Skills.mltelepathy > 0
+            skills['Mental Lore - Transference'] = Skills.mltransference if Skills.mltransference > 0
+            skills['Mental Lore - Transformation'] = Skills.mltransformation if Skills.mltransformation > 0
+            skills['Survival'] = Skills.survival if Skills.survival > 0
+            skills['Disarming Traps'] = Skills.disarmingtraps if Skills.disarmingtraps > 0
+            skills['Picking Locks'] = Skills.pickinglocks if Skills.pickinglocks > 0
+            skills['Stalking and Hiding'] = Skills.stalkingandhiding if Skills.stalkingandhiding > 0
+            skills['Perception'] = Skills.perception if Skills.perception > 0
+            skills['Climbing'] = Skills.climbing if Skills.climbing > 0
+            skills['Swimming'] = Skills.swimming if Skills.swimming > 0
+            skills['First Aid'] = Skills.firstaid if Skills.firstaid > 0
+            skills['Trading'] = Skills.trading if Skills.trading > 0
+            skills['Pickpocketing'] = Skills.pickpocketing if Skills.pickpocketing > 0
+            skills['Major Elemental'] = Spells.majorelemental if Spells.majorelemental > 0
+            skills['Minor Elemental'] = Spells.minorelemental if Spells.minorelemental > 0
+            begin
+              skills['Minor Mental'] = Spells.minormental if Spells.minormental > 0
+            rescue
+              nil
+            end
+            skills['Major Spirit'] = Spells.majorspiritual if Spells.majorspiritual > 0
+            skills['Minor Spirit'] = Spells.minorspiritual if Spells.minorspiritual > 0
+            skills['Wizard'] = Spells.wizard if Spells.wizard > 0
+            skills['Sorcerer'] = Spells.sorcerer if Spells.sorcerer > 0
+            skills['Ranger'] = Spells.ranger if Spells.ranger > 0
+            skills['Paladin'] = Spells.paladin if Spells.paladin > 0
+            skills['Empath'] = Spells.empath if Spells.empath > 0
+            skills['Cleric'] = Spells.cleric if Spells.cleric > 0
+            skills['Bard'] = Spells.bard if Spells.bard > 0
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, skills)
+          else
+            echo "rejecting request from #{name} for skills..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        elsif type == 'info'
+          if LNet.allow?('info', name)
+            echo "sending stats to #{name}..."
+            info = {
+              'Race' => Stats.race,
+              'Profession' => Stats.prof,
+              'Gender' => Stats.gender,
+              'Age' => Stats.age,
+              'Expr' => Stats.exp,
+              'Level' => XMLData.level,
+              'Strength' => Stats.str,
+              'Constitution' => Stats.con,
+              'Dexterity' => Stats.dex,
+              'Agility' => Stats.agi,
+              'Discipline' => Stats.dis,
+              'Aura' => Stats.aur,
+              'Logic' => Stats.log,
+              'Intuition' => Stats.int,
+              'Wisdom' => Stats.wis,
+              'Influence' => Stats.inf,
+              'Mana' => mana,
+            }
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, info)
+          else
+            echo "rejecting request from #{name} for stats..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        elsif type == 'locate'
+          if LNet.allow?('locate', name)
+            echo "sending location to #{name}..."
+            room = {
+              'title' => XMLData.room_title,
+              'description' => XMLData.room_description,
+              'exits' => XMLData.room_exits_string,
+              'loot' => GameObj.loot.collect { |loot| loot.name },
+            }
+            room['pcs'] = Array.new
+            GameObj.pcs.each { |pc| room['pcs'].push(hash={'name'=>pc.name, 'status'=>pc.status}) }
+            unless hidden? or invisible?
+              status = Array.new
+              status.push 'dead' if dead?
+              status.push 'webbed' if webbed?
+              status.push 'stunned' if stunned?
+              if kneeling?
+                status.push 'kneeling'
+              elsif sitting?
+                status.push 'sitting'
+              elsif !standing?
+                if GameObj.pcs.any? { |pc| pc.status =~ /prone/ } or GameObj.pcs.any? { |pc| pc.status =~ /prone/ }
+                  status.push 'prone'
+                else
+                  status.push 'lying down'
+                end
+              end
+              if status.empty?
+                room['pcs'].push(h={'name'=>Char.name, 'status'=>nil})
+              else
+                room['pcs'].push(h={'name'=>Char.name, 'status'=>status.join(' ')})
+              end
+            end
+            room['npcs'] = Array.new
+            GameObj.npcs.each { |npc| room['npcs'].push(hash={'name'=>npc.name, 'status'=>npc.status}) }
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, room)
+          else
+            echo "rejecting request from #{name} for location..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        elsif type == 'health'
+          if LNet.allow?('health', name)
+            echo "sending health to #{name}..."
+            health = {
+              'injuries' => XMLData.injuries,
+              'health' => XMLData.health,
+              'max_health' => XMLData.max_health,
+              'spirit' => XMLData.spirit,
+              'max_spirit' => XMLData.max_spirit,
+              'stamina' => XMLData.stamina,
+              'max_stamina' => XMLData.max_stamina,
+            }
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, health)
+          else
+            echo "rejecting request from #{name} for health info..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        elsif type == 'bounty'
+          if LNet.allow?('bounty', name)
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, bounty?)
+          else
+            echo "rejecting request from #{name} for bounty info..."
+            LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+          end
+        else
+          echo "rejecting unknown request (#{type}) from #{name}..."
+          LNet.send_data(attr={'type'=>type, 'to'=>name}, nil)
+        end
+      elsif (tag_name == 'notify')
+        if (attributes['type'] == 'new-spell-ranks') and defined?(SpellRanks)
+          LNet.send_request(attr={'type'=>'spell-ranks', 'to'=>'server', 'timestamp'=>SpellRanks.timestamp.to_s})
+        elsif attributes['type'] == 'server-restart'
+          @@server_restart = true
+          @@server.close rescue()
+        end
+      end
+    rescue
+      echo $!
+      respond $!.backtrace[0..1]
+    end
+  end
+
+  def text(text)
+    begin
+      if @active_tags.last == 'message'
+        if @active_attributes.last['type'] == 'greeting'
+          respond text if @@options['greeting']
+        elsif @active_attributes.last['type'] == 'server'
+          if text =~ /(?!kill).*(?:incorrect password|password required)/
+            output = "\n"
+            output.concat "If you have forgotten your password, visit https://lnet.lichproject.org to reset it."
+            output.concat "\n"
+            output.concat "To attempt to log in with a different password, type: #{$clean_lich_char}#{@@script.name} password=<password>\n"
+            output.concat "\n"
+            respond output
+            Script.self.kill
+          end
+          LNet.echo_thought('[server]', text, '')
+        elsif (@active_attributes.last['type'] == 'private') and (from = @active_attributes.last['from'])
+          @@last_priv = from
+          LNet.echo_thought(from, text, 'Private')
+        elsif (@active_attributes.last['type'] == 'privateto') and (to = @active_attributes.last['to'])
+          if text.length < 512 # fixme
+            LNet.echo_thought(to, text, 'PrivateTo')
+          end
+        elsif (@active_attributes.last['type'] == 'channel') and (from = @active_attributes.last['from']) and (channel = @active_attributes.last['channel'])
+          LNet.echo_thought(from, text, channel)
+        end
+      elsif (@active_tags.last == 'data')
+        begin
+          data = Marshal.load(text.unpack('m').first)
+        rescue
+          return
+        end
+        if @active_attributes.last['from'] and @active_attributes.last['type'] and (waiter = @@waiting.find { |w| (@active_attributes.last['from'] =~ /^#{Regexp.escape(w['name'])}/i) and (w['type'] == @active_attributes.last['type']) and w['data'] == :waiting })
+          waiter['data'] = data
+        elsif (@active_attributes.last['type'] == 'connected') and (@active_attributes.last['from'] == 'server')
+          output = String.new
+          sort_by_game = Hash.new
+          for name in data
+            if name =~ /^(.+)\:(.+)$/
+              sort_by_game[$1] ||= Array.new
+              sort_by_game[$1].push($2)
+            else
+              sort_by_game['unknown'] ||= Array.new
+              sort_by_game['unknown'].push(name)
+            end
+          end
+          who_columns = 5
+          sort_by_game.each_pair { |game,name_list|
+            name_list = name_list.sort { |a,b| if (a =~ /\^$/) or (a =~ /\*$/ and b !~ /\^$/); 1; else; 0; end }
+            output.concat "\n#{game} (#{name_list.length}):\n\n"
+            column = Array.new
+            longest = Array.new
+            who_columns.times {
+              column.push Array.new
+              longest.push 0
+            }
+            until name_list.empty?
+              for i in 0..(who_columns-1)
+                if name = name_list.pop
+                  column[i].push(name)
+                  longest[i] = [ longest[i], name.length ].max
+                end
+              end
+            end
+            until column[0].empty?
+              for i in 0..(who_columns-1)
+                if name = column[i].shift
+                  output.concat name.ljust(longest[i]+3)
+                end
+              end
+              output = output.strip.concat "\n"
+            end
+          }
+          if channel = @active_attributes.last['channel']
+            output.concat "\nTotal tuned to #{channel}: #{data.length}\n\n"
+          else
+            output.concat "\nTotal connected: #{data.length}\n\n"
+          end
+          respond "\n#{output}"
+        elsif (@active_attributes.last['type'] == 'channels') and (@active_attributes.last['from'] == 'server')
+          total = @active_attributes.last['total']
+          name_width = tuned_width = 0
+          data.each { |channel|
+            name_width = [ name_width, channel['name'].length ].max
+            tuned_width = [ tuned_width, channel['tuned'].to_s.length ].max
+          }
+          output = "\nAvailable channels:\n\n"
+          data.each { |channel|
+            output.concat "#{if channel['status'] == 'default'; '+' elsif channel['status'] == 'tuned'; '-'; else ' '; end} #{channel['name'].rjust(name_width)}   #{channel['tuned'].to_s.rjust(tuned_width)}   #{channel['description']}\n"
+          }
+          output.concat "\nuse \";channels full\" to see #{total.to_i - data.length} more\n" if data.length < total.to_i
+          output.concat "\n"
+          respond output
+        elsif (@active_attributes.last['type'] == 'server stats') and (@active_attributes.last['from'] == 'server')
+          format_time = proc { |time|
+            seconds    =  time.to_i % 60
+            difference = (time - seconds) / 60
+            minutes    =  difference % 60
+            difference = (difference - minutes) / 60
+            hours      =  difference % 24
+            days       = (difference - hours) / 24
+            formatted_time = Array.new
+            formatted_time.push "#{days.to_i} day#{'s' unless days == 1}" if days > 0
+            formatted_time.push "#{hours.to_i} hour#{'s' unless hours == 1}" if hours > 0
+            formatted_time.push "#{minutes.to_i} minute#{'s' unless minutes == 1}" if minutes > 0
+            formatted_time.push "#{seconds.to_i} second#{'s' unless seconds == 1}" if (seconds > 0) and (days < 1) and (hours < 1)
+            formatted_time = formatted_time.join(', ').sub(/^1 day$/, '24 hours')
+            formatted_time
+          }
+          output = "\n"
+          if data['uptime'] and data['uptime'].to_i > 0
+            output.concat "No major accidents in the last #{format_time.call(data['uptime'])}\n"
+          end
+          if data['character connections'] and not data['character connections'].empty?
+            for length,num in data['character connections']
+              output.concat "#{num} characters have connected in the last #{format_time.call(length)}\n"
+            end
+          end
+          if data['ip connections'] and not data['ip connections'].empty?
+            for length,num in data['ip connections']
+              output.concat "About #{num} players have connected in the last #{format_time.call(length)}\n"
+            end
+          end
+          output.concat "\n"
+          for channel_name,channel_data in data['own_channels']
+            output.concat "#{channel_name} (owner)\n"
+            if channel_data['moderators'].empty?
+              output.concat "   moderators: none\n"
+            else
+              output.concat "   moderators: #{channel_data['moderators'].join(', ')}\n"
+            end
+            if channel_data['invited'].nil?
+              nil
+            elsif channel_data['invited'].empty?
+              output.concat "   invited: none\n"
+            else
+              output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
+            end
+            if channel_data['banned'].nil?
+              nil
+            elsif channel_data['banned'].empty?
+              output.concat "   banned: none\n"
+            else
+              output.concat "   banned:\n"
+              for name,ban_time in channel_data['banned']
+                if ban_time.nil?
+                  ban_time = 'indefinite'
+                else
+                  ban_time = format_time.call(ban_time)
+                end
+                output.concat "      #{name.ljust(16)} (#{ban_time})\n"
+              end
+            end
+            if channel_data['gagged'].empty?
+              output.concat "   gagged: none\n"
+            else
+              output.concat "   gagged:\n"
+              for name,gag_time in channel_data['gagged']
+                if gag_time.nil?
+                  gag_time = 'indefinite'
+                else
+                  #echo "gag_time: #{gag_time.inspect}"
+                  gag_time = format_time.call(gag_time)
+                end
+                output.concat "      #{name.ljust(16)} (#{gag_time})\n"
+              end
+            end
+          end
+          for channel_name,channel_data in data['mod_channels']
+            output.concat "#{channel_name} (moderator)\n"
+            if channel_data['invited'].nil?
+              nil
+            elsif channel_data['invited'].empty?
+              output.concat "   invited: none\n"
+            else
+              output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
+            end
+            if channel_data['banned'].nil?
+              nil
+            elsif channel_data['banned'].empty?
+              output.concat "   banned: none\n"
+            else
+              output.concat "   banned:\n"
+              for name,ban_time in channel_data['banned']
+                if ban_time.nil?
+                  ban_time = 'indefinite'
+                else
+                  ban_time = format_time.call(ban_time)
+                end
+                output.concat "      #{name.ljust(16)} (#{ban_time})\n"
+              end
+            end
+            if channel_data['gagged'].empty?
+              output.concat "   gagged: none\n"
+            else
+              output.concat "   gagged:\n"
+              for name,gag_time in channel_data['gagged']
+                if gag_time.nil?
+                  gag_time = 'indefinite'
+                else
+                  gag_time = format_time.call(gag_time)
+                end
+                output.concat "      #{name.ljust(16)} (#{gag_time})\n"
+              end
+            end
+          end
+          output.concat "\n" unless data['own_channels'].empty? and data['mod_channels'].empty?
+          respond output
+        elsif (@active_attributes.last['type'] == 'spell-ranks') and (@active_attributes.last['from'] == 'server') and defined?(SpellRanks)
+               echo 'spell-ranks' if $lnet_debug
+          begin
+            # fixme: really really slow to do the whole list, also too large (1.7mb or something)
+            format = data['_format_']
+            for name,ranks in data
+              next if name =~ /^_/
+              name = name.sub(/^.*\:/, '')
+              char = SpellRanks[name] || SpellRanks.new(name)
+              data['_format_'].each_index { |i|
+                char.send("#{data['_format_'][i]}=", ranks[i].to_i) rescue()
+              }
+            end
+            SpellRanks.timestamp = data['_timestamp_']
+            SpellRanks.save
+          rescue
+            echo $!
+            echo $!.backtrace[0..2]
+          end
+        elsif (@active_attributes.last['type'] == 'spells') and (name = @active_attributes.last['from'])
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for spell information."
+            elsif data == false
+              echo 'no such user'
+            elsif data.empty?
+              echo "#{name} has no spells."
+            else
+              output = "\n#{name}:\n"
+              last_circle = nil
+              data.sort.each { |spell|
+                unless last_circle == Spell[spell[0]].circlename
+                  last_circle = Spell[spell[0]].circlename
+                  output.concat "\n- #{last_circle}:\n"
+                end
+                output.concat "#{spell[0].to_s.rjust(4)}:  #{Spell[spell[0]].name.ljust(22)}- #{spell[1].as_time}\n"
+              }
+              output.concat "\n"
+              respond output
+            end
+          end
+        elsif (@active_attributes.last['type'] == 'skills') and (name = @active_attributes.last['from'])
+          order = [ 'Two Weapon Combat', 'Armor Use', 'Shield Use', 'Combat Maneuvers', 'Edged Weapons', 'Blunt Weapons', 'Two-Handed Weapons', 'Ranged Weapons', 'Thrown Weapons', 'Polearm Weapons', 'Brawling', 'Ambush', 'Multi Opponent Combat', 'Combat Leadership', 'Physical Fitness', 'Dodging', 'Arcane Symbols', 'Magic Item Use', 'Spell Aiming', 'Harness Power', 'Elemental Mana Control', 'Mental Mana Control', 'Spirit Mana Control', 'Elemental Lore - Air', 'Elemental Lore - Earth', 'Elemental Lore - Fire', 'Elemental Lore - Water', 'Spiritual Lore - Blessings', 'Spiritual Lore - Religion', 'Spiritual Lore - Summoning', 'Sorcerous Lore - Demonology', 'Sorcerous Lore - Necromancy', 'Mental Lore - Divination', 'Mental Lore - Manipulation', 'Mental Lore - Telepathy', 'Mental Lore - Transference', 'Mental Lore - Transformation', 'Survival', 'Disarming Traps', 'Picking Locks', 'Stalking and Hiding', 'Perception', 'Climbing', 'Swimming', 'First Aid', 'Trading', 'Pickpocketing', 'Major Elemental', 'Minor Elemental', 'Minor Mental', 'Major Spirit', 'Minor Spirit', 'Wizard', 'Sorcerer', 'Ranger', 'Paladin', 'Empath', 'Cleric', 'Bard' ]
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for skill information."
+            elsif data == false
+              echo 'no such user'
+            else
+              output = "\n#{name}:\n\n"
+              output.concat "  Skill Name                         | Current Current\n"
+              output.concat "                                     |   Bonus   Ranks\n"
+              order.each { |skill_name|
+                if data[skill_name]
+                  if skill_name =~ /Minor Elemental|Major Elemental|Minor Mental|Minor Spirit|Major Spirit|Wizard|Sorcerer|Ranger|Paladin|Empath|Cleric|Bard/
+                    output.concat "\nSpell Lists\n"
+                    output.concat "  #{skill_name.ljust(35, '.')}|#{data[skill_name].to_s.rjust(16)}\n"
+                  else
+                    output.concat "  #{skill_name.ljust(35, '.')}|#{Skills.to_bonus(data[skill_name]).to_s.rjust(8)}#{data[skill_name].to_s.rjust(8)}\n"
+                  end
+                  data.delete(skill_name)
+                end
+              }
+              # data should be empty by now, but just in case..
+              data.each_pair { |skill_name,ranks|
+                if skill_name =~ /Minor Elemental|Major Elemental|Minor Mental|Minor Spirit|Major Spirit|Wizard|Sorcerer|Ranger|Paladin|Empath|Cleric|Bard/
+                  output.concat "\nSpell Lists\n"
+                  output.concat "  #{skill_name.ljust(35, '.')}|#{ranks.to_s.rjust(16)}\n"
+                else
+                  output.concat "  #{skill_name.ljust(35, '.')}|#{Skills.to_bonus(ranks).to_s.rjust(8)}#{ranks.to_s.rjust(8)}\n"
+                end
+              }
+              output.concat "\n"
+              respond output
+            end
+          end
+        elsif (@active_attributes.last['type'] == 'info') and (name = @active_attributes.last['from'])
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for stat information."
+            elsif data == false
+              echo 'no such user'
+            else
+              output = String.new
+              output.concat "\nName: #{name} Race: #{data['Race']}  Profession: #{data['Profession']}\n"
+              output.concat "Gender: #{data['Gender']}    Age: #{data['Age']}    Expr: #{data['Expr']}    Level:  #{data['Level']}\n"
+              output.concat "                  Normal (Bonus)  ...  Enhanced (Bonus)\n"
+              output.concat "    Strength (STR):   #{data['Strength'][0].to_s.rjust(3)} (#{data['Strength'][1].to_s.rjust(2)})    ...  #{data['Strength'][0].to_s.rjust(3)} (#{data['Strength'][1].to_s.rjust(2)})\n"
+              output.concat "Constitution (CON):   #{data['Constitution'][0].to_s.rjust(3)} (#{data['Constitution'][1].to_s.rjust(2)})    ...  #{data['Constitution'][0].to_s.rjust(3)} (#{data['Constitution'][1].to_s.rjust(2)})\n"
+              output.concat "   Dexterity (DEX):   #{data['Dexterity'][0].to_s.rjust(3)} (#{data['Dexterity'][1].to_s.rjust(2)})    ...  #{data['Dexterity'][0].to_s.rjust(3)} (#{data['Dexterity'][1].to_s.rjust(2)})\n"
+              output.concat "     Agility (AGI):   #{data['Agility'][0].to_s.rjust(3)} (#{data['Agility'][1].to_s.rjust(2)})    ...  #{data['Agility'][0].to_s.rjust(3)} (#{data['Agility'][1].to_s.rjust(2)})\n"
+              output.concat "  Discipline (DIS):   #{data['Discipline'][0].to_s.rjust(3)} (#{data['Discipline'][1].to_s.rjust(2)})    ...  #{data['Discipline'][0].to_s.rjust(3)} (#{data['Discipline'][1].to_s.rjust(2)})\n"
+              output.concat "        Aura (AUR):   #{data['Aura'][0].to_s.rjust(3)} (#{data['Aura'][1].to_s.rjust(2)})    ...  #{data['Aura'][0].to_s.rjust(3)} (#{data['Aura'][1].to_s.rjust(2)})\n"
+              output.concat "       Logic (LOG):   #{data['Logic'][0].to_s.rjust(3)} (#{data['Logic'][1].to_s.rjust(2)})    ...  #{data['Logic'][0].to_s.rjust(3)} (#{data['Logic'][1].to_s.rjust(2)})\n"
+              output.concat "   Intuition (INT):   #{data['Intuition'][0].to_s.rjust(3)} (#{data['Intuition'][1].to_s.rjust(2)})    ...  #{data['Intuition'][0].to_s.rjust(3)} (#{data['Intuition'][1].to_s.rjust(2)})\n"
+              output.concat "      Wisdom (WIS):   #{data['Wisdom'][0].to_s.rjust(3)} (#{data['Wisdom'][1].to_s.rjust(2)})    ...  #{data['Wisdom'][0].to_s.rjust(3)} (#{data['Wisdom'][1].to_s.rjust(2)})\n"
+              output.concat "   Influence (INF):   #{data['Influence'][0].to_s.rjust(3)} (#{data['Influence'][1].to_s.rjust(2)})    ...  #{data['Influence'][0].to_s.rjust(3)} (#{data['Influence'][1].to_s.rjust(2)})\n"
+              output.concat "Mana:  #{data['Mana']}\n\n"
+              respond output
+            end
+          end
+        elsif (@active_attributes.last['type'] == 'health') and (name = @active_attributes.last['from'])
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for health information."
+            elsif data == false
+              echo 'no such user'
+            else
+              wound_message = {
+                'head'      => [ '', 'minor bruises about the head', 'minor lacerations about the head and a possible mild concussion', 'severe head trauma and bleeding from the ears' ],
+                'neck'      => [ '', 'minor bruises on your neck', 'moderate bleeding from your neck', 'snapped bones and serious bleeding from the neck' ],
+                'chest'     => [ '', 'minor cuts and bruises on your chest', 'deep lacerations across your chest', 'deep gashes and serious bleeding from your chest' ],
+                'abdomen'   => [ '', 'minor cuts and bruises on your abdominal area', 'deep lacerations across your abdominal area', 'deep gashes and serious bleeding from your abdominal area' ],
+                'back'      => [ '', 'minor cuts and bruises on your back', 'deep lacerations across your back', 'deep gashes and serious bleeding from your back' ],
+                'rightEye'  => [ '', 'a bruised right eye', 'a swollen right eye', 'a blinded right eye' ],
+                'leftEye'   => [ '', 'a bruised left eye', 'a swollen left eye', 'a blinded left eye' ],
+                'rightLeg'  => [ '', 'some minor cuts and bruises on your right leg', 'a fractured and bleeding right leg', 'a completely severed right leg' ],
+                'leftLeg'   => [ '', 'some minor cuts and bruises on your left leg', 'a fractured and bleeding left leg', 'a completely severed left leg' ],
+                'rightArm'  => [ '', 'some minor cuts and bruises on your right arm', 'a fractured and bleeding right arm', 'a completely severed right arm' ],
+                'leftArm'   => [ '', 'some minor cuts and bruises on your left arm', 'a fractured and bleeding left arm', 'a completely severed left arm' ],
+                'rightHand' => [ '', 'some minor cuts and bruises on your right hand', 'a fractured and bleeding right hand', 'a completely severed right hand' ],
+                'leftHand'  => [ '', 'some minor cuts and bruises on your left hand', 'a fractured and bleeding left hand', 'a completely severed left hand' ],
+                'nsys'      => [ '', 'a strange case of muscle twitching', 'a case of sporadic convulsions', 'a case of uncontrollable convulsions' ],
+                'rightFoot' => [ '', 'missing message', 'missing message', 'missing message' ],
+                'leftFoot'  => [ '', 'missing message', 'missing message', 'missing message' ],
+              }
+              scar_message = {
+                'head'      => [ '', 'a scar across your face', 'several facial scars', 'old mutilation wounds about your head' ],
+                'neck'      => [ '', 'a scar across your neck', 'some old neck wounds', 'terrible scars from some serious neck injury' ],
+                'chest'     => [ '', 'an old battle scar across your chest', 'several painful-looking scars across your chest', 'terrible, permanent mutilation of your chest muscles' ],
+                'abdomen'   => [ '', 'an old battle scar across your abdominal area', 'several painful-looking scars across your abdominal area', 'terrible, permanent mutilation of your abdominal muscles' ],
+                'back'      => [ '', 'an old battle scar across your back', 'several painful-looking scars across your back', 'terrible, permanent mutilation of your back muscles' ],
+                'rightEye'  => [ '', 'a black-and-blue right eye', 'severe bruises and swelling around your right eye', 'a missing right eye' ],
+                'leftEye'   => [ '', 'a black-and-blue left eye', 'severe bruises and swelling around your left eye', 'a missing left eye' ],
+                'rightLeg'  => [ '', 'old battle scars on your right leg', 'a mangled right leg', 'a missing right leg' ],
+                'leftLeg'   => [ '', 'old battle scars on your left leg', 'a mangled left leg', 'a missing left leg' ],
+                'rightArm'  => [ '', 'old battle scars on your right arm', 'a mangled right arm', 'a missing right arm' ],
+                'leftArm'   => [ '', 'old battle scars on your left arm', 'a mangled left arm', 'a missing left arm' ],
+                'rightHand' => [ '', 'old battle scars on your right hand', 'a mangled right hand', 'a missing right hand' ],
+                'leftHand'  => [ '', 'old battle scars on your left hand', 'a mangled left hand', 'a missing left hand' ],
+                'nsys'      => [ '', 'developed slurred speech', 'constant muscle spasms', 'a very difficult time with muscle control' ],
+                'rightFoot' => [ '', 'missing message', 'missing message', 'missing message' ],
+                'leftFoot'  => [ '', 'missing message', 'missing message', 'missing message' ],
+              }
+              output = "\n#{name}:\n\n"
+              if data['injuries'].values.any? { |hash| (hash['wound'].to_i > 0) or (hash['scar'].to_i > 0) }
+                wound_array = data['injuries'].to_a.collect { |inj| wound_message[inj[0]][inj[1]['wound'].to_i] }.delete_if { |msg| msg.nil? or msg.empty? }
+                if wound_array.length == 1
+                  output.concat "You have #{wound_array.first}.\n"
+                elsif wound_array.length > 1
+                  output.concat "You have #{wound_array[0..-2].join(', ')}, and #{wound_array[-1]}.\n"
+                end
+                scar_array = data['injuries'].to_a.collect { |inj| scar_message[inj[0]][inj[1]['scar'].to_i] }.delete_if { |msg| msg.nil? or msg.empty? }
+                if scar_array.length == 1
+                  output.concat "You have #{scar_array.first}.\n"
+                elsif scar_array.length > 1
+                  output.concat "You have #{scar_array[0..-2].join(', ')}, and #{scar_array[-1]}.\n"
+                end
+              else
+                output.concat "You seem to be in one piece.\n"
+              end
+              output.concat "\n"
+              output.concat "    Maximum Health Points: #{data['max_health']}\n"
+              output.concat "  Remaining Health Points: #{data['health']}\n"
+              output.concat "\n"
+              output.concat "    Maximum Spirit Points: #{data['max_spirit']}\n"
+              output.concat "  Remaining Spirit Points: #{data['spirit']}\n"
+              output.concat "\n"
+              output.concat "    Maximum Stamina Points: #{data['max_stamina']}\n"
+              output.concat "  Remaining Stamina Points: #{data['stamina']}\n"
+              output.concat "\n"
+              respond output
+            end
+          end
+        elsif (@active_attributes.last['type'] == 'locate') and (name = @active_attributes.last['from'])
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for location information."
+            elsif data == false
+              echo 'no such user'
+            else
+              output = "\n#{name}:\n\n"
+              also_see = Array.new
+              data['npcs'].each { |npc| if npc['status'].nil?; also_see.push(npc['name']); else; also_see.push("#{npc['name']} (#{npc['status']})"); end }
+              also_see = (also_see + data['loot']) unless data['loot'].nil? or data['loot'].empty?
+              also_here = Array.new
+              data['pcs'].each { |pc| if pc['status'].nil?; also_here.push(pc['name']); else; also_here.push("#{pc['name']} (#{pc['status']})"); end }
+              room = Map.list.find { |room| room.title.include?(data['title']) and room.desc.include?(data['description'].strip) and room.paths.include?(data['exits']) }
+              unless room
+                desc_regex = /#{Regexp.escape(data['description'].strip.sub(/\.+$/, '')).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+                room = Map.list.find { |room| room.title.include?(data['title']) and room.paths.include?(data['exits']) and room.desc.find { |desc| desc =~ desc_regex } }
+              end
+              output.concat "#{data['title']}#{' (' + room.id.to_s + ')' if room}\n"
+              if also_see.empty?
+                output.concat "#{data['description']}\n"
+              else
+                output.concat "#{data['description']}  You also see #{also_see.join(', ')}.\n"
+              end
+              output.concat "Also here: #{also_here.join(', ')}\n" unless also_here.empty?
+              output.concat "#{data['exits']}\n"
+              respond output
+            end
+          end
+        elsif (@active_attributes.last['type'] == 'bounty') and (name = @active_attributes.last['from'])
+          unless LNet.ignored?(name)
+            if data.nil?
+              echo "#{name} declined your request for bounty information."
+            elsif data == false
+              echo 'no such user'
+            else
+              respond "\n#{name}:\n#{data}\n\n"
+            end
+          end
+        else
+          # echo data.inspect
+        end
+
+      end
+    rescue
+      echo $!
+      respond $!.backtrace[0..1]
+    end
+  end
+
+  def tag_end(tag_name)
+    @active_tags.pop
+    @active_attributes.pop
+  end
+
+end
+
+unless defined?(UNTRUSTED_LNET_GET_DATA)
+  UNTRUSTED_LNET_GET_DATA = proc { |name, type| LNet.get_data(name, type) }
+end
+
+unless defined?(UNTRUSTED_LNET_UPLOAD_SPELL_RANKS)
+  UNTRUSTED_LNET_UPLOAD_SPELL_RANKS = proc { LNet.upload_spell_ranks }
+end
+
+def lichnet_get_spells(name)
+  LNet.get_data(name, 'spells')
+end
+
+CharSettings['options'] ||= Hash.new
+LNet.options = CharSettings['options']
+
+CharSettings['secret'] ||= Array.new
+LNet.store_secret = CharSettings['secret']
+
+if LNet.options.empty?
+  LNet.options['timestamps'] = Settings['options']['timestamps']
+  LNet.options['fam_window'] = Settings['options']['fam_window']
+  LNet.options['greeting']   = Settings['options']['greeting']
+  LNet.options['friends']    = Settings['options']['friends'].dup
+  LNet.options['enemies']    = Settings['options']['enemies'].dup
+  LNet.options['permission'] = Settings['options']['permission'].dup
+  LNet.options['ignore']     = Settings['options']['ignore'].dup
+  LNet.secret                = Settings['options'][XMLData.name]['password'].dup
+  Settings['options'][XMLData.name]['password'] = nil
+end
+
+LNet.options['timestamps'] = false if LNet.options['timestamps'].nil?
+LNet.options['fam_window'] = false if LNet.options['timestamps'].nil?
+LNet.options['greeting']   = true  if LNet.options['greeting'].nil?
+
+LNet.options['friends']    = Array.new unless LNet.options['friends'].class    == Array
+LNet.options['enemies']    = Array.new unless LNet.options['enemies'].class    == Array
+LNet.options['permission'] = Hash.new  unless LNet.options['permission'].class == Hash
+LNet.options['ignore']     = Array.new unless LNet.options['ignore'].class     == Array
+
+Settings['alias']          = Hash.new  unless Settings['alias'].class          == Hash
+LNet.alias = Settings['alias']
+
+if script.vars[1] =~ /^password=([^\s]+)$/i
+  if $1 == 'nil'
+    LNet.secret = nil
+    echo 'Password cleared.'
+  else
+    LNet.secret = $1
+    echo 'Password saved locally.'
+  end
+elsif script.vars[1].downcase == 'help'
+  script.unique_buffer.push('help')
+end
+
+before_dying { LNet.server.close rescue(); LNet.script = nil }
+LNet.script = Script.self
+
+#
+# capture input from the client
+#
+script_name = script.name.dup
+action = proc { |client_string|
+  begin
+    if client_string =~ /^(?:<c>)?#{$lich_char}(,|chat |reply |who|locate |spells |info |skills |health |bounty |tune |untune |channels?)(.*)/
+      cmd, extra = $1, $2
+      cmd = 'chat ' if cmd == ','
+      if s = (Script.running + Script.hidden).find { |val| val.name == script_name }
+        s.unique_buffer.push("#{cmd}#{extra}")
+        nil
+      else
+        respond '--- Lich: lnet is not running'
+        UpstreamHook.remove(script_name)
+        nil
+      end
+    elsif client_string =~ /^(?:<c>)?#{$lich_char}([A-z]+):(.*)/
+      name, message = $1, $2
+      if s = (Script.running + Script.hidden).find { |val| val.name == script_name }
+        s.unique_buffer.push("chat ::#{name} #{message}")
+        nil
+      else
+        respond '--- Lich: lnet is not running'
+        UpstreamHook.remove(script_name)
+        nil
+      end
+    elsif client_string =~ /^(?:<c>)?#{$lich_char}#{script_name}(.*)/
+      cmd = $1
+      if s = (Script.running + Script.hidden).find { |val| val.name == script_name }
+        s.unique_buffer.push(cmd)
+        nil
+      else
+        UpstreamHook.remove(script_name)
+        client_string
+      end
+    else
+      client_string
+    end
+  rescue
+    UpstreamHook.remove(script_name)
+    client_string
+  end
+}
+before_dying { UpstreamHook.remove(script_name) }
+UpstreamHook.add(script_name, action)
+
+#
+# keepalive
+#
+Thread.new {
+  loop {
+    begin
+      sleep [50 - (Time.now - LNet.last_send), 5].max
+      LNet.send_ping if (Time.now - LNet.last_send) > 49
+    rescue
+      echo $!
+      puts $!.backtrace[0..1]
+      sleep 1
+    end
+  }
+}
+
+#
+# connect and listen to the server
+#
+Thread.new {
+  loop {
+    last_connect_attempt = Time.now
+    begin
+      LNet.connect
+      LNet.send_request(attr={'type'=>'spell-ranks', 'to'=>'server', 'timestamp'=>SpellRanks.timestamp.to_s}) if defined?(SpellRanks)
+      REXML::Document.parse_stream(LNet.server, LNet.new)
+    rescue
+      echo $!
+      respond $!.backtrace[0..1]
+    end
+    LNet.server.close rescue()
+    if LNet.server_restart
+      LNet.server_restart = false
+      echo 'server is restarting; waiting 30 seconds to reconnect...'
+      sleep 30
+    else
+      echo 'connection lost'
+      wait_time = [300 - (Time.now - last_connect_attempt), 1].max
+      if wait_time > 1
+        echo "waiting #{wait_time.to_i} seconds before trying to reconnect..."
+      end
+      sleep wait_time
+    end
+  }
+}
+
+#
+# report found herb locations
+#
+if XMLData.game =~ /^GS/
+  room_title = XMLData.room_title
+  room_description = XMLData.room_description
+  room_exits = XMLData.room_exits_string
+  found_list = Array.new
+  stick = /^(?:stick|thick|stained|slender|pointed|twisted|long|slim|charred|flexible|sturdy|dark|hefty|cracked|thin|small|bent|short|heavy) stick$/
+  hook_proc = proc { |server_string|
+    if server_string =~ /^(?:<.*?>)?.*?<streamWindow id='room' title=.*? subtitle=" - (.*?)" location=.*?>.*?<compDef id='room desc'>(.*?)<\/compDef>/
+      room_title = "[#{$1}]"
+      room_description = $2.gsub(/<.*?>/, '')
+    elsif server_string =~ /<compDef id='room exits'>(.*?)<\/compDef>/
+      room_exits = $1.gsub(/<.*?>/, '')
+    elsif server_string =~ /^You forage briefly and manage to find (?:a |an )?<a exist=".*?" noun=".*?">(.*?)<\/a>!/
+      herb = $1
+      if herb =~ stick
+        herb = 'stick'
+      end
+      found_list.push h={ :herb => herb, :room_title => room_title, :room_description => room_description, :room_exits => room_exits }
+    end
+    server_string
+  }
+  Thread.new {
+    begin
+      DownstreamHook.add('lnet-watch-forage', hook_proc)
+      loop {
+        wait_while { found_list.empty? }
+        found = found_list.shift
+        room_list = Map.list.find_all { |r| r.title.include?(found[:room_title]) and r.description.include?(found[:room_description].strip) and r.paths.include?(found[:room_exits].strip) }
+        if room_list.length == 1
+          room = room_list.first
+          unless room.tags.include?(found[:herb])
+            room.tags.push(found[:herb])
+            found[:game] = XMLData.game
+            LNet.send_data(a={'to'=>'server','type'=>'forage'}, found)
+          end
+        end
+      }
+    rescue
+      echo $!
+      respond $![0..1]
+      sleep 0.3
+    ensure
+      DownstreamHook.remove('lnet-watch-forage')
+    end
+  }
+end
+
+if XMLData.game =~ /^DR/
+  room_title = XMLData.room_title
+  room_description = XMLData.room_description
+  room_exits = XMLData.room_exits_string
+  found_list = Array.new
+  hook_proc = proc { |server_string|
+    if server_string =~ /^(?:<.*?>)?.*?<streamWindow id='room' title=.*? subtitle=" - (.*?)" location/
+      room_title = "[#{$1}]"
+    elsif server_string =~ /<component id='room desc'>(.*?)<\/component>/
+      room_description = $1.gsub(/<.*?>/, '')
+    elsif server_string =~ /<component id='room exits'>(.*?)<\/component>/
+      room_exits = $1.gsub(/<.*?>/, '')
+    elsif server_string =~ /^(?:<.*?>)?You manage to find (?:a |an |some )?(.*?)\./
+      herb = $1
+      found_list.push h={ :herb => herb, :room_title => room_title, :room_description => room_description, :room_exits => room_exits }
+    elsif server_string =~ /^(?:<.*?>)?You manage to collect a pile of (.*?)s\./
+      herb = $1
+      herb.sub!(/leave$/, 'leaf')
+      herb.sub!(/gras$/, 'grass')
+      herb.sub!(/branche$/, 'branch')
+      found_list.push h={ :herb => herb, :room_title => room_title, :room_description => room_description, :room_exits => room_exits }
+    end
+    server_string
+  }
+  Thread.new {
+    begin
+      DownstreamHook.add('lnet-watch-forage', hook_proc)
+      loop {
+        wait_while { found_list.empty? }
+        found = found_list.shift
+        room_list = Map.list.find_all { |r| r.title.include?(found[:room_title]) and r.description.include?(found[:room_description].strip) and r.paths.include?(found[:room_exits].strip) }
+        if room_list.length == 1
+          room = room_list.first
+          unless room.tags.include?(found[:herb])
+            room.tags.push(found[:herb])
+            found[:game] = XMLData.game
+            LNet.send_data(a={'to'=>'server','type'=>'forage'}, found)
+          end
+        end
+      }
+    rescue
+      echo $!
+      respond $![0..1]
+      sleep 0.3
+    ensure
+      DownstreamHook.remove('lnet-watch-forage')
+    end
+  }
+end
+
+#
+# listen to the user
+#
+while msg = unique_get.strip
+  if msg =~ /^chat\s+\:\:(.+?) (.*)/i or msg =~ /^chat\s+to\s+(.+?) (.*)/i
+    LNet.send_message(attr={'type'=>'private', 'to'=>$1}, $2)
+  elsif msg =~ /^chat\s+\:([^\:].*?) (.*)/i or msg =~ /^chat\s+on\s+(.+?) (.*)/i
+    LNet.send_message(attr={'type'=>'channel', 'channel'=>$1}, $2)
+  elsif msg =~ /^chat\s+(?!:\:|to |on |ot )(.*)/i
+    message = $1.sub(/^\.(to|on) /i, '\\1 ')
+    LNet.send_message(attr={'type'=>'channel'}, message)
+  elsif msg =~/reply\s(.+)/i
+    if LNet.last_priv
+      LNet.send_message(attr={'type'=>'private', 'to'=>LNet.last_priv}, $1)
+    else
+      echo "No private message to reply to."
+    end
+  elsif msg =~ /^who$/i
+    LNet.send_query(attr={'type'=>'connected'})
+  elsif msg =~ /^stats$/i
+    LNet.send_query(attr={'type'=>'server stats'})
+  elsif msg =~ /^who\s+([A-z\:]+)$/i
+    LNet.send_query(attr={'type'=>'connected', 'name'=>$1})
+  elsif msg =~ /^channels?\s*(full|all)?/i
+    if $1
+      LNet.send_query(attr={'type'=>'channels'})
+    else
+      LNet.send_query(attr={'type'=>'channels', 'num'=>'15'})
+    end
+  elsif msg =~ /^tune\s+([A-z]+)$/i
+    LNet.tune_channel($1)
+  elsif msg =~ /^untune\s+([A-z]+)$/i
+    LNet.untune_channel($1)
+  elsif msg =~ /^(spells|skills|info|locate|health|bounty)\s+([A-z\:]+)$/i
+    type = $1.downcase
+    name = $2
+    if LNet.ignored?(name)
+      echo "There's no point in sending a request to someone you're ignoring."
+    else
+      LNet.send_request(attr={'type'=>type, 'to'=>name})
+    end
+  elsif msg =~ /^add\s?alias\s+([^\s]+)\s+(.+)$/i
+    real_name = $1
+    aliased_name = $2
+    old_alias = LNet.alias[real_name]
+    LNet.alias[real_name] = aliased_name
+    echo "chats from #{real_name} will now appear as #{aliased_name}"
+    if real_name !~ /^[A-Z][A-z]+:[A-Z][a-z]+$/
+      echo "The name should be entered exactly as it appears in the thought window, for example:   ;lnet add alias GSIV:Jeril StrangerDanger"
+      echo "If #{real_name} is incorrect, you can remove it using:   ;lnet remove alias #{aliased_name}"
+    end
+  elsif msg =~ /^(?:del|rem|delete|remove)\s?alias\s+(.+)$/i
+    aliased_name = $1
+    if LNet.alias.values.any? { |v| v == aliased_name }
+      LNet.alias.delete_if { |k,v| v == aliased_name }
+      echo "alias deleted"
+    else
+      echo "couldn't find an alias by that name"
+    end
+  elsif msg =~ /^aliases$/i
+    if LNet.alias.empty?
+      echo 'You have no aliases.'
+    else
+      output = "\n"
+      max_k = 0; max_v = 0; LNet.alias.each_pair { |k,v| max_k = [max_k,k.length].max; max_v = [max_v,v.length].max }
+      LNet.alias.each_pair { |k,v|
+        output.concat "   #{k.ljust(max_k)} => #{v.ljust(max_v)}\n"
+      }
+      output.concat "\n"
+      respond output
+    end
+  elsif msg =~ /^add\s?friends?\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['friends'].include?(name)
+      echo "#{name} is already on your friend list."
+    else
+      LNet.options['friends'].push(name)
+      echo "#{name} was added to your friend list."
+    end
+  elsif msg =~ /^(?:del|rem|delete|remove)\s?friends?\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['friends'].delete(name)
+      echo "#{name} was removed from your friend list."
+    else
+      echo "#{name} was not found on your friend list."
+    end
+  elsif msg =~ /^add\s?en[ie]m(?:y|ies)\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['enemies'].include?(name)
+      echo "#{name} is already on your enemy list."
+    else
+      LNet.options['enemies'].push(name)
+      echo "#{name} was added to your enemy list."
+    end
+  elsif msg =~ /^(?:del|rem|delete|remove)\s?en[ie]m(?:y|ies)\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['enemies'].delete(name)
+      echo "#{name} was removed from your enemy list."
+    else
+      echo "#{name} was not found on your enemy list."
+    end
+  elsif msg =~ /^friends?$/i
+    if LNet.options['friends'].empty?
+      echo 'You have no friends.'
+    else
+      echo "friends: #{LNet.options['friends'].join(', ')}"
+    end
+  elsif msg =~ /^enem(?:y|ies)$/i
+    if LNet.options['enemies'].empty?
+      echo 'You have no enemies.'
+    else
+      echo "enemies: #{LNet.options['enemies'].join(', ')}"
+    end
+  elsif msg =~ /^allow$/i
+    fix_type = { 'all' => 'everyone', 'friends' => 'only your friends', 'enemies' => 'everyone except your enemies', 'none' => 'no one', nil => 'no one' }
+    fix_action = { 'locate' => 'locate you', 'spells' => 'view your active spells', 'skills' => "view your #{if rand(100)==0; 'mad '; end}skills", 'info' => 'view your stats', 'health' => 'view your health', 'bounty' => 'view your bounties' }
+    [ 'locate', 'spells', 'skills', 'info', 'health', 'bounty' ].each { |action|
+      respond "You are allowing #{fix_type[LNet.options['permission'][action]]} to #{fix_action[action]}."
+    }
+  elsif msg =~ /^allow\s+(locate|spells|skills|info|health|bounty|all)\s+(all|friend|friends|non\-enemies|nonenemies|enemies|enemy|none)$/i
+    action, group = $1, $2
+    fix_action = { 'locate' => 'locate you', 'spells' => 'view your active spells', 'skills' => "view your #{if rand(100)==0; 'mad '; end}skills", 'info' => 'view your stats', 'health' => 'view your health', 'bounty' => 'view your bounties' }
+    if action =~ /^all$/i
+      for action in [ 'locate', 'spells', 'skills', 'info', 'health', 'bounty' ]
+        if group =~ /^all$/i
+          LNet.options['permission'][action] = 'all'
+          echo "You are now allowing everyone to #{fix_action[action]}."
+        elsif group =~ /^friends?$/i
+          LNet.options['permission'][action] = 'friends'
+          echo "You are now allowing only your friends to #{fix_action[action]}."
+        elsif group =~ /enem/i
+          LNet.options['permission'][action] = 'enemies'
+          echo "You are now allowing everyone except your enemies to #{fix_action[action]}."
+        elsif group =~ /^none$/i
+          LNet.options['permission'][action] = 'none'
+          echo "You are now allowing no one to #{fix_action[action]}."
+        end
+      end
+    elsif group =~ /^all$/i
+      LNet.options['permission'][action] = 'all'
+      echo "You are now allowing everyone to #{fix_action[action]}."
+    elsif group =~ /^friends?$/i
+      LNet.options['permission'][action] = 'friends'
+      echo "You are now allowing only your friends to #{fix_action[action]}."
+    elsif group =~ /enem/i
+      LNet.options['permission'][action] = 'enemies'
+      echo "You are now allowing everyone except your enemies to #{fix_action[action]}."
+    elsif group =~ /^none$/i
+      LNet.options['permission'][action] = 'none'
+      echo "You are now allowing no one to #{fix_action[action]}."
+    end
+  elsif msg =~ /^ignore$/i
+    if LNet.options['ignore'].empty?
+      echo 'You are not ignoring anyone.'
+    else
+      echo "You are ignoring the following people: #{LNet.options['ignore'].join(', ')}"
+    end
+  elsif msg =~ /^ignore\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['ignore'].include?(name)
+      echo "You were already ignoring #{name}."
+    else
+      LNet.options['ignore'].push(name)
+      echo "You are now ignoring #{name}."
+    end
+  elsif msg =~ /^unignore\s+([A-z]+\:)?([A-z]+)$/i
+    fix_game = { 'gsf' => 'GSF', 'gsiv' => 'GSIV', 'gsplat' => 'GSPlat' }
+    name = $2.capitalize
+    if game = $1.sub(/\:$/, '')
+      game = fix_game[game.downcase] if fix_game[game.downcase]
+      name = "#{game}:#{name}"
+    end
+    if LNet.options['ignore'].delete(name)
+      echo "You are no longer ignoring #{name}."
+    else
+      echo "#{name} wasn't being ignored."
+    end
+  elsif msg =~ /^timestamps?=(on|off)$/i
+    if $1 == 'on'
+      LNet.options['timestamps'] = true
+      echo 'timestamps will be shown'
+    else
+      LNet.options['timestamps'] = false
+      echo 'timestamps will not be shown'
+    end
+  elsif msg =~ /^famwindow=(on|off)$/i
+    if $1 == 'on'
+      LNet.options['fam_window'] = true
+      echo 'chats will be sent to the familiar window'
+    else
+      LNet.options['fam_window'] = false
+      echo 'chats will be sent to the thought window'
+    end
+  elsif msg =~ /^greeting=(on|off)$/i
+    if $1 == 'on'
+      LNet.options['greeting'] = true
+      echo 'greeting will be shown at login'
+    else
+      LNet.options['greeting'] = false
+      echo 'getting will not be shown'
+    end
+  elsif msg =~ /^password=([^\s]+)$/i
+    LNet.send_data(attr={'type'=>'newpassword'}, $1)
+    if $1 == 'nil'
+      LNet.secret = nil
+      echo 'Password cleared.'
+    else
+      LNet.secret = $1
+      echo 'Password saved locally.'
+    end
+  elsif msg =~ /^email=([^\s]+)$/i
+    LNet.send_data(attr={'type'=>'newemail'}, $1)
+  elsif msg =~ /^(ban|gag|mod|banip)\s+([\:A-z0-9]+)\s+on\s+([A-z]+)$/i
+    LNet.moderate(attr={'action'=>$1.downcase, 'name'=>$2, 'channel'=>$3})
+  elsif msg =~ /^(ban|gag|banip)\s+([\:A-z0-9]+)\s+on\s+([A-z]+)\s+for\s+([0-9]+)\s*(seconds?|minutes?|hours?|days?|years?|s|m|h|d|y)$/i
+    multiplier = { nil => 1, 's' => 1, 'second' => 1, 'seconds' => 1, 'm' => 60, 'minute' => 60, 'minutes' => 60, 'h' => 3600, 'hour' => 3600, 'hours' => 3600, 'd' => 86400, 'day' => 86400, 'days' => 86400, 'y' => 31536000, 'year' => 31536000, 'years' => 31536000 }
+    LNet.moderate(attr={'action'=>$1.downcase, 'name'=>$2, 'channel'=>$3, 'length'=>($4.to_i * multiplier[$5]).to_s})
+  elsif msg =~ /^(unban|ungag|unmod)\s+([\:A-z0-9]+)\s+on\s+([A-z]+)$/i
+    LNet.moderate(attr={'action'=>$1.downcase, 'name'=>$2, 'channel'=>$3})
+  elsif msg =~ /^create\s+(hidden)?\s*(private)?\s*channel\s+([A-z]+)\s+(.+?)$/i
+    attr = attr={ 'action'=>'create channel', 'name'=>$3, 'description'=>$4.strip }
+    if $1
+      attr['hidden'] = 'yes'
+    else
+      attr['hidden'] = 'no'
+    end
+    if $2
+      attr['private'] = 'yes'
+    else
+      attr['private'] = 'no'
+    end
+    LNet.admin(attr)
+  elsif msg =~ /^create\s+poll\s+/i
+    if msg =~ /\-\-question\s+(.+?)\s*(?:\-\-|$)/
+      question = $1[0,512].strip
+    else
+      question = nil
+    end
+    if msg =~ /\-\-vote\-time\s+([0-9]+)\s*(seconds?|minutes?|hours?|days?|years?|s|m|h|d|y)(?:\-\-|$)/
+      multiplier = { nil => 1, 's' => 1, 'second' => 1, 'seconds' => 1, 'm' => 60, 'minute' => 60, 'minutes' => 60, 'h' => 3600, 'hour' => 3600, 'hours' => 3600, 'd' => 86400, 'day' => 86400, 'days' => 86400, 'y' => 31536000, 'year' => 31536000, 'years' => 31536000 }
+      vote_time = $1.to_i * multiplier[$2]
+    else
+      vote_time = nil
+    end
+    num = 1
+    option = Hash.new
+    while msg =~ /\-\-option\-#{num}\s+(.+?)\s*(?:\-\-|$)/
+      option[num] = $1[0,64].strip
+      num += 1
+    end
+    if question and (option.length > 1)
+      attr = { 'action'=>'create poll', 'question'=>question }
+      option.each_pair { |num,opt| attr["option #{num}"] = opt }
+      if vote_time
+        attr['length'] = vote_time
+      end
+      # fixme: confirm
+      LNet.admin(attr)
+    else
+      echo "You're doing it wrong.  Type #{$clean_lich_char}#{script.name} help"
+    end
+  elsif msg =~ /^delete\s+channel\s+([A-z]+)$/i
+    LNet.admin(attr={'action'=>'delete channel', 'name'=>$1})
+  elsif msg =~ /^eval (.+)$/
+    LNet.send_data(attr={'type'=>'eval'}, $1)
+  elsif msg =~ /^help$/i
+    output = String.new
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}chat <message>                     send a message to your default channel\n"
+    output.concat "#{$clean_lich_char},<message>                         ''\n"
+    output.concat "#{$clean_lich_char}chat on <channel name> <message>   send a message to the given channel\n"
+    output.concat "#{$clean_lich_char}chat :<channel name> <message>     ''\n"
+    output.concat "#{$clean_lich_char}chat to <name> <message>           send a private message\n"
+    output.concat "#{$clean_lich_char}chat ::<name> <message>            ''\n"
+    output.concat "#{$clean_lich_char}<name>:<message>                   ''\n"
+    output.concat "#{$clean_lich_char}who                                list who's connected\n"
+    output.concat "#{$clean_lich_char}who <channel>                      list who's tuned into the given channel\n"
+    output.concat "#{$clean_lich_char}who <name>                         tells if a user is connected\n"
+    output.concat "#{$clean_lich_char}channels                           list the 15 most populated channels\n"
+    output.concat "#{$clean_lich_char}channels full                      list all available channels\n"
+    output.concat "#{$clean_lich_char}tune <channel name>                listen to the given channel, or set as default if already tuned\n"
+    output.concat "#{$clean_lich_char}untune <channel name>              stop listening to the given channel\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}locate <name>                      show someone's current room\n"
+    output.concat "#{$clean_lich_char}spells <name>                      show someone's active spells and time remaining\n"
+    output.concat "#{$clean_lich_char}skills <name>                      show someone's skills\n"
+    output.concat "#{$clean_lich_char}info <name>                        show someone's stats\n"
+    output.concat "#{$clean_lich_char}health <name>                      show someone's health, spirit, stamina and injuries\n"
+    output.concat "#{$clean_lich_char}bounty <name>                      show someone's current adventurer's guild task\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} stats                         unhelpful information\n"
+    output.concat "#{$clean_lich_char}#{script.name} timestamps=<on/off>           turn on/off all chats having a timestamp\n"
+    output.concat "#{$clean_lich_char}#{script.name} famwindow=<on/off>            turn on/off sending chats to your familiar window\n"
+    output.concat "#{$clean_lich_char}#{script.name} greeting=<on/off>             turn on/off showing a server greeting at logon\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} friends                       list friends\n"
+    output.concat "#{$clean_lich_char}#{script.name} add friend <name>             add a name to your friend list\n"
+    output.concat "#{$clean_lich_char}#{script.name} del friend <name>             delete a name from your friend list\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} enemies                       list enemies\n"
+    output.concat "#{$clean_lich_char}#{script.name} add enemy <name>              add a name to your enemy list\n"
+    output.concat "#{$clean_lich_char}#{script.name} del enemy <name>              delete a name from your enemy list\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} allow                         list your current permissions\n"
+    output.concat "#{$clean_lich_char}#{script.name} allow <action> <group>        set permissions\n"
+    output.concat "      <action> can be one of: locate, spells, skills, info, health, bounty, all\n"
+    output.concat "      <group> can be one of: all, friends, non-enemies, none\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} aliases                       list aliases\n"
+    output.concat "#{$clean_lich_char}#{script.name} add alias <name> <new_name>   causes chats from name to appear as new_name\n"
+    output.concat "#{$clean_lich_char}#{script.name} del alias <new_name>          delete an alias\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} ignore                        list names currently being ignored\n"
+    output.concat "#{$clean_lich_char}#{script.name} ignore <name>                 ignore chats/private chats/data requests from a person\n"
+    output.concat "#{$clean_lich_char}#{script.name} unignore <name>               unignore a person\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} password=<password>           protect your character name on the server with a password\n"
+    output.concat "#{$clean_lich_char}#{script.name} password=nil                  remove password protection\n"
+#   output.concat "#{$clean_lich_char}#{script.name} email=<email>                 save your email address on the server for password recovery\n"
+#   output.concat "#{$clean_lich_char}#{script.name} email=nil                     delete your email address from the server\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} create [hidden] [private] channel <name> <description>\n"
+    output.concat "      hidden channels don't show up in the channel list\n"
+    output.concat "      private channels ban everyone by default, and the owner (or moderator) must unban anyone he wants to allow in\n"
+#   output.concat "#{$clean_lich_char}#{script.name} modify channel <name> <new description>\n"
+    output.concat "#{$clean_lich_char}#{script.name} delete channel <name>\n"
+    output.concat "\n"
+    output.concat "#{$clean_lich_char}#{script.name} ban <character> on <channel> for <time>\n"
+    output.concat "#{$clean_lich_char}#{script.name} unban <character> on <channel>\n"
+    output.concat "#{$clean_lich_char}#{script.name} gag <character> on <channel> for <time>\n"
+    output.concat "#{$clean_lich_char}#{script.name} ungag <character> on <channel>\n"
+    output.concat "#{$clean_lich_char}#{script.name} mod <character> on <channel>\n"
+    output.concat "#{$clean_lich_char}#{script.name} unmod <character> on <channel>\n"
+    output.concat "      <time> should be a number followed by one of: seconds, minutes, hours, days, or years (may be abbreviated to one letter)\n"
+    output.concat "\n"
+    respond output
+  else
+    echo "You're doing it wrong.  Type #{$clean_lich_char}#{script.name} help"
+  end
+end

--- a/spec/jinx/repos/core/assets/spell-list.xml
+++ b/spec/jinx/repos/core/assets/spell-list.xml
@@ -1,0 +1,2527 @@
+<?xml version='1.0'?>
+<list>
+   <spell availability='all' name='Spirit Warding I' number='101' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>1</cost>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='elemental-td'>5</bonus>
+      <bonus type='spirit-td'>10</bonus>
+      <bonus type='sorcerer-td'>8</bonus>
+      <message type='start'>A light blue glow surrounds you\.</message>
+      <message type='end'>The light blue glow leaves you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Spirit Barrier' number='102' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <duration cast-type='target' span='stackable'>if (history = reget.reverse) and (line = history.find { |l| l =~ /^The air thickens and begins to swirl around you\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <cost type='mana'>2 + (([Spells.minorspiritual,Stats.level].min - 2) / 6)</cost>
+      <bonus type='physical-as'>0-(20+((Spells.minorspiritual-2)/2))</bonus>
+      <bonus type='bolt-ds'>[20+((Spells.minorspiritual-2)/2),20].max</bonus>
+      <bonus type='physical-ds'>[20+((Spells.minorspiritual-2)/2),20].max</bonus>
+      <message type='start'>The air thickens and begins to swirl around you\.</message>
+      <message type='end'>The air calms down around you\.</message>
+   </spell>
+   <spell availability='all' name='Spirit Defense' number='103' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>3</cost>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='physical-ds'>10</bonus>
+      <message type='start'>You suddenly feel more powerful\.</message>
+      <message type='end'>The powerful look leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Disease Resistance' number='104' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>4</cost>
+      <message type='start'>You feel a strengthening of your internal fortitude\.</message>
+      <message type='end'>You lose your extra internal fortitude\.</message>
+   </spell>
+   <spell availability='all' name='Poison Resistance' number='105' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>5</cost>
+      <message type='start'>You feel a strengthening of your blood flow\.</message>
+      <message type='end'>You notice your blood flow go back to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='Spirit Fog' number='106' type='defense'>
+      <duration>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Spirit Warding II' number='107' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>7</cost>
+      <bonus type='bolt-ds'>25</bonus>
+      <bonus type='elemental-td'>7</bonus>
+      <bonus type='spirit-td'>15</bonus>
+      <bonus type='sorcerer-td'>11</bonus>
+      <message type='start'>A deep blue glow surrounds you\.</message>
+      <message type='end'>The deep blue glow leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Stun Relief' number='108' type='utility'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Dispel Invisibility' number='109' type='utility'>
+      <cost type='mana'>9</cost>
+   </spell>
+   <spell availability='all' name='Unbalance' number='110' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Fire Spirit' number='111' stance='yes' type='attack/utility'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='all' name='Water Walking' number='112' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <cost type='mana'>12</cost>
+      <message type='start'>A misty halo surrounds you\.</message>
+      <message type='end'>The misty halo fades from you\.</message>
+   </spell>
+   <spell availability='all' name='Undisease' number='113' type='utility'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='all' name='Unpoison' number='114' type='utility'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Fasthr&apos;s Reward' number='115' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <duration cast-type='target'>2</duration>
+      <cost type='mana'>15</cost>
+      <message type='start'>A dull golden nimbus surrounds you\.</message>
+      <message type='end'>The dull golden nimbus fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Locate Person' number='116' type='utility'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='all' name='Spirit Strike' number='117' type='offense'>
+      <duration span='stackable'>2</duration>
+      <cost type='mana'>17</cost>
+      <bonus type='bolt-as'>75</bonus>
+      <bonus type='physical-as'>75</bonus>
+      <message type='start'>An invisible force guides you\.</message>
+      <message type='end'>The guiding force leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Web' number='118' stance='yes' type='attack'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='all' name='Spirit Dispel' number='119' type='attack/utility'>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='all' name='Lesser Shroud' number='120' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.minorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>2</duration>
+      <cost type='mana'>20 + (([[Spells.minorspiritual,Stats.level].min - 20,0].max) / 6.0).round</cost>
+      <bonus type='bolt-ds'>[15+((Spells.minorspiritual-20)/2),15].max</bonus>
+      <bonus type='physical-ds'>[15+((Spells.minorspiritual-20)/2),15].max</bonus>
+      <bonus type='elemental-td'>10</bonus>
+      <bonus type='spirit-td'>20</bonus>
+      <bonus type='sorcerer-td'>15</bonus>
+      <message type='start'>You suddenly feel a lot more powerful\.</message>
+      <message type='end'>The very powerful look leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Call Lightning' number='125' type='attack/utility'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Spirit Guide' number='130' type='utility'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Searing Light' number='135' type='attack'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Wall of Force' number='140' type='defense'>
+      <duration cast-type='self' span='refreshable'>1.5</duration>
+      <duration cast-type='target' span='refreshable'>1</duration>
+      <cost type='mana'>40</cost>
+      <bonus type='bolt-ds'>100</bonus>
+      <bonus type='physical-ds'>100</bonus>
+      <message type='start'>A wall of force surrounds you\.</message>
+      <message type='end'>The wall of force disappears from around you\.</message>
+   </spell>
+   <spell availability='all' name='Calm' number='201' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' name='Spirit Shield' number='202' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20+Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>20+Spells.majorspiritual</duration>
+      <cost type='mana'>[2+(([Spells.majorspiritual,Stats.level].min-2)/6),2].max</cost>
+      <bonus type='physical-ds'>[10+(([Spells.majorspiritual,Stats.level].min-2)/3),10].max</bonus>
+      <message type='start'>A dim aura surrounds you\.</message>
+      <message type='end'>The dim aura fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Manna' number='203' type='utility'>
+      <duration span='stackable'>5</duration>
+      <cost type='mana'>3</cost>
+      <message type='start'>The spiritual nourishment has a replenishing effect upon you\.</message>
+      <message type='end'>The replenishing effect fades, but you are left with a feeling of wellbeing\.</message>
+   </spell>
+   <spell availability='all' name='Unpresence' number='204' type='utility'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.majorspiritual</duration>
+      <cost type='mana'>4</cost>
+      <message type='start'>You feel more secure\.</message>
+      <message type='end'>You feel less secure\.</message>
+   </spell>
+   <spell availability='all' name='Light' number='205' type='utility'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Darkness' number='206' type='utility'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Purify Air' number='207' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.majorspiritual</duration>
+      <cost type='mana'>7</cost>
+      <message type='start'>You begin to breathe more deeply\.</message>
+      <message type='end'>Your breathing becomes more shallow\.</message>
+   </spell>
+   <spell availability='all' name='Living Spell' number='208' type='attack/utility'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='self-cast' name='Untrammel' number='209' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <cost type='mana'>9</cost>
+      <message type='start'>A faint slick sheen makes the air about you visible for the briefest of moments, then sinks into you and disappears\.</message>
+      <message type='end'>The air shivers about you, glistening faintly before stilling to normalcy\.</message>
+   </spell>
+   <spell availability='all' name='Silence' number='210' type='attack' incant='no'>
+      <duration cast-type='target'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^A pall of silence settles over you\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 0.5 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='group' name='Bravery' number='211' type='offense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>1</duration>
+      <cost type='mana'>11</cost>
+      <bonus type='bolt-as'>15</bonus>
+      <bonus type='physical-as'>15</bonus>
+      <message type='start'>You (?:and your group stand tall and )?feel more confident\.</message>
+      <message type='end'>You feel less confident\.</message>
+   </spell>
+   <spell availability='all' name='Interference' number='212' type='attack'>
+      <cost type='mana'>12</cost>
+      <message type='end'>The distracting force passes away from you\.</message>
+   </spell>
+   <spell availability='all' name='Minor Sanctuary' number='213' type='utility'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='all' name='Bind' number='214' type='attack'>
+      <cost type='mana'>14</cost>
+      <duration cast-type='target' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelops you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <duration cast-type='self' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelops you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <message type='start'>An unseen force envelops you, restricting all movement\.</message>
+      <message type='end'>The restricting force that envelops you dissolves away\.</message>
+   </spell>
+   <spell availability='group' name='Heroism' number='215' type='offense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>1</duration>
+      <cost type='mana'>15 + (Skills.slblessings / 30.0).round</cost>
+      <bonus type='bolt-as'>25+(Skills.slblessings/10)</bonus>
+      <bonus type='physical-as'>25+(Skills.slblessings/10)</bonus>
+      <message type='start'>A brilliant aura surrounds you and (?:sinks into your skin|your group)\.  You feel charged with extra vitality\.</message>
+      <message type='end'>The brilliant aura fades away from you\.</message>
+   </spell>
+   <spell availability='all' name='Frenzy' number='216' type='attack'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='all' name='Mass Interference' number='217' type='attack' incant='no'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='self-cast' name='Spirit Servant' number='218' type='utility'>
+      <duration span='refreshable'>20 + Spells.majorspiritual</duration>
+      <cost type='mana'>18</cost>
+      <message type='start'>A bright pulse of soft energy moves away from your hands and beckons a spirit to your aid\.\.\.</message>
+      <message type='start'>You infuse your .*?spirit with the mana necessary to maintain its corporeal form\.</message>
+      <message type='end'>(?:An?|The).*? spirit fades into ethereal form and wafts away\.</message>
+   </spell>
+   <spell availability='group' name='Spell Shield' number='219' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorspiritual</duration>
+      <duration cast-type='target' span='refreshable'>2</duration>
+      <cost type='mana'>19</cost>
+      <bonus type='bolt-ds'>40</bonus>
+      <bonus type='elemental-td'>15</bonus>
+      <bonus type='spirit-td'>30</bonus>
+      <bonus type='sorcerer-td'>22</bonus>
+      <message type='start'>An opalescent aura surrounds you(?: and your group)?\.</message>
+      <message type='end'>The opalescent aura fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Major Sanctuary' number='220' type='utility'>
+      <duration>10 + (Spells.majorspiritual/2.0)</duration>
+      <cost type='mana'>20</cost>
+      <message type='start'>A brilliant light bathes you as your surroundings blur for a moment\.\.\.</message>
+      <message type='start'>Whipping winds carry the hot, metallic taste of lightning to you as your surroundings blur\.\.\.</message>
+      <message type='start'>A deep shadow descends upon you and your breath is briefly muffled as your vision blurs with darkness\.\.\.</message>
+      <message type='start'>A shiver of wind touches your breath and you feel your eyelashes grow thick with a coating of snow\.  You lift your eyes to the sky and white blurs your vision\.\.\.</message>
+      <message type='end'>A bright light surrounds you and your visions of sanctuary slowly fade\.\.\.</message>
+      <message type='end'>The blinding flash of lightning shatters the chamber in a cloud of wind and light, causing it to dissolve around you\.\.\.</message>
+      <message type='end'>Suddenly the candles at the heart of the room go out and you are plunged into a deep darkness that obscures your vision of the world around you\.\.\.</message>
+      <message type='end'>Rising suddenly, the chill air sends a flurry of snow towards you and your vision swims with white flakes\.\.\.</message>
+   </spell>
+   <spell availability='all' name='Transference' number='225' type='utility'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Spiritual Abolition' number='230' type='attack'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='self-cast' name='Spirit Slayer' number='240' type='offense'>
+      <duration span='refreshable'>0.5</duration>
+      <cost type='mana'>40</cost>
+      <message type='start'>A small mote of bright white light swirls into existence around you\.</message>
+      <message type='start'>A pulse of bright white light flows from your hand into the mote\.  You feel the spirit's presence grow stronger\.</message>
+      <message type='end'>The mote of white light next to you disappears\.</message>
+   </spell>
+   <spell availability='all' name='Prayer of Holding' number='301' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' channel='yes' name='Smite' number='302' type='attack'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='all' name='Prayer of Protection' number='303' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <duration cast-type='target' span='refreshable'>2</duration>
+      <cost type='mana'>3 + [(([Spells.cleric,Stats.level].min - 3) / 6),0].max</cost>
+      <bonus type='bolt-ds'>[10+(([Spells.cleric,Stats.level].min - 3)/2),10].max</bonus>
+      <bonus type='physical-ds'>[10+(([Spells.cleric,Stats.level].min - 3)/2),10].max</bonus>
+      <message type='start'>A pure white aura sparkles around you\.</message>
+      <message type='end'>A white glow rushes away from you\.</message>
+   </spell>
+   <spell availability='all' name='Bless Item' number='304' type='utility'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='all' name='Preservation' number='305' type='utility'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Holy Bolt' number='306' stance='yes' type='attack'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='group' name='Benediction' number='307' type='offense/defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.cleric</duration>
+      <cost fixme='extra cost when in group' type='mana'>7+[([Spells.cleric, 27].min-7)/2,0].max + [([Stats.level, Spells.cleric].min-27)/2, 0].max</cost>
+      <bonus type='bolt-as'>5+[([Spells.cleric,Stats.level].min-7)/2,0].max</bonus>
+      <bonus type='physical-as'>[[5+((Spells.cleric-7)/2),5].max,15].min</bonus>
+      <bonus type='physical-ds'>[[5+((Spells.cleric-7)/2),5].max,15].min</bonus>
+      <message type='start'>Your spirit is bolstered by a great sense of faith and conviction\.</message>
+      <message type='end'>Your sense of faith and conviction wanes\.(?:  You are less sure of yourself\.)?</message>
+   </spell>
+   <spell availability='all' name='Well of Life' number='308' type='utility'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Neutralize Curse' number='309' type='utility'>
+      <cost type='mana'>9</cost>
+   </spell>
+   <spell availability='group' name='Warding Sphere' number='310' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.cleric</duration>
+      <cost type='mana'>10 + [[(Spells.cleric - 10)/2, 10].min,0].max</cost>
+      <bonus type='bolt-ds'>(10+[([Spells.cleric-10,0].max/2),10].min)</bonus>
+      <bonus type='physical-ds'>(10+[([Spells.cleric-10,0].max/2),10].min)</bonus>
+      <bonus type='elemental-td'>(10+[([Spells.cleric-10,0].max/2),10].min/2).to_i</bonus>
+      <bonus type='spirit-td'>(10+[([Spells.cleric-10,0].max/2),10].min).to_i</bonus>
+      <bonus type='sorcerer-td'>((10+[([Spells.cleric-10,0].max/2),10].min)*0.75).to_i</bonus>
+      <message type='start'>You feel more secure basking in the glow of divine protection\.</message>
+      <message type='end'>You suddenly feel less protected\.</message>
+   </spell>
+   <spell availability='all' name='Blind' number='311' type='attack'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='all' channel='yes' name='Fervent Reproach' number='312' type='attack'>
+      <cost type='mana'>12</cost>
+   </spell>
+   <spell availability='self-cast' name='Prayer' number='313' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <cost type='mana'>13 + ((if [Spells.cleric,Stats.level].min &gt; 35 then [Spells.cleric,Stats.level].min - 35 else 0 end) / 3)</cost>
+      <bonus type='bolt-ds'>if Spells.cleric &gt; 34 then ([Spells.cleric,Stats.level].min - 25) else 0 end</bonus>
+      <bonus type='physical-ds'>if Spells.cleric &gt; 34 then ([Spells.cleric,Stats.level].min - 25) else 0 end</bonus>
+      <bonus type='elemental-td'>5</bonus>
+      <bonus type='spirit-td'>10</bonus>
+      <bonus type='sorcerer-td'>7</bonus>
+      <message type='start'>Turning your thoughts inward\, you ask for the .* of your deity to protect you\.\s+.+, and you sense that your prayer has been granted\.</message>
+      <message type='end'>You feel the protection of your deity&apos;s influence fade\.</message>
+   </spell>
+   <spell availability='all' name='Relieve Burden' number='314' type='utility'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <duration cast-type='target' span='refreshable'>2</duration>
+      <cost type='mana'>c = 14; r = 0; s = 4; c += 0.5 while (Skills.slblessings &gt;= (r += (s += 1))); c</cost>
+      <message type='start'>A glittering golden collection bowl materializes above you\.  It slowly tips upside down, causing a shower of silver sparks to rain down upon your body, then vanishes\.</message>
+      <message type='end'>An ethereal golden collection bowl drifts out of your body, then vanishes\.</message>
+   </spell>
+   <spell availability='all' name='Remove Curse' number='315' type='utility'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='all' name='Censure' number='316' type='attack' incant='no'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='all' channel='yes' name='Divine Fury' number='317' type='attack'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Raise Dead' number='318' type='utility'>
+      <cost type='mana'>if Spells.cleric &gt;= 40 then 40 elsif Spells.cleric &gt;= 25 then 25 else 18 end</cost>
+      <cost type='spirit'>if Spells.cleric &gt;= 40 then 3 elsif Spells.cleric &gt;= 25 then 5 else 8 end</cost>
+   </spell>
+   <spell availability='self-cast' name='Soul Ward' number='319' type='defense'>
+      <cost type='mana'>19</cost>
+      <duration span='stackable' multicastable='yes'>20 + Spells.cleric</duration>
+      <message type='start'>Drawing deep from the well of your soul, you summon forth a thread of your essence and weave it into an evanescent shield to shroud your form\.</message>
+      <message type='end'>The air about you shimmers momentarily before the evanescent shield surrounding you collapses\.</message>
+   </spell>
+   <spell availability='self-cast' name='Ethereal Censer' number='320' type='offensive/utility'>
+      <cost type='mana'>20</cost>
+	  <duration>0.5</duration>
+      <message type='start'>Mana swirls into the visible spectrum and manifests as an ethereal, pure golden censer swinging pendulously through the air beside you\.  A black haze of incense smoke trails in its wake, quickly spreading in sinuous tendrils through the area\.</message>
+	  <message type='start'>As the fragrant haze settles over you, you feel revitalized\.</message>
+      <message type='end'>You sense the flows of mana around you are once again strong enough to support the manifestation of an ethereal censer\.</message>
+   </spell>
+   <spell availability='all' name='Divine Wrath' number='335' type='attack' incant='no'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Holy Receptacle' number='325' type='utility'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Prayer of Communion' number='330' type='utility'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Symbol of the Proselyte' number='340' type='utility'>
+      <cost type='mana'>40</cost>
+      <cost type='spirit'>2</cost>
+   </spell>
+   <spell availability='all' name='Miracle' number='350' type='utility'>
+      <cost type='mana'>50</cost>
+   </spell>
+   <spell availability='all' name='Elemental Defense I' number='401' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>1</cost>
+      <bonus type='bolt-ds'>5</bonus>
+      <bonus type='physical-ds'>5</bonus>
+      <bonus type='elemental-td'>5</bonus>
+      <bonus type='spirit-td'>2</bonus>
+      <bonus type='sorcerer-td'>4</bonus>
+      <message type='start'>A silvery luminescence surrounds you\.</message>
+      <message type='end'>The silvery luminescence fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Presence' number='402' type='utility'>
+      <duration span='refreshable' max='5'>5</duration>
+      <cost type='mana'>2</cost>
+      <message type='start'>You continue to feel much more aware of your surroundings\.</message>
+      <message type='end'>Your senses are no longer as sharp\.</message>
+   </spell>
+   <spell availability='all' name='Lock Pick Enhancement' number='403' type='utility'>
+      <duration span='stackable'>0.5 + Stats.level / 60.0</duration>
+      <cost type='mana'>3</cost>
+      <message type='start'>A scintillating light surrounds your hands\.</message>
+      <message type='end'>The scintillating light fades from your hands\.</message>
+   </spell>
+   <spell availability='all' name='Disarm Enhancement' number='404' type='utility'>
+      <duration span='stackable'>0.5 + Stats.level / 60.0</duration>
+      <cost type='mana'>4</cost>
+      <message type='start'>You become calm and focused\.</message>
+      <message type='end'>The focused look leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Elemental Detection' number='405' type='utility'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Elemental Defense II' number='406' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>6</cost>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='physical-ds'>10</bonus>
+      <bonus type='elemental-td'>10</bonus>
+      <bonus type='spirit-td'>5</bonus>
+      <bonus type='sorcerer-td'>8</bonus>
+      <message type='start'>A bright luminescence surrounds you\.</message>
+      <message type='end'>The bright luminescence fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Unlock' number='407' type='utility'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Disarm' number='408' type='utility'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Elemental Blast' number='409' type='attack'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Elemental Wave' number='410' type='attack/area' incant='no'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Elemental Blade' number='411' type='utility'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='all' name='Weapon Deflection' number='412' type='attack'>
+      <cost type='mana'>12</cost>
+   </spell>
+   <spell availability='all' name='Elemental Saturation' number='413' type='attack'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='all' name='Elemental Defense III' number='414' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>14</cost>
+      <bonus type='bolt-ds'>20</bonus>
+      <bonus type='physical-ds'>20</bonus>
+      <bonus type='elemental-td'>15</bonus>
+      <bonus type='spirit-td'>7</bonus>
+      <bonus type='sorcerer-td'>10</bonus>
+      <message type='start'>A brilliant luminescence surrounds you(?: and your group)?\.</message>
+      <message type='end'>The brilliant luminescence fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Elemental Strike' number='415' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='all' name='Piercing Gaze' number='416' type='utility'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='all' name='Elemental Dispel' number='417' type='attack/utility'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Mana Focus' number='418' type='utility'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='group' name='Mass Elemental Defense' number='419' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='all' name='Magic Item Creation' number='420' type='utility'>
+      <cost type='mana'>20</cost>
+   </spell>
+   <spell availability='self-cast' name='Elemental Targeting' number='425' type='offense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>25</cost>
+      <bonus type='bolt-as'>[25+((Spells.minorelemental-25)/2),50].min</bonus>
+      <bonus type='physical-as'>[25+((Spells.minorelemental-25)/2),50].min</bonus>
+      <bonus type='elemental-cs'>[25+((Spells.minorelemental-25)/2),50].min</bonus>
+      <bonus type='sorcerer-cs'>[25+((Spells.minorelemental-25)/2),50].min/2</bonus>
+      <message type='start'>You are filled with a sense of great confidence\.</message>
+      <message type='end'>You feel less confident than before\.</message>
+   </spell>
+   <spell availability='self-cast' name='Elemental Barrier' number='430' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minorelemental</duration>
+      <cost type='mana'>30</cost>
+      <bonus type='bolt-ds'>[(Spells.minorelemental/2),50].min</bonus>
+      <bonus type='physical-ds'>[(Spells.minorelemental/2),50].min</bonus>
+      <bonus type='elemental-td'>[(Spells.minorelemental/2),50].min</bonus>
+      <bonus type='spirit-td'>([(Spells.minorelemental/2),50].min/2).to_i</bonus>
+      <bonus type='sorcerer-td'>([(Spells.minorelemental/2),50].min*0.75).to_i</bonus>
+      <message type='start'>Your skin tingles for a moment and you feel more secure\.</message>
+      <message type='end'>The tingling sensation and sense of security leaves you\.</message>
+   </spell>
+   <spell availability='all' name='Major Elemental Wave' number='435' type='attack/area' incant='no'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Mana Focus Water Bonus' number='499' type='utility'>
+   </spell>
+   <spell availability='all' name='Sleep' number='501' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' name='Chromatic Circle' number='502' type='attack'>
+      <cost type='mana'>2</cost>
+   </spell>
+   <spell availability='all' name='Thurfel&apos;s Ward' number='503' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <cost cast-type='self' type='mana'>3 + (([Spells.majorelemental,Stats.level].min - 3) / 12.0).round</cost>
+      <cost cast-type='target' type='mana'>3</cost>
+      <bonus type='bolt-ds'>[20+((Spells.majorelemental-5)/4),20].max</bonus>
+      <bonus type='physical-ds'>[20+((Spells.majorelemental-5)/4),20].max</bonus>
+      <message type='start'>Glowing specks of \w+ \w+ energy begin to spin around you\.</message>
+      <message type='end'>The glowing specks of energy surrounding you suddenly shoot off in all directions, then quickly fade away\.</message>
+   </spell>
+   <spell availability='all' name='Slow' number='504' type='attack'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='all' name='Hand of Tonis' number='505' stance='yes' type='attack'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Celerity' number='506' type='utility'>
+      <duration span='refreshable'>1</duration>
+      <cost type='mana'>6</cost>
+      <message type='start'>You (?:and your group )?suddenly start moving light\-footedly\.</message>
+      <message type='end'>You suddenly feel less light\-footed\.</message>
+   </spell>
+   <spell availability='self-cast' name='Elemental Deflection' number='507' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <cost type='mana'>7+(([Spells.majorelemental,Stats.level].min-7)/6)</cost>
+      <bonus type='bolt-ds'>[20+((Spells.majorelemental-7)/2),20].max</bonus>
+      <bonus type='physical-ds'>[20+((Spells.majorelemental-7)/2),20].max</bonus>
+      <message type='start'>You are surrounded by a shimmering field of energy\.</message>
+      <message type='end'>You feel a slight tingling as the shimmering field fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Elemental Bias' number='508' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <cost type='mana'>8</cost>
+      <bonus type='elemental-td'>20</bonus>
+      <bonus type='spirit-td'>10</bonus>
+      <bonus type='sorcerer-td'>15</bonus>
+      <message type='start'>You feel more magically aware\.</message>
+      <message type='end'>You feel your extra magical awareness leave you\.</message>
+   </spell>
+   <spell availability='all' name='Strength' number='509' type='offense/utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <cost type='mana'>9</cost>
+      <bonus type='physical-as'>15 + (n=0; [4,9,15,22,30,39,49,60,72,85,99,114,130,147,165,184].each{ |limit| if Skills.elearth &gt;= limit then n += 1 end }; n;)</bonus>
+      <bonus type='strength'>15</bonus>
+      <message type='start'>You feel much stronger\.</message>
+      <message type='end'>You feel your extra strength departing\.</message>
+   </spell>
+   <spell availability='all' name='Hurl Boulder' number='510' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Floating Disk' number='511' type='utility'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='all' name='Cold Snap' number='512' type='attack'>
+      <cost type='mana'>12</cost>
+   </spell>
+   <spell availability='self-cast' name='Elemental Focus' number='513' type='offense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <duration cast-type='target' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^You bristle with energy\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; ($1.to_i - 100)/120.0; else; 0.25; end</duration>
+      <cost type='mana'>13 + (([Spells.majorelemental,Stats.level].min - 13)/2)</cost>
+      <bonus type='bolt-as'>[20+(([Spells.majorelemental,Stats.level].min-13)/2),20].max</bonus>
+      <bonus type='physical-as'>-40</bonus>
+      <message type='start'>You bristle with energy\.</message>
+      <message type='end'>You no longer bristle with energy\.</message>
+   </spell>
+   <spell availability='all' name='Stone Fist' number='514' type='attack'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Rapid Fire' number='515' type='utility'>
+      <duration>1</duration>
+      <cost type='mana'>15</cost>
+      <message type='start'>You feel the magic surge through you\.</message>
+      <message type='end'>You feel the surge of magic depart\.</message>
+   </spell>
+   <spell availability='all' name='Mana Leech' number='516' type='attack/utility'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='all' name='Charge Item' number='517' type='utility'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Cone of Elements' number='518' channel='yes' stance='yes' type='attack/area' incant='no'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='all' name='Immolation' number='519' type='attack'>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='self-cast' name='Mage Armor' number='520' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + [Spells.majorelemental,Stats.level].min</duration>
+      <cost type='mana'>20</cost>
+      <cast-proc>if defined?(target) and not target.nil?; cmd = &quot;incant 520 #{target}&quot;; else; cmd=&quot;incant 520 #{UserVars.element}&quot;; end; dothistimeout(&apos;release&apos;, 5, /^You feel the magic of your spell rush away from you\.$|^You don&apos;t have a prepared spell to release!$/) if (checkprep != &apos;Mage Armor&apos;) and (checkprep != &apos;None&apos;); dothistimeout(cmd, 5, /^A layer of raw elemental energy forms around you|^You already have a different spell readied|^Cast Roundtime [0-9]+ Seconds?\.|^But you don&apos;t have any mana!|^\[Spell Hindrance for|keeps? the spell from working\.|^As you focus on your magic, your vision swims with a swirling haze of crimson\.|^Your magic fizzles ineffectually\.|^All you manage to do is cough up some blood\.|^And give yourself away!  Never!|^You are unable to do that right now\.|^You don&apos;t seem to be able to move to do that\.|^You can&apos;t think clearly enough to prepare a spell!/)</cast-proc>
+      <message type='start'>A layer of raw elemental energy forms around you\.</message>
+      <message type='end'>The layer of raw elemental energy surrounding you dissipates\.</message>
+   </spell>
+   <spell availability='all' name='Meteor Swarm' number='525' type='attack' incant='no'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Elemental Disjunction' number='530' type='attack'>
+      <cost type='mana'>30</cost>
+   </spell>
+    <spell availability='self-cast' name='Haste' number='535' type='utility'>
+      <duration span='stackable'>20 + [Spells.majorelemental, Stats.level].min</duration>
+      <cost type='mana'>35</cost>
+      <message type='start'>You begin to notice the world slow down around you\.  Strange\.</message>
+      <message type='start'>The world stutters around you for a moment, then resumes its slower speed\.</message>
+      <message type='end'>You notice that things have returned to their normal speed\.</message>
+   </spell>
+   <spell availability='self-cast' name='Temporal Reversion' number='540' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.majorelemental</duration>
+      <cost type='mana'>40</cost>
+      <message type='start'>For a moment, everything you hear and see echoes weirdly around you, but then everything seems normal again\.  Your personal temporal reality has been slightly offset from the true flow of time\.</message>
+      <message type='end'>Abruptly, everything you see and hear comes into better focus\.  Your personal temporal reality has rejoined the true flow of time\.</message>
+   </spell>
+  <spell availability='self-cast' name='Rapid Fire Penalty' number='597' type='timer'>
+      <duration>1</duration>
+      <message type='start'>You feel the magic surge through you, but the feeling of fatigue lingers\.</message>
+   </spell>
+  <spell availability='self-cast' name='Celerity Recovery' number='598'>
+      <duration>3</duration>
+      <message type='start'>You suddenly feel less light\-footed and your feet take on a leaden quality\.</message>
+      <message type='end'>The leaden quality leaves your feet\.</message>
+  </spell>
+  <spell availability='self-cast' name='Rapid Fire Recovery' number='599'>
+      <duration>if Skills.emc >= 199; 0; else; 1 + (((90 - (Skills.emc/2.2)).ceil + 1) / 60.0); end</duration>
+      <message type='end'>You notice the feeling of elemental fatigue fade away\.</message>
+   </spell>
+   <spell availability='all' name='Natural Colors' number='601' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>1</cost>
+      <bonus type='bolt-ds'>bonus = 10; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <bonus type='physical-ds'>bonus = 10; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <message type='start'>You(?: and your group)? seem to blend into the surroundings better\.</message>
+      <message type='end'>You return to normal color\.</message>
+   </spell>
+   <spell availability='all' name='Resist Elements' number='602' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>2</cost>
+      <bonus type='bolt-ds'>bonus = 15; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <message type='start'>The air about you shimmers slightly\.</message>
+      <message type='end'>The air about you stops shimmering\.</message>
+   </spell>
+   <spell availability='all' name='Wild Entropy' number='603' type='attack'>
+      <cost type='mana'>3</cost>
+   </spell>
+   <spell availability='self-cast' name='Nature&apos;s Bounty' number='604' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>4</cost>
+      <message type='start'>You feel your vision sharpen\.</message>
+      <message type='end'>You feel your vision return to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='Barkskin' number='605' type='defense'>
+      <duration span='refreshable' multicastable='no'>1</duration>
+      <cost type='mana'>5</cost>
+      <message type='start'>A knobby layer of bark swiftly forms on you\.</message>
+      <message type='end'>The knobby layer of bark on you creaks and twists briefly before disintegrating.\.</message>
+   </spell>
+   <spell availability='self-cast' name='Phoen&apos;s Strength' number='606' type='offense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>6</cost>
+      <bonus type='physical-as'>10</bonus>
+      <bonus type='strength'>10</bonus>
+      <message type='start'>Your body suddenly fills with a warm strength\.</message>
+      <message type='end'>You feel the inner strength leave you\.</message>
+   </spell>
+   <spell availability='all' name='Sounds' number='607' type='attack'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Camouflage' number='608' type='offense'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Sun Burst' number='609' type='attack/utility' incant='no'>
+      <cost type='mana'>9</cost>
+   </spell>
+   <spell availability='all' name='Tangleweed' number='610' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Moonbeam' number='611' type='attack'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='self-cast' name='Breeze' number='612' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>12</cost>
+      <message type='start'>A breeze stirs the air about you, swirling and tugging at your clothing\.</message>
+      <message type='end'>The swirling breeze around you finally settles\.</message>
+   </spell>
+   <spell availability='self-cast' name='Self Control' number='613' type='defense/utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>13</cost>
+      <bonus type='physical-ds'>[20+((Spells.ranger-13)/2),20].max</bonus>
+      <bonus type='elemental-td'>bonus = 20; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus/2</bonus>
+      <bonus type='spirit-td'>bonus = 20; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <bonus type='sorcerer-td'>bonus = 20; [5, 11, 18, 26, 35, 45, 56, 68, 81, 95].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; (bonus*0.75).to_i</bonus>
+      <message type='start'>You feel an aura of natural confidence surrounding you\.</message>
+      <message type='end'>You feel the aura of confidence leave you\.</message>
+   </spell>
+   <spell availability='all' name='Imbue' number='614' type='utility'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Call Swarm' number='615' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='all' name='Spike Thorn' number='616' type='attack'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='self-cast' name='Sneaking' number='617' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>17</cost>
+      <message type='start'>You begin to move with cat-like grace\.</message>
+      <message type='end'>You are no longer moving silently\.</message>
+   </spell>
+   <spell availability='all' name='Mobility' number='618' type='defense/utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>18+((Spells.ranger-18)/5)</cost>
+      <bonus type='dodging'>[20+(Spells.ranger-18),20].max</bonus>
+      <message type='start'>You suddenly feel much more dextrous\.</message>
+      <message type='end'>You no longer feel so dextrous\.</message>
+   </spell>
+   <spell availability='all' name='Mass Calm' number='619' type='attack' incant='no'>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='all' name='Resist Nature' number='620' type='utility'>
+      <cost type='mana'>20</cost>
+   </spell>
+   <spell availability='self-cast' name='Nature&apos;s Touch' number='625' type='defense/utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>25</cost>
+      <bonus type='elemental-td'>([1+((Spells.ranger-25)/2),12].min/2).to_i</bonus>
+      <bonus type='spirit-td'>[1+((Spells.ranger-25)/2),12].min</bonus>
+      <bonus type='sorcerer-td'>([1+((Spells.ranger-25)/2),12].min*0.75).to_i</bonus>
+      <message type='start'>You suddenly feel the power of nature surround you\.</message>
+      <message type='end'>You feel the gathering of nature&apos;s power leave you\.</message>
+   </spell>
+   <spell availability='all' name='Animal Companion' number='630' type='attack/utility'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Nature&apos;s Fury' number='635' type='attack' incant='no'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='self-cast' name='Wall of Thorns' number='640' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.ranger</duration>
+      <cost type='mana'>40</cost>
+      <bonus type='bolt-ds'>20</bonus>
+      <bonus type='physical-ds'>20</bonus>
+      <message type='start'>You are surrounded by a (?:dense, )?writhing barrier of sharp thorns\.</message>
+      <message type='end'>You seem to lose the thorny barrier that surrounds you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Assume Aspect' number='650' type='utility'>
+      <duration>10</duration>
+      <cost type='mana'>50</cost>
+      <message type='start'>Gold-traced pale green ribbons of energy swirl about and coalesce upon you, reinforcing the intense natural prowess that races through every fiber of your being\.</message>
+      <message type='end'>The green and gold energy fades from around you, bringing your awareness of nature to its original state\.</message>
+   </spell>
+   <spell availability='all' name='Blood Burst' number='701' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' channel='yes' name='Mana Disruption' number='702' type='attack'>
+      <cost type='mana'>2</cost>
+   </spell>
+   <spell availability='all' name='Corrupt Essence' number='703' type='attack'>
+      <duration>0.33</duration>
+      <cost type='mana'>3</cost>
+      <message type='start'>You feel weakened as a blood red haze forms around you\.</message>
+      <message type='end'>The blood red haze dissipates from around you\.</message>
+   </spell>
+   <spell availability='all' name='Phase' number='704' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.sorcerer</duration>
+      <cost type='mana'>4</cost>
+      <message type='start'>A wave of tingling passes across your body, momentarily casting it into semi-transparency\.</message>
+      <message type='end'>Your body pulses momentarily into semi transparency and then returns to normal\.</message>
+   </spell>
+   <spell availability='all' channel='yes' name='Disintegrate' number='705' type='attack'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Mind Jolt' number='706' type='attack'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Eye Spy' number='707' type='utility'>
+      <duration span='refreshable'>19 + Spells.sorcerer</duration>
+      <cost type='mana'>7</cost>
+      <message type='start'>Casually you push your finger into your eye socket and cup it around the throbbing eyeball\.  With a little leverage you pop the eye from your skull and watch as it sprouts little batlike wings and begins to hover before you\.</message>
+      <message type='end'>You hear a soft hiss as your wandering eye rushes towards you\.  You reach out and catch the squishy globe and quickly press it back into your eye socket\.  After a few blinks it seems to seat itself properly\.  You wipe off some gooey red residue with your sleeve, and feel yourself once again presentable\.</message>
+   </spell>
+   <spell availability='all' name='Limb Disruption' number='708' type='attack'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Quake' number='709' type='attack'>
+      <cost type='mana'>9</cost>
+   </spell>
+   <spell availability='all' name='Energy Maelstrom' number='710' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Pain' number='711' type='attack'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='self-cast' name='Cloak of Shadows' number='712' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.sorcerer</duration>
+      <cost type='mana'>12 + [(([Spells.sorcerer,Stats.level].min - 12) / 3),0].max</cost>
+      <bonus type='bolt-ds'>[25+([Spells.sorcerer,Stats.level].min-12),25].max</bonus>
+      <bonus type='physical-ds'>[25+([Spells.sorcerer,Stats.level].min-12),25].max</bonus>
+      <bonus type='elemental-td'>([20+(([Spells.sorcerer,Stats.level].min-12)/10),20].max*0.75).to_i</bonus>
+      <bonus type='spirit-td'>([20+(([Spells.sorcerer,Stats.level].min-12)/10),20].max*0.75).to_i</bonus>
+      <bonus type='sorcerer-td'>[20+(([Spells.sorcerer,Stats.level].min-12)/10),20].max</bonus>
+      <message type='start'>A shadowy patch of ether rises up through the (?:floor|ground) to encompass you, swiftly sinking into your skin\.</message>
+      <message type='end'>A dark shadow seems to detach itself from your body, swiftly dissipating into the air\.</message>
+   </spell>
+   <spell availability='all' name='Balefire' number='713' stance='yes' type='attack'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='all' name='Scroll Infusion' number='714' type='utility'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Curse' number='715' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='self-cast' name='Pestilence' number='716' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.sorcerer</duration>
+      <cost type='mana'>16</cost>
+      <message type='start'>A cankerous ripple of vesicles temporarily disfigures your face and travels down your body, leaving a sickly green miasma as it disappears\.</message>
+      <message type='end'>You exhale the last of a virulent green mist\.</message>
+   </spell>
+   <spell availability='all' name='Evil Eye' number='717' type='attack' incant='no'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Torment' number='718' type='attack'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='all' name='Dark Catalyst' number='719' type='attack'>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='all' name='Implosion' number='720' type='attack' incant='no'>
+      <cost type='mana'>20</cost>
+   </spell>
+   <spell availability='self-cast' name='Minor Summoning' number='725' type='utility'>
+      <duration span='refreshable'>10 + (Spells.sorcerer/3.0) + (Skills.sldemonology/2.0)</duration>
+      <cost type='mana'>25</cost>
+      <message type='start'>You trace an arcane sigil over your .+ while incanting\.  Your .+ glows momentarily and you succeed in opening an interplanar rift from which you manage to pull .+\.</message>
+      <message type='start'>You trace the runes on .+ to strengthen the binding between your .+ and this plane\.  You feel a bit of power leeched from your .+ as a spark follows your finger&apos;s path across the .+\.</message>
+      <message type='end'>You sense that you will not be able to control .+ much longer so you incant arcanely while concentrating upon the .+\.  You gesture vividly causing a small interplanar rift to open.  The .+ is pulled through the rift\.</message>
+   </spell>
+   <spell name='Illusion - Demon' number='9725' type='timer'>
+      <duration>30</duration>
+      <message type='start'>You shift your gaze to your .+ and focus your energy upon creating the illusion of disguise\.  You move quickly towards .+, feeling your energy focus upon your fist and causing it to radiate with a black essence\.  At the last moment, you plunge your fist into the .+ of your .+\.  .+ suddenly erupts in a shroud of black essence and tries to recoil away from you\.  You focus your will upon the essence and .+, and watch as the creature begins to ripple\.  Piece by piece, the creature&apos;s form changes until .+ stands in its place and you withdraw your hand\.</message>
+      <message type='start'>You glide your hand over .+, leaving rippling motes of color in the wake of your hand as you attempt to strengthen the flows of essence around .+\.  You sense a pulse as the motes disappear within .+, revitalizing the .+ into an impeccable illusion\.</message>
+      <message type='end'>Droplets of inky black ichor begin to drip down from .+ and pool underneath as the veil of an illusion peels back\.  The visage of .+ begins to distort and reveals behind it .+\.  As the last droplet \*plops\* into the pool, it dissolves into mist that .+\.</message>
+   </spell>
+   <spell availability='all' name='Animate Dead' number='730' type='utility'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Ensorcell' number='735' type='utility'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Planar Shift' number='740' type='utility'>
+      <cost type='mana'>40</cost>
+   </spell>
+   <spell availability='all' name='Minor Shock' number='901' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' name='Minor Elemental Edge' number='902' type='offense'>
+      <cost type='mana'>2</cost>
+   </spell>
+   <spell availability='all' name='Minor Water' number='903' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>3</cost>
+   </spell>
+   <spell availability='all' name='Minor Acid' number='904' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='self-cast' name='Prismatic Guard' number='905' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.wizard</duration>
+      <cost type='mana'>bonus=0;[5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200,221,243].each { |n| bonus += 1 if Skills.elearth &gt;= n };5 + (((([Spells.wizard,Stats.level].min - 5) / 4.0).floor + bonus)/3.0).floor</cost>
+      <bonus type='bolt-ds'>bonus=0;[5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200,221,243].each { |n| bonus += 1 if Skills.elearth &gt;= n };[20+((Spells.wizard-5)/4),20].max + bonus</bonus>
+      <bonus type='physical-ds'>bonus=0;bonus=0;[5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200,221,243].each { |n| bonus += 1 if Skills.elearth &gt;= n };[5+((Spells.wizard-5)/4),5].max + bonus</bonus>
+      <message type='start'>Multicolored rays shoot out of your body and flow into (?:the|a) shimmering sphere around you\.</message>
+      <message type='end'>The shimmering multicolored sphere fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Minor Fire' number='906' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Major Cold' number='907' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Major Fire' number='908' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='all' name='Tremors' number='909' type='attack/area/utility'>
+      <duration span='refreshable' multicastable='no'>20 + Spells.wizard</duration>
+      <cost type='mana'>9</cost>
+      <message type='start'>Faint ripples in the (?:dirt|floor|ground|ice|muck|sand|snow|soil) form beneath you for a moment\.</message>
+      <message type='end'>Faint ripples in the (?:dirt|floor|ground|ice|muck|sand|snow|soil) beneath you become apparent before quickly dissipating\.</message>
+   </spell>
+   <spell availability='all' name='Major Shock' number='910' channel='yes' stance='yes' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='group' name='Mass Blur' number='911' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.wizard</duration>
+      <cost type='mana'>11</cost>
+      <bonus type='dodging'>[1,3,6,10,15,21,28,36,45,55,66,78,91,105,120,136,153,171,190].inject(20) { |bonus, n| bonus += 1 if Skills.elair &gt;= n; bonus }</bonus>
+      <message type='start'>Your form(?:, as well as your group,)? blurs\.</message>
+      <message type='start'>If you were visible, your form would have blurred\.</message>
+      <message type='end'>You become solid again\.</message>
+   </spell>
+   <spell availability='all' name='Call Wind' number='912' type='attack/area' incant='no'>
+      <cost type='mana'>12</cost>
+   </spell>
+   <spell availability='self-cast' name='Melgorehn&apos;s Aura' number='913' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.wizard</duration>
+      <cost type='mana'>13 + (([Spells.wizard,Stats.level].min - 13) / 3.0).round</cost>
+      <bonus type='bolt-ds'>[Spells.wizard-3,10].max</bonus>
+      <bonus type='physical-ds'>[Spells.wizard-3,10].max</bonus>
+      <bonus type='elemental-td'>[20+((Spells.wizard-13)/3),20].max</bonus>
+      <bonus type='spirit-td'>([20+((Spells.wizard-13)/3),20].max/2).to_i</bonus>
+      <bonus type='sorcerer-td'>([20+((Spells.wizard-13)/3),20].max*0.75).to_i</bonus>
+      <message type='start'>A luminescent aura begins to swirl around you\.</message>
+      <message type='end'>A luminescent aura fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Sandstorm' number='914' type='attack'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Weapon Fire' number='915' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='self-cast' name='Invisibility' number='916' type='utility'>
+      <duration span='refreshable'>20 + (Spells.wizard / 2)</duration>
+      <cost type='mana'>16</cost>
+      <message type='start'>You become invisible\.</message>
+      <message type='start'>Your invisibility is extended\.</message>
+      <message type='start'>You refresh your invisibility\.</message>
+      <message type='end'>You (become|are) visible again\.</message>
+      <message type='end'>You fade into (?:view|sight|visibility)(\.| and strike!)</message>
+      <message type='end'>Your invisibili?ty (falls\.|fails\.|has been dispelled!)</message>
+      <message type='end'>Your startled movement makes you visible again!</message>
+      <message type='end'>You make so much noise that only the dead would not notice you thrashing about in your unsuccessful search\.|^The driving storm breaks your concentration, leaving you visible again\.|^An? [\w\s]+ discovers you and your invisibility fails!</message>
+      <message type='end'>[A-Z][a-z]+ dispels your invisibility!</message>
+      <message type='end'>But you are not hidden!</message>
+      <message type='end'>Dark, swirling mist billows before you from nothingness, tiny pinpoints of light glimmering from its inky depths\.  Slight crackling can be heard from within and the scent of ozone tickles at your nose\.  Suddenly, a blinding arc of lightning tears through the air and stikes you, causing your invisibility to fade\.</message>
+      <message type='end'>Trying to move through [\w\s]+ reveals you\.$|discovers your hiding place!$|your invisibility fails!</message>
+   </spell>
+   <spell availability='all' name='Earthen Fury' number='917' type='attack'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Duplicate' number='918' type='utility'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='self-cast' name='Wizard&apos;s Shield' number='919' type='defense'>
+      <duration span='refreshable'>1</duration>
+      <cost type='mana'>19</cost>
+      <bonus type='bolt-ds'>50</bonus>
+      <bonus type='physical-ds'>50</bonus>
+      <message type='start'>A translucent sphere forms around you\.</message>
+      <message type='end'>The translucent sphere fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Call Familiar' number='920' type='utility'>
+      <duration persist-on-death='yes' span='refreshable'>20 + Spells.wizard</duration>
+      <cost type='mana'>20</cost>
+      <message type='start'>You (concentrate on the [a-z]+ talisman as you )?cast your conciousness out into the ether in search of a (specific type of )?familiar\.</message>
+      <message type='start'>You feel the magical link between you and your (?:[\-\w+])[\-\s\w]* (?:grow stronger|strengthen)\.</message>
+      <message type='start'>As you gaze into the depths of the tiny pool, you notice a faint tickle\.  It is almost as if the ring is drawing energy from your very being\.\.\.</message>
+      <message type='end'>You sense the link between you and your (?:[\-\w+])[\-\s\w]* weaken and vanish\.</message>
+   </spell>
+   <spell availability='all' name='Enchant Item' number='925' type='utility'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Familiar Gate' number='930' type='utility'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Core Tap' number='950' type='attack'>
+      <cost type='mana'>50</cost>
+   </spell>
+   <spell availability='self-cast' name='Core Tap Recovery (1 Charge)' number='996'>
+      <duration>1</duration>
+   </spell>
+   <spell availability='self-cast' name='Core Tap Recovery (2 Charges)' number='997'>
+      <duration>s = Spell['Core Tap Recovery (1 Charge)'];s.timeleft &gt; 0.0 ? s.timeleft : 1</duration>
+   </spell>
+   <spell availability='self-cast' name='Core Tap Recovery (3 Charges)' number='998'>
+      <duration>s = Spell['Core Tap Recovery (2 Charges)'];s.timeleft &gt; 0.0 ? s.timeleft : 1</duration>
+   </spell>
+   <spell availability='self-cast' name='Core Tap Recovery' number='999'>
+      <duration>if which = ['3 Charges','2 Charges','1 Charge'].find { |w| Spell["Core Tap Recovery (#{w})"].timeleft > 0 }; Spell["Core Tap Recovery (#{which})"].timeleft; else; 1; end</duration>
+      <message type='start'>Tapping into the elemental core of Elanthia, you seize part of its energy\.  Swirling ribbons of fiery red, deep blue, earthen brown, and airy white energy rise up from the (?:floor|ground) and surround you\.  They linger for a brief moment, then explode into a shower of sparks!</message>
+      <message type='start'>You are too exhausted to cast Core Tap right now\.</message>
+      <message type='end'>Your exhaustion from tapping into the elemental core fades\.</message>
+   </spell> 
+   <spell availability='all' name='Holding Song' number='1001' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' name='Vibration Chant' number='1002' type='attack'>
+      <cost type='mana'>2</cost>
+   </spell>
+   <spell availability='self-cast' name='Fortitude Song' number='1003' type='defense'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>3</cost>
+      <cost type='renew'>1</cost>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='physical-ds'>10</bonus>
+      <message type='start'>You begin to sing of heroic deeds and bolster your confidence\.</message>
+      <message type='end'>You no longer feel a sense of confidence\.</message>
+   </spell>
+   <spell availability='all' name='Purification Song' number='1004' type='utility'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='all' name='Lullabye' number='1005' type='attack'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='self-cast' name='Song of Luck' number='1006' type='utility'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>6+([Spells.bard-6,0].max/4)</cost>
+      <cost type='renew'>3+([Spells.bard-6,0].max/8)</cost>
+      <message type='start'>As (?:you|[A-Z][a-z]+) sings?, the air sparkles briefly (?:with tiny flashing motes of light before returning to normal|around you)\.  You feel strangely lucky!</message>
+      <message type='end'>The air stops shimmering around you(?: and your group)?\.</message>
+   </spell>
+   <spell availability='self-cast' name='Kai&apos;s Triumph Song' number='1007' type='offense/bonus'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>7+[[Spells.bard-7,0].max,13].min</cost>
+      <cost type='renew'>2+[[Spells.bard-7,0].max,13].min</cost>
+      <bonus type='bolt-as'>([[3+Spells.bard,10].max,20].min)+(bonus=0;[3,7,12,18,25,33,42,52,63,75,88,102,117,133,150,168,187].each { |n| bonus+=1 if Skills.mltelepathy &gt;= n }; bonus)</bonus>
+      <bonus type='physical-as'>([[3+Spells.bard,10].max,20].min)+(bonus=0;[3,7,12,18,25,33,42,52,63,75,88,102,117,133,150,168,187].each { |n| bonus+=1 if Skills.mltelepathy &gt;= n }; bonus)</bonus>
+      <message type='start'>Your (?:spirit is|spirits are) lifted by the verses praising Kai\.$|^[A-Z][a-z]+ sings of Kai&apos;s many triumphs, lifting your spirits\.</message>
+      <message type='end'>Your (?:spirit is|spirits are|spirits, and those of your group, are) no longer lifted by stories of Kai&apos;s Triumphs\.</message>
+   </spell>
+   <spell availability='all' name='Stunning Shout' number='1008' type='attack'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='self-cast' name='Sonic Shield Song' number='1009' type='defense'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>9</cost>
+      <cost type='renew'>4</cost>
+      <bonus type='bolt-ds'>[10+(Spells.bard/2.0).round,35].min</bonus>
+      <bonus type='physical-ds'>[10+(Spells.bard/2.0).round,35].min</bonus>
+      <message type='start'>You begin singing and focus your voice into a vortex of air centered on your left arm\.</message>
+      <message type='end'>Your(?: sonic)? (?:buckler|kidney|small|targe|heater|knight&apos;s|lantern|medium|parma|target|aegis|kite|large|pageant|round|scutum|greatshield|mantlet|pavis|tower|wall|shield|translucent)?(?:\sshield)? dissipates\.</message>
+   </spell>
+   <spell availability='self-cast' name='Song of Valor' number='1010' type='defense'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>10+((Spells.bard-10)/4)</cost>
+      <cost type='renew'>3+((Spells.bard-10)/10)</cost>
+      <bonus type='bolt-ds'>10+(([Spells.bard,Stats.level].min-10)/2)+([Spells.bard-Stats.level,0].max/5)</bonus>
+      <bonus type='physical-ds'>10+(([Spells.bard,Stats.level].min-10)/2)+([Spells.bard-Stats.level,0].max/5)</bonus>
+      <message type='start'>As you begin to sing of valiant legends, you feel more protected\.</message>
+      <message type='end'>You no longer feel a sense of protection\.</message>
+   </spell>
+   <spell availability='self-cast' name='Song of Peace' number='1011' type='utility'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>11</cost>
+      <cost type='renew'>4</cost>
+      <message type='start'>The surroundings respond to the soothing melody of your song, becoming calm and still\.</message>
+      <message type='end'>The sense of peace and security passes away from the area\.|You stop singing Song of Peace\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sonic Weapon Song' number='1012' type='attack'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>12</cost>
+      <cost type='renew'>4</cost>
+      <bonus type='physical-as'>[10+(Spells.bard/2.0).round,35].min</bonus>
+      <message type='start'>You begin singing and focus your voice into a (?:vortex of air shaped like a )?sonic (?:[\w\-]+\s?){1,3}(?:,| shaped vortex of air) centered on your (?:right|left) hand\.</message>
+      <message type='end'>Your (?:sonic|twohanded|main) (?!barrier|buckler|kidney|small|targe|heater|knight&apos;s|lantern|medium|parma|target|aegis|kite|large|pageant|round|scutum|greatshield|mantlet|pavis|tower|wall|shield|barrier)[\w\s\-]+ dissipates\.|Your sonic weapon is not in your hands\.(?:  You are unable to renew the song\.)?</message>
+   </spell>
+   <spell availability='all' name='Song of Unravelling' number='1013' type='attack/utility'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='self-cast' name='Sonic Armor' number='1014' type='defense'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>14</cost>
+      <cost type='renew'>5</cost>
+      <bonus type='bolt-ds'>[15+(Spells.bard/2.0).round,35].min</bonus>
+      <bonus type='physical-ds'>[15+(Spells.bard/2.0).round,35].min</bonus>
+      <message type='start'>You begin singing and focus your voice into a vortex of air centered around your body\.</message>
+      <message type='end'>Your sonic barrier dissipates\.</message>
+   </spell>
+   <spell availability='all' name='Song of Depression' number='1015' type='attack'>
+      <cost type='mana'>15</cost>
+      <cost type='renew'>6</cost>
+   </spell>
+   <spell availability='all' name='Song of Rage' number='1016' type='attack'>
+      <cost type='mana'>16</cost>
+   </spell>
+   <spell availability='self-cast' name='Song of Noise' number='1017' type='utility'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>17</cost>
+      <cost type='renew'>7</cost>
+      <message type='start'>The surroundings respond to your piercing voice, disrupting the normal flow of mana\.</message>
+      <message type='end'>The cacophony of sound finally passes away from the area\.|You stop singing Song of Noise\.</message>
+   </spell>
+   <spell availability='self-cast' name='Song of Power' number='1018' type='bonus'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>18</cost>
+      <cost type='renew'>15</cost>
+      <message type='start'>As you sing, you feel the mana around you begin to swirl and move with a subtle grace\.</message>
+      <message type='end'>The mana around you slowly returns to its natural state\.</message>
+   </spell>
+   <spell availability='self-cast' name='Song of Mirrors' number='1019' type='defense'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>19+((Spells.bard-19)/5)</cost>
+      <cost type='renew'>8+((Spells.bard-19)/10)</cost>
+      <bonus type='dodging'>[20+((Spells.bard-19)/2),20].max</bonus>
+      <message type='start'>As you begin to sing a sibilant melody, shimmering mirror images of you appear in the area\.</message>
+      <message type='start'>The mirror images surrounding you undulate and grow stronger\.</message>
+      <message type='end'>The mirror images surrounding you undulate and fade away\.</message>
+   </spell>
+   <spell availability='all' name='Traveller&apos;s Song' number='1020' type='utility'>
+      <cost type='mana'>20</cost>
+   </spell>
+   <spell availability='all' name='Singing Sword Song' number='1025' type='attack/utility'>
+      <duration>Spellsong.timeleft</duration>
+      <cost type='mana'>25</cost>
+      <cost type='renew'>15</cost>
+      <message type='start'>An animated .+ appears and hovers near you\.</message>
+      <message type='end'>Your animated .+ dissipates in a shower of sparkling motes of light\.</message>
+      <message type='end'>You feel the magic of your animated .+ unravel and end\.</message>
+   </spell>
+   <spell availability='all' name='Song of Sonic Disruption' number='1030' type='attack'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='self-cast' name='Song of Tonis' number='1035' type='defense/bonus'>
+      <duration>dur = 60.0; 1.upto(Skills.mltelepathy) { |val| if 20 &gt;= val then dur += 1.0 else dur += 0.5 end }; dur / 60.0</duration>
+      <cost type='mana'>35</cost>
+      <bonus type='dodging'>bonus = 20; [1,2,3,5,8,10,14,17,21,26,31,36,42,49,55,63,70,78,87,96].each { |n| bonus += 1 if Skills.elair &gt;= n }; bonus</bonus>
+      <message type='start'>As [A-z]+ sings?, a(?:n invigorating)? squall of wind (?:briefly )?swirls (?:around|about) you(?: and you hear a barely audibl[ey] burst of laughter)?\.(?:  You feel yourself moving (?:a bit )?more smoothly and quickly than before!)?</message>
+      <message type='end'>You hear a laugh and a clink of coins, and (?:you and your group )?become a bit less nimble\.</message>
+   </spell>
+   <spell availability='all' name='Troubadour&apos;s Rally' number='1040' type='defense/utility'>
+      <cost type='mana'>40</cost>
+   </spell>
+   <spell availability='all' name='Heal' number='1101' type='utility/attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='all' name='Limb Repair' number='1102' type='utility'>
+      <cost type='mana'>if (Wounds.limbs &gt; 1) and (Spells.empath &gt;= 7) then 7 else 2 end</cost>
+   </spell>
+   <spell availability='all' name='System Repair' number='1103' type='utility'>
+      <cost type='mana'>if (Wounds.nerves &gt; 1) and (Spells.empath &gt;= 8) then 8 else 3 end</cost>
+   </spell>
+   <spell availability='all' name='Head Repair' number='1104' type='utility'>
+      <cost type='mana'>if ([Wounds.head, Wounds.neck].max &gt; 1) and (Spells.empath &gt;= 9) then 9 else 4 end</cost>
+   </spell>
+   <spell availability='all' name='Organ Repair' number='1105' type='utility'>
+      <cost type='mana'>if (Wounds.torso &gt; 1) and (Spells.empath &gt;= 10) then 10 else 5 end</cost>
+   </spell>
+   <spell availability='all' channel='yes' name='Bone Shatter' number='1106' type='attack'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Adrenal Surge' number='1107' type='utility'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Empathy' number='1108' type='attack'>
+      <cost type='mana'>8</cost>
+   </spell>
+   <spell availability='self-cast' name='Empathic Focus' number='1109' type='offense/defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.empath</duration>
+      <cost type='mana'>9 + [(([Spells.empath,Stats.level].min - 9) / 6.0).round,0].max</cost>
+      <bonus type='physical-as'>15</bonus>
+      <bonus type='bolt-ds'>[25+(([Stats.level,Spells.empath].min-9)/2),25].max</bonus>
+      <bonus type='physical-ds'>[25+(([Stats.level,Spells.empath].min-9)/2),25].max</bonus>
+      <bonus type='elemental-td'>7</bonus>
+      <bonus type='spirit-td'>15</bonus>
+      <bonus type='sorcerer-td'>10</bonus>
+      <message type='start'>You center yourself and (?:focus|renew) your concentration\.</message>
+      <message type='end'>Your mind&apos;s keen focus fades away\.</message>
+   </spell>
+   <spell availability='all' name='Empathic Assault' number='1110' stance='yes' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Limb Scar Repair' number='1111' type='utility'>
+      <cost type='mana'>if (Scars.limbs &gt; 1) and (Spells.empath &gt;= 15) then 15 else 11 end</cost>
+   </spell>
+   <spell availability='all' name='System Scar Repair' number='1112' type='utility'>
+      <cost type='mana'>if (Scars.nerves &gt; 1) and (Spells.empath &gt;= 16) then 16 else 12 end</cost>
+   </spell>
+   <spell availability='all' name='Head Scar Repair' number='1113' type='utility'>
+      <cost type='mana'>if ([Scars.head,Scars.neck].max &gt; 1) and (Spells.empath &gt;= 17) then 17 else 13 end</cost>
+   </spell>
+   <spell availability='all' name='Organ Scar Repair' number='1114' type='utility'>
+      <cost type='mana'>if (Scars.torso &gt; 1) and (Spells.empath &gt;= 18) then 18 else 14 end</cost>
+   </spell>
+   <spell availability='all' name='Wither' number='1115' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='all' name='Rapid Healing' number='1116' type='utility'>
+      <duration>1</duration>
+      <cost type='mana'>16</cost>
+      <message type='start'>You narrow your focus on your healing energies, stimulating their flow\.</message>
+   </spell>
+   <spell availability='all' name='Empathic Link' number='1117' type='attack'>
+      <cost type='mana'>8 + (Stats.level/10)</cost>
+   </spell>
+   <spell availability='all' name='Herb Production' number='1118' type='utility'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='self-cast' name='Strength Of Will' number='1119' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.empath</duration>
+      <cost type='mana'>19 + (([Spells.empath,Stats.level].min - 19) / 6.0).round</cost>
+      <bonus type='bolt-ds'>[[12+((Spells.empath-19)/3),12].max,25].min</bonus>
+      <bonus type='physical-ds'>[[12+((Spells.empath-19)/3),12].max,25].min</bonus>
+      <bonus type='elemental-td'>([[12+((Spells.empath-19)/3),12].max,25].min/2).to_i</bonus>
+      <bonus type='spirit-td'>[[12+((Spells.empath-19)/3),12].max,25].min</bonus>
+      <bonus type='sorcerer-td'>([[12+((Spells.empath-19)/3),12].max,25].min*0.75).to_i</bonus>
+      <message type='start'>You feel an aura of resolve surround you\.  The exhilarating sensation sends your heart racing and a warm flush tingling through your body\.</message>
+      <message type='end'>Your aura of resolve dissipates\.</message>
+   </spell>
+   <spell availability='all' name='Sympathy' number='1120' type='attack'>
+      <cost type='mana'>20</cost>
+   </spell>
+   <spell availability='self-cast' name='Troll&apos;s Blood' number='1125' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.empath</duration>
+      <cost type='mana'>25</cost>
+      <message type='start'>Dark red droplets coalesce upon your skin before sinking into your flesh\.  (?:Your heart stutters for an instant before settling into a steady, powerful rhythm|Your heart, already beating strongly with Troll&apos;s Blood, accelerates with new vigor as your body accepts the new infusion)\.</message>
+      <message type='end'>Your heart staggers briefly before slowing to a more regular speed\.  Dark red droplets seep out of your skin and evaporate as the influence of Troll&apos;s Blood leaves you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Intensity' number='1130' type='offense/defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.empath</duration>
+      <cost type='mana'>30 + ([(([Spells.empath,Stats.level].min-30)/2),0].max/3)</cost>
+      <bonus type='bolt-as'>[20+(([Spells.empath,Stats.level].min-30)/2),20].max</bonus>
+      <bonus type='physical-as'>[20+(([Spells.empath,Stats.level].min-30)/2),20].max</bonus>
+      <bonus type='bolt-ds'>[20+(([Spells.empath,Stats.level].min-30)/2),20].max</bonus>
+      <bonus type='physical-ds'>[20+(([Spells.empath,Stats.level].min-30)/2),20].max</bonus>
+      <message type='start'>You feel an intense resolve fill your mind, and concentrate on improving your efforts to guard yourself\.</message>
+      <message type='end'>Your intensity subsides\.</message>
+   </spell>
+   <spell availability='all' name='Regeneration' number='1150' type='utility'>
+      <cost type='mana'>50</cost>
+   </spell>
+    <spell availability='all' name='Rapid Healing Recovery' number='1199'>
+      <duration>30</duration>
+      <message type='start'>You release your pinpoint focus on your healing energies and allow their stimulated flow to settle to normal rates\.</message>
+	</spell>
+   <spell availability='all' name='Soothing Word' number='1201' type='attack'>
+      <cost type='mana'>1</cost>
+   </spell>
+   <spell availability='self-cast' name='Iron Skin' number='1202' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>2</cost>
+      <bonus type='asg'>6 + (bonus = 0; [5,15,30,50,75,105,140,180,225].each { |n| bonus += 1 if Skills.mltransformation &gt;= n }; bonus) + (Char.prof == 'Monk' ? (bonus = 0; [5,15,30,50,75].each { |n| bonus += 1 if Char.level &gt;= n }; bonus) : 0)</bonus>
+      <message type='start'>You feel your skin grow tight all across your body and your complexion takes on a .*? quality\.</message>
+      <message type='end'>You feel the tension in your skin ease and notice that your complexion returns to normal\.</message>
+   </spell>
+   <spell availability='all' name='Powersink' number='1203' type='attack'>
+      <cost type='mana'>3</cost>
+   </spell>
+   <spell availability='all' name='Foresight' number='1204' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>4</cost>
+      <bonus type='physical-ds'>10</bonus>
+      <message type='start'>Opening your mind&apos;s eye to the progression of time, a myriad of possible future events fills your consciousness\.</message>
+      <message type='end'>Like sand through an hourglass, your visions of the future slip away and fade from your mind\.</message>
+   </spell>
+   <spell availability='all' name='Glamour' number='1205' type='utility'>
+      <cost type='mana'>5</cost>
+   </spell>
+   <spell availability='all' name='Telekinesis' number='1206' type='attack'>
+      <cost type='mana'>6</cost>
+   </spell>
+   <spell availability='all' name='Force Projection' number='1207' type='attack'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Mindward' number='1208' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>8 + ([([([Spells.minormental,Stats.level].min - 8), 0].max/2), 20].min/2)</cost>
+      <bonus type='elemental-td'>[20 + ([([Spells.minormental,Stats.level].min - 8), 0].max/2), 40].min/2</bonus>
+      <bonus type='mental-td'>[20 + ([([Spells.minormental,Stats.level].min - 8), 0].max/2), 40].min</bonus>
+      <bonus type='spirit-td'>[20 + ([([Spells.minormental,Stats.level].min - 8), 0].max/2), 40].min/2</bonus>
+      <bonus type='sorcerer-td'>[20 + ([([Spells.minormental,Stats.level].min - 8), 0].max/2), 40].min/2</bonus>
+      <message type='start'>You feel your forehead pulse as your mind hardens to deter invading thoughts\.</message>
+      <message type='end'>You feel your forehead pulse as your mind relaxes\.</message>
+   </spell>
+   <spell availability='self-cast' name='Dragonclaw' number='1209' type='offense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>9</cost>
+      <bonus type='unarmed-af'>10+(bonus=0;[1,3,6,10,15,21,28,36,45,55,66,78,91,105,120,136,153,171,190].each { |n| bonus += 1 if Skills.mltransformation >= n }; bonus)</bonus>
+      <message type='start'>Your hands grow hard and scaly\.</message>
+      <message type='end'>The scales covering your hands turn brittle and flake away\.</message>
+   </spell>
+   <spell availability='all' name='Thought Lash' number='1210' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='all' name='Confusion' number='1211' type='attack'>
+      <cost type='mana'>11</cost>
+   </spell>
+   <spell availability='all' name='Shroud of Deception' number='1212'/>
+   <spell availability='self-cast' name='Mind over Body' number='1213' type='utility'>
+      <duration max="599">599</duration>
+      <cost type='mana'>13</cost>
+      <bonus type='stamina-reduction'>20+(bonus=0;[6,15,30,80,150,230].each { |n| bonus += 5 if Skills.mltelepathy &gt;= n };bonus)</bonus>
+      <message type='start'>Your muscles ripple momentarily and you suddenly become aware of a multitude of your body&apos;s processes\.  You feel an unnatural control over your breathing, heart rate and muscle tension\.(?:\s+Your group appears similarly affected\.)?</message>
+      <message type='end'>You feel your muscles begin to strain for an instant\.  The sense of body control has left you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Brace' number='1214' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>14</cost>
+      <message type='start'>Thick plates of bone grow from your forearms\.</message>
+      <message type='start'>The bones surrounding your forearms shift and fortify\.</message>
+      <message type='end'>The thick plates of bone around your forearms begin to crack, then shatter into a fine white dust\.</message>
+   </spell>
+   <spell availability='all' name='Blink' number='1215' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <duration cast-type='target' span='refreshable'>2</duration>
+      <cost type='mana'>15</cost>
+      <message type='start'>A momentary eruption of starlit darkness engulfs you\.  As the shadow thins, double images of the world sway dizzyingly around you before regaining solidity\.$|^A momentary eruption of a flurry of squeaking bats engulfs you, flapping with a frenzy of shrill squeaks and chitters as they cyclone wildly about you. \s?As the bats wing away into the sky, double images of the world sway dizzyingly around you before regaining solidity\.</message>
+      <message type='end'>Darkness punctuated by a constellation of starry pinpoints wells up to the surface of your skin and splinters away with a sound like shattering crystal\.$|^A cloud of bats suddenly appear and wing straight for you, disappearing into a fine mist just before impact\.</message>
+   </spell>
+   <spell availability='all' name='Focus Barrier' number='1216' type='defense'>
+      <duration max="599">599</duration>
+      <cost type='mana'>16</cost>
+      <bonus type='physical-ds'>30</bonus>
+      <message type='start'>A barrier of force forms around you(?: and your group)?\.</message>
+      <message type='end'>The barrier of force around you dissipates\.</message>
+   </spell>
+   <spell availability='all' name='Vision' number='1217' type='utility'>
+      <cost type='mana'>17</cost>
+   </spell>
+   <spell availability='all' name='Mental Dispel' number='1218' type='attack/utility'>
+      <cost type='mana'>18</cost>
+   </spell>
+   <spell availability='all' name='Vertigo' number='1219' type='attack'>
+      <cost type='mana'>19</cost>
+   </spell>
+   <spell availability='self-cast' name='Premonition' number='1220' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.minormental</duration>
+      <cost type='mana'>20 + ([([Spells.minormental,Stats.level].min - 20), 0].max/4)</cost>
+      <bonus type='bolt-ds'>20 + ([([Spells.minormental,Stats.level].min - 20), 0].max/2)</bonus>
+      <bonus type='physical-ds'>20 + ([([Spells.minormental,Stats.level].min - 20), 0].max/2)</bonus>
+      <message type='start'>A flood of visions fills your mind and you strain to pick out your place amongst the countless blurred images and muted sound\.</message>
+      <message type='end'>The visions slowly trickle from your mind, and you are left with the world before you once again\.</message>
+   </spell>
+   <spell availability='all' name='Mindwipe' number='1225'/>
+   <spell availability='all' name='Provoke' number='1235' type='utility'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Mantle of Faith' number='1601' type='defense'>
+      <duration cast-type='self' span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <duration cast-type='target' span='refreshable'>20 + Spells.paladin</duration>
+      <cost type='mana'>cost = 1; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| cost += 1 if Skills.slblessings &gt;= n }; cost</cost>
+      <bonus type='bolt-ds'>bonus = 5; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <bonus type='physical-ds'>bonus = 5; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <bonus type='elemental-td'>((bonus = 5; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)/2).to_i</bonus>
+      <bonus type='spirit-td'>bonus = 5; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus</bonus>
+      <bonus type='sorcerer-td'>((bonus = 5; [2,5,9,14,20,27,35,44,54,65,77,90,104,119,135,152,170,189].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)*0.75).to_i</bonus>
+      <message type='start'>A whirl of spiritual energy streaks down from above, creating a dully illuminated mantle around your form\.|^The dully illuminated mantle surrounding your form seems to gain some cohesion\.</message>
+      <message type='end'>The dully illuminated mantle protecting you begins to falter, then completely fades away\.</message>
+   </spell>
+   <spell availability='all' name='Pious Trial' number='1602' type='attack'>
+      <cost type='mana'>2</cost>
+   </spell>
+   <spell availability='all' name='Templar&apos;s Verdict' number='1603' type='attack'>
+      <cost type='mana'>3</cost>
+   </spell>
+   <spell availability='all' name='Consecrate' number='1604' type='utility'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='group' name='Arm of the Arkati' number='1605' type='offense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>cost = 5; [5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200].each { |n| cost += 1 if Skills.slsummoning &gt;= n }; if group? then cost + 1 else cost end</cost>
+      <bonus type='damagefactor'>10 + (bonus = 0; [5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200].each { |n| bonus += 1 if Skills.slsummoning &gt;= n }; bonus)</bonus>
+      <message type='start'>You feel a subdued warmth through your arms and torso, accompanied by a preponderant sense of engagement\.</message>
+      <message type='end'>The warmth surrounding you fades with the spiritual force that was surrounding your arms\.</message>
+   </spell>
+   <spell availability='self-cast' name='Dauntless' number='1606' type='offense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>6</cost>
+      <bonus type='bolt-as'>10</bonus>
+      <bonus type='physical-as'>10</bonus>
+      <message type='start'>You are filled with a deeply confident and fearless composure\.|Your confidence and fearlessness is bolstered\.</message>
+      <message type='end'>Your boosted confidence and fearlessness fade\.</message>
+   </spell>
+   <spell availability='self-cast' name='Rejuvenation' number='1607' type='utility'>
+      <duration>5.13</duration>
+      <cost type='mana'>7</cost>
+      <message type='start'>Granules of cobalt light coalesce around you and as they begin to seep into your exposed skin, you feel invigorated\.</message>
+      <message type='end'>Cobalt light separates itself from your skin and scatters into oblivion\.</message>
+   </spell>
+   <spell availability='self-cast' name='Defense of the Faithful' number='1608' type='defense/utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>8</cost>
+      <bonus type='fof-offset'>0</bonus>
+      <message type='start'>Motes of lambent white-gold light appear and begin to swirl around you, coalescing into a radiant aura.</message>
+      <message type='end'>The aura of lambent white-gold light motes surrounding you dissipates slowly, winking out of existence.</message>
+   </spell>
+   <spell availability='group' name='Divine Shield' number='1609' type='defense'>
+      <duration max="599">599</duration>
+      <cost type='mana'>9</cost>
+      <bonus type='physical-ds'>15+(bonus = 0; [6,13,21,30,40].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)</bonus>
+      <bonus type='block'>10 + (bonus = 0; [3,7,12,18,25,33,42,52,63,75,88,102,117,133,150,168,187].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)</bonus>
+      <message type='start'>The warmth works its way toward you, and your shield arm feels much more nimble\.</message>
+      <message type='end'>Your skin grows slightly numb for a moment as the warm glow fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Higher Vision' number='1610' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>cost = 10; cost += (([Spells.paladin,Stats.level].min - 10) / 2).round; if cost &gt; 20 then cost = 20 end; cost</cost>
+      <bonus type='bolt-ds'>[[10+((Spells.paladin-10)/2),10].max,20].min+(bonus = 0; [5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200].each { |n| bonus += 1 if Skills.slreligion &gt;= n }; bonus)</bonus>
+      <bonus type='physical-ds'>[[10+((Spells.paladin-10)/2),10].max,20].min+(bonus = 0; [5,11,18,26,35,45,56,68,81,95,110,126,143,161,180,200].each { |n| bonus += 1 if Skills.slreligion &gt;= n }; bonus)</bonus>
+      <message type='start'>Visions of future battles fill your eyes, providing you with knowledge of conflicts yet unfought\.</message>
+      <message type='end'>You lose a bit of focus as the knowledge of future battles drifts from your mind\.</message>
+   </spell>
+   <spell availability='self-cast' name='Patron&apos;s Blessing' number='1611' type='defense'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>11 + ((([Spells.paladin,Stats.level].min - 11) * 0.75).round / 3).round</cost>
+      <bonus type='combatmaneuvers'>(10 + (0.75 * (Spells.paladin - 10)).round) + (bonus = 0; [3,7,12,18,25,33,42,52,63,75,88,102,117,133,150,168,187].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)</bonus>
+      <message type='start'>An unbridled power surges through you, infusing your body with might and improving your reactions\.</message>
+      <message type='end'>You feel your abilities diminish as the energy provided by your patron fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Faith&apos;s Clarity' number='1612' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>12</cost>
+      <message type='start'>The divine power grants you lucid understanding of the spiritual and you become much more clearly focused\.</message>
+      <message type='end'>Your sense of clarity fades\.</message>
+   </spell>
+   <spell availability='all' name='Aid the Fallen' number='1613' type='utility'>
+      <cost type='mana'>13</cost>
+   </spell>
+   <spell availability='all' name='Aura of the Arkati' number='1614' type='attack'>
+      <cost type='mana'>14</cost>
+   </spell>
+   <spell availability='all' name='Repentance' number='1615' type='attack'>
+      <cost type='mana'>15</cost>
+   </spell>
+   <spell availability='self-cast' name='Vigor' number='1616' type='utility'>
+      <duration span='stackable' multicastable='yes'>20 + Spells.paladin</duration>
+      <cost type='mana'>16</cost>
+      <bonus type='constitution'>4+((Spells.paladin-16)/4 ).floor</bonus>
+      <bonus type='health'>(Spell[1616].constitution*2)+(bonus = 0; [1,3,6,10,15,21,28,36,45,55,66,78,91,105,120,136,153,171,190].each { |n| bonus += 1 if Skills.slblessings &gt;= n }; bonus)</bonus>
+      <message type='start'>The blood in your veins thickens and pulses with renewed life!</message>
+      <message type='end'>You feel slightly weakened as the blood in your veins thins\.</message>
+   </spell>
+   <spell availability='self-cast' name='Zealot' number='1617' type='offense'>
+      <duration max="599">599</duration>
+      <cost type='mana'>17</cost>
+      <bonus type='physical-as'>30+(bonus = 0; [1,3,6,10,15,21,28,36,45,55,66,78,91,105,120,136,153,171,190].each { |n| bonus += 1 if Skills.slreligion &gt;= n }; bonus)</bonus>
+      <message type='start'>A surge of radiant energy coalesces around you and (?:then fades into obscurity|those nearby)\.</message>
+      <message type='end'>You feel less resolved as the divine urging subsides, fading into obscurity\.</message>
+   </spell>
+   <spell availability='group' name='Fervor' number='1618' type='offense'>
+      <duration max="599">599</duration>
+      <cost type='mana'>18</cost>
+      <message type='start'>You utter a pious chant and a divine force suddenly radiates around you\.  The intensity of your patron&apos;s aid billows out from you in a wave of righteous indignation\!</message>
+      <message type='end'>The divine force surrounding you slowly fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Faith Shield' number='1619' type='defense'>
+      <duration>dur = 0.5 + (Spells.paladin - 19) / 60.0; if dur &gt; (70.0 / 60.0) then dur = (70.0 / 60.0) else dur end</duration>
+      <cost type='mana'>19</cost>
+      <bonus type='elemental-td'>((50+(bonus = 0; [5,11,18,26,35,45,56,68].each { |n| bonus += 3 if Skills.slreligion &gt;= n }; bonus))/2).to_i</bonus>
+      <bonus type='spirit-td'>50+(bonus = 0; [5,11,18,26,35,45,56,68].each { |n| bonus += 3 if Skills.slreligion &gt;= n }; bonus)</bonus>
+      <bonus type='sorcerer-td'>((50+(bonus = 0; [5,11,18,26,35,45,56,68].each { |n| bonus += 3 if Skills.slreligion &gt;= n }; bonus))*0.75).to_i</bonus>
+      <message type='start'>A muted pale blue sphere surrounds you\.</message>
+      <message type='end'>The muted pale blue sphere surrounding you flickers once and shudders before fading completely\.</message>
+   </spell>
+   <spell availability='all' name='Holy Weapon' number='1625' type='utility'>
+      <cost type='mana'>25</cost>
+   </spell>
+   <spell availability='all' name='Judgment' number='1630' type='attack'>
+      <cost type='mana'>30</cost>
+   </spell>
+   <spell availability='all' name='Divine Intervention' number='1635' type='utility/defense'>
+      <cost type='mana'>35</cost>
+   </spell>
+   <spell availability='all' name='Divine Word' number='1640' type='utility'>
+      <cost type='mana'>40</cost>
+   </spell>
+   <spell availability='all' name='Divine Incarnation' number='1650' type='utility'>
+      <duration>10</duration>
+      <cost type='mana'>50</cost>
+   </spell>
+   <spell availability='all' name='Arcane Blast' number='1700' type='attack'>
+   </spell>
+   <spell availability='all' name='Arcane Decoy' number='1701' type='defense'>
+      <duration span='refreshable'>15 + (Skills.magicitemuse/6.0)</duration>
+      <cost type='mana'>1</cost>
+      <message type='start'>A brilliant, rapidly shifting aura swirls around you\.</message>
+      <message type='end'>The brilliant, rapidly shifting aura around you shimmers and (?:flickers briefly before fading\.|bursts in a bright flash!)</message>
+   </spell>
+   <spell availability='all' name='Stun Cloud' number='1704' type='attack'>
+      <cost type='mana'>4</cost>
+   </spell>
+   <spell availability='all' name='Flaming Aura' number='1706' type='attack'>
+      <duration>4</duration>
+      <cost type='mana'>6</cost>
+      <message type='start'>Thin wisps of blue flame suddenly surround your body!</message>
+      <message type='end'>The licks of blue flame surrounding you flare up one last time before vanishing with a staticky crackle\.</message>
+   </spell>
+   <spell availability='all' name='Minor Steam' number='1707' type='attack'>
+      <cost type='mana'>7</cost>
+   </spell>
+   <spell availability='all' name='Mystic Impedance' number='1708' type='attack'>
+      <duration>3</duration>
+      <cost type='mana'>8</cost>
+      <message type='start'>A dizzying array of golden runes surround and suffuse you before being absorbed into your body\.</message>
+      <message type='end'>Golden runes enscribe themselves upon your body, quickly fading into nothingness\.</message>
+   </spell>
+   <spell availability='all' name='Minor Cold' number='1709' type='attack'>
+      <cost type='mana'>9</cost>
+   </spell>
+   <spell availability='all' name='Major Acid' number='1710' type='attack'>
+      <cost type='mana'>10</cost>
+   </spell>
+   <spell availability='self-cast' name='Mystic Focus' number='1711' type='offense'>
+      <duration>5</duration>
+      <bonus type='elemental-cs'>10 + [20 - Stats.level, 0].max</bonus>
+      <bonus type='spirit-cs'>10 + [20 - Stats.level, 0].max</bonus>
+      <bonus type='sorcerer-cs'>10 + [20 - Stats.level, 0].max</bonus>
+      <message type='start'>A sudden clarity of thought comes over you, and you realize that you now understand arcane mysteries that were previously incomprehensible\.</message>
+      <message type='end'>Like a faint wisp of a barely-remembered dream, your brief, enhanced comprehension of arcane mysteries slips away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Spirit Guard' number='1712' type='defense'>
+      <duration span='stackable'>20 + (Skills.magicitemuse/2.0)</duration>
+      <bonus type='bolt-ds'>25</bonus>
+      <bonus type='physical-ds'>25</bonus>
+      <message type='start'>A faint silvery glow surrounds your body\.</message>
+      <message type='end'>A faint silvery glow fades from around you\.</message>
+   </spell>
+   <spell availability='all' name='Death Cloud' number='1713' type='attack' incant='no'/>
+   <spell availability='all' name='Firestorm' number='1715' type='attack'/>
+   <spell availability='all' name='V&apos;Tull&apos;s Fury' number='1718' type='attack'/>
+   <spell availability='all' name='Arcane Barrier' number='1720' type='defense'>
+      <duration>30</duration>
+      <cost type='mana'>20</cost>
+      <message type='start'>A .*? ellipsoid barrier slowly materializes around you and fades through a color spectrum into invisibility\.</message>
+      <message type='end'>Your .*? barrier flashes rapidly and the sound of breaking crystal can be heard as it cascades down around you\.</message>
+   </spell>
+   <spell availability='all' name='Fash&apos;lo&apos;nae&apos;s Gift' number='1750' type='utility'/>
+   <spell availability='self-cast' name='Decaying' number='6666' type='timer'>
+      <duration persist-on-death='yes'>16</duration>
+      <message type='start'>The time left until you decay should never match any game line; it&apos;s specifically handled by infomonitor.lic in order to get the duration and effects right\.  So unless it\&apos;s malfunctioning, don\&apos;t change this\.</message>
+      <message type='end'>The time left until you decay should never match any game line; it&apos;s specifically handled by infomonitor.lic in order to get the duration and effects right\.  So unless it\&apos;s malfunctioning, don\&apos;t change this\.</message>
+   </spell>
+   <spell availability='self-cast' name='Champion&apos;s Might' number='1912' type='offense'>
+      <duration span='stackable' multicastable='yes'>20</duration>
+      <cost type='mana'>12</cost>
+      <bonus type='elemental-cs'>([[3+Spells.paladin,15].max,25].min/2).to_i</bonus>
+      <bonus type='spirit-cs'>[[3+Spells.paladin,15].max,25].min</bonus>
+      <bonus type='sorcerer-cs'>([[3+Spells.paladin,15].max,25].min*0.75).to_i</bonus>
+      <message type='start'>A dim celadon wisp flares briefly about each of your hands, trailing soft pulses of residual light as they move\.</message>
+      <message type='end'>The dim celadon wisps about your hands flare up once more and fade completely away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Tortoise Stance' number='9401' type='defense'>
+      <duration>240</duration>
+      <cost type='stamina'>20</cost>
+      <message type='start'>You (?:assume|re-settle into) the Stance of the Tortoise, holding back your offensive power in order to maximize your defense\.</message>
+      <message type='end'>You relax from your continuous efforts to maximize your defense\.</message>
+      <cast-proc>fput &quot;shield tortoise&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Slash Protection' number='9501' type='defense'>
+      <duration>240</duration>
+   </spell>
+   <spell availability='all' name='Crush Protection' number='9502' type='defense'>
+      <duration>240</duration>
+   </spell>
+   <spell availability='all' name='Puncture Protection' number='9503' type='defense'>
+      <duration>240</duration>
+   </spell>
+   <spell availability='all' name='Armor Support' number='9504' type='bonus'>
+      <duration>240</duration>
+      <message type='start'>(?:You adjust|[A-Z][a-z]+ adjusts) your .*?, improving its ability to support the weight of your gear\.</message>
+   </spell>
+   <spell availability='all' name='Armored Evasion' number='9505' type='bonus'>
+      <duration>240</duration>
+      <message type='start'>(?:You adjust|[A-Z][a-z]+ adjusts) your .*?, improving its comfort and maneuverability\.</message>
+      <message type='end'>Your .*? shifts out of place and feels much less comfortable than before\.</message>
+   </spell>
+   <spell availability='all' name='Armored Casting' number='9506' type='bonus'>
+      <duration>240</duration>
+   </spell>
+   <spell availability='all' name='Armored Fluidity' number='9507' type='bonus'>
+      <duration>240</duration>
+      <message type='start'>(?:You adjust|[A-Z][a-z]+ adjusts) your .*?, making it easier for you to cast spells\.</message>
+      <message type='end'>Your .*? shifts out of place and feels somewhat more hindering\.$</message>
+   </spell>
+   <spell availability='all' name='Armored Stealth' number='9508' type='bonus'>
+      <duration>240</duration>
+      <message type='start'>(?:You adjust|[A-Z][a-z]+ adjusts) your .*? to cushion your movements\.</message>
+      <message type='end'>Your .*? shifts out of place and no longer cushions your movements\.</message>
+   </spell>
+   <spell availability='all' name='Armor Reinforcement' number='9509' type='defense'>
+      <duration>240</duration>
+      <message type='start'>(?:You adjust|[A-Z][a-z]+ adjusts) your .*?, reinforcing weak spots\.</message>
+   </spell>
+   <spell availability='self-cast' name='Combat Movement' number='9601' type='defense'>
+      <duration>3</duration>
+      <cost type='stamina'>5</cost>
+      <cast-proc>fput &quot;cman cmovement&quot;</cast-proc>
+      <message type='start'>Your body becomes tense and ready for action\.</message>
+      <message type='end'>Your close concentration on your movements fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Combat Focus' number='9602' type='defense'>
+      <duration>3</duration>
+      <cost type='stamina'>5</cost>
+      <cast-proc>fput &quot;cman focus&quot;</cast-proc>
+      <message type='start'>You sharpen your focus on combat and fortify yourself against distractions.</message>
+      <message type='end'>Your singular focus on combat slowly drifts away.</message>
+   </spell>
+   <spell availability='self-cast' name='Shadow Mastery' number='9603' type='utility'>
+      <duration>3.13</duration>
+      <cost type='stamina'>if Spell[9604].active? then 60 else 20 end</cost>
+      <cast-proc>dothistimeout &apos;cman smastery&apos;, 3, /^You focus your mind on the shadows and gird your body for stealth\.(?:  You find maintaining this mindset to be exceptionally tiring\.)?$|^Your muscles ache much too badly to even think about attempting this maneuver\.$/</cast-proc>
+      <message type='start'>You focus your mind on the shadows and gird your body for stealth\.(?:  You find maintaining this mindset to be exceptionally tiring\.)?</message>
+      <message type='end'>Your body relaxes as your thoughts stray from the shadows\.</message>
+   </spell>
+   <spell availability='self-cast' name='Shadow Mastery Cooldown' number='9604'>
+      <duration>2</duration>
+      <message type='start'>Your body relaxes as your thoughts stray from the shadows\.</message>
+      <message type='end'>The residual strain on your mind of such intense focus on the shadows fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Surge of Strength' number='9605' type='utility'>
+      <duration>1.5</duration>
+      <cost type='stamina'>(if Spell[9606].active? then 60 else 30 end)*((Spell[1213].active? and defined?(Spell[1213].stamina_reduction)) ? (1-(Spell[1213].stamina_reduction/100.0)) : 1)</cost>
+      <cast-proc>dothistimeout &apos;cman surge&apos;, 3, /^You feel (?:significantly|a great deal|a fair amount) stronger\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$/</cast-proc>
+      <message type='start'>You focus deep within yourself, searching for untapped sources of strength[\s\w\.]*</message>
+      <message type='end'>You begin to lose touch with your internal sources of strength\.</message>
+   </spell>
+   <spell availability='self-cast' name='Surge of Strength Cooldown' number='9606'>
+      <duration>dur = { nil =&gt; 5, 0 =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan.surge_of_strength]; else; 5; end</duration>
+      <message type='start'>You feel (?:significantly|a great deal|a fair amount) stronger\.</message>
+      <message type='end'>Your internal strength fully recovers from your most recent attempt to tap into it\.</message>
+   </spell>
+   <spell availability='all' name='Berserk' number='9607' type='attack'>
+      <duration>5</duration>
+      <cast-proc>result = dothistimeout &apos;berserk&apos;, 5, /^Everything around you turns red as you work yourself into a berserker&apos;s rage!|^You rage across the battlefield, striking with unrelenting fury!/; if result; done = false; 450.times { sleep 0.1; if clear.any? { |line| line =~ /^The redness fades from the world/ }; done = true; break; end; break unless GameObj.npcs.any? { |npc| npc.status !~ /dead/ } }; unless done; fput &apos;stop berserk&apos;; end; end</cast-proc>
+      <message type='start'>Everything around you turns red as you work yourself into a berserker&apos;s rage!</message>
+      <message type='end'>The redness fades from the world and you begin to breathe harder\.</message>
+   </spell>
+   <spell availability='self-cast' name='Rolling Krynch Stance' number='9620' type='timer'>
+      <duration>240</duration>
+      <cost type='stamina'>20</cost>
+      <cast-proc>fput &quot;cman krynch&quot;</cast-proc>
+      <message type='start'>You (?:assume|re-settle into) the Rolling Krynch Stance\.</message>
+      <message type='end'>You relax from the Rolling Krynch Stance\.</message>
+   </spell>
+   <spell availability='self-cast' name='Stance of the Mongoose' number='9621' type='timer'>
+      <duration>240</duration>
+      <cost type='stamina'>20</cost>
+      <cast-proc>fput &quot;cman mongoose&quot;</cast-proc>
+      <message type='start'>You (?:assume|re-settle into) the Stance of the Mongoose, ready to retaliate instantly against your foes\.</message>
+      <message type='end'>You relax from the Stance of the Mongoose, no longer ready to retaliate instantly against your foes\.</message>
+   </spell>
+   <spell availability='self-cast' name='Slippery Mind' number='9622' type='timer'>
+      <duration>240</duration>
+      <cost type='stamina'>20</cost>
+      <cast-proc>fput &quot;cman slipp&quot;</cast-proc>
+      <message type='start'>You focus inward and prepare to blank your mind at a moment&apos;s notice\.</message>
+      <message type='end'>You relax your mind and are no longer prepared to blank it at a moment&apos;s notice\.</message>
+   </spell>
+   <spell availability='self-cast' name='Flurry of Blows' number='9623' type='timer'>
+      <duration>240</duration>
+      <cost type='stamina'>30</cost>
+      <cast-proc>fput &quot;cman flurry&quot;</cast-proc>
+      <message type='start'>You (?:assume|re-settle into) a stance suitable to unleash a flurry of blows\.</message>
+      <message type='end'>You relax from a stance suitable to unleash a flurry of blows\.</message>
+   </spell>
+   <spell availability='self-cast' name='Inner Harmony' number='9624' type='timer'>
+      <duration>240</duration>
+      <cost type='stamina'>40</cost>
+      <cast-proc>fput &quot;cman iharm&quot;</cast-proc>
+      <message type='start'>You (?:center your mind, body and soul and enter a|continue in your) state of inner harmony\.</message>
+      <message type='end'>You feel your state of inner harmony slip away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Burst of Swiftness' number='9625' type='utility'>
+      <duration>1.5</duration>
+      <cost type='stamina'>(if Spell[9051].active?; 60; else; 30; end)*((Spell[1213].active? and defined?(Spell[1213].stamina_reduction)) ? (1-(Spell[1213].stamina_reduction/100.0)) : 1)</cost>
+      <cast-proc>dothistimeout &apos;cman burst&apos;, 3, /^You feel (?:significantly|a great deal|a fair amount) more (?:agile|dextrous)\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$/</cast-proc>
+      <message type='start'>You prepare yourself to move swiftly at a moment&apos;s notice.*</message>
+      <message type='end'>You feel less prepared to move as swiftly as before\.</message>
+   </spell>
+   <spell availability='self-cast' name='Ki Focus' number='9626' type='offense'>
+      <duration>1.0</duration>
+      <cost type='stamina'>20+5+5</cost> <!-- fixme: rank dependent cost but no CMan.kifocus in lich.rb -->
+      <cast-proc>dothistimeout &apos;cman kifocus&apos;, 3, /^You summon your inner ki|^You have already summoned your inner ki/</cast-proc>
+      <message type='start'>You summon your inner ki and focus it to enhance your next attack\.</message>
+      <message type='start'>You have already summoned your inner ki and are ready for a devastating attack\.</message>
+      <message type='end'>You lose the intense focus of your ki energy\.</message>
+   </spell>
+   <spell availability='self-cast' name='Duck and Weave' number='9627' type='utility'>
+      <duration span='refreshable'>0.5</duration>
+      <cost type='stamina'>(if Spell[9052].active?; 90; else; 30; end)*((Spell[1213].active? and defined?(Spell[1213].stamina_reduction)) ? (1-(Spell[1213].stamina_reduction/100.0)) : 1)</cost>
+      <cast-proc>dothistimeout &apos;cman weave&apos;, 3, /^You balance your posture and narrow your eyes, preparing to misdirect your foes' attacks\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$/</cast-proc>
+      <message type='start'>You balance your posture and narrow your eyes, preparing to misdirect your foes' attacks\.</message>
+      <message type='end'>You relax your posture and blink to clear your eyes\.</message>
+   </spell>
+   <spell availability='self-cast' name='POPed muscles' number='9699'>
+      <duration>10.5</duration>
+      <message type='start'>You hear a loud \*POP\* come from your muscles!</message>
+      <message type='end'>Your muscles (?:feel much less strained than|no longer feel as weak as) they did a moment ago\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Recognition' number='9701' type='utility'>
+      <cast-proc>fput &quot;sigil of recognition&quot;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Location' number='9702' type='utility'>
+      <cast-proc>fput &quot;sigil of location&quot;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Contact' number='9703' type='utility'>
+      <duration span='stackable'>17</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sigil of contact&apos;, 3, /^You feel your mind open up to the world around you\.$|^The distant thoughts in your mind feel stronger\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>You concentrate on your sigil\.</message>
+      <message type='end'>You sense that your attunement to the minds of others has ceased\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Resolve' number='9704' type='utility'>
+      <duration>1.5</duration>
+      <cost type='stamina'>5</cost>
+      <cast-proc>dothistimeout &apos;sigil of resolve&apos;, 3, /^You experience a momentary flash of insight on how to best overcome nature&apos;s obstacles\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>You experience a momentary flash of insight on how to best overcome nature&apos;s obstacles\.</message>
+      <message type='end'>You feel your added insight slip away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Minor Bane' number='9705' type='offense'>
+      <duration>1</duration>
+      <cost type='mana'>3</cost>
+      <cost type='stamina'>3</cost>
+      <cast-proc>dothistimeout &apos;sigil of minor bane&apos;, 3, /^As you concentrate on your sigil, you become slightly more aware of your foes and the weakest spots in their defenses\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>As you concentrate on your sigil, you become slightly more aware of your foes and the weakest spots in their defenses\.</message>
+      <message type='end'>Your heightened awareness of your foes fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Bandages' number='9706' type='utility'>
+      <duration>3</duration>
+      <cost type='stamina'>10</cost>
+      <cast-proc>dothistimeout &apos;sigil of bandages&apos;, 3, /^Your awareness of your own movements heightens as you begin to act with an unusual fluidity\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>Your awareness of your own movements heightens as you begin to act with an unusual fluidity\.</message>
+      <message type='end'>Your actions become less fluid as your close concentration on your movements begins to falter\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Defense' number='9707' type='defense'>
+      <duration>5</duration>
+      <cost type='mana'>5</cost>
+      <cost type='stamina'>5</cost>
+      <cast-proc>dothistimeout &apos;sigil of defense&apos;, 3, /^A shimmering aura surrounds you\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='bolt-ds'>Society.rank</bonus>
+      <bonus type='physical-ds'>Society.rank</bonus>
+      <message type='start'>A shimmering aura surrounds you\.</message>
+      <message type='end'>The shimmering aura fades from around you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Offense' number='9708' type='offense'>
+      <duration>5</duration>
+      <cost type='mana'>5</cost>
+      <cost type='stamina'>5</cost>
+      <cast-proc>dothistimeout &apos;sigil of offense&apos;, 3, /^A faint blue glow surrounds your hands, subtly guiding your movements\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='bolt-as'>Society.rank</bonus>
+      <bonus type='physical-as'>Society.rank</bonus>
+      <message type='start'>A faint blue glow surrounds your hands, subtly guiding your movements\.</message>
+      <message type='end'>The faint blue glow fades from around your hands\.</message>
+   </spell>
+   <spell availability='all' name='Sigil of Distraction' number='9709' type='attack'>
+      <duration>5</duration>
+      <cost type='mana'>5</cost>
+      <cost type='stamina'>10</cost>
+      <cast-proc>dothistimeout &apos;sigil of distraction&apos;, 3, /^You carefully school your thoughts, focusing on the thresholds of disorder inherent in your environs, and etch the Sigil of Distraction in the air before you\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Minor Protection' number='9710' type='defense'>
+      <duration max='3.0' span='stackable'>1</duration>
+      <cost type='mana'>5</cost>
+      <cost type='stamina'>10</cost>
+      <cast-proc>dothistimeout &apos;sigil of minor protection&apos;, 3, /^As you concentrate on your sigil, you become slightly more aware of weak spots in your defenses\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='bolt-ds'>5</bonus>
+      <bonus type='physical-ds'>5</bonus>
+      <message type='start'>As you concentrate on your sigil, you become slightly more aware of weak spots in your defenses\.</message>
+      <message type='end'>Your heightened awareness of your own defensive weaknesses fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Focus' number='9711' type='defense'>
+      <duration max='3.0' span='stackable'>1</duration>
+      <cost type='mana'>5</cost>
+      <cost type='stamina'>5</cost>
+      <cast-proc>dothistimeout &apos;sigil of focus&apos;, 3, /^You feel your mind and body gird themselves against magical interference\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='elemental-td'>Society.rank</bonus>
+      <bonus type='spirit-td'>Society.rank</bonus>
+      <bonus type='sorcerer-td'>Society.rank</bonus>
+      <message type='start'>You feel your mind and body gird themselves against magical interference\.</message>
+      <message type='end'>Your mind and body begin to relax after that period of intense focus\.</message>
+   </spell>
+   <spell availability='all' name='Sigil of Intimidation' number='9712' type='attack'>
+      <cost type='mana'>if checkpcs.length &gt; 1 then 10 else 5 end</cost>
+      <cost type='stamina'>if checkpcs.length &gt; 1 then 15 else 10 end</cost>
+      <cast-proc>dothistimeout &apos;sigil of intimidation&apos;, 3, /^You carefully school your thoughts, focusing on the enhancement of your aspect and bearing, and etch the Sigil of Intimidation in the air before you\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Mending' number='9713' type='utility'>
+      <duration>10</duration>
+      <cost type='mana'>10</cost>
+      <cost type='stamina'>15</cost>
+      <cast-proc>dothistimeout &apos;sigil of mending&apos;, 3, /^Your heart begins to beat faster as your entire body becomes awash with a pleasantly warm sensation\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>Your heart begins to beat faster as your entire body becomes awash with a pleasantly warm sensation\.</message>
+      <message type='end'>The pleasantly warm sensation fades as your heart beat begins to return to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Concentration' number='9714' type='bonus'>
+      <duration>10</duration>
+      <cost type='stamina'>30</cost>
+      <cast-proc>dothistimeout &apos;sigil of concentration&apos;, 3, /^As you concentrate on your sigil, you feel more attuned to the flows of mana\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>As you concentrate on your sigil, you feel more attuned to the flows of mana\.</message>
+      <message type='end'>Your heightened attunement to the flows of mana begins to fade\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Major Bane' number='9715' type='offense'>
+      <duration>1</duration>
+      <cost type='mana'>10</cost>
+      <cost type='stamina'>10</cost>
+      <cast-proc>dothistimeout &apos;sigil of major bane&apos;, 3, /^As you concentrate on your sigil, you become much more aware of your foes and the most vulnerable portions of their bodies\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='bolt-as'>10</bonus>
+      <bonus type='physical-as'>10</bonus>
+      <message type='start'>As you concentrate on your sigil, you become much more aware of your foes and the most vulnerable portions of their bodies\.</message>
+      <message type='end'>Your heightened awareness of your foes fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Determination' number='9716' type='utility'>
+      <duration>3</duration>
+      <cost type='stamina'>30</cost>
+      <cast-proc>dothistimeout &apos;sigil of determination&apos;, 3, /^You begin to focus sharply upon the task at hand, pushing all thoughts and sensations of pain far from your mind\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <message type='start'>You begin to focus sharply upon the task at hand, pushing all thoughts and sensations of pain far from your mind\.</message>
+      <message type='end'>Your sharp concentration upon your current task falters as the pain of your injuries rushes back into your mind\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Health' number='9717' type='utility'>
+      <cost type='mana'>10</cost>
+      <cost type='stamina'>20</cost>
+      <cast-proc>dothistimeout &apos;sigil of health&apos;, 3, /^As you concentrate on your sigil, you feel a brief surge of vitality course throughout your body\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Power' number='9718' type='utility'>
+      <cost type='stamina'>50</cost>
+      <cast-proc>dothistimeout &apos;sigil of power&apos;, 3, /^As you concentrate on the signal, you feel exceptionally tired as your physical energy rapidly transforms into magical energy\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Major Protection' number='9719' type='defense'>
+      <duration max='3.0' span='stackable'>1</duration>
+      <cost type='mana'>10</cost>
+      <cost type='stamina'>15</cost>
+      <cast-proc>dothistimeout &apos;sigil of major protection&apos;, 3, /^As you concentrate on your sigil, you become much more aware of vulnerable spots in your defenses\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='physical-ds'>10</bonus>
+      <message type='start'>As you concentrate on your sigil, you become much more aware of vulnerable spots in your defenses\.</message>
+      <message type='end'>Your heightened awareness of your own vulnerabilities fades away\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sigil of Escape' number='9720' type='utility'>
+      <cost type='mana'>15</cost>
+      <cost type='stamina'>75</cost>
+      <cast-proc>fput &quot;sigil of escape&quot;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Recognition' number='9801' type='utility'>
+      <cast-proc>dothistimeout &quot;symbol of recognition&quot;, 5, /^There are no undead creatures present\.|^You recognize no fellow members|is and undead creature\.|is a member of the Order of Voln\./</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Blessing' number='9802' type='utility'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of blessing#{target}&quot;, 5, /^You must specify something\.|^A wave of power flows outward from you|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Thought' number='9803' type='utility'>
+      <cast-proc>fput &quot;&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Diminishment' number='9804' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of diminishment#{target}&quot;, 5, /^What were you referring to\?|^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Courage' number='9805' type='offense'>
+      <duration span='stackable'>Society.rank / 6.0</duration>
+      <cast-proc>dothistimeout &quot;symbol of courage&quot;, 5, /^You feel more courageous\.|^You strain to perform the symbol/</cast-proc>
+      <bonus type='bolt-as'>Society.rank</bonus>
+      <bonus type='physical-as'>Society.rank</bonus>
+      <message type='start'>You feel more courageous\.</message>
+      <message type='end'>You feel the extra courage wane\.</message>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Protection' number='9806' type='defense'>
+      <duration span='stackable'>Society.rank / 3.0</duration>
+      <cast-proc>dothistimeout &quot;symbol of protection&quot;, 5, /^You feel a layer of protection surround you\.|^You strain to perform the symbol/</cast-proc>
+      <bonus type='bolt-ds'>Society.rank</bonus>
+      <bonus type='physical-ds'>Society.rank</bonus>
+      <bonus type='elemental-td'>Society.rank/2</bonus>
+      <bonus type='mental-td'>Society.rank/2</bonus>
+      <bonus type='spirit-td'>Society.rank/2</bonus>
+      <bonus type='sorcerer-td'>Society.rank/2</bonus>
+      <message type='start'>You feel a layer of protection surround you\.</message>
+      <message type='end'>The layer of protection fades away\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Submission' number='9807' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of submission#{target}&quot;, 5, /^What were you referring to\?|^You feel the power of the symbol project|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Kai&apos;s Strike' number='9808'>
+      <cast-proc>fput &quot;&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Holiness' number='9809' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of holiness#{target}&quot;, 5, /^What were you referring to\?|^A wave of power flows out of you|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Recall' number='9810' type='utility'>
+      <cast-proc>fput &quot;symbol of recall&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Sleep' number='9811' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sleep#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Transcendence' number='9812' type='defense'>
+      <duration>0.5</duration>
+      <cast-proc>dothistimeout &quot;symbol of transcendence#{target}&quot;, 5, /^You step into the space between the corporeal and ethereal realms\.|^You have already stepped into the space between the corporeal and ethereal realms\.|^The bonds of the corporeal realm hold fast and you remain fully within its grasp\.|^You strain to perform the symbol/</cast-proc>
+      <message type='start'>(?:With difficulty, you manage to will yourself|You step) into the space between the corporeal and ethereal realms\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Mana' number='9813' type='utility'>
+      <cast-proc>dothistimeout &apos;symbol of mana&apos;, 5, /^You call upon a special blessing from Koar.|^You are already at your maximum mana level\.|^You must CONFIRM that you wish to use this symbol during its recovery period\.|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Sight' number='9814' type='utility'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sight#{target}&quot;, 5, /^You concentrate|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Retribution' number='9815' type='attack/utility'>
+      <duration span='stackable'>Society.rank / 6.0</duration>
+      <cast-proc>fput &quot;symbol of retribution&quot;</cast-proc>
+      <message type='start'>You feel an aura of righteous wrath surround you\.</message>
+      <message type='end'>The aura of righteous wrath leaves you\.</message>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Supremacy' number='9816' type='offensive'>
+      <duration span='stackable'>Society.rank / 6.0</duration>
+      <cast-proc>dothistimeout &apos;symbol of supremacy&apos;, 5, /^You feel infused with a collective knowledge on the undead and their weaknesses\.|^You strain to perform the symbol/</cast-proc>
+      <message type='start'>You feel infused with a collective knowledge on the undead and their weaknesses\.</message>
+      <message type='end'>The rush of collective knowledge of the undead fades from your mind\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Restoration' number='9817' type='utility'>
+      <cast-proc>dothistimeout &apos;symbol of restoration&apos;, 5, /^The power of the symbol begins to rise in you, but then fades\.|^You feel the power of the symbol course through your body\.|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Need' number='9818' type='utility'>
+      <cast-proc>fput &quot;symbol of need&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Renewal' number='9819' type='utility'>
+      <cast-proc>dothistimeout &apos;symbol of renewal&apos;, 5, /^You are already at your maximum spirit level\.|^You call upon the vitality of nature to renew your soul\.|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Disruption' number='9820' type='offensive'>
+      <cast-proc>dothistimeout &apos;symbol of disruption&apos;, 5, /^A churning spectral aura surrounds you|^You strain to perform the symbol/</cast-proc>
+      <duration span='stackable'>Society.rank / 6.0</duration>
+      <message type='start'>A churning spectral aura surrounds you(?: and your group)?\.</message>
+      <message type='end'>The churning spectral aura suddenly vanishes from around you\.</message>
+   </spell>
+   <spell availability='all' name='Kai&apos;s Smite' number='9821' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;smite#{target}&quot;, 5, /^You currently have no valid target\.  You will need to specify one\.|doesn&apos;t appear to be suffering from the curse of undeath\.|^You .*?smite/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Turning' number='9822' type='attack'>
+      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Fixnum; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of turning#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Preservation' number='9823' type='utility'>
+      <cast-proc>fput &quot;symbol of preservation&quot;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Symbol of Dreams' number='9824' type='utility'>
+      <duration>240</duration>
+      <cast-proc>fput &quot;symbol of dreams&quot;</cast-proc>
+      <message type='start'>You feel suddenly tired and lie down for a nap\.</message>
+      <message type='end'>Your sleep is interrupted\.|You wake up from your sleep\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Return' number='9825' type='utility'>
+      <cast-proc>fput &quot;symbol of return&quot;</cast-proc>
+   </spell>
+   <spell availability='all' name='Symbol of Seeking' number='9826' type='utility'>
+      <cast-proc>fput &quot;symbol of seeking&quot;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Recognition' number='9901' type='utility'>
+      <cast-proc>dothistimeout &apos;sign of recognition&apos;, 3, /^You (?:touch|scratch|rub|tap|point to) your (?:right|left) (?:eyebrow|nostril|earlobe|shoulder|cheek) with your (?:right|left) (?:pinky|forefinger|thumb|index finger)\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Warding' number='9903' type='defense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of warding&apos;, 3, /^Your dancing fingers weave a web of protection around you!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-ds'>5</bonus>
+      <bonus type='physical-ds'>5</bonus>
+      <message type='start'>Your dancing fingers weave a web of protection around you!</message>
+      <message type='end'>Your SIGN OF WARDING is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Striking' number='9904' type='offense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of striking&apos;, 3, /^You (?:flex your muscles|grip your .*?) with renewed vigor!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-as'>5</bonus>
+      <bonus type='physical-as'>5</bonus>
+      <message type='start'>You (?:grip|flex) your [\w\s']+ with renewed vigor!</message>
+      <message type='end'>Your SIGN OF STRIKING is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Clotting' number='9905' type='utility'>
+      <duration>1+(Stats.level/6.0)</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of clotting&apos;, 3, /^Your veins throb and your blood sings\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Thought' number='9906' type='utility'>
+      <duration span='stackable'>10 + Stats.level / 10.0</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of thought&apos;, 3, /^Your hypnotic gesture makes your mind receptive to the thoughts of others\.  You feel their distant, comforting presence\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <message type='start'>Your hypnotic gesture makes your mind receptive to the thoughts of others\.  You feel their distant, comforting presence\.</message>
+      <message type='end'>You sense that your attunement to the minds of others has ceased\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Defending' number='9907' type='defense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='mana'>2</cost>
+      <cast-proc>dothistimeout &apos;sign of defending&apos;, 3, /^Your dancing fingers weave a web of protection around you!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-ds'>10</bonus>
+      <bonus type='physical-ds'>10</bonus>
+      <message type='start'>Your dancing fingers weave a web of protection around you!</message>
+      <message type='end'>Your SIGN OF DEFENDING is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Smiting' number='9908' type='offense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='mana'>2</cost>
+      <cast-proc>dothistimeout &apos;sign of smiting&apos;, 3, /^You (?:flex your muscles|grip your .*?) with renewed vigor!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-as'>10</bonus>
+      <bonus type='physical-as'>10</bonus>
+      <message type='start'>You (?:grip|flex) your [\w\s']+ with renewed vigor!</message>
+      <message type='end'>Your SIGN OF SMITING is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Staunching' number='9909' type='utility'>
+      <duration>2 + Stats.level / 3.0</duration>
+      <cost type='mana'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of staunching&apos;, 3, /^Your veins throb and your blood sings\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <message type='start'>Your veins throb and your blood sings\.</message>
+      <message type='end'>Your SIGN OF (?:STAUNCHING|CLOTTING) is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Deflection' number='9910' type='defense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='mana'>3</cost>
+      <cast-proc>dothistimeout &apos;sign of deflection&apos;, 3, /^You feel magical energies distort and flow around you\.$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-ds'>20</bonus>
+      <message type='start'>You feel magical energies distort and flow around you\.</message>
+      <message type='end'>Your SIGN OF DEFLECTION is no longer effective\.</message>
+   </spell>
+   <spell availability='all' name='Sign of Hypnosis' number='9911' type='attack'>
+      <cost type='spirit'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of hypnosis&apos; 3, /^You project your will upon your opponents!|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Swords' number='9912' type='offense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='spirit'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of swords&apos;, 3, /^You (?:flex your muscles|grip your .*?) with renewed vigor!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-as'>20</bonus>
+      <bonus type='physical-as'>20</bonus>
+      <message type='start'>You (?:grip|flex) your [\w\s']+ with renewed vigor!</message>
+      <message type='end'>Your SIGN OF SWORDS is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Shields' number='9913' type='defense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='spirit'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of shields&apos;, 3, /^Your dancing fingers weave a web of protection around you!$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-ds'>20</bonus>
+      <bonus type='physical-ds'>20</bonus>
+      <message type='start'>Your dancing fingers weave a web of protection around you!</message>
+      <message type='end'>Your SIGN OF SHIELDS is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Dissipation' number='9914' type='defense'>
+      <duration>1 + Stats.level / 6.0</duration>
+      <cost type='spirit'>1</cost>
+      <cast-proc>dothistimeout &apos;sign of dissipation&apos;, 3, /^Magic flows towards you, but does not reach you\.$|^Repeating the sign has no effect!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='elemental-td'>15</bonus>
+      <bonus type='mental-td'>15</bonus>
+      <bonus type='spirit-td'>15</bonus>
+      <bonus type='sorcerer-td'>15</bonus>
+      <message type='start'>Magic flows towards you, but does not reach you\.</message>
+      <message type='end'>Your SIGN OF DISSIPATION is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Healing' number='9915' type='utility'>
+      <cost type='spirit'>2</cost>
+      <cast-proc>dothistimeout &apos;sign of healing&apos;, 3, /^You shudder as your life force is torn and reshaped!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Madness' number='9916' type='offense'>
+      <duration>0.25</duration>
+      <cost type='spirit'>3</cost>
+      <cast-proc>dothistimeout &apos;sign of madness&apos;, 3, /^You are filled with berserk rage!  Attack!  Attack!  Attack!$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-as'>50</bonus>
+      <bonus type='physical-as'>50</bonus>
+      <message type='start'>You are filled with berserk rage!  Attack!  Attack!  Attack!</message>
+      <message type='end'>Your SIGN OF MADNESS is no longer effective\.</message>
+   </spell>
+   <spell availability='self-cast' name='Sign of Possession' number='9917' type='attack'>
+      <cost type='spirit'>4</cost>
+      <cast-proc>dothistimeout &apos;sign of possession&apos; 3, /^You project your will upon your opponents!|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <bonus type='bolt-as'>50</bonus>
+      <bonus type='physical-as'>50</bonus>
+   </spell>
+   <spell availability='self-cast' name='Sign of Wracking' number='9918' type='utility'>
+      <cost type='spirit'>5</cost>
+      <cast-proc>result = nil; loop { waitrt?; waitcastrt?; if percentmana == 100; result = true; break; end; unless Spell[9918].affordable?; result = false; break; end; put &apos;sign of wracking&apos;; 20.times { sleep 0.1; while line = get?; if line == &apos;You shudder as your life force is torn and reshaped!&apos;; result = true; break; elsif line =~ /^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^I don&apos;t think so\.$/; result = false; break; end; end; break unless result.nil? }; break unless result.nil?; dothis &apos;help no-double-wrack&apos;, /^No help files matching that entry were found\.$/ }; result</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Darkness' number='9919' type='utility'>
+      <cost type='spirit'>6</cost>
+      <cast-proc>dothistimeout &apos;sign of darkness&apos; 3, /^Darkness enfolds and surrounds you\.\.\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Sign of Hopelessness' number='9920' type='utility'>
+      <cost type='spirit'>11</cost>
+      <cast-proc>echo &apos;.cast called for spell 9920 (Sign of Hopelessness)... what the hell is wrong with you?&apos;</cast-proc>
+   </spell>
+   <spell availability='self-cast' name='Arcane Mobility' number='9002' type='offense'>
+      <duration>5</duration>
+      <message type='start'>You feel a wave of strength enter your muscles, and with it a newfound sense of confidence\.</message>
+      <message type='end'>You are suddenly overcome by anxiety, but it quickly passes, leaving you feeling only slightly weaker and less assured than you were a moment ago\.</message>
+   </spell>
+   <spell availability='self-cast' name='Next Bounty' number='9003' type='timer'>
+      <duration persist-on-death='yes' real-time='yes'>15</duration>
+      <message type='start'>[A-Z][a-z]+ says, &quot;Hmm, I&apos;ve got a task here|^[A-Z][a-z]+ says, &quot;I&apos;ve got a special mission for you.*</message>
+   </spell>
+   <spell availability='self-cast' name='Next Group Bounty' number='9056' type='timer'>
+      <duration persist-on-death='yes' real-time='yes'>15</duration>
+      <message type='start'>[A-Z][a-z]+ turns to you and says, "[A-Z][a-z]+ has signed you up to join (?:him|her) on (?:his|her) task\.  I trust that s?he has adequately informed you of the nature of the task.*</message>
+   </spell>
+   <spell availability='self-cast' name='Next GoS Task' number='9004' type='timer'>
+      <duration>15</duration>
+      <message type='start'>[A-Z][a-z]+ nods to you.*?Grimswarm.*</message>
+   </spell>
+   <spell availability='all' name='MStrike Cooldown' number='9005' type='timer'>
+      <duration>1</duration>
+      <message type='start'>Your (?:flurry|series) of strikes(?: and ripostes)? leaves you (?:off-balance|winded) and out of position\.</message>
+      <message type='end'>You feel recovered from your whirlwind flurry of strikes\.</message>
+   </spell>
+   <spell availability='all' name='Lichbane' number='9006' type='defense'>
+      <duration>10</duration>
+      <message type='start'>You feel more courageous as a \w+ aura appears about you\.</message>
+      <message type='end'>The sense of courage departs as the \w+ aura fades from about you\.</message>
+   </spell>
+   <spell availability='all' name='Well of Life Cooldown' number='9007' type='timer'>
+      <duration>if defined?(XMLData.last_spirit); ([XMLData.last_spirit-XMLData.spirit,1].max*2) - (Skills.slblessings/60.0); else; 6; end</duration>
+      <message type='start'>You are left feeling weakened and feeble\.</message>
+      <message type='end'>The feeling of weakness fades from you\. You feel ripe to transfer spirit once again\.</message>
+   </spell>
+   <spell availability='all' name='Sacrifice Cooldown' number='9008' type='timer'>
+      <duration>10.0 - ([Skills.slnecromancy, 120].min * 2)/60.0 - ([[(Skills.slnecromancy - 120), 0].max, 80].min * 0.75)/60.0 - ([(Skills.slnecromancy - 200), 0].max * 1.5)/60.0</duration>
+      <message type='start'>Your senses tingle, then become awash in a flood of power as the life leaves your hapless foe!</message>
+      <message type='end'>You feel refreshed enough to sacrifice another animus\.</message>
+   </spell>
+   <spell availability='all' name='Raise Dead Cooldown' number='9009' type='timer'>
+      <duration persist-on-death='yes'>s = Spell['Raise Dead Cooldown']; if s.active?; s.timeleft; else; if reget.any? { |line| line =~ /^You have a foreboding sense of darkness enveloping your soul as you realize [A-Z][a-z]+ has died while both of you are still soul linked!  You can sense the tugging of [A-Z][a-z]+&apos;s? soul clinging on to life, pulling you headlong into the long dark\.  It takes every ounce of spiritual energy you have to sever the link and claw yourself back to the world of the living!  You feel empty and torpid, unable to focus your spiritual self\./ }; 60.0; else; 5-(Skills.slblessings/60.0)+0.05; end; end</duration>
+      <message type='start'>Moisture beads upon your skin and you feel your eyes cloud over with the darkness of a rising storm\.  Power builds upon the air, and when you utter the last syllable of your spell thunder rumbles from your lips\.  The sound ripples upon the air, colliding with [A-Z][a-z]+'s prone form, and a brilliant flash transfers the spiritual energy between you\.</message>
+      <message type='start'>You have a foreboding sense of darkness enveloping your soul as you realize [A-Z][a-z]+ has died while both of you are still soul linked!  You can sense the tugging of [A-Z][a-z]+&apos;s? soul clinging on to life, pulling you headlong into the long dark\.  It takes every ounce of spiritual energy you have to sever the link and claw yourself back to the world of the living!  You feel empty and torpid, unable to focus your spiritual self\.</message>
+      <message type='start'>You are unable to gather enough strength to focus your spirit\.  Perhaps you should rest some\.</message>
+      <message type='start'>Deep and resonating, you feel the chant that falls from your lips instill within you with the strength of your faith\.  You crouch beside [A-Z][a-z]+ and gently lift (?:he|she|him|her) into your arms, your muscles swelling with the power of your deity, and cradle (?:him|her) close to your chest\.  Strength and life momentarily seep from your limbs, causing them to feel laden and heavy, and you are overcome with a sudden weakness\.  With a sigh, you are able to lay [A-Z][a-z]+ back down\.</message>
+      <message type='start'>Moisture beads upon your skin and you feel your eyes cloud over with the darkness of a rising storm\.  Power builds upon the air and when you utter the last syllable of your spell thunder rumbles from your lips\.  The sound ripples upon the air, and colling with [A-Z][a-z&apos;]+ prone form and a brilliant flash transfers the spiritual energy between you\.</message>
+      <message type='start'>Lifting your finger, you begin to chant and draw a series of conjoined circles in the air\.  Each circle turns to mist and takes on a different hue - white, blue, black, red, and green\.  As the last ring is completed, you spread your fingers and gently allow your tips to touch each color before pushing the misty creation towards [A-Z][a-z]+\.  A shock of energy courses through your body as the mist seeps into [A-Z][a-z&apos;]+ chest and life is slowly returned to (?:his|her) body\.</message>
+      <message type='start'>Crouching beside the prone form of [A-Z][a-z]+, you softly issue the last syllable of your chant\.  Breathing deeply, you take in the scents around you and let the feel of your surroundings infuse you\.  With only your gaze, you track the area and recreate the circumstances of [A-Z][a-z&apos;]+ within your mind\.  Touching [A-Z][a-z]+, you follow the lines of the web that holds (?:his|her) soul in place and force it back into (?:his|her) body\.  Raw energy courses through you and you feel your sense of justice and vengeance filling [A-Z][a-z]+ with life\.</message>
+      <message type='start'>Murmuring softly, you call upon your connection with the Destroyer,? and feel your words twist into an alien, spidery chant\.  Dark shadows laced with crimson swirl before your eyes and at your forceful command sink into the chest of [A-Z][a-z]+\.  The transference of energy is swift and immediate as you bind [A-Z][a-z]+ back into (?:his|her) body\.</message>
+      <message type='start'>Rich and lively, the scent of wild flowers suddenly fills the air as you finish your chant, and you feel alive with the energy of spring\.  With renewal at your fingertips, you gently touch [A-Z][a-z]+ on the brow and revel in the sweet rush of energy that passes through you into (?:him|her|his)\.</message>
+      <message type='start'>Breathing slowly, you extend your senses towards the world around you and draw into you the very essence of nature\.  You shift your gaze towards [A-z][a-z]+ and carefully release the energy you&apos;ve drawn into yourself towards (?:him|her)\.  A rush of energy briefly flows between the two of you as you feel life slowly return to (?:him|her)\.</message>
+      <message type='start'>Your surroundings grow dim\.\.\.you lapse into a state of awareness only, unable to do anything\.\.\.</message>
+      <message type='start'>Murmuring softly, a mournful chant slips from your lips and you feel welts appear upon your wrists\.  Dipping them briefly, you smear the crimson liquid the leaks from these sudden wounds in a thin line down [A-Z][a-z&apos;]+ face\.  Tingling with each second that your skin touches (?:his|hers), you feel the transference of your raw energy pass into [A-Z][a-z]+ and momentarily reel with the pain of its release\.  Slowly, the wounds on your wrists heal, though a lingering throb remains\.</message>
+      <message type='start'>Emptying all breathe from your body, you slowly still yourself and close your eyes\.  You reach out with all of your senses and feel a film shift across your vision\.  Opening your eyes, you gaze through a white haze and find images of [A-Z][a-z]+ floating above his prone form\.  Acts of [A-Z][a-z]&apos;s? past, present, and future play out before your clouded vision\.  With conviction and faith, you pluck a future image of [A-Z][a-z]+ from the air and coax (?:he|she|his|her) back into (?:he|she|his|her) body\.  Slowly, the film slips from your eyes and images fade away\.</message>
+      <message type='start'>Thin at first, a fine layer of rime tickles your hands and fingertips\.  The hoarfrost smoothly glides between you and [A-Z][a-z]+, turning to a light powder as it traverses the space\.  The white substance clings to [A-Z][a-z]+&apos;s? eyelashes and cheeks for a moment before it becomes charged with spiritual power, then it slowly melts away\.</message>
+      <message type='start'>As you begin to chant,? you notice the scent of dry, dusty parchment and feel a cool mist cling to your skin somewhere near your feet\.  You sense the ethereal tendrils of the mist as they coil about your body and notice that the world turns to a yellowish hue as the mist settles about your head\.  Focusing on [A-Z][a-z]+, you feel the transfer of energy pass between you as you return (?:him|her) to life\.</message>
+      <message type='start'>Wrapped in an aura of chill, you close your eyes and softly begin to chant\.  As the cold air that surrounds you condenses you feel it slowly ripple outward in waves that turn the breath of those nearby into a fine mist\.  This mist swiftly moves to encompass you and you feel a pair of wings arc over your back\.  With the last words of your chant, you open your eyes and watch as foggy wings rise above you and gently brush against [A-Z][a-z]+\.  As they dissipate in a cold rush against [A-Z][a-z]+, you feel a surge of power spill forth from you and into (?:him|her)\.</message>
+      <message type='start'>Low and monotonous, you begin a chant to draw [A-Z][a-z]+ back to life and feel the deep shadows of the area rise to meet you\.  Falling upon you like a cloak of darkness, the twisting, inky blackness transforms into the visage of a jackal from a once-forgotten nightmare\.  Sweeping from your body into [A-Z][a-z]+'s?, the raw energy of your prayer transfers into (?:his|her) prone form\.  Slowly, the shadows recede back into the surrounding area\.</message>
+      <message type='end'>The feeling of weakness leaves you\.  Your spirits are somewhat rejuvenated\.</message>
+   </spell>
+   <spell availability='all' name='Adrenal Surge Cooldown' number='9010' type='timer'>
+      <duration>if Spell[9010].active?; Spell[9010].timeleft; else; 5; end</duration>
+      <message type='start'>You feel a surge of energy that carries you to your feet in a heartbeat, with no sense of effort whatsoever!</message>
+      <message type='start'>You feel a momentary surge of energy rush through you giving you strength\.</message>
+      <message type='start'>You feel a surge of energy shoot through you!</message>
+   </spell>
+   <spell availability='self-cast' name='Council Task' number='9011' type='timer'>
+      <duration persist-on-death='yes' real-time='yes'>if defined?(line) and line.slice(/[0-9]+/).to_f > 0; line.slice(/[0-9]+/).to_f; else; 30; end</duration>
+      <message type='start'>The High Taskmaster looks at you, consults her notes, and then announces in a loud voice: &quot;[A-Z][a-z]+, I&apos;m rather busy right now\.  I know you have completed the requirements for advancement in rank, but I cannot take the time to instruct you\.  Let me check my schedule\.\.\. Ah, yes, I can squeeze you in in [0-9]+ minutes or so\.  Come back then and I&apos;ll take care of you\.&quot;</message>
+   </spell>
+   <spell availability='self-cast' name='Council Punishment' number='9012' type='timer'>
+      <duration persist-on-death='yes'>if defined?(line) and (line =~ /[0-9]+/); line.slice(/[0-9]+/).to_f; else; 20; end</duration>
+      <message type='start'>powers for [0-9]+ minutes, so that you might have</message>
+      <message type='start'>Your punishment does not end for another [0-9]+ minutes?\.</message>
+      <message type='end'>the fold\.  DO NOT FAIL ME AGAIN!&quot;</message>
+   </spell>
+   <spell availability='self-cast' name='Fog Concealment' number='9013' type='timer'>
+      <duration>0.5</duration>
+      <message type='start'>Fog swirls and eddies about the area\.  Wispy grey tendrils writhe as they climb around your form until you are completely enshrouded in the mist\.  You feel confident that no one can see you behind your mask of fog\.</message>
+      <message type='end'>The fog enshrouding you drifts off your form and gathers with the rest in the area\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Wolf' number='9014' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume wolf&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Wolf\.  .*Your vision takes on a slightly yellow hue, and you feel a stronger center of coordination and balance\.</message>
+      <message type='end'>The golden distortion fades from your sight, and your balance returns to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Wolf Cooldown' number='9015' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Jackal' number='9016' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume jackal&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Jackal\.  .*A twinge of red passes through your eyes, as your thoughts turn toward waylaying your next quarry\.</message>
+      <message type='end'>The redness fades from your eyes as your focus of the hunt returns to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Jackal Cooldown' number='9017' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Lion' number='9018' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume lion&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Lion\.  .*You feel yourself infused with a regal air, as a wave of power ripples through your muscles\.</message>
+      <message type='end'>Your regal influence and extra strength swiftly drift away\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Lion Cooldown' number='9019' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Panther' number='9020' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume panther&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Panther\.  .*A distinct awareness of the shadows surfaces to your thoughts, springing forth with the lucidity of a once-forgotten memory\.</message>
+      <message type='end'>Your extra awareness of the shadows steals away back into the recesses of your subconscious\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Panther Cooldown' number='9021' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Owl' number='9022' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume owl&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Owl\.  .*A dawn of enlightenment rises over your consciousness, honing your comprehension of the flows of magic around and within you\.</message>
+      <message type='end'>The moment of enlightenment and magical comprehension fades from your mind\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Owl Cooldown' number='9023' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Hawk' number='9024' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume hawk&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Hawk\.  .*You become more aware of the environs as every nuance of your surroundings comes into focus with sharp clarity\.</message>
+      <message type='end'>The degree of resolution in your vision diminishes as your perception returns to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Hawk Cooldown' number='9025' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Rat' number='9026' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume rat&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Rat\.  .*Your thoughts drift inward, girding your mind with a strong determination and your body with great agility\.</message>
+      <message type='end'>The strong sense of determination and agility fades from within you\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Rat Cooldown' number='9027' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Porcupine' number='9028' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume porcupine&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Porcupine\.  .*A simple cognition bubbles to the front of your mind, broadening your understanding of events that previously went unnoticed\.</message>
+      <message type='end'>Your increased cognition fades away, returning your comprehension to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Porcupine Cooldown' number='9029' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Bear' number='9030' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume bear&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Bear\.  .*You hear a deep bellowing reverberate through your mind, inspiring an invigorating fortitude that spreads to your very core\.</message>
+      <message type='end'>Your ursine fortitude parts, returning your endurance to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Bear Cooldown' number='9031' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Serpent' number='9032' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume serpent&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Serpent\.  .*Your skin suddenly feels a bit more scaled, and you notice a distinctly natural fluidity in your movements\.</message>
+      <message type='end'>The scaliness of your complexion fades away, taking with it your natural-feeling fluid movements\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Serpent Cooldown' number='9033' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Burgee' number='9034' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume burgee&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Burgee\.  .*Grey-green diamond scales form across your skin, and you note that your shield arm feels somehow lighter\.</message>
+      <message type='end'>The grey-green scales fade away from your skin, with your shield arm,s reflexes returning to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Burgee Cooldown' number='9035' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Mantis' number='9036' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume mantis&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Mantis\.  .*A slightly uncomfortable pressure builds behind your eyes as you note an improved eyesight and renewed vigor in your weapon arm\.</message>
+      <message type='end'>You feel the pressure behind your eyes relent, as the movement in your weapon arm returns to normal\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Mantis Cooldown' number='9037' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Yierka' number='9038' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume yierka&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Yierka\.  .*A gruff, yet contenting inspiration courses through your senses, putting you at one with the offerings and spirits of nature\.</message>
+      <message type='end'>Your extra illumination of the natural fades with a final wisp of inspiration\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Yierka Cooldown' number='9039' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='self-cast' name='AA: Spider' number='9040' type='timer'>
+      <duration>2</duration>
+      <cost type='mana'>Spell[650].active ? 25 : 50</cost>
+      <cast-proc>Spell[650].cast if not Spell[650].active?; waitcastrt?; (dothistimeout &apos;assume spider&apos;, 3, /^You feel that you will not be able to fully concentrate upon the Aspect|^You concentrate your focus upon the Aspect/) =~ /^You concentrate/ ? true : false</cast-proc>
+      <message type='start'>You concentrate your focus upon the Aspect of the Spider\.  .*You feel a tingling sensation shiver through your limbs as your field of vision darkens and expands\.</message>
+      <message type='end'>Your field of vision returns to normal as the tingling sensation in your limbs scatters away\.</message>
+   </spell>
+   <spell availability='self-cast' name='AA: Spider Cooldown' number='9041' type='timer'>
+      <duration>4</duration>
+   </spell>
+   <spell availability='all' name='Meditation' number='9075' type='timer'>
+      <duration>12</duration>
+      <message type='start'>You (?:kneel down and |kneel and )?begin to meditate on your lot in life\.</message>
+      <message type='end'>Your action interrupts your meditation\.</message>
+      <message type='end'>Your meditation is interrupted by .+\.</message>
+      <message type='end'>The lingering effects of your meditation fade away\.</message>
+   </spell>
+<!--
+   <spell availability='all' name='Pre-Meditate' number='9042' type='timer'>
+      <duration>2</duration>
+      <message type='start'>You kneel (?:down )?and begin to meditate on your lot in life\.</message>
+      <message type='end'>Your action interrupts your meditation\.</message>
+      <message type='end'>Your meditation is interrupted by .+\.</message>
+   </spell>
+   <spell availability='all' name='Meditate' number='9043' type='timer'>
+      <duration>10</duration>
+      <message type='start'>You wake from your meditation, yet a deep feeling of relaxation remains present\.</message>
+      <message type='end'>The lingering effects of your meditation fade away\.</message>
+   </spell>
+-->
+   <spell availability='all' name='Miracle Cooldown' number='9044' type='timer'>
+      <duration max='1440.0' persist-on-death='yes' real-time='yes'>dur = 1440; [ 4, 9, 15, 22, 30, 39, 49, 60, 72, 85, 99, 114, 130, 147, 165, 184 ].each { |num| dur -= 60 if Skills.slreligion &gt;= num }; dur</duration>
+      <message type='start'>Spidery and incomprehensible words reach you, and are given life by an aged, bodiless voice that carries with it the scent of dusty tomes and candle tallow\.  A point of dark light appears high over your body and expands to form a yellowed eye with a slit pupil\.  With each uttered syllable the eye&apos;s iris contracts and the meaning of the words that wrap you become clear\.  &quot;You still have much more to learn,&quot; they say, and before you the eye explodes in a blinding, fiery light\.</message>
+      <message type='start'>You feel a tingling at the edges of your perception and the air comes alive with a feeling of raw power\. You sense something greater than yourself tugging on your spirit\. As the power grows in intensity, you feel it draw you closer to your lifeless body and you marvel as it ushers your spirit forward\. An extremely bright nimbus floods you as your spirit sinks into your body, which begins to fill with life\.</message>
+      <message type='start'>Silence descends upon the room and a double\-headed serpent slithers to you\. Each of its heads moves of its own accord, and slit\-pupiled eyes take in everything as they wind a sinuous path up your prone form\. As it reaches your chest, it lifts its heads up high and begins to sway from side to side in a hypnotic pattern\. &quot;You have learned the ssssacrifice issss everything, now we ssssacrifice oursssselves sssso that you may teach otherssss,&quot; the one head says before striking the other head at the neck\. In one swift, painless bite, the head is severed and the open neck falls upon you, its lifeblood draining into your mouth\. Moments pass as the ferric taste of the serpent&apos;s sacrifice fills you, and then suddenly it disappears\.</message>
+      <message type='start'>As the air stirs, you feel your spirit drawn to the heavy scent of the ocean and feel a deep sense of peace\. Clouds move into the area, their murky depths heavy with rain unshed and you can see lightning dancing within them\. The pressure builds all around you until suddenly, the heavens release dozens of slender blue bands of lightning\. The lightning fills your body with its energy and the very air around you seems to tingle with it\. Moments later, the lightning is gone and the clouds soon follow\.</message>
+      <message type='start'>Odd whirls and metallic clangs herald the arrival of a dwarf crafted entirely of bronze\. The strange, mechanical man moves with jerky movements to a position beside the prone form of Cleric and begins to tinker with his appearance and clothing\. At first, nothing seems to come of the strange bronze creature&apos;s meddling, but slowly color returns to Cleric&apos;s face\. Steam billowing from its ears, the metallic dwarf straightens and teeters from the area, dissipating as it moves\.</message>
+      <message type='start'>Stealing all sound as it travels to you, a soft zephyr gently caresses your skin and you sense the frigid brush of final death near at hand\. A tug on your spirit heralds the arrival of impossibly long feathers in shades of white, grey, and black, as they appear before you and coalesce into a beautiful insubstantial being\. It lifts you up into its arms and you feel as if you have found home in its embrace\.</message>
+      <message type='start'>Filling your spirit with a deep anger, a long discordant horn blast drowns your senses and sets your lifeless flesh to vibrating with its wild call\. An enormous hunting hound bearing an angry look of focus bounds towards you\. You feel its front paws forcibly slam into your chest and watch the beast disappear deep within you with the cry of a wild hunt falling from its parted lips\. Slowly, the sound of the horn echoes into silence\.</message>
+      <message type='start'>Time stills around you, and you feel your spirit drawn forward by a pale ethereal light which quickly transforms into a translucent woman\. She moves to your side and withdraws two crimson oak leaves and an acorn from her basket\. You hear her soft prayer as she places the leaves upon your eyes and presses the acorn past your lips\. She turns her eyes to the sky, her arms rising in supplication, and then lays her hands briefly on your chest\. Instantly, warmth floods your limbs and the woman returns to the pale light\.</message>
+      <message type='start'>Large and ethereal, rectangular talismans rise from the ground to form a ring around your lifeless form\. Each talisman is carved with a different word and glows with a brilliant light\. One by one, the talismans tumble into you\. As the first falls upon you, you are filled with a deep sense of Honor, the second reminds you of Valor in battle, and the third causes your spirit to surge with Hope, while the fourth binds you with the strength of your Faith\. The remaining two tumble into you simultaneously and, in a flash of white light, you absorb them all\.</message>
+      <message type='start'>Creating a myriad of colorful whorls in the air, a flock of small rainbow-winged lizards swirls towards you and you are filled with a deep connection to them\. Diving and darting, they cavort above your corpse in an intricate dance that is breathtaking to behold\. As they dance, their wings shimmer and shed multi-colored sparks that rain down upon your body\. With each spark that alights upon your flesh, you are filled with a tingling sensation that draws your spirit deep into your body\. The aerial display ends in one final loop and the rainbow\-winged lizards dart off into the distance, only to wink out of sight a moment later\.</message>
+      <message type='start'>Your spirit feels a sudden stirring in the air above your lifeless body and moments later a brilliantly white owl appears out of nowhere\. It spreads its wings and you hear the audible crack of the air as they expand, lifting the owl in a lazy spiral above you\. The bird&apos;s unblinking gaze falls upon you and you feel a deep connection with it before it gives three mighty beats of its wings and surges high into the sky and disappears\.</message>
+      <message type='start'>Distant and echoing, the sound of keys jingling strikes a familiar chord within you as it precedes the sound of a heavy metal gate slamming shut\. Pale snowflakes drift through the air and settle upon your lifeless body\. As the snow accumulates into a thin, chilling layer, you distinctly hear the somber voice of a female speaking softly in your ear\. &quot;The gates are closed to you for now, my child,&quot; she says, and several moments later the snow seeps into your skin, leaving you chilled and damp\.</message>
+      <message type='start'>Punctuating the sudden calm of the area, the sound of slithering is quickly followed by a long, sibilant hiss\. Winding a sinuous pattern to your head, an impossibly large copper-head snake with emerald green eyes begins to hiss at you\. &quot;There are more liessss to sssspread, and deathssss to ssssteal,&quot; it says, and then swiftly raises high into the air to gaze down at you\. Faster than the blink of an eye, the serpent dives into your chest and disperses into a shimmering green mist that seeps into your skin\.</message>
+      <message type='start'>Dark clouds swirl across your prone form and the area is plunged into darkness\. The hair on your body stands on end and a deep pressure builds around your spirit, threatening to consume it\. Blue lightning lances through the air, heralding an ear-shattering ripple of thunder, and at the edge of your senses you feel the demonic horde surging forward to take you\. Each sizzling bolt strikes your chest repeatedly for several moments and the horde closes in on you until every last one of them is absorbed by your spirit\.</message>
+      <message type='start'>Wraithlike mourners suddenly slip free of the shadows and form a tight ring around you\. Silvery tears slip from their faces to splash ineffectively against your lifeless body, and the blood that stains their white garments trickles in a splash across your face\. They kneel in a tight ring about you, obscuring your view of the world beyond, and you feel a deep connection to them\. &quot;There is yet more pain to release,&quot; they seem to tell you before their lips part in a deafening keen of anguish that shatters their ethereal forms\.</message>
+      <message type='start'>A playful feeling sweeps over you as a fuzzy pair of otters fills your vision\. Clutched in their teeth are midnight blue mussels, which they hold tightly in place as they comically bounce and leap around you\. They playfully paw at your lifeless chest, begging with their furry faces, and you sense they want you to come and play\. As if sensing you cannot, they curl their sleek, wet forms briefly around your head and nuzzle against your neck for several moments\. Then, they carefully drop the mussels upon your chest\. A brief, child-like joy fills you as the mussels sink into your lifeless body, and the otters turn as one to slide out of sight on their slippery bellies\.</message>
+      <message type='start'>Shadows slant across the ground as they slither toward you and a deep chill touches your spirit\. As the shadows writhe in a thick mass of darkness over your body, you distinctly hear a quiet whisper in your ear, &quot;This was not the death I had in mind for you\.&quot; A flash of light tears across your vision as it is consumed by the image of a cracked white skull\.</message>
+      <message type='start'>Regal and proud, a broad-shouldered ethereal lion strides towards your lifeless form and you are filled with a sense of power and glory\. As it moves towards you, its mane begins to shimmer with licking flames that resemble the rays of the sun\. It lowers its gaze to you and you feel yourself drawn into their amber depths\. The golden beast lifts a paw to your chest and a wave of warmth floods your limbs\. As the light grows, the lion begins to dissipate into a golden nimbus that sinks into your body\.</message>
+      <message type='start'>The sounds of night drift to your ears and you feel a deep lassitude flood your spirit\. At the edge of your vision the pale white beautiful image of a unicorn begins to take shape\. It paws at the air, its silver hooves creating sparks of light that twinkle like a thousand stars\. As it lowers the horn to touch your forehead you feel a deep sense of peace that intensifies as a silver nimbus blankets you\. The unicorn and the nimbus disappear at once, and you feel yourself waking slowly from a dream\.</message>
+      <message type='start'>Shadows lengthen and grow around you until their edges are sharp and twisted\. Macabre and ungraceful, they slink with jerky movements toward you as their depths are briefly illuminated by countless yellowed eyes set into the faces of a thousand horrors\. They snarl as they writhe across your prone form, their maws snapping ineffectively at your flesh\. One by one, they twist and squirm into your slack jaw and fill you with bitter madness\.</message>
+      <message type='start'>Silver motes of light cavort upon the air, their movements turning into a twisted dance that is punctuated by the sound of dozens of laughing voices\. Deep in your spirit, you feel a binding connection to their mirth\. Converging above you, the light transforms in a slender crescent moon that begins to whirl\. At one moment, full, and then the next, a sliver, the faster the moon spins, the louder the laughter gets\. Suddenly, the light ceases all movement and explodes into a brilliant shower of silver sparks accompanied by laughter for several moments\.</message>
+   </spell>
+   <spell availability='all' name='Sigil of Escape Cooldown' number='9045' type='timer'>
+      <duration max='1440.0' persist-on-death='yes' real-time='yes'>1440</duration>
+      <message type='start'>Your incapacitation makes it all the more difficult, but as you concentrate \(as best you can\) on your sigil, you feel yourself being whisked away\.\.\.</message>
+   </spell>
+   <spell availability='all' name='Regeneration Cooldown' number='9046' type='timer'>
+      <duration max='1440.0' persist-on-death='yes' real-time='yes'>1440</duration>
+      <message type='start'>Points of silvery light begin to flicker around you\. They grow in number, swirling into a bright flash as your injuries heal to scars, then gradually fade completely\. Dimming slowly, the light settles into a shimmering silver cocoon that surrounds you\.</message>
+   </spell>
+   <spell availability='all' name='Lantern Charm Cooldown' number='9047' type='timer'>
+      <duration max='1440.0' persist-on-death='yes' real-time='yes'>1440</duration>
+      <message type='start'>The flame within the lantern builds and brightens, escalating rapidly from bright to blinding\.  A heady rush overcomes you as the charm&apos;s radiance suffuses your flesh and falls, like a glowing veil, over your vision\.  Heat blossoms within your core, and a soft voice promises, &quot;While hearth and home are firm in your heart, they cannot be more than a breath away from your lungs\.&quot;</message>
+   </spell>
+   <spell availability='all' name='Symbol of Mana Cooldown' number='9048' type='timer'>
+      <duration max='5.0' persist-on-death='yes'>5</duration>
+      <message type='start'>You call upon a special blessing from Koar\.</message>
+      <message type='end'>You feel Koar&apos;s blessing return to you\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Transcendence Cooldown' number='9049' type='timer'>
+      <duration persist-on-death='yes'>if $infomon_transcendance_emergency; 10; else; 3; end</duration>
+      <message type='start'>You feel yourself being pulled back fully into the corporeal realm\.</message>
+   </spell>
+   <spell availability='all' name='Symbol of Renewal Cooldown' number='9050' type='timer'>
+      <duration>2</duration>
+      <message type='start'>You feel a surge of life flow through you\.</message>
+      <message type='end'>You feel your connection to vitality of nature renew itself once more\.</message>
+   </spell>
+   <spell availability='self-cast' name='Burst of Swiftness Cooldown' number='9051' type='timer'>
+      <duration>dur = { nil =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan.burst_of_swiftness]; else; 5; end</duration>
+      <message type='start'>You feel (?:significantly|a great deal|a fair amount) more agile\.</message>
+      <message type='end'>You feel entirely capable of preparing yourself to once again move swiftly at a moment&apos;s notice\.</message>
+   </spell>
+   <spell availability='self-cast' name='Curse of the Star (bonus)' number='9053' type='timer'>
+      <duration span='stackable'>20</duration>
+      <message type='start'>You acquire a certain murky complexion, and you feel more deft\.</message>
+      <message type='start'>Your complexion grows murkier\.</message>
+      <message type='end'>Your murky complexion fades away, and you feel less deft\.</message>
+   </spell>
+   <spell availability='self-cast' name='Doomstone Curse' number='9054' type='timer'>
+      <duration span='refreshable'>60</duration>
+      <message type='start'>You feel a strange, foreboding sensation as your hand touches the black doomstone\.</message>
+      <message type='end'>The foreboding sensation recedes\.</message>
+   </spell>
+   <spell availability='self-cast' name='Divine Word Cooldown' number='9055' type='timer'>
+      <duration persist-on-death='yes' real-time='yes' span='refreshable'>if Skills.slreligion >= 40; 480; elsif Skills.slreligion >= 20; 720; else 1440; end</duration>
+      <message type='start'>Your surroundings grow dim\.\.\.you lapse into a state of awareness only, unable to do anything\.\.\.</message>
+   </spell>
+   <spell availability='all' name='Planar Fragment Cooldown' number='9057' type='timer'>
+      <duration max='5760.0' persist-on-death='yes' real-time='yes'>5760</duration>
+      <message type='start'>Shifting your gaze, you use the fragment&apos;s influence to pierce the veil between the planes of existence\.  An other-worldly landscape fills your vision, and you sense an object of potential interest within arms reach\.  Without waiting to actually see it, you reach out and yank .+ into your current temporal sphere\.</message>
+   </spell>
+   <spell availability='all' name='Chronomage Teleport Staff Cooldown' number='9058' type='timer'>
+      <duration max='1440.0' persist-on-death='yes' real-time='yes'>1440</duration>
+      <message type='start'>When the air around you settles and your mind calms, you realize that your very existence has been catapulted into the past\.  The sand in the hourglass is now in the upper bulb, trickling slowly into the lower chamber\.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (acid)' number='9060' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (acidic) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (cold)' number='9061' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (freezing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (crush)' number='9062' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (crushing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (disintegration)' number='9063' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (disintegrating) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (disruption)' number='9064' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (disruptive) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (electrical)' number='9065' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (electrical) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (grapple)' number='9066' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (grappling) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (fire)' number='9067' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (burning) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (impact)' number='9068' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (impacting) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (plasma)' number='9069' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (plasmatic) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (puncture)' number='9070' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (puncturing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (slash)' number='9071' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (slashing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (steam)' number='9072' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (scalding) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (unbalance)' number='9073' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (unbalancing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Meditative Resistance (vacuum)' number='9074' type='defense'>
+      <duration persist-on-death='no' span='refreshable'>250</duration>
+      <message type='start'>You assume a meditative posture, .+ (decompressing) .+\.</message>
+      <message type='end'>Your concentration slips, and you no longer feel prepared to resist \w+ damage.</message>
+      <message type='end'>You cease concentrating on your preparations to resist \w+ damage.</message>
+   </spell>
+   <spell availability='self-cast' name='Tracking Recovery' number='9076' type='timer'>
+      <duration>1</duration>
+      <message type='start'>You carefully study the area, searching for signs of .+ presence\.  Your keen eye spots the beginnings of a trail and you rush to follow it while taking care to remain hidden\.</message>
+      <message type='start'>You carefully study the area, searching for signs of .+ presence\.  Your keen eye spots the beginnings of a trail and you rush to follow it\.</message>
+      <message type='start'>You carefully study the area, searching for signs of .+ presence\.  You can tell the .+ is somewhere nearby but the paths all seem to lead in different directions\.  You take a chance on one, but quickly realize you've been led astray\.</message>
+      <message type='start'>You carefully study the area, searching for signs of .+ presence\.  You can tell the .+ is somewhere nearby but the paths all seem to lead in different directions\.  You take a chance on one while taking care to remain hidden, but quickly realize you've been led astray\.</message>
+      <message type='end'>You feel refreshed and ready to track again\.</message>
+   </spell>
+   <spell availability='self-cast' name='Lumnis&#39; Repose' number='9077' type='timer'>
+      <duration>30</duration>
+      <message type='start'>You trace the central orb of white in your brooch and your fingertips begin to tingle as ordered energy flows into you\.  Within seconds, you feel Lumnis' Repose course through your veins\.</message>
+      <message type='end'>Your skin tingles as the ordered energy of Lumnis' Repose slips from you and recedes into your brooch\.</message>
+   </spell>
+   <spell availability='all' name='Elemental Aura Stabilization' number='9078' type='defense'>
+      <duration>5</duration>
+      <message type='start'>Elemental energy wraps around you, stabilizing your aura\.</message>
+      <message type='end'>The elemental energy stabilizing your aura dissipates\.</message>
+   </spell>
+   <spell availability='all' name='Elemental Transfer Protection' number='9079' type='defense'>
+      <duration>5</duration>
+      <message type='start'>A thin coating of elemental energy sinks into you, keeping minor fluctuations in elemental energy at bay\.</message>
+      <message type='end'>Your thin coating of elemental energy dissipates away\.</message>
+   </spell>
+   <spell availability='all' name='Feather Charm' number='9080' type='utility'>
+      <duration>30</duration>
+      <message type='start'>Oddly enough, you feel somewhat more buoyant\.</message>
+      <message type='end'>You feel somewhat less buoyant\.</message>
+   </spell>
+   <spell availability='all' name='Encumbrance Boost' number='9081' type='utility'>
+      <duration>15</duration>
+      <message type='start'>\[You have activated an Encumbrance Boost.  Your net encumbrance will be reduced by 50 lbs for 15 minutes\.\]</message>
+      <message type='end'>\[Your Encumbrance Boost has ended\.\]</message>
+   </spell>
+   <spell availability='self-cast' name='Major Loot Boost' number='9100' type='utility'>
+      <duration persist-on-death='yes'>15</duration>
+      <cast-proc>fput &apos;boost loot major&apos;</cast-proc>
+      <message type='start'>\[You have activated a Major Loot Boost\.  Your chances for better LOOT will be boosted for 15 minutes\.\]</message>
+      <message type='end'>\[Your Major Loot Boost has ended\.\]</message>
+   </spell>
+   <spell availability='self-cast' name='Minor Loot Boost' number='9101' type='utility'>
+      <duration persist-on-death='yes'>15</duration>
+      <cast-proc>fput &apos;boost loot minor&apos;</cast-proc>
+      <message type='start'>\[You have activated a Minor Loot Boost\.  Your chances for better LOOT will be boosted for 15 minutes\.\]</message>
+      <message type='end'>\[Your Minor Loot Boost has ended\.\]</message>
+   </spell>
+   <spell availability='self-cast' name='Mana Leech Recovery' number='9516' type='timer'>
+      <duration persist-on-death='yes' span='stackable'>1</duration>
+      <message type='start'>You feel a sudden rush of power as you absorb [0-9]+ mana!</message>
+      <message type='end'>You no longer feel the effect of casting mana leech\.</message>
+   </spell>
+  <spell availability='self-cast' name='Duck and Weave Cooldown' number='9052' type='timer'>
+      <duration>5</duration>
+      <message type='start'>You balance your posture and narrow your eyes, preparing to misdirect your foes' attacks\.</message>
+      <message type='end'>Your recent exploits of weaving through your foes' attacks no longer strains your body and mind\.</message>
+   </spell>
+</list>

--- a/spec/jinx/repos/core/assets/vars.lic
+++ b/spec/jinx/repos/core/assets/vars.lic
@@ -1,0 +1,212 @@
+#quiet
+=begin
+
+   edit variables shared by all scripts
+
+   ;vars help
+
+   author: Tillmen (tillmen@lichproject.org)
+   game: any
+   tags: core
+   required: Lich >= 4.6.14
+   version: 0.8
+
+   changelog:
+      0.8 (2019-02-23):
+         fixes for compatibility with Ruby >= 2.3
+      0.7 (2015-04-26):
+         prompt to save in GUI when new vars are added
+      0.6 (2015-02-01):
+         add default text to new var textboxes
+
+=end
+=begin
+
+      0.5 (2015-02-01):
+         sort vars alphabetically in gui
+      0.4 (2015-02-01):
+         add gui
+      0.3 (2015-01-06):
+         fix bug when updating a setting
+      0.2 (2014-12-17):
+         don't use Vars.send
+
+=end
+
+if (script.vars[1] == 'set') and (script.vars[0] =~ /^set\s+([^\s]+)\s*=\s*(.+)/)
+   name = $1
+   value = $2.strip
+   if Vars[name].nil?
+      Vars[name] = value
+      respond "\n--- variable \"#{name}\" set to: \"#{value}\"\n\n"
+   else
+      old_value = Vars[name]
+      Vars[name] = value
+      respond "\n--- variable #{name} changed to: #{value} (was #{old_value})\n\n"
+   end
+elsif (script.vars[1] =~ /^del(ete)?$|^rem(?:ove)?$/) and script.vars[2]
+   if Vars[script.vars[2]].nil?
+      respond "\n--- variable #{script.vars[2]} does not exist\n\n"
+   else
+      Vars[script.vars[2]] = nil
+      respond "\n--- variable #{script.vars[2]} was deleted\n\n"
+   end
+elsif script.vars[1] == 'list'
+   if Vars.list.empty?
+      respond "\n--- no variables are set\n\n"
+   else
+      output = "\n--- #{XMLData.name}'s variables:\n\n"
+      max_name = 0; Vars.list.keys.each { |k| max_name = [max_name,k.length].max }
+      Vars.list.each { |name,value|
+         output.concat "   #{name.rjust(max_name)}:  #{value}\n"
+      }
+      output.concat "\n"
+      respond output
+   end
+elsif defined?(Gtk) and (script.vars[1] == 'setup')
+   window = nil
+   done = false
+   Gtk.queue {
+      vars = Vars.list.to_a.sort { |a,b| a[0].to_s <=> b[0].to_s }
+      textboxes = Array.new
+      table = Gtk::Table.new((vars.length + 1), 3)
+      vars.each_index { |i|
+         label = Gtk::Label.new(vars[i][0].to_s)
+         box = Gtk::HBox.new
+         box.pack_end(label, false, false, 0)
+         table.attach(box, 0, 1, i, (i + 1), Gtk::FILL, Gtk::FILL, 3, 3)
+         textbox = Gtk::Entry.new
+         if vars[i][1].class == String
+            textbox.text = vars[i][1]
+         else
+            textbox.text = "#{vars[i][1].class}: #{vars[i][1].inspect}"
+            textbox.editable = false
+         end
+         table.attach(textbox, 1, 2, i, (i + 1), (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+         textboxes[i] = textbox
+         delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+         table.attach(delete_button, 2, 3, i, (i + 1), Gtk::SHRINK, Gtk::FILL, 3, 3)
+         delete_button.signal_connect('clicked') {
+            report_errors {
+               label.sensitive = false
+               textbox.sensitive = false
+               delete_button.sensitive = false
+               textboxes[i] = nil
+            }
+         }
+      }
+      new_vars = Array.new
+      sw = nil
+      add_new_row = proc {
+         i = new_vars.length
+         table.n_rows = table.n_rows + 1
+         label = Gtk::Entry.new
+         label.text = "(new var name)"
+         table.attach(label, 0, 1, (table.n_rows - 1), table.n_rows, Gtk::FILL, Gtk::FILL, 3, 3)
+         textbox = Gtk::Entry.new
+         textbox.text = "(new var value)"
+         textbox.sensitive = false
+         table.attach(textbox, 1, 2, (table.n_rows - 1), table.n_rows, (Gtk::EXPAND|Gtk::FILL), Gtk::FILL, 3, 3)
+         new_vars[i] = [ label, textbox ]
+         delete_button = Gtk::Button.new(Gtk::Stock::DELETE)
+         delete_button.sensitive = false
+         table.attach(delete_button, 2, 3, (table.n_rows - 1), table.n_rows, Gtk::SHRINK, Gtk::FILL, 3, 3)
+         label.show
+         textbox.show
+         delete_button.show
+         label.signal_connect('focus-in-event') {
+            report_errors {
+               if label.text == "(new var name)"
+                  label.text = ''
+               end
+               unless textbox.sensitive?
+                  textbox.sensitive = true
+                  delete_button.sensitive = true
+                  add_new_row.call
+                  Thread.new {
+                     sleep 0.05
+                     inc = (sw.vadjustment.upper - sw.vadjustment.value - sw.vadjustment.page_size) / 10.0
+                     10.times { sw.vadjustment.value = sw.vadjustment.value + inc; sleep 0.02 }
+                     sw.vadjustment.value = (sw.vadjustment.upper - sw.vadjustment.page_size)
+                  }
+               end
+            }
+         }
+         textbox.signal_connect('focus-in-event') {
+            report_errors {
+               if textbox.text == "(new var value)"
+                  textbox.text = ''
+               end
+            }
+         }
+         delete_button.signal_connect('clicked') {
+            report_errors {
+               label.sensitive = false
+               textbox.sensitive = false
+               delete_button.sensitive = false
+               new_vars[i][1] = nil
+            }
+         }
+      }
+      add_new_row.call
+      vp = Gtk::Viewport.new(nil, nil)
+      vp.add(table)
+      sw = Gtk::ScrolledWindow.new
+      sw.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS)
+      sw.add(vp)
+      window = Gtk::Window.new
+      window.title = "Lich - #{Char.name}'s Vars"
+      window.add(sw)
+      window.signal_connect('delete_event') {
+         report_errors {
+            modified = new_vars.any? { |v| (v[1] != nil) and v[1].sensitive? }
+            unless modified
+               vars.each_index { |i| if textboxes[i].nil? or ((vars[i][1].class == String) and (vars[i][1] != textboxes[i].text)); modified = true; break; end }
+            end
+            if modified
+               dialog = Gtk::MessageDialog.new(nil, Gtk::Dialog::MODAL, Gtk::MessageDialog::QUESTION, Gtk::MessageDialog::BUTTONS_YES_NO, "Save changes?")
+               dialog.title = "Lich - #{Char.name}'s Vars"
+               response = nil
+               dialog.run { |r| response = r; dialog.destroy }
+               if response == Gtk::Dialog::RESPONSE_YES
+                  vars.each_index { |i|
+                     if textboxes[i].nil?
+                        Vars[vars[i][0]] = nil
+                     elsif (vars[i][1].class == String) and (vars[i][1] != textboxes[i].text)
+                        Vars[vars[i][0]] = textboxes[i].text
+                     end
+                  }
+                  new_vars.each { |var|
+                     if (var[1] != nil) and var[1].sensitive?
+                        if var[0].text.empty?
+                           echo "warning: ignoring new variable with no name"
+                        elsif Vars.list.keys.include?(var[0].text)
+                           echo "warning: new variable #{var[0].text} already exists; ignoring"
+                        else
+                           Vars[var[0].text] = var[1].text
+                        end
+                     end
+                  }
+               end
+            end
+            done = true
+         }
+      }
+      window.set_default_size((Gdk.screen_width/2), (Gdk.screen_height/2))
+      window.set_window_position(Gtk::Window::POS_CENTER)
+      window.show_all
+   }
+   begin
+      wait_until { done }
+   ensure
+      Gtk.queue { window.destroy }
+   end
+else
+   output = "\n"
+   output.concat "   #{$clean_lich_char}#{script.name} setup              open a window to edit variables\n" if defined?(Gtk)
+   output.concat "   #{$clean_lich_char}#{script.name} set NAME=VALUE     add or change a variable\n"
+   output.concat "   #{$clean_lich_char}#{script.name} delete NAME        delete a variable\n"
+   output.concat "   #{$clean_lich_char}#{script.name} list               show current variables\n"
+   output.concat "\n"
+   respond output
+end

--- a/spec/jinx/repos/core/headers/alias.header
+++ b/spec/jinx/repos/core/headers/alias.header
@@ -1,0 +1,20 @@
+
+   Implements aliases for Lich.
+
+   Start the script and type ;alias help
+
+   author: Tillmen (tillmen@lichproject.org)
+   game: any
+   tags: core
+   required: Lich >= 4.6.0
+   version: 0.8
+
+   changelog:
+      0.8 (2018-08-29):
+         fixes for compatibility with Ruby >= 2.3
+      0.7 (2015-08-31):
+         make triggers case-insensitive
+      0.6 (2015-03-10):
+         don't allow the script to run as trusted
+         update trigger regex after deleting a trigger
+

--- a/spec/jinx/repos/core/headers/autostart.header
+++ b/spec/jinx/repos/core/headers/autostart.header
@@ -1,0 +1,33 @@
+
+  Automatically starts scripts when Lich starts.
+
+  ;autostart help
+
+        author: Tillmen (tillmen@lichproject.org)
+  contributors: Athias, Doug
+          game: any
+          tags: core
+       version: 0.52
+      required: Lich >= 4.6.58
+
+  changelog:
+    0.52 (2021-01-04):
+      Fix to only run ;repository download-updates if in autostart list instead of forced.
+    0.51 (2020-09-09):
+      Added LostRanger gtk_version method to detect GTK version
+      Forcing unset-lich-updatable to prevent overwriting GTK3-enabled Lich only if GTK3 detected
+      Exclude narost / alias from update list if GTK3 detected
+      The above are only intended to be used in the GTK3 distro.
+    0.5 (2020-07-05):
+      Forced infomon and repository update to run at start
+      Prevented duplicate runs of infomon
+      Fixed bug with repository update not running
+      Made go2 and narost defaults
+      Formatting changes
+    0.4 (2015-07-12):
+      start infomon before other scripts
+    0.3 (2014-11-23):
+      add default settings on first run
+    0.2 (2014-11-10):
+      auto add infomon to global autostart list
+

--- a/spec/jinx/repos/core/headers/demo.header
+++ b/spec/jinx/repos/core/headers/demo.header
@@ -1,0 +1,1 @@
+  Jinx repo demo

--- a/spec/jinx/repos/core/headers/go2.header
+++ b/spec/jinx/repos/core/headers/go2.header
@@ -1,0 +1,20 @@
+
+   attempts to find the shortest route between any two rooms in the game
+   requires a map database (;repository download-mapdb)
+
+   ;go2 help
+
+            author: Tillmen (tillmen@lichproject.org)
+   original author: Shaelun
+              game: any
+              tags: core, movement
+           version: 1.26
+          required: Lich >= 4.6.14
+
+   changelog:
+      1.26 (2020-10-08):
+        Fix silver check broken by Commageddon
+      1.25 (2019-05-11):
+        Fix DragonRealms auto drag feature (Sarvatt)
+      1.24 (2019-03-03):
+         Updated formatting for ";go2 list" in GSPlat and GSF

--- a/spec/jinx/repos/core/headers/infomon.header
+++ b/spec/jinx/repos/core/headers/infomon.header
@@ -1,0 +1,33 @@
+
+    This script tracks a bunch of info about your character that isn't available as XML, such as your skills and stats, the spells you have on and their duration, gift of lumis, and other random things.
+    Use   ;magic   to see what spells you have on.
+    Use   ;banks   to see how poor you are.
+
+             author: Tillmen (tillmen@lichproject.org)
+    original author: Shaelun
+               game: Gemstone
+               tags: core
+           required: Lich > 4.6.10
+            version: 1.18.2
+
+  Version Control:
+    Major_change.feature_addition.bugfix
+
+    changelog:
+      1.18.2 (2021-01-06):
+        Previous fix exposed different bug. Updated infomon to maintain bind spell
+        state in both $infomon_bound (for checkbound) and Spell[214].active?
+      1.18.1 (2021-01-05):
+        Typo for infomon_bound with envelopes should be envelop
+      1.18 (2021-01-01):
+        update stat parsing regex to handle negative enhanced bonuses
+      1.17 (2020-12-19):
+        Recorded previous commageddon fixes in change log
+        Updated formatting for viewer friendly goodness
+      1.16 (2018-07-30):
+        Rename Core Tap Recovery to match spell active
+      1.15 (2018-07-22):
+        improved tracking for Core Tap
+        fix spell active match for Cloak of Shadows
+      1.14 (2017-10-08):
+        detect Mage Armor in spell active

--- a/spec/jinx/repos/core/headers/lnet.header
+++ b/spec/jinx/repos/core/headers/lnet.header
@@ -1,0 +1,20 @@
+
+  Chat client for Lich.
+
+  ;lnet help
+
+    author: Tillmen (tillmen@lichproject.org)
+      game: any
+      tags: core
+  required: Lich >= 4.3.12
+   version: 1.6
+
+  changelog:
+    1.6 (2016-01-10):
+      fixed room id lookup for ;locate command
+      added alias feature
+    1.5 (2015-11-25):
+      added reply command (DR:Etreu)
+    1.4 (2015-05-13):
+      move channel owners and moderators to the front of the ;who list
+

--- a/spec/jinx/repos/core/headers/vars.header
+++ b/spec/jinx/repos/core/headers/vars.header
@@ -1,0 +1,19 @@
+
+   edit variables shared by all scripts
+
+   ;vars help
+
+   author: Tillmen (tillmen@lichproject.org)
+   game: any
+   tags: core
+   required: Lich >= 4.6.14
+   version: 0.8
+
+   changelog:
+      0.8 (2019-02-23):
+         fixes for compatibility with Ruby >= 2.3
+      0.7 (2015-04-26):
+         prompt to save in GUI when new vars are added
+      0.6 (2015-02-01):
+         add default text to new var textboxes
+

--- a/spec/jinx/repos/core/manifest.json
+++ b/spec/jinx/repos/core/manifest.json
@@ -1,0 +1,93 @@
+{
+    "available": [
+        {
+            "file": "/assets/alias.lic",
+            "type": "script",
+            "md5": "iPFnzk6GdEdVPED9H/x4G+UJho0=",
+            "last_commit": 1608381386,
+            "header": "/headers/alias.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.8",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/vars.lic",
+            "type": "script",
+            "md5": "+YS4ve4rPIiihmG694l0o9SAzXQ=",
+            "last_commit": 1608291353,
+            "header": "/headers/vars.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.8",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/lnet.lic",
+            "type": "script",
+            "md5": "ipCwPHr8pgsie17QeM3EWMSxYHo=",
+            "last_commit": 1608381386,
+            "header": "/headers/lnet.header",
+            "tags": [
+                "core"
+            ],
+            "version": "1.6",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/spell-list.xml",
+            "type": "data",
+            "md5": "ubCnjrWWUPb3g7uvcTAPpLrElfw=",
+            "last_commit": 1609919384,
+            "tags": []
+        },
+        {
+            "file": "/assets/autostart.lic",
+            "type": "script",
+            "md5": "FzlA4ILkCih30ySm6p7PswoUUYs=",
+            "last_commit": 1609776873,
+            "header": "/headers/autostart.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.52",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/go2.lic",
+            "type": "script",
+            "md5": "daif7orusRQOUixmWbcoV34mPAY=",
+            "last_commit": 1608257679,
+            "header": "/headers/go2.header",
+            "tags": [
+                "core",
+                "movement"
+            ],
+            "version": "1.26",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        },
+        {
+            "file": "/assets/demo.lic",
+            "type": "script",
+            "md5": "39KPDWjIFMPAHKvXGn+M08O92K8=",
+            "last_commit": 1607647171,
+            "header": "/headers/demo.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/infomon.lic",
+            "type": "script",
+            "md5": "vioCE2K9F2jyKmkbfvJRWyjGVDs=",
+            "last_commit": 1609921363,
+            "header": "/headers/infomon.header",
+            "tags": [
+                "core"
+            ],
+            "version": "1.18.2",
+            "author": "Tillmen (tillmen@lichproject.org)"
+        }
+    ],
+    "last_updated": 1610245929
+}

--- a/spec/jinx/repos/extras/assets/noop.lic
+++ b/spec/jinx/repos/extras/assets/noop.lic
@@ -1,0 +1,13 @@
+=begin
+        A simple script to allow for learning elanthia-online integration
+        with Github + CI environments.
+ 
+              author: elanthia-online
+                game: Gemstone
+                tags: testing
+             version: 1.0
+ 
+		To help contribute: https://github.com/elanthia-online/scripts
+=end
+
+exit

--- a/spec/jinx/repos/extras/headers/noop.header
+++ b/spec/jinx/repos/extras/headers/noop.header
@@ -1,0 +1,9 @@
+        A simple script to allow for learning elanthia-online integration
+        with Github + CI environments.
+ 
+              author: elanthia-online
+                game: Gemstone
+                tags: testing
+             version: 1.0
+ 
+		To help contribute: https://github.com/elanthia-online/scripts

--- a/spec/jinx/repos/extras/manifest.json
+++ b/spec/jinx/repos/extras/manifest.json
@@ -1,0 +1,1219 @@
+{
+    "available": [
+        {
+            "file": "/assets/reimmessage.lic",
+            "type": "script",
+            "md5": "W4WUKc27+gOTDq4d/9Jkks8ytSQ=",
+            "last_commit": 1575423815,
+            "header": "/headers/reimmessage.header",
+            "tags": [
+                "reim",
+                "hand of the arkati",
+                "hoa"
+            ],
+            "version": "1.3",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/to.lic",
+            "type": "script",
+            "md5": "y1qNkf4zwBJ/t1wglCDL6waKcdM=",
+            "last_commit": 1602356151,
+            "tags": []
+        },
+        {
+            "file": "/assets/totalrecall.lic",
+            "type": "script",
+            "md5": "qTwCIXQt3vrLvKhIrWqKn1hOvAk=",
+            "last_commit": 1608255892,
+            "header": "/headers/totalrecall.header",
+            "tags": [
+                "totalrecall",
+                "recall",
+                "loresinging",
+                "bard",
+                "lkp",
+                "unlocking",
+                "murderverse",
+                "murder",
+                "murderverses"
+            ],
+            "version": "1.2",
+            "author": "Naamit"
+        },
+        {
+            "file": "/assets/jbook.lic",
+            "type": "script",
+            "md5": "4oRQnV0p+HXrrLY0UU8Rnctb3Pw=",
+            "last_commit": 1568598373,
+            "header": "/headers/jbook.header",
+            "tags": [
+                "lich",
+                "book",
+                "books",
+                "journal",
+                "journals",
+                "search"
+            ],
+            "version": "0.0.5",
+            "author": "Richard A. Secor (rsecor@rsecor.com) AKA Jahadeem"
+        },
+        {
+            "file": "/assets/shop-me-not.lic",
+            "type": "script",
+            "md5": "XAvCFdEWCxUf2QmZR0K9HRL/1Bo=",
+            "last_commit": 1595967149,
+            "header": "/headers/shop-me-not.header",
+            "tags": [
+                "util",
+                "shop"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/purser.lic",
+            "type": "script",
+            "md5": "+7QRrZMRGVH1K+ZMMnVIdwB3gKE=",
+            "last_commit": 1602356151,
+            "header": "/headers/purser.header",
+            "tags": [],
+            "version": "0.0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/disarmed.lic",
+            "type": "script",
+            "md5": "quDilgCAK2VMtHZ2eNB/8FLV3DM=",
+            "last_commit": 1588950942,
+            "header": "/headers/disarmed.header",
+            "tags": [
+                "disarm",
+                "disarmed",
+                "recover",
+                "recovery"
+            ],
+            "version": "1.4",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/inbox.lic",
+            "type": "script",
+            "md5": "RSyDz2J6yN0tMetmyIIlGAQyml4=",
+            "last_commit": 1528389930,
+            "header": "/headers/inbox.header",
+            "tags": [
+                "lnet",
+                "0net",
+                "meta",
+                "core"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/briefcombat.lic",
+            "type": "script",
+            "md5": "3lKmCI/h4ra9/xnTkqifTtyKY+c=",
+            "last_commit": 1589548535,
+            "header": "/headers/briefcombat.header",
+            "tags": [
+                "brief",
+                "briefcombat",
+                "condensing",
+                "condense",
+                "combat",
+                "squelch"
+            ],
+            "version": "0.0.7",
+            "author": "Daedeus (updates by Tysong/Ragz)"
+        },
+        {
+            "file": "/assets/snapshot.lic",
+            "type": "script",
+            "md5": "QxXfsSgLE9G7p+GDcbLUKmwDNGo=",
+            "last_commit": 1549215808,
+            "tags": []
+        },
+        {
+            "file": "/assets/moneychanger.lic",
+            "type": "script",
+            "md5": "XN+UNapzFrh7jrHyOUD2nmjSvT4=",
+            "last_commit": 1602356151,
+            "header": "/headers/moneychanger.header",
+            "tags": [],
+            "version": "1.0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/duskruin_watch.lic",
+            "type": "script",
+            "md5": "uuFw8iK0ytHcqhyb+9lSWQGG6s0=",
+            "last_commit": 1565362049,
+            "header": "/headers/duskruin_watch.header",
+            "tags": [
+                "duskruin",
+                "arena"
+            ],
+            "version": "1.5",
+            "author": "Tysong (horibu on PC), original Nylis"
+        },
+        {
+            "file": "/assets/asexualfavors.lic",
+            "type": "script",
+            "md5": "Jfl88BgQ2863MmLNlEN/Z9+Tx3E=",
+            "last_commit": 1605093159,
+            "header": "/headers/asexualfavors.header",
+            "tags": [
+                "voln",
+                "favor"
+            ],
+            "version": "0.0.6",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/tduskpray.lic",
+            "type": "script",
+            "md5": "9OOpC7/WtQUD5lxSXGnqyARCzOs=",
+            "last_commit": 1581651497,
+            "header": "/headers/tduskpray.header",
+            "tags": [
+                "duskruin",
+                "arena",
+                "dusk ruin",
+                "tdusk",
+                "pray"
+            ],
+            "version": "1.3",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/proctor.lic",
+            "type": "script",
+            "md5": "x2w+oOmpNnpgGIii4zHW7ZG53oY=",
+            "last_commit": 1541215416,
+            "header": "/headers/proctor.header",
+            "tags": [
+                "core",
+                "util",
+                "mapdb",
+                "strinprocs"
+            ],
+            "version": "1.0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/milkman.lic",
+            "type": "script",
+            "md5": "Bv+ckjuuFm416GhqoRN69xkjkfk=",
+            "last_commit": 1605093159,
+            "header": "/headers/milkman.header",
+            "tags": [
+                "thoughts"
+            ],
+            "version": "0.0.7",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/citizenship.lic",
+            "type": "script",
+            "md5": "zNqJNaDHo6VgNNP8yfCqyf2cZ6g=",
+            "last_commit": 1608254823,
+            "header": "/headers/citizenship.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/manaleech.lic",
+            "type": "script",
+            "md5": "7LYw6IAZ3PUhBia3EQDsbKPFgoI=",
+            "last_commit": 1581603530,
+            "header": "/headers/manaleech.header",
+            "tags": [
+                "mana leech",
+                "mana",
+                "leech",
+                "516",
+                "wizard"
+            ],
+            "version": "2.6",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/deepthoughts.lic",
+            "type": "script",
+            "md5": "O4pZ1R5RHc0mag5XxPC5VFFon5w=",
+            "last_commit": 1593747260,
+            "header": "/headers/deepthoughts.header",
+            "tags": [
+                "lich",
+                "amunet",
+                "esp",
+                "speech"
+            ],
+            "version": "1.0.0",
+            "author": "HebrewToYou"
+        },
+        {
+            "file": "/assets/familiar.lic",
+            "type": "script",
+            "md5": "7ZwPrQzoqpFStDL9v1lx7zSvIoo=",
+            "last_commit": 1538932212,
+            "header": "/headers/familiar.header",
+            "tags": [
+                "familiar",
+                "920",
+                "wizard"
+            ],
+            "version": "1.42",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/mend.lic",
+            "type": "script",
+            "md5": "s4ACk27FmvCoUJjZqGaFDnTnAjU=",
+            "last_commit": 1602356151,
+            "header": "/headers/mend.header",
+            "tags": [
+                "healing",
+                "beta"
+            ],
+            "version": "0.0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/puritan.lic",
+            "type": "script",
+            "md5": "odrqs3jtLu42zqn1UbrFOp6Q4p4=",
+            "last_commit": 1603077241,
+            "header": "/headers/puritan.header",
+            "tags": [
+                "util",
+                "gems",
+                "1004",
+                "purify"
+            ],
+            "version": "1.1.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/cluster.lic",
+            "type": "script",
+            "md5": "G+VzNLX4u/kUCPZL9d1SxP+AH14=",
+            "last_commit": 1561213262,
+            "header": "/headers/cluster.header",
+            "tags": [],
+            "version": "0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/gem.lic",
+            "type": "script",
+            "md5": "ZP5CtlKjOCq/NT0sJgQug/vNj0U=",
+            "last_commit": 1602356151,
+            "header": "/headers/gem.header",
+            "tags": [],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/tperfume.lic",
+            "type": "script",
+            "md5": "anbnvnoHhNy1Gt6f4NXQazgQjl0=",
+            "last_commit": 1567363047,
+            "header": "/headers/tperfume.header",
+            "tags": [
+                "perfume",
+                "shifting perfume",
+                "cologne"
+            ],
+            "version": "1.0",
+            "author": "Tysong"
+        },
+        {
+            "file": "/assets/boxes.lic",
+            "type": "script",
+            "md5": "Af8biOHCh52YJ4eNDF3qlVcwz5c=",
+            "last_commit": 1602356151,
+            "tags": []
+        },
+        {
+            "file": "/assets/bigshot.lic",
+            "type": "script",
+            "md5": "tx5YujRXrr7HFTMgCm9rhKx6zfw=",
+            "last_commit": 1609469854,
+            "header": "/headers/bigshot.header",
+            "tags": [
+                "hunting"
+            ],
+            "version": "4.1.1",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/rofl-questions.lic",
+            "type": "script",
+            "md5": "UMVBT0DciQFf6Q77z48ks8rivlY=",
+            "last_commit": 1587489216,
+            "header": "/headers/rofl-questions.header",
+            "tags": [
+                "festival",
+                "RoL",
+                "Rings"
+            ],
+            "version": "1.3",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/looploot.lic",
+            "type": "script",
+            "md5": "QK5JfH583szOauozBJjVcuCDebo=",
+            "last_commit": 1567363047,
+            "header": "/headers/looploot.header",
+            "tags": [
+                "looting",
+                "gems"
+            ],
+            "version": "1.1",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/messaging.lic",
+            "type": "script",
+            "md5": "0+QRahllrKyE8n6zSiLrULEP7ts=",
+            "last_commit": 1567363047,
+            "header": "/headers/messaging.header",
+            "tags": [
+                "death",
+                "messaging",
+                "login",
+                "logout"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/holdhands.lic",
+            "type": "script",
+            "md5": "RY4f9uY5c14FSOuO5R8GBzsmz68=",
+            "last_commit": 1521579860,
+            "header": "/headers/holdhands.header",
+            "tags": [
+                "reim group"
+            ],
+            "version": "1.3",
+            "author": "Elanthia-Online"
+        },
+        {
+            "file": "/assets/tonis.lic",
+            "type": "script",
+            "md5": "Ny3+P+tfxNHHCKnUw5VzORtI7MI=",
+            "last_commit": 1602356151,
+            "header": "/headers/tonis.header",
+            "tags": [],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/botcamp.lic",
+            "type": "script",
+            "md5": "eBMrRH71F2ZVCCzYWXlLVVHx9tI=",
+            "last_commit": 1567363047,
+            "header": "/headers/botcamp.header",
+            "tags": [
+                "botcamp",
+                "warcamp",
+                "GOS"
+            ],
+            "version": "1.8",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/coins.lic",
+            "type": "script",
+            "md5": "9MwHmelgRBp4vqwZx+uHVrlq+Kc=",
+            "last_commit": 1599597107,
+            "header": "/headers/coins.header",
+            "tags": [
+                "coins",
+                "silver"
+            ],
+            "version": "1.02",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/traffle.lic",
+            "type": "script",
+            "md5": "e27g52brpqrba9hW4uPn0k0VUqU=",
+            "last_commit": 1570760616,
+            "header": "/headers/traffle.header",
+            "tags": [
+                "raffle",
+                "raffles"
+            ],
+            "version": "1.13",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/boltdf.lic",
+            "type": "script",
+            "md5": "D0StEA9qjMknNJ4T3NiCHk+oRjI=",
+            "last_commit": 1567363047,
+            "header": "/headers/boltdf.header",
+            "tags": [
+                "bolt",
+                "df",
+                "spells"
+            ],
+            "version": "2.2",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/slop-lib.lic",
+            "type": "script",
+            "md5": "uSrg5W7unDvhmpqU15rgGdHQRyw=",
+            "last_commit": 1601168610,
+            "header": "/headers/slop-lib.header",
+            "tags": [
+                "library"
+            ],
+            "version": "3.6.0",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/notify.lic",
+            "type": "script",
+            "md5": "gQ6db/Rpt/SHCOh/WMTqONlabBk=",
+            "last_commit": 1581557715,
+            "header": "/headers/notify.header",
+            "tags": [
+                "util"
+            ],
+            "version": "1.2.0, 1.3.0",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/oleani-lib.lic",
+            "type": "script",
+            "md5": "GAWHHiT4UamljFw/5bNMCPUgXHE=",
+            "last_commit": 1605144918,
+            "header": "/headers/oleani-lib.header",
+            "tags": [
+                "library"
+            ],
+            "version": "0.0.10",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/0net.lic",
+            "type": "script",
+            "md5": "DnzW3ryvpY2Y13l4j8AjnR9hoFw=",
+            "last_commit": 1602356151,
+            "header": "/headers/0net.header",
+            "tags": [
+                "core"
+            ],
+            "version": "0.0.3",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/give.lic",
+            "type": "script",
+            "md5": "uFXgoepnLcTIzmQRhL3OUb/J3CQ=",
+            "last_commit": 1602356151,
+            "header": "/headers/give.header",
+            "tags": [
+                "lockers",
+                "movers",
+                "move"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/rofl-puzzles.lic",
+            "type": "script",
+            "md5": "PcvD76whC/pY5VJ51hWfQBn75b8=",
+            "last_commit": 1587522922,
+            "header": "/headers/rofl-puzzles.header",
+            "tags": [
+                "festival",
+                "RoL",
+                "Rings"
+            ],
+            "version": "1.3",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/webui.lic",
+            "type": "script",
+            "md5": "qf9fRNAbL/q7tGOd5UXnWrMZF+A=",
+            "last_commit": 1536639794,
+            "tags": []
+        },
+        {
+            "file": "/assets/assess.lic",
+            "type": "script",
+            "md5": "bh9TUrK69VH8pCik2iI9jjvbem8=",
+            "last_commit": 1549036935,
+            "tags": []
+        },
+        {
+            "file": "/assets/jbackup.lic",
+            "type": "script",
+            "md5": "i3JEVClKuveuTFHlC+u3M01P+sU=",
+            "last_commit": 1569893394,
+            "header": "/headers/jbackup.header",
+            "tags": [
+                "backup",
+                "back up",
+                "lich",
+                "files",
+                "copy"
+            ],
+            "version": "0.2.1",
+            "author": "Richard A. Secor (rsecor@rsecor.com) AKA Jahadeem"
+        },
+        {
+            "file": "/assets/shopkeeper.lic",
+            "type": "script",
+            "md5": "e2lTfAqn/CWrYrH/fhQJoKy2qzA=",
+            "last_commit": 1516208838,
+            "tags": []
+        },
+        {
+            "file": "/assets/tfish.lic",
+            "type": "script",
+            "md5": "fVJZkymvaU/sOatnQ4o12MBTaJE=",
+            "last_commit": 1603077074,
+            "header": "/headers/tfish.header",
+            "tags": [
+                "EG",
+                "Ebon Gate",
+                "fish",
+                "fishing"
+            ],
+            "version": "1.7",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/tmillicent.lic",
+            "type": "script",
+            "md5": "+9iveSFL7F1C5zdeD4MHfOnAnBY=",
+            "last_commit": 1567363047,
+            "header": "/headers/tmillicent.header",
+            "tags": [
+                "millicent",
+                "millicent gown",
+                "gown"
+            ],
+            "version": "1.0",
+            "author": "Tysong"
+        },
+        {
+            "file": "/assets/orbuculum.lic",
+            "type": "script",
+            "md5": "ySeiJetuXIRSNSwrtBJ2kspprNQ=",
+            "last_commit": 1527517398,
+            "header": "/headers/orbuculum.header",
+            "tags": [
+                "core",
+                "movement"
+            ]
+        },
+        {
+            "file": "/assets/tgames.lic",
+            "type": "script",
+            "md5": "WsB+Qu5gZHXV0P6/XfcOdzgB0Yg=",
+            "last_commit": 1602852343,
+            "header": "/headers/tgames.header",
+            "tags": [
+                "games",
+                "eg",
+                "ebon gate",
+                "ebon"
+            ],
+            "version": "1.9",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/tilde.lic",
+            "type": "script",
+            "md5": "YJicXK1X8/icZszJbERxyo101iw=",
+            "last_commit": 1561675907,
+            "header": "/headers/tilde.header",
+            "tags": [
+                "util",
+                "containers"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/treim.lic",
+            "type": "script",
+            "md5": "L39w2g5VN5BQfgp3gE5atdU60JQ=",
+            "last_commit": 1609128005,
+            "header": "/headers/treim.header",
+            "tags": [
+                "reim"
+            ],
+            "version": "2.22",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/tdig.lic",
+            "type": "script",
+            "md5": "YZ1mAd7PrLbtQxMNhb8JVLHIzMY=",
+            "last_commit": 1603074686,
+            "header": "/headers/tdig.header",
+            "tags": [
+                "EG",
+                "digging",
+                "Ebon Gate",
+                "dig"
+            ],
+            "version": "1.14",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/uhaul.lic",
+            "type": "script",
+            "md5": "LRQuYka09Baq/zBgl/urt/7Py/4=",
+            "last_commit": 1599833606,
+            "header": "/headers/uhaul.header",
+            "tags": [
+                "lockers",
+                "movers",
+                "move"
+            ],
+            "version": "2",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/tdarts.lic",
+            "type": "script",
+            "md5": "OTJZ2tkXs+8//azSDhqB7+jXaXM=",
+            "last_commit": 1567363047,
+            "header": "/headers/tdarts.header",
+            "tags": [
+                "darts",
+                "games"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/tsquelch.lic",
+            "type": "script",
+            "md5": "8a/ee0cZKbjRS/Vc4QjlSXjZKD8=",
+            "last_commit": 1567363047,
+            "header": "/headers/tsquelch.header",
+            "tags": [
+                "EG",
+                "digging",
+                "Ebon Gate",
+                "dig",
+                "squelching",
+                "squelch",
+                "fishing",
+                "fish"
+            ],
+            "version": "1.4",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/jinx.lic",
+            "type": "script",
+            "md5": "01KR1JrA8pJ/kiCX45r0wu7wTrc=",
+            "last_commit": 1609534975,
+            "header": "/headers/jinx.header",
+            "tags": []
+        },
+        {
+            "file": "/assets/coin4deed.lic",
+            "type": "script",
+            "md5": "GJ7Ga7KBjT5t1JhuEUzt2B653zE=",
+            "last_commit": 1592524870,
+            "header": "/headers/coin4deed.header",
+            "tags": [
+                "deeds"
+            ],
+            "version": "1.0",
+            "author": "Athias"
+        },
+        {
+            "file": "/assets/lte.lic",
+            "type": "script",
+            "md5": "7g7TcjnfnICprftkxzXdgaLYW5o=",
+            "last_commit": 1602356151,
+            "header": "/headers/lte.header",
+            "tags": [],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/webdispel.lic",
+            "type": "script",
+            "md5": "96x3zo5cStSnCX3qhzv0Q6QMnxM=",
+            "last_commit": 1567363047,
+            "header": "/headers/webdispel.header",
+            "tags": [
+                "dispel",
+                "dispell",
+                "417",
+                "119",
+                "web"
+            ],
+            "version": "1.0",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/arenatimer.lic",
+            "type": "script",
+            "md5": "ztJrmAygo1rNbjBYPhVCkJH1TLY=",
+            "last_commit": 1567363047,
+            "header": "/headers/arenatimer.header",
+            "tags": [
+                "duskruin",
+                "arena",
+                "timer"
+            ],
+            "version": "1.1",
+            "author": "Tysong (horibu on PC), original Nylis"
+        },
+        {
+            "file": "/assets/cartograph.lic",
+            "type": "script",
+            "md5": "n+UeHnPiT27joeyU0LxhXZSNlrc=",
+            "last_commit": 1591139016,
+            "header": "/headers/cartograph.header",
+            "tags": [
+                "mapdb",
+                "cartograph"
+            ],
+            "version": "0.0.1-rc.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/commas.lic",
+            "type": "script",
+            "md5": "iUh04PKiayW6uhHzmEsJQCeaZt0=",
+            "last_commit": 1593041657,
+            "header": "/headers/commas.header",
+            "tags": [],
+            "version": "0.2",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/trove.lic",
+            "type": "script",
+            "md5": "mJJViyQxPH86YvgbawdE8+WKPaU=",
+            "last_commit": 1570805749,
+            "header": "/headers/trove.header",
+            "tags": [
+                "trove",
+                "duskruin",
+                "eg"
+            ],
+            "version": "1.1",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/tears.lic",
+            "type": "script",
+            "md5": "jxDac78Vx7311AilYK3qtbMzhlU=",
+            "last_commit": 1607275621,
+            "header": "/headers/tears.header",
+            "tags": [
+                "tears",
+                "essence",
+                "enchant",
+                "enchanting",
+                "925"
+            ],
+            "version": "1.7",
+            "author": "Elanthia-Online"
+        },
+        {
+            "file": "/assets/scripts.lic",
+            "type": "script",
+            "md5": "WNcBBgRjDUAgX3uhXRpJg5/bN24=",
+            "last_commit": 1507220330,
+            "header": "/headers/scripts.header",
+            "tags": [],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/resource.lic",
+            "type": "script",
+            "md5": "Xtc7f8N9N7irC+d4J/NmY3uv9H0=",
+            "last_commit": 1609347791,
+            "header": "/headers/resource.header",
+            "tags": [
+                "resource",
+                "tears",
+                "essence",
+                "enchant",
+                "enchanting",
+                "925",
+                "recall",
+                "loresinging",
+                "bard",
+                "lkp",
+                "unlocking",
+                "murderverse",
+                "murder",
+                "juice",
+                "necrojuice",
+                "ensorcell",
+                "ensorcelling",
+                "735",
+                "mystic tattoo",
+                "tattoo",
+                "mystic"
+            ],
+            "version": "1.1",
+            "author": "Elanthia-Online"
+        },
+        {
+            "file": "/assets/tag_checker.lic",
+            "type": "script",
+            "md5": "d3HUVSEmlZQhiCtnGwDsKtU0qHg=",
+            "last_commit": 1549215808,
+            "tags": []
+        },
+        {
+            "file": "/assets/isquelch.lic",
+            "type": "script",
+            "md5": "nSndJTZ3qR3it7fMIcXfAJstCJw=",
+            "last_commit": 1607050636,
+            "tags": []
+        },
+        {
+            "file": "/assets/grep.lic",
+            "type": "script",
+            "md5": "IlrR24lnh3zABDW+TfE1SNwzfn0=",
+            "last_commit": 1602356151,
+            "header": "/headers/grep.header",
+            "tags": [
+                "util",
+                "grep",
+                "search"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/tradingranks.lic",
+            "type": "script",
+            "md5": "iwzy0Kc4NyGJ3L4n0p5mN/bNXaI=",
+            "last_commit": 1607546677,
+            "header": "/headers/tradingranks.header",
+            "tags": [
+                "trading"
+            ],
+            "version": "1.3",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/experfect.lic",
+            "type": "script",
+            "md5": "I4ZiGnTuVIZm3kYvt6vuJmI3Ync=",
+            "last_commit": 1603398179,
+            "header": "/headers/experfect.header",
+            "tags": [
+                "cosmetic",
+                "experience"
+            ],
+            "version": "0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/battery.lic",
+            "type": "script",
+            "md5": "QDZHPBT1gf6pP0z+iQKmKMZ4LtA=",
+            "last_commit": 1602356151,
+            "header": "/headers/battery.header",
+            "tags": [
+                "mana",
+                "send mana",
+                "send",
+                "battery"
+            ],
+            "version": "0.0.2",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/alter.lic",
+            "type": "script",
+            "md5": "blnA+SEso45WzSOyU0DDGfH0kuI=",
+            "last_commit": 1608313906,
+            "header": "/headers/alter.header",
+            "tags": [
+                "alter",
+                "alteration",
+                "alterations",
+                "gownifer"
+            ],
+            "version": "1.1",
+            "author": "Naamit"
+        },
+        {
+            "file": "/assets/send.lic",
+            "type": "script",
+            "md5": "VBZKOHu/jWX+zegR0fTKx3IKQLA=",
+            "last_commit": 1602356151,
+            "tags": []
+        },
+        {
+            "file": "/assets/signore.lic",
+            "type": "script",
+            "md5": "ZpVHq9bDObvrB+VcIWBe3sjYntw=",
+            "last_commit": 1602356151,
+            "header": "/headers/signore.header",
+            "tags": [],
+            "version": "0.0.5",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/diskus.lic",
+            "type": "script",
+            "md5": "bQVR20ZDYdIRZowfdq3ezKUy3bg=",
+            "last_commit": 1522434104,
+            "header": "/headers/diskus.header",
+            "tags": [
+                "magic",
+                "disk"
+            ],
+            "version": "0.10",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/samaritan.lic",
+            "type": "script",
+            "md5": "CAWvS7CGFNLC29RFC+unk5CRl4g=",
+            "last_commit": 1602356151,
+            "header": "/headers/samaritan.header",
+            "tags": [
+                "util"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/portkey.lic",
+            "type": "script",
+            "md5": "LdBFGwTg2FEEmeuwZAA/sEx+4Pk=",
+            "last_commit": 1549733220,
+            "header": "/headers/portkey.header",
+            "tags": [
+                "lockers",
+                "movers",
+                "move"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/poolparty.lic",
+            "type": "script",
+            "md5": "VUo9EhyKFqoL5hpfknX359ZD+yU=",
+            "last_commit": 1605253650,
+            "header": "/headers/poolparty.header",
+            "tags": [
+                "locksmith",
+                "picker",
+                "pool",
+                "locksmith pool",
+                "picking",
+                "boxes",
+                "loot",
+                "locksmith",
+                "locksmithing",
+                "rogue"
+            ],
+            "version": "2.10",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/clobber.lic",
+            "type": "script",
+            "md5": "B8FJN5N4a7BVQJZuTU+V/rG2bQc=",
+            "last_commit": 1602356151,
+            "header": "/headers/clobber.header",
+            "tags": [],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/no_mstrike.lic",
+            "type": "script",
+            "md5": "/PXwH3ADjJvYHPYJNSsEwMZ8pUM=",
+            "last_commit": 1555263204,
+            "header": "/headers/no_mstrike.header",
+            "tags": [
+                "squelch",
+                "no mstrike"
+            ],
+            "version": "1.0",
+            "author": "Elanthia-Online"
+        },
+        {
+            "file": "/assets/group.lic",
+            "type": "script",
+            "md5": "VgIdrIG9KUNLktch4xtRHwa8icY=",
+            "last_commit": 1567363047,
+            "header": "/headers/group.header",
+            "tags": [
+                "group",
+                "reim",
+                "random",
+                "silvers",
+                "share"
+            ],
+            "version": "3.1",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/noop.lic",
+            "type": "script",
+            "md5": "m2FA3a6kco6IxVjpBUF4hZi69hc=",
+            "last_commit": 1532526180,
+            "header": "/headers/noop.header",
+            "tags": [
+                "testing"
+            ],
+            "version": "1.0",
+            "author": "elanthia-online"
+        },
+        {
+            "file": "/assets/bodega.lic",
+            "type": "script",
+            "md5": "G1m6BJp49yK+MxWEIo13vYJdvr0=",
+            "last_commit": 1557070980,
+            "header": "/headers/bodega.header",
+            "tags": [
+                "playershops"
+            ],
+            "version": "0.1",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/bottle.lic",
+            "type": "script",
+            "md5": "ePLyiViLHZ8h+YbhQyjQzLkZk7U=",
+            "last_commit": 1602356151,
+            "tags": []
+        },
+        {
+            "file": "/assets/tdusk.lic",
+            "type": "script",
+            "md5": "jajgJsCWE3Sbrafxb3ilMBS0gbw=",
+            "last_commit": 1597961882,
+            "header": "/headers/tdusk.header",
+            "tags": [
+                "duskruin",
+                "arena",
+                "dusk ruin",
+                "tdusk"
+            ],
+            "version": "1.21",
+            "author": "Tysong (horibu on PC), original Nylis"
+        },
+        {
+            "file": "/assets/healbot_core.lic",
+            "type": "script",
+            "md5": "NkTpy6rdhrvvg6SvufWFAHzoZp4=",
+            "last_commit": 1602356151,
+            "header": "/headers/healbot_core.header",
+            "tags": [
+                "utility",
+                "shattered",
+                "automated"
+            ],
+            "version": "1.0",
+            "author": "Elanthia-Online"
+        },
+        {
+            "file": "/assets/cake.lic",
+            "type": "script",
+            "md5": "MPzCYVO5r+0Py2Dgr69HN40nXL8=",
+            "last_commit": 1606677259,
+            "tags": []
+        },
+        {
+            "file": "/assets/standgroup.lic",
+            "type": "script",
+            "md5": "xaXdLQ5b9DKJ/t/ejvtqerC4EUw=",
+            "last_commit": 1567363047,
+            "header": "/headers/standgroup.header",
+            "tags": [
+                "stand",
+                "group"
+            ],
+            "version": "1.2",
+            "author": "Tysong (horibu on PC)"
+        },
+        {
+            "file": "/assets/wps.lic",
+            "type": "script",
+            "md5": "gjJ3CZRvKNS0ZNUtlKuFj87iaQQ=",
+            "last_commit": 1598941631,
+            "header": "/headers/wps.header",
+            "tags": [
+                "util",
+                "ccf",
+                "duskruin",
+                "festival",
+                "merchant",
+                "wps",
+                "smithy"
+            ],
+            "version": "1.1",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/restart.lic",
+            "type": "script",
+            "md5": "wAiHdwJ6eY21mtWT1eELMEqpyKY=",
+            "last_commit": 1602356151,
+            "header": "/headers/restart.header",
+            "tags": [],
+            "version": "0.0.2",
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/absorb.lic",
+            "type": "script",
+            "md5": "5SohyPqscphcHhXqpbokjiIfIy4=",
+            "last_commit": 1521577561,
+            "header": "/headers/absorb.header",
+            "tags": [
+                "util"
+            ],
+            "version": "1.0",
+            "author": "Kragdruk"
+        },
+        {
+            "file": "/assets/tags.lic",
+            "type": "script",
+            "md5": "hx46XxC0zoQkxPyz6yh48K8LJWQ=",
+            "last_commit": 1522776841,
+            "header": "/headers/tags.header",
+            "tags": [
+                "tags"
+            ],
+            "author": "Ondreian"
+        },
+        {
+            "file": "/assets/warcries.lic",
+            "type": "script",
+            "md5": "4NGeQwyFi5vUAWL4GaQkmcRFxyQ=",
+            "last_commit": 1549215808,
+            "tags": []
+        },
+        {
+            "file": "/assets/healbot_actions.lic",
+            "type": "script",
+            "md5": "6BKWbeARjc0CV1zJZ2lcK8Q1I/Q=",
+            "last_commit": 1602356151,
+            "header": "/headers/healbot_actions.header",
+            "tags": [
+                "utility",
+                "shattered",
+                "automated"
+            ],
+            "version": "1.0.1",
+            "author": "Elanthia-Online"
+        }
+    ],
+    "last_updated": 1609539697
+}


### PR DESCRIPTION
Sets up Webmock to respond to repo URIs to serve the manifest and assets locally. 

* By default, the specs will use the local repo servers. We accomplish this by mapping local directories to each repo domain used in the tests. This is really fast:
```
> rspec spec/jinx/jinx_spec.rb
..............

Finished in 0.189 seconds (files took 0.27725 seconds to load)
14 examples, 0 failures
```
* You can also set the `ENABLE_EXTERNAL_NETWORKING` environmental variable run the specs against the live external servers. This takes a bit longer:
```
> ENABLE_EXTERNAL_NETWORKING=true rspec spec/jinx/jinx_spec.rb
..............

Finished in 13.2 seconds (files took 0.27649 seconds to load)
14 examples, 0 failures
```
* I also created a Github Actions workflow to run the jinx spec against the live servers on an hourly schedule.