### PR TITLE
Run build against ruby matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,18 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4', '2.5', '2.6', '2.7']
+    name: Ruby ${{ matrix.ruby }} Build
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '20'
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: ${{ matrix.ruby }}
       - name: Setup bundler cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Runs the tests against all ruby versions supported by GitHub's setup-ruby actions: 2.4, 2.5, 2.6, and 2.7. These are all of the [currently maintained Ruby versions](https://www.ruby-lang.org/en/downloads/branches/) except 3.0 which was just released and has some pretty big probably lich breaking changes.