### PR TITLE
jinx: explicit error message for ancient ruby versions

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -1,6 +1,23 @@
 =begin
   Package Manager
 =end
+
+if RUBY_VERSION < "2.3"
+  respond <<ERROR
+
+  RUBY #{RUBY_VERSION} NOT SUPPORTED
+
+  This version of Ruby is extremely out-of-date and has not been supported for
+  many years. You will need to upgrade your Ruby installation to use #{$clean_lich_char}#{Script.current.name}.
+
+  For detailed directions on how to install a modern version of Ruby:
+
+  https://gswiki.play.net/Lich_(software)/Installation
+
+ERROR
+  exit
+end
+
 require 'fileutils'
 require 'ostruct'
 require 'yaml'


### PR DESCRIPTION
Much better error message including link to wiki installation instructions for people trying to run ;jinx on ancient ruby versions. I picked 2.3 because that's when the squiggly heredoc was added which should be the most recently added ruby feature used in this script. 2.3 is already eol and 2.4 is coming up on eol in March, so I think this is a reasonable minimum version to support.