### PR TITLE
build: split test and release actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,19 @@
-name: Build
-on: [push, pull_request]
+name: Publish Updates
+on:
+  push:
+    branches: [ $default-branch ]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
-    name: Ruby ${{ matrix.ruby }} Build
+    name: Publish Updates
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '20'
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '2.7'
       - name: Setup bundler cache
         uses: actions/cache@v2
         with:
@@ -31,10 +30,7 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Run type data migrations to create gameobj-data.xml
         run: bin/migrate
-      - name: Run RSpec tests
-        run: bundle exec rspec
       - name: Release updates to Tillmen's Lich repository
-        if: github.ref == 'refs/heads/master'
         env:
           AUTHOR: ${{ secrets.repo_author }}
           PASSWORD: ${{ secrets.repo_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4', '2.5', '2.6', '2.7']
+    name: Run tests on Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Setup bundler cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+      - name: Install ruby gem dependencies with bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run type data migrations to create gameobj-data.xml
+        run: bin/migrate
+      - name: Run RSpec tests
+        run: bundle exec rspec


### PR DESCRIPTION
This avoids us releasing 4 times (one for each ruby version in the matrix). There is a fair amount of repetition in the workflows but I don't know Actions well enough to DRY it up yet.