### PR TITLE
jinx: fix for Jinx::Folder.path to use the correct base dir

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -13,7 +13,7 @@
 
    author: elanthia-online
      tags: utility, util, repository, repo, update, upgrade, meta, ruby, development
-  version: 0.1.0
+  version: 0.1.1
 
 =end
 
@@ -194,7 +194,7 @@ module Jinx
     end
 
     def self.path(*args)
-      File.join(data_dir, *args.map(&:to_s))
+      File.join(jinx_data_dir, *args.map(&:to_s))
     end
 
     def self.read(*args)

--- a/spec/jinx/jinx_spec.rb
+++ b/spec/jinx/jinx_spec.rb
@@ -115,6 +115,8 @@ module Jinx
       Service.run("script update go2 --repo=core")
       update_output = game_output
       expect(update_output).to include("go2.lic from repo:core already installed")
+
+      expect(File.exist?(File.join($data_dir, '_jinx', 'repos.yaml'))).to be true
     end
 
     it "script info" do


### PR DESCRIPTION
I broke this and it was putting everything in `$data_dir/` instead of $data_dir/_jinx`