### PR TITLE
Update bigshot.lic

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributers: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.2.2
+       version: 4.2.3
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -16,6 +16,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+
+  v4.2.3 (2021-02-10)
+    -Fix for certain values getting set when opening GUI, overwriting own settings
 
   v4.2.2 (2021-01-19)
     -Fix for certain values getting set when opening GUI, overwriting own settings
@@ -120,7 +123,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.2.1' # updated for GTK2 and GTK3
+BIGSHOT_VERSION = '4.2.3' # updated for GTK2 and GTK3
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -1070,14 +1073,14 @@ class Bigshot
       cmd(force_this, npc)
       buffer = reget(20)
       buffer.each_with_index { |line, i|
-        if (line =~ /^You.*(#{checknpcs.join('|')})(\.|!)|^You feint (high|low|(to the (left|right)))/)
-            if (buffer[i + 1] && buffer[i + 1] =~ /== \+(\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /== \+(\d+)/)
-              return if $1.to_i >= goal # spell/swing
-        elsif (buffer[i - 1] && buffer[i - 1] =~ /^\[(?:Roll|SMR) result: (\d+)/) || (buffer[i - 2] && buffer[i - 2] =~ /^\[(?:Roll|SMR) result: (\d+)/)
-          return if $1.to_i >= goal # cman
-        elsif (buffer[i + 1] =~ /^As you focus on your magic, your vision swims with a swirling haze of crimson/) || (buffer[i + 2] =~ /^As you focus on your magic, your vision swims with a swirling haze of crimson/)
-          return
-        end
+        if (line =~ /^You.*(#{checknpcs.join('|')})|^You feint (high|low|(to the (left|right)))/)
+          if (buffer[i + 1] && buffer[i + 1] =~ /== \+(\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /== \+(\d+)/)
+            return if $1.to_i >= goal # spell/swing
+          elsif (buffer[i - 1] && buffer[i - 1] =~ /^\[(?:Roll|SMR) result: (\d+)/) || (buffer[i - 2] && buffer[i - 2] =~ /^\[(?:Roll|SMR) result: (\d+)/) || (buffer[i + 1] && buffer[i + 1] =~ /^\[(?:Roll|SMR) result: (\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /^\[(?:Roll|SMR) result: (\d+)/)
+            return if $1.to_i >= goal # cman
+          elsif (buffer[i + 1] =~ /^As you focus on your magic, your vision swims with a swirling haze of crimson/) || (buffer[i + 2] =~ /^As you focus on your magic, your vision swims with a swirling haze of crimson/)
+            return
+          end
         elsif (line =~ /^You do not have enough stamina to attempt this maneuver\./)
           return
         elsif (line =~ /^Your magic fizzles ineffectually\./)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -18,7 +18,7 @@
     Major_change.feature_addition.bugfix
 
   v4.2.3 (2021-02-10)
-    -Fix for certain values getting set when opening GUI, overwriting own settings
+    -Fixes cman's to be usable with the force until option.
 
   v4.2.2 (2021-01-19)
     -Fix for certain values getting set when opening GUI, overwriting own settings


### PR DESCRIPTION
fixes cman's to be usable with the force <cmd> until <result> option.