### PR TITLE
Support for a Node variable for 418

### DIFF
--- a/scripts/tdusk.lic
+++ b/scripts/tdusk.lic
@@ -115,6 +115,7 @@ UserVars.tdusk[:open_lootsack]		= false							if UserVars.tdusk[:open_lootsack].
 UserVars.tdusk[:maxvitals]          = false                         if UserVars.tdusk[:maxvitals].nil?
 UserVars.tdusk[:using_bigshot]      = false
 UserVars.tdusk[:bardnode] = true if UserVars.tdusk[:bardnode].nil?
+UserVars.tdusk[:node] = true if UserVars.tdusk[:node].nil?
 
 UserVars.tdusk[:activescripts].delete("duskruin_watch") if UserVars.tdusk[:activescripts].include?("duskruin_watch")
 
@@ -1137,6 +1138,9 @@ elsif variable[1].downcase == "help" || UserVars.tdusk[:token] == nil
 
     Auto-Casts Song of Power (1018) if you're a bard - Default is set to TRUE (Current: #{UserVars.tdusk[:bardnode]})
     ;e echo UserVars.tdusk[:bardnode] = false
+   
+    Auto-Casts Mana Focus (418) if you're a Wizard or Sorcerer - Default is set to TRUE (Current: #{UserVars.tdusk[:node]})
+    ;e echo UserVars.tdusk[:node] = false
 
     Active Hunting Scripts (Default to stand)
     (Current: #{UserVars.tdusk[:activescripts]})
@@ -1210,7 +1214,7 @@ loop {
 		end
 		Spell[240].cast if Spell[240].affordable? && !Spell[240].active? && Char.name =~ /Siierra|Katiesa/
 		waitcastrt? if Char.prof =~ /Wizard|Sorcerer|Bard/
-		Spell[418].cast if Char.prof =~ /Wizard|Sorcerer/
+		Spell[418].cast if Char.prof =~ /Wizard|Sorcerer/ && UserVars.tdusk[:node]
 		Spell[1018].cast if Char.prof =~ /Bard/ && UserVars.tdusk[:bardnode]
 		if Char.name =~ /Nodyre/
 			put "ready shield"

--- a/scripts/tdusk.lic
+++ b/scripts/tdusk.lic
@@ -14,9 +14,11 @@
      author: Tysong (horibu on PC), original Nylis
        name: tdusk
        tags: duskruin, arena, dusk ruin, tdusk
-    version: 1.23.0
+    version: 1.23.1
 
     changelog:
+        1.23.1 (2021-02-14)
+            Added new variable node to enable/disable 418 casting
         1.23.0 (2021-02-13)
             Added new variable maxvitals to pause till max vitals between runs.
         1.22.3 (2021-02-13)


### PR DESCRIPTION
Added a new variable, defaulted to true, for casting 418 as a sorc/wizard.

This shouldn't break anything for existing scripts, but will let folks - moving forward - disable it when running with a bard, for example.