### PR TITLE
Remove Ruby 2.4 from test matrix 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7']
     name: Run tests on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The upstream action deprecated this ruby version because its very old.

```
Run actions/setup-ruby@v1
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.4 not found