### PR TITLE
Remove ;tears reference

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -235,7 +235,7 @@ class Resource
         end
         if ending_bonus <= starting_bonus
             _respond "Ending bonus must be greater than starting bonus"
-            _respond ";tears calc [starting bonus] [ending bonus]"
+            _respond ";resource calc [starting bonus] [ending bonus]"
             return
         end
 


### PR DESCRIPTION
The error message for when the starting bonus was less than the ending bonus returned an error to the user stating to use ';tears calc [start] [end]'. This fixes the error so it says ';resource calc....', which is the correct reference since ;tears was deprecated.