### PR TITLE
jinx: post-install hooks and mapdb.json

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -373,6 +373,18 @@ module Jinx
 end
 
 module Jinx
+  module Lookup
+    class << self
+      def find_asset_in(repo, name)
+        repo[:available].find do |asset|
+          URI.decode(File.basename(asset[:file])).eql?(name)
+        end
+      end
+    end
+  end
+end
+
+module Jinx
   module Metadata
     module Base
       include Enumerable
@@ -465,27 +477,25 @@ module Jinx
   module Installer
     # ensure an installer command is specific enough that
     # there is exactly 1 script that matches
-    def self.ensure_specific(script, sources)
-      script = normalize_filename(script)
+    def self.ensure_specific(file_name, sources)
+      file_name = normalize_filename(file_name)
 
       advertised = sources.select {|repo|
         Repo.manifest(repo) unless repo[:available].is_a?(Array)
-        Log.out("could not load available scripts from repo(%s)" % repo[:name],
+        Log.out("could not load available assets from repo(%s)" % repo[:name],
           label: %i(warn)) unless repo[:available].is_a?(Array)
-        repo[:available].is_a?(Array) && repo[:available].any? {|remote_asset|
-          File.basename(remote_asset[:file]).eql?(script)
-        }
+        repo[:available].is_a?(Array) && Jinx::Lookup.find_asset_in(repo, file_name)
       }
 
       if sources.size.eql?(1) && advertised.size.eql?(0)
         fail Jinx::Error, <<~ERROR
-          repo(#{sources.first[:name]}) does not advertise script(#{script})
+          repo(#{sources.first[:name]}) does not advertise asset(#{file_name})
         ERROR
       end
 
       if advertised.size > 1
         fail Jinx::Error, <<~ERROR
-          more than one repo has script(#{script})
+          more than one repo has asset(#{file_name})
 
           please be more specific by adding --repo={name}
 
@@ -495,7 +505,7 @@ module Jinx
 
       if advertised.size.eql?(0)
         fail Jinx::Error, <<~ERROR
-          no known repos have script(#{script}) available
+          no known repos have asset(#{file_name}) available
         ERROR
       end
 
@@ -533,10 +543,15 @@ module Jinx
       remote_name  = Installer.normalize_filename(remote_name)
       sources = sources.map {|source| Repo.manifest(source) }
       repo = Installer.ensure_specific(remote_name, sources)
-      asset = repo[:available].find {|remote_asset|
-        File.basename(remote_asset[:file]).eql?(remote_name)
-      }
-      local_asset_name = File.basename(local_asset_name || asset[:file])
+      asset = Jinx::Lookup.find_asset_in(repo, remote_name)
+      local_asset_name = URI.decode(File.basename(local_asset_name || asset[:file]))
+
+      if local_asset_name.eql?("mapdb.json")
+        local_asset_name = Pathname.new(XMLData.game).join(
+          "mapdb-#{asset[:last_commit]}.json"
+        )
+      end
+
       local_asset = File.join(local_asset_directory, local_asset_name)
       if !force && File.exists?(local_asset)
         source = File.read(local_asset)
@@ -575,17 +590,59 @@ end
 
 module Jinx
   module PostInstall
+    module MapImages
+      def self.download_missing(repo)
+        ensure_map_directory_exists
+        return if missing_images.none?
+        Log.out("downloading missing map images", label: %i(install env lich map image))
+        missing_images.each do |image|
+          Jinx::Installer.download(
+            repo,
+            Jinx::Lookup.find_asset_in(repo, image),
+            map_dir.join(image)
+          )
+        end
+      end
+
+      def self.images_in_mapdb
+        Map.list.map(&:image).compact.sort.uniq
+      end
+
+      def self.missing_images
+        images_in_mapdb.reject do |image|
+          map_dir.join(image).exist?
+        end
+      end
+
+      def self.ensure_map_directory_exists
+        unless map_dir.exist?
+          Log.out("creating map directory at %s" % map_dir,
+            label: %i(install env lich map directory))
+          map_dir.mkdir
+        end
+      end
+
+      def self.map_dir
+        Pathname.new($lich_dir).join("maps")
+      end
+    end
+
     HOOKS = {
       "gameobj-data.xml" => -> { GameObj.load_data },
       "spell-list.xml" => -> { Spell.load },
+      "mapdb.json" => proc do |repo|
+        Log.out("reloading mapdb", label: %i(install env lich map))
+        Map.reload
+        MapImages.download_missing(repo)
+      end
     }.freeze
 
     def self.run(repo, asset, local_asset)
-      Metadata.update(repo, asset)
       if h = hook_for(asset)
         Log.out("running post-install hooks for %s" % [File.basename(asset[:file])], label: %i(postinstall hook lich))
-        h.call
+        h.call(repo)
       end
+      Metadata.update(repo, asset)
     end
 
     def self.hook_for(asset)
@@ -605,8 +662,8 @@ end
 
 module Jinx
   module LichData
-    def self.install(script, sources, overwrite: false, force: false)
-      LichInstaller.install(script, sources, Folder.data_dir, overwrite: overwrite, force: force)
+    def self.install(data_file, sources, overwrite: false, force: false)
+      LichInstaller.install(data_file, sources, Folder.data_dir, overwrite: overwrite, force: force)
     end
   end
 end

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -628,8 +628,8 @@ module Jinx
     end
 
     HOOKS = {
-      "gameobj-data.xml" => -> { GameObj.load_data },
-      "spell-list.xml" => -> { Spell.load },
+      "gameobj-data.xml" => proc { GameObj.load_data },
+      "spell-list.xml" => proc { Spell.load },
       "mapdb.json" => proc do |repo|
         Log.out("reloading mapdb", label: %i(install env lich map))
         Map.reload
@@ -640,7 +640,7 @@ module Jinx
     def self.run(repo, asset, local_asset)
       if h = hook_for(asset)
         Log.out("running post-install hooks for %s" % [File.basename(asset[:file])], label: %i(postinstall hook lich))
-        h.call(repo)
+        h.call(repo, asset, local_asset)
       end
       Metadata.update(repo, asset)
     end

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -545,7 +545,7 @@ module Jinx
       sources = sources.map {|source| Repo.manifest(source) }
       repo = Installer.ensure_specific(remote_name, sources)
       asset = Jinx::Lookup.find_asset_in(repo, remote_name)
-      local_asset_name = URI.decode(File.basename(local_asset_name || asset[:file]))
+      local_asset_name = CGI.unescape(File.basename(local_asset_name || asset[:file]))
 
       if local_asset_name.eql?("mapdb.json")
         local_asset_name = Pathname.new(XMLData.game).join(

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -548,7 +548,7 @@ module Jinx
 
       if local_asset_name.eql?("mapdb.json")
         local_asset_name = Pathname.new(XMLData.game).join(
-          "mapdb-#{asset[:last_commit]}.json"
+          "map-#{asset[:last_commit]}.json"
         )
       end
 

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -13,7 +13,7 @@
 
    author: elanthia-online
      tags: utility, util, repository, repo, update, upgrade, meta, ruby, development
-  version: 0.3.0
+  version: 0.4.0
 
 =end
 

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -568,8 +568,29 @@ module Jinx
       Log.out("installing %s from repo:%s with md5(%s)" % [remote_name, repo[:name], asset[:md5]],
         label: %i(install env lich))
       Installer.download(repo, asset, local_asset)
+      PostInstall.run(repo, asset, local_asset)
+    end
+  end
+end
+
+module Jinx
+  module PostInstall
+    HOOKS = {
+      "gameobj-data.xml" => -> { GameObj.load_data },
+      "spell-list.xml" => -> { Spell.load },
+    }.freeze
+
+    def self.run(repo, asset, local_asset)
       Metadata.update(repo, asset)
-      Log.out("successfully installed %s" % [remote_name], label: %i(install env lich))
+      if h = hook_for(asset)
+        Log.out("running post-install hooks for %s" % [File.basename(asset[:file])], label: %i(postinstall hook lich))
+        h.call
+      end
+    end
+
+    def self.hook_for(asset)
+      f = asset[:file]
+      HOOKS[f] || HOOKS[File.basename(f)]
     end
   end
 end

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -629,18 +629,20 @@ module Jinx
     end
 
     HOOKS = {
-      "gameobj-data.xml" => proc { GameObj.load_data },
-      "spell-list.xml" => proc { Spell.load },
-      "mapdb.json" => proc do |repo|
-        Log.out("reloading mapdb", label: %i(install env lich map))
-        Map.reload
-        MapImages.download_missing(repo)
-      end
+      lich: {
+        "gameobj-data.xml" => proc { GameObj.load_data },
+        "spell-list.xml" => proc { Spell.load },
+        "mapdb.json" => proc do |repo|
+          Map.reload
+          MapImages.download_missing(repo)
+        end
+      }.freeze,
+      urnon: {}.freeze,
     }.freeze
 
     def self.run(repo, asset, local_asset)
       if h = hook_for(asset)
-        Log.out("running post-install hooks for %s" % [File.basename(asset[:file])], label: %i(postinstall hook lich))
+        Log.out("running #{Jinx.mode} post-install hooks for %s" % [File.basename(asset[:file])], label: %i(postinstall hook))
         h.call(repo, asset, local_asset)
       end
       Metadata.update(repo, asset)
@@ -648,7 +650,8 @@ module Jinx
 
     def self.hook_for(asset)
       f = asset[:file]
-      HOOKS[f] || HOOKS[File.basename(f)]
+      hooks = HOOKS.fetch(Jinx.mode, {})
+      hooks[f] || hooks[File.basename(f)]
     end
   end
 end

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -24,6 +24,7 @@ require 'json'
 require 'net/https'
 require 'net/http'
 require 'open-uri'
+require 'cgi'
 
 module Jinx
   # our app specific error that we can catch for Jinx errors
@@ -377,7 +378,7 @@ module Jinx
     class << self
       def find_asset_in(repo, name)
         repo[:available].find do |asset|
-          URI.decode(File.basename(asset[:file])).eql?(name)
+          CGI.unescape(File.basename(asset[:file])).eql?(name)
         end
       end
     end

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -239,8 +239,8 @@ module Jinx
     end
 
     def self.mkdir(*args)
-      folder = path(*args)
-      Dir.mkdir folder
+      folder = Pathname.new(*args)
+      folder.mkpath
     end
 
     def self.atomic(path)
@@ -315,7 +315,7 @@ module Jinx
           fail "repo(%s) already exists" % name if repos[name]
           argv.delete(:name)
           Log.out("registering repo(%s) at %s" % [name, argv[:url]], label: %i(repo create))
-          Folder.mkdir(name)
+          Folder.mkdir(name.to_s)
           repos[name] = argv
           repos
         }

--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -597,11 +597,11 @@ module Jinx
         return if missing_images.none?
         Log.out("downloading missing map images", label: %i(install env lich map image))
         missing_images.each do |image|
-          Jinx::Installer.download(
-            repo,
-            Jinx::Lookup.find_asset_in(repo, image),
-            map_dir.join(image)
-          )
+          if asset = Jinx::Lookup.find_asset_in(repo, image)
+            Jinx::Installer.download(repo, asset, map_dir.join(image))
+          else
+            Log.out("no asset found for #{image}", label: %i(install env lich map image))
+          end
         end
       end
 

--- a/spec/jinx/jinx_spec.rb
+++ b/spec/jinx/jinx_spec.rb
@@ -252,6 +252,17 @@ module Jinx
           %r[repo\(archive\) is not known])
     end
 
+    it "repo can readd a previously removed repo" do
+      Service.run("repo add archive https://archive.lich.elanthia.online")
+      game_output
+      Service.run("repo rm archive")
+      expect(Repo.find {|repo| repo[:name].eql?(:archive)})
+        .to be_nil
+
+      Service.run("repo add archive https://archive.lich.elanthia.online")
+      Repo.lookup("archive")
+    end
+
     it "repo change {repo:name} {repo:url}" do
       Service.run("repo change core https://example.com")
       change_output = game_output

--- a/spec/jinx/jinx_spec.rb
+++ b/spec/jinx/jinx_spec.rb
@@ -199,11 +199,11 @@ module Jinx
       # now two repos advertise noop, so it should error
       expect {Service.run("script info noop")}
         .to raise_error(Jinx::Error, 
-          %r[more than one repo has script\(noop.lic\)])
+          %r[more than one repo has asset\(noop.lic\)])
 
       expect {Service.run("script info noop --repo=core")}
         .to raise_error(Jinx::Error, 
-          %r[repo\(core\) does not advertise script\(noop.lic\)])
+          %r[repo\(core\) does not advertise asset\(noop.lic\)])
       game_output # clear
       # make sure it checks the elanthia-online repo
       Service.run("script info noop --repo=elanthia-online")
@@ -268,11 +268,25 @@ module Jinx
       let(:local_asset_path) { File.join($data_dir, "spell-list.xml") }
 
       describe "install" do
+        class Spell
+          def self.load
+          end
+        end
+
         it "will install the first time cleanly on 1-to-1" do
+          allow(Spell).to receive(:load)
           Service.run("data install spell-list.xml")
 
           _first_attempt = game_output
           expect(File.exist?(local_asset_path)).to be true
+        end
+
+        it "runs the post-install hook after installing" do
+          allow(Spell).to receive(:load)
+          Service.run("data install spell-list.xml")
+
+          _first_attempt = game_output
+          expect(Spell).to have_received(:load)
         end
 
         it "is a noop is the local file matches the expected digest" do


### PR DESCRIPTION
Adds post-install hooks for spell-list.xml, gameobj-data.xml, and mapdb.json. They all reload the newly downloaded data file, and the mapdb hook also attempts to download any image files referenced in the mapdb that aren't already present in the map directory.