### PR TITLE
resource.lic: add proposed cleric for 330 values

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -22,7 +22,7 @@
      author: Elanthia-Online
        name: resource
        tags: resource, tears, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic
-    version: 1.1
+    version: 1.2
 
     changelog:
         1.2 (2021-06-23)

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -1,6 +1,7 @@
 =begin
     A universal resource script to calculate various RESOURCE and bonus needs.
     Suitable for the following professions: Wizard, Sorcerer, Bard & Monk
+                                            Cleric (proposed values)
     
     SYNTAX - ;resource <OPTION>
     
@@ -24,6 +25,8 @@
     version: 1.1
 
     changelog:
+        1.2 (2021-06-23)
+            Proposed bonus for clerics 330
         1.1 (2020-12-30)
             Monk bonus math fix
         1.0 (2020-12-29)
@@ -304,10 +307,15 @@ class Resource
             respond ""
             respond "Tattoos come with 100 max charges and are fully charged upon applying or upgrading to next tier."
             respond "To recharge a tattoo, it costs 1,000 Motes of Tranquility per charge being filled."
+        elsif (Char.prof == "Cleric" && variable[2].nil?) || variable[2] =~ /^cleric/i
+            COST_OTHER.each_index { |resource|
+                respond "T#{(resource+1).to_s.rjust(1, " ")} Sanctify - #{number_commas(COST_OTHER[resource]).rjust(7, " ")} Devotion"
+            }
+            respond "Add Perm Holy Water Flares to T5".to_s.rjust(1, " ") + " Sanctify - #{number_commas(200000).rjust(7, " ")} Devotion"
         else
             respond "You're not a wizard, sorcerer, bard, or monk. Please use the following to show an appropriate table:"
             respond "   ;resource chart <PROFESSION>"
-            respond "   Professions supported: wizard, sorcerer, bard, monk"
+            respond "   Professions supported: wizard, sorcerer, bard, monk, cleric"
         end
         respond ""
     end
@@ -317,14 +325,14 @@ class Resource
         arcanesymbols = magicitemuse = physicalfitness = firstaid = 0
         elementalmanacontrol = spiritmanacontrol = mentalmanacontrol = 0
         mentalloretelepathy = mentalloretelepathybonus = mentalloretransformation = mentalloretransformationbonus = 0
-        bardranks = sorcererranks = wizardranks = minormentalranks = minorspiritranks = 0
+        bardranks = sorcererranks = wizardranks = clericranks = minormentalranks = minorspiritranks = 0
         strength = constitution = dexterity = agility = discipline = 0
         aura = logic = intuition = wisdom = influence = 0
 
-        if Char.prof !~ /^(?:Wizard|Sorcerer|Bard|Monk)$/ && variable[2].nil?
+        if Char.prof !~ /^(?:Wizard|Sorcerer|Bard|Monk|Cleric)$/ && variable[2].nil?
             respond "You're not a wizard, sorcerer, bard, or monk. Please use the following to show an appropriate table:"
             respond "   ;resource chart <PROFESSION>"
-            respond "   Professions supported: wizard, sorcerer, bard, monk"
+            respond "   Professions supported: wizard, sorcerer, bard, monk, cleric"
             return
         end
         
@@ -355,6 +363,8 @@ class Resource
                 wizardranks = $1.to_i
             elsif line =~ /Sorcerer.*?(\d+)$/
                 sorcererranks = $1.to_i
+            elsif line =~ /Cleric.*?(\d+)$/
+                clericranks = $1.to_i
             elsif line =~ /Minor Mental.*?(\d+)$/
                 minormentalranks = $1.to_i
             elsif line =~ /Minor Spiritual.*?(\d+)$/
@@ -465,6 +475,19 @@ class Resource
             respond "+ #{((bardranks > level)? (level * 2) + (bardranks - level) : bardranks * 2).to_s.rjust(3)} : Bard Spells (to level *2)+(over level)"
             respond "==========================="
             respond "Total of #{level + (aura) + (influence) + (magicitemuse/2).truncate + (elementalmanacontrol/2).truncate + (mentalmanacontrol/2).truncate + (mentalloretelepathy) + ((bardranks > level)? (level * 2) + (bardranks - level) : bardranks * 2).truncate}"
+        elsif (Char.prof == "Cleric" && variable[2].nil?) || variable[2] =~ /^cleric/i
+            respond "Sanctify Success Formula"
+            respond "---------------------------"
+            respond "  #{(level).to_s.rjust(3)} : Level"
+            respond "+ #{(wisdom).to_s.rjust(3)} : WIS Bonus"
+            respond "+ #{(influence).to_s.rjust(3)} : INF Bonus"
+            respond "+ #{((magicitemuse/10).truncate).to_s.rjust(3)} : trunc(MIU ranks/10)"
+            respond "+ #{((arcanesymbols/10).truncate).to_s.rjust(3)} : trunc(AS ranks/10)"
+            respond "+ #{((spiritmanacontrol/2).truncate).to_s.rjust(3)} : trunc(SMC ranks/2)"
+            respond "+ #{((clericranks > (level + 1) ? (level + 1)*2 + (clericranks - (level + 1)) : clericranks * 2)).to_s.rjust(3)} : Cleric Spells"
+            respond "+  20 : Shrine Bonus (10 if aligned to pantheon but not your specific deity)"
+            respond "==========================="
+            respond "Total of #{level + wisdom + influence + (magicitemuse/10).truncate + (arcanesymbols/10).truncate + (spiritmanacontrol/2).truncate + (clericranks > (level + 1) ? (level + 1)*2 + (clericranks - (level + 1)) : clericranks * 2) + 20}"
         elsif (Char.prof == "Monk" && variable[2].nil?) || variable[2] =~ /^monk/i
             respond "Tattoo Success Formula"
             respond "---------------------------"


### PR DESCRIPTION
```
;resource bonus
Sanctify Success Formula
---------------------------
   68 : Level
+  26 : WIS Bonus
+   4 : INF Bonus
+   3 : trunc(MIU ranks/10)
+   3 : trunc(AS ranks/10)
+  34 : trunc(SMC ranks/2)
+ 164 : Cleric Spells
+  20 : Shrine Bonus (10 if aligned to pantheon but not your specific deity)
===========================
Total of 322
--- Lich: resource has exited.

>;resource chart
--- Lich: resource active.
Resource needed per tier profession services
T1 Sanctify -  50,000 Devotion
T2 Sanctify -  75,000 Devotion
T3 Sanctify - 100,000 Devotion
T4 Sanctify - 125,000 Devotion
T5 Sanctify - 150,000 Devotion
Add Perm Holy Water Flares to T5 Sanctify - 200,000 Devotion
--- Lich: resource has exited.
```

Add proposed cleric values from 330 doc to chart/bonus. With checking from a cleric, or another profession.