### PR TITLE
Add option to loot boxes and put items into stow list containers

### DIFF
--- a/scripts/poolparty.lic
+++ b/scripts/poolparty.lic
@@ -10,7 +10,7 @@
  author: elanthia-online
 
  tags: locksmith, picker, pool, locksmith pool, picking, boxes, loot, locksmith, locksmithing, rogue
- version: 2.12
+ version: 2.13
 
  Original work done by Glaves, but now maintained via elanthia-online
 
@@ -72,7 +72,8 @@
  2.11 - Added the option to look into each box before dumping it
         Fixed error when attempting to hand in an already unlocked box
  2.12 - Add trickster to list of pool boss names (Icemule update)
-
+ 2.13 - Add loot option to loot boxes to match stow list before dumping in default container
+ 
  Use ;version to verify you are not running ruby 2.0 - You need 2.4+
  Seriously, if your ruby is asking you to trust scripts its too old and this wont work.
  Update your ruby!!!!  There is an installer on the wiki
@@ -308,7 +309,7 @@ module PoolParty
       @look_in_box = CharSettings['look_in_box']
     end
 
-    def toggle_loot_commamd
+    def toggle_loot_command
       CharSettings['loot_command'] = !@loot_command
 
       @loot_command = CharSettings['loot_command']
@@ -662,6 +663,16 @@ optsx = Slop.new strict: true do
       Oleani::IO.send("**You have chosen to look in boxes before dumping their contents.**")
     else
       Oleani::IO.send("**You have chosen to** !!NOT!! **look in boxes before dumping their contents.**")
+    end
+  end
+
+  on 'loot-command', "Loot boxes prior to dumping them into containers,\n#{' ' * 34}**Currently:**[`#{PoolParty.config.loot_command.to_s.upcase}`]" do |opt, args|
+    PoolParty.config.toggle_loot_command
+
+    if PoolParty.config.loot_command
+      Oleani::IO.send("**You have chosen to loot boxes before dumping their contents.**")
+    else
+      Oleani::IO.send("**You have chosen to** !!NOT!! **loot boxes before dumping their contents.**")
     end
   end
 


### PR DESCRIPTION
This enables the loot command that appears to have been partly stubbed in the script at some point.  When enabled poolparty will first use the LOOT command to get all items that can be sorted to STOW containers and then anything left over will be emptied into the default container.