### PR TITLE
Fix Zelnorn and Adamantine

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -47,7 +47,7 @@ class Resource
     PRIVATE_WORKSHOP = ["Tysong"]
     
     #Array of Material Modifiers [12, 4, 4, 4, 4, 4]
-    MAT_LIST = [["Adamantine  ", "-500", "-500", "-500", "N/A ", "N/A "],
+    MAT_LIST = [["Adamantine  ", "-150", "-150", "-150", "N/A ", "N/A "],
                 ["Alexandrite ", "-500", "0   ", "N/A ", "N/A ", "N/A "],
                 ["Black-alloy ", "0   ", "-50 ", "0   ", "N/A ", "N/A "],
                 ["Bone        ", "-250", "+10 ", "-250", "N/A ", "N/A "],
@@ -117,7 +117,7 @@ class Resource
                 ["Wood        ", "-100", "-10 ", "-100", "-10 ", "-10 "],
                 ["Wyrwood     ", "N/A ", "N/A ", "N/A ", "-60 ", "N/A "],
                 ["Yew         ", "N/A ", "N/A ", "N/A ", "-20 ", "N/A "],
-                ["Zelnorn     ", "-999", "-999", "-999", "N/A ", "N/A "],
+                ["Zelnorn     ", "-250", "-250", "-250", "N/A ", "N/A "],
                 ["Zorchar     ", "-50 ", "-50 ", "-50 ", "N/A ", "N/A "],
                 ["Metal       ", "-500", "-500", "-500", "N/A ", "N/A "]]
     


### PR DESCRIPTION
Zelnorn (-999) and Adamantine (-500) had the wrong difficulties listed in the materials table. I updated them to the correct values, -250 and -150, respectively.