### PR TITLE
add feature --revert to lich5-update

### DIFF
--- a/scripts/lich5-update.lic
+++ b/scripts/lich5-update.lic
@@ -14,7 +14,18 @@
                game: Gemstone
                tags: core, update, lich, lich5
            required: Lich > 5.0.1
-            version: 1.2.2
+            version: 1.3.1
+
+    2021-09-05 -  1.3.1 bring version in line with semver requirements
+                  add --revert feature
+    2021-09-03 -  1.2.1 convert update-lich5 to lich5-update
+                  add json lookup for current file information
+                  add --announce feature
+                  add --snapshot feeture
+                  add --refresh feature
+                  add --update feature
+                  add --script feature
+                  add --updater-update feature
 
 =end
 
@@ -34,7 +45,11 @@ prep_update = proc { |type|
       @update_scripts = entry["update_core_scripts"] if !entry["update_core_scripts"].empty?
       @update_lib = entry["update_libs"] if !entry["update_libs"].empty?
       convert_hash = JSON[entry["recommend_update_scripts"]] if !entry["recommend_update_scripts"].empty?
+      if convert_hash
       @recommend_scripts = JSON[convert_hash]
+      else
+        @recommend_scripts = []
+      end
       @new_features = entry["announce_features"] if !entry["announce_features"].empty?
     else
       next
@@ -118,6 +133,29 @@ download_core = proc {
     echo "#{script} has been updated."
   }
 }
+
+revert_lich = proc {
+  filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
+  backupfilename = "#{$temp_dir}revert-lich-#{LICH_VERSION}.rb"
+  revert_array = Dir.glob("#{$temp_dir}lich*").sort.reverse
+  tempfilename = revert_array[0]
+  if tempfilename.nil?
+    _respond "No prior Lich5 version found. Seek assistance."
+    exit
+  else
+    targetfilename = tempfilename.gsub("#{$temp_dir}", '').to_s
+    targetversion = targetfilename.gsub("lich-", '').gsub(".rb", '')
+    _respond "Restoring Lich5 file #{targetfilename}"
+
+    File.open(filename, 'rb') { |r| File.open(backupfilename, 'wb') { |w| w.write(r.read) } }
+    File.open(tempfilename, 'rb') { |r| File.open(filename, 'wb') { |w| w.write(r.read) } }
+    File.delete(tempfilename)
+    echo "Lich5 has been reverted to Lich5 version #{targetversion}"
+    echo 'You should exit the game, then log back in.  This will start the game'
+    echo 'with your previous version of Lich.  Enjoy!'
+  end
+}
+
 
 script.vars.uniq.each { |arg|
   if (arg == '-h') || (arg == '--help')
@@ -219,6 +257,10 @@ Example usage:
     @update_scripts = ["lich5-update.lic"]
     download_core.call
     @update_scripts = []
+
+  elsif arg == '--revert'
+    echo 'Reverting Lich5 to previously installed / used version'
+    revert_lich.call
 
   else
     echo "Command '#{arg}' unknown, illegitimate and ignored.  Exiting . . ."


### PR DESCRIPTION
To support the recently reverted 5.0.18 lich.rbw build, the updater process now has a '--revert' argument feature, which will scan for the last lich file saved during a lich5 update process (legacy or current script files).