### PR TITLE
Rapid repair for --snapshot

### DIFF
--- a/lich5-update.lic
+++ b/lich5-update.lic
@@ -1,0 +1,276 @@
+=begin
+
+    Update your Lich version from 5.x to the current release version.
+    Logout of all characters except one and run the script ;lich5-update --announce
+    Review the changes, and if you like the changes you can ;lich5-update --update
+    Then quit and restart lich.
+
+    Pro Tip - check out ;lich5-update --help for options on how to include in
+    your autostart list, how to backup your existing Lich5 files (not all
+    scripts, just these distributed by EO for Lich5), and even how to completely
+    refresh your Lich5 ecosystem to current files, if you're unsure what you need.
+
+             author: Elanthia-Online
+               game: Gemstone
+               tags: core, update, lich, lich5
+           required: Lich > 5.0.1
+            version: 1.3.1
+
+    2021-09-05 -  1.3.1 bring version in line with semver requirements
+                  add --revert feature
+    2021-09-03 -  1.2.1 convert update-lich5 to lich5-update
+                  add json lookup for current file information
+                  add --announce feature
+                  add --snapshot feeture
+                  add --refresh feature
+                  add --update feature
+                  add --script feature
+                  add --updater-update feature
+
+=end
+
+require 'json'
+require 'open-uri'
+
+@current = LICH_VERSION
+@update_to = @update_scripts = @update_lib = @recommend_scripts = @new_features = ''
+
+prep_update = proc { |type|
+  installed = Gem::Version.new(@current)
+  filename = "https://raw.githubusercontent.com/elanthia-online/lich-5/master/data/update-lich5.json"
+  update_info = open(filename).read
+  JSON::parse(update_info).each { |entry|
+    if entry["update_type"]["#{type}"] && (Gem::Version.new(entry["version_lich"]) > installed || type = :refresh)
+      @update_to = entry["version_lich"]
+      @update_scripts = entry["update_core_scripts"] if !entry["update_core_scripts"].empty?
+      @update_lib = entry["update_libs"] if !entry["update_libs"].empty?
+      convert_hash = JSON[entry["recommend_update_scripts"]] if !entry["recommend_update_scripts"].empty?
+      if convert_hash
+      @recommend_scripts = JSON[convert_hash]
+      else
+        @recommend_scripts = []
+      end
+      @new_features = entry["announce_features"] if !entry["announce_features"].empty?
+    else
+      next
+    end
+   }
+}
+
+snapshot_existing = proc {
+
+  prep_update.call(:refresh)
+
+  snapshot_subdir = "#{BACKUP_DIR}/L5-snapshot-#{Time.now.strftime("%Y-%m-%d-%H-%M-%S")}"
+  unless File.exists?(snapshot_subdir)
+    Dir.mkdir(snapshot_subdir)
+  end
+  filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
+  copyfilename = "#{snapshot_subdir}/#{File.basename($PROGRAM_NAME)}"
+  File.open(filename, 'rb') { |r| File.open(copyfilename, 'wb') { |w| w.write(r.read) } }
+
+  snapshot_lib_subdir = "#{snapshot_subdir}/lib"
+  unless File.exists?(snapshot_lib_subdir)
+    Dir.mkdir(snapshot_lib_subdir)
+  end
+  pp @update_lib
+  @update_lib.each { |file|
+    File.open("#{$lich_dir}/lib/#{file}", 'rb')\
+      { |r| File.open("#{snapshot_lib_subdir}/#{file}", 'wb') { |w| w.write(r.read) } }
+  }
+
+  snapshot_script_subdir = "#{snapshot_subdir}/scripts"
+  unless File.exists?(snapshot_script_subdir)
+    Dir.mkdir(snapshot_script_subdir)
+  end
+  pp @update_scripts
+  @update_scripts.each { |file|
+    File.open("#{$lich_dir}/scripts/#{file}", 'rb')\
+      { |r| File.open("#{snapshot_script_subdir}/#{file}", 'wb') { |w| w.write(r.read) } }
+  }
+
+  echo "Current Lich ecosystem files (only) backed up to:"
+  echo "    #{snapshot_subdir}"
+}
+
+download_lich = proc {
+    echo "Downloading Lich5 version #{@update_to}"
+    File.open("#{$lich_dir}temp_lich.rbw", "wb") do |file|
+      file.write open('https://raw.githubusercontent.com/elanthia-online/lich-5/master/lich.rbw').read
+    end
+    filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
+    backupfilename = "#{$temp_dir}lich-#{LICH_VERSION}.rb"
+    tempfilename = "#{$lich_dir}temp_lich.rbw"
+    File.open(filename, 'rb') { |r| File.open(backupfilename, 'wb') { |w| w.write(r.read) } }
+    File.open(tempfilename, 'rb') { |r| File.open(filename, 'wb') { |w| w.write(r.read) } }
+    File.delete(tempfilename)
+    echo "Lich5 has been updated to Lich5 version #{@udpate_to}"
+    echo 'You should exit the game, then log back in.  This will start the game'
+    echo 'with your updated Lich.  Enjoy!'
+}
+
+download_lib = proc {
+  unless Dir.exists?("#{LICH_DIR}/lib")
+    Dir.mkdir("#{LICH_DIR}/lib")
+  end
+  echo 'Downloading new or updated lib files'
+  lib_needed = @update_lib
+  lib_needed.each { |file|
+    File.delete("#{LICH_DIR}/lib/#{file}") if File.exists?("#{LICH_DIR}/lib/#{file}")
+    File.open("#{LICH_DIR}/lib/#{file}", "wb") do |nlf|
+      nlf.write open("https://raw.githubusercontent.com/elanthia-online/lich-5/master/lib/#{file}").read
+    end
+    echo "#{file} has been updated."
+  }
+}
+
+download_core = proc {
+  echo 'Downloading new or updated core scripts'
+  needed = @update_scripts
+  needed.each { |script|
+    File.delete("#{$script_dir}#{script}") if File.exists?("#{$script_dir}#{script}")
+    File.open("#{$script_dir}#{script}", "wb") do |file|
+      file.write open("https://raw.githubusercontent.com/elanthia-online/lich-5/master/scripts/#{script}").read
+    end
+    echo "#{script} has been updated."
+  }
+}
+
+revert_lich = proc {
+  filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
+  backupfilename = "#{$temp_dir}revert-lich-#{LICH_VERSION}.rb"
+  revert_array = Dir.glob("#{$temp_dir}lich*").sort.reverse
+  tempfilename = revert_array[0]
+  if tempfilename.nil?
+    _respond "No prior Lich5 version found. Seek assistance."
+    exit
+  else
+    targetfilename = tempfilename.gsub("#{$temp_dir}", '').to_s
+    targetversion = targetfilename.gsub("lich-", '').gsub(".rb", '')
+    _respond "Restoring Lich5 file #{targetfilename}"
+
+    File.open(filename, 'rb') { |r| File.open(backupfilename, 'wb') { |w| w.write(r.read) } }
+    File.open(tempfilename, 'rb') { |r| File.open(filename, 'wb') { |w| w.write(r.read) } }
+    File.delete(tempfilename)
+    echo "Lich5 has been reverted to Lich5 version #{targetversion}"
+    echo 'You should exit the game, then log back in.  This will start the game'
+    echo 'with your previous version of Lich.  Enjoy!'
+  end
+}
+
+
+script.vars.uniq.each { |arg|
+  if (arg == '-h') || (arg == '--help')
+    _respond "
+   --help                   Display this message then exit
+   --announce               Get summary of changes for next version
+   --update                 Update all changes for next version
+   --refresh                Hamertime!  Update everything to the most current ecosystem
+   --snapshot               Grab current snapshot of Lich5 ecosystem and put in backup
+
+Example usage:
+
+  [One time suggestions]
+    ;autostart add --global lich5-update --announce    To receive new version info only at login
+    ;autostart add --global lich5-update --update      To auto accept all updates at login
+
+  [On demand suggestions]
+    ;lich5-update --refresh                   Update everything Lich5 core related
+    ;lich5-update --snapshot --refresh        Backup to default location then refresh
+    ;lich5-update --snapshot --update         Backup to default location then update
+
+    *NOTE* If you use '--snapshot' in ';autostart' you will create a new
+            snapshot folder every time you log a character in.  NOT recommended.
+
+"
+    exit
+
+  elsif arg == '--snapshot'  ## ALWAYS HANDLE THIS FIRST if requested
+    echo 'Creating a snapshot of current Lich core files ONLY.'
+    echo 'You may wish to copy your entire Lich5 folder to another location'
+    echo 'for additional safety.'
+    snapshot_existing.call
+
+  elsif arg == '--announce'
+    prep_update.call(:current)
+    if "#{LICH_VERSION}".chr == '5'
+      if Gem::Version.new(@current) < Gem::Version.new(@update_to)
+        if !@new_features.empty?
+          _respond ''; _respond monsterbold_start()+"*** NEW VERSION AVAILABLE ***"+monsterbold_end()
+          _respond ''; _respond ''
+          @new_features.each { |line| _respond line.gsub(/[\"]/, '') }
+          _respond''; _respond "If you are interested in updating, run ';lich5-update --update' now."
+          _respond ''
+        end
+        # return nothing if @current >= @update_to
+      end
+    else
+      # lich version 4 - just say 'no'
+      _respond "This script does not support Lich #{LICH_VERSION}."
+    end
+
+  elsif arg == '--refresh'
+    if "#{LICH_VERSION}".chr == '5'
+      prep_update.call(:refresh)
+      echo "Updating Lich5 ecosystem to Lich #{@update_to}"
+      download_lib.call if !@update_lib.empty?
+      download_core.call if !@update_scripts.empty?
+      download_lich.call
+      _respond ''
+      @new_features.each { |line| puts line.gsub(/[\"]/, '') } if !@new_features.empty?
+      if !@recommend_scripts.empty?
+        @recommend_scripts.each { |k,v|
+          _respond ''; _respond "The popular Lich script #{k} should be updated for full benefit."
+          _respond "Get the right version of #{k} with #{v}"; _respond ''
+        }
+      end
+    else
+      _respond ''; _respond "You are currently on Lich #{LICH_VERSION}. This script is probably is not for you."
+      _respond 'Please update your Ruby and Lich. Visit the GSWiki for Lich installation help.'
+    end
+
+  elsif arg == '--update'
+    prep_update.call(:current)
+    if Gem::Version.new(@current) < Gem::Version.new(@update_to) && "#{LICH_VERSION}".chr == '5'
+      echo "Updating Lich #{@current} to Lich #{@update_to}"
+      download_lib.call if !@update_lib.empty?
+      download_core.call if !@update_scripts.empty?
+      download_lich.call
+      _respond ''
+      @new_features.each { |line| puts line.gsub(/[\"]/, '') } if !@new_features.empty?
+      if !@recommend_scripts.empty?
+        @recommend_scripts.each { |k,v|
+          _respond ''; _respond "The popular Lich script #{k} should be updated for full benefit."
+          _respond "Get the right version of #{k} with #{v}"; _respond ''
+        }
+      end
+    elsif "#{LICH_VERSION}".chr == '5'
+      _respond ''; _respond 'Lich is running at the current version.'; _respond ''
+    else
+      _respond ''; _respond "You are currently on Lich #{LICH_VERSION}. This script is probably is not for you."
+      _respond 'Please update your Ruby and Lich. Visit the GSWiki for Lich installation help.'
+    end
+
+  elsif arg =~ /^--script=([\w\d\-\_]+)(?:.lic)?$/i
+    requested_script = $1.dup
+    echo "Downloading #{requested_script}"
+    @update_scripts = ["#{requested_script}.lic"]
+    download_core.call
+    @update_scripts = []
+
+  elsif arg == '--updater-update'
+    echo "Updating self."
+    @update_scripts = ["lich5-update.lic"]
+    download_core.call
+    @update_scripts = []
+
+  elsif arg == '--revert'
+    echo 'Reverting Lich5 to previously installed / used version'
+    revert_lich.call
+
+  else
+    echo "Command '#{arg}' unknown, illegitimate and ignored.  Exiting . . ."
+  end
+}
+
+@update_to = @update_scripts = @update_lib = @recommend_scripts = @new_features = ''


### PR DESCRIPTION
The --snapshot feature fails in certain test cases where the existing lich version is the same as the current json lich version.  These changes address validations and permit the --snapshot feature to function.  Adding directly to master branch to limit poor update experiences.