### PR TITLE
Fixed misspelled reference

### DIFF
--- a/scripts/forgery.lic
+++ b/scripts/forgery.lic
@@ -751,7 +751,7 @@ class << forger
   def oil
     waitrt?
     fput "wear forging" if checkright =~ /forging-hammer/ && !(checkleft and checkright).nil?
-    oil = Material_oil[@material_name]
+    oil = material_oil[@material_name]
     res = dothistimeout "look in trough", 10, /In the trough/
     unless res =~ /#{oil_trough[oil]}/    #ie.. unless you already have the oil you need in the trough
       if res =~ /oil|water/


### PR DESCRIPTION
The reference to the dictionary 'material_oil' on line 754 was misspelled as 'Material_oil', causing an uninitialized variable error.