### PR TITLE
Convert script name asexual to voln and update regex for recent change

### DIFF
--- a/scripts/voln-favor.lic
+++ b/scripts/voln-favor.lic
@@ -261,7 +261,7 @@ class VolnFavors
 
     if running?("asexualfavors")
       Oleani::IO.send("**Killing ASexualFavors as it is outdated.**")
-      Oleani::IO.send("**You should make sure that ASexualfavors does not autostart**")
+      Oleani::IO.send("**You should make sure that ASexualFavors does not autostart**")
       kill_script("asexualfavors")
       Object.send(:remove_const, :ASexualFavors)
     end


### PR DESCRIPTION
Changing script name from asexualfavors to voln-favors.  Includes script object names, and a regex update to account for recent voln undead release verbiage.  No issue logged.