### PR TITLE
[game-obj] adds new migration file for FWI skins

### DIFF
--- a/type_data/migrations/42_mist_harbor_skins.rb
+++ b/type_data/migrations/42_mist_harbor_skins.rb
@@ -1,0 +1,6 @@
+migrate :skin, :furrier do
+  insert(:name, %{bristly tapir snout})
+  insert(:name, %{tapir snout})
+  insert(:name, %{dark brown forest ape pelt})
+  insert(:name, %{forest ape pelt})
+end


### PR DESCRIPTION
```
>get pelt
You remove a dark brown forest ape pelt from in your heavy backpack.
>get snout
You remove a bristly tapir snout from in your heavy backpack.

>;e echo GameObj.right_hand.name;echo GameObj.left_hand.name
--- Lich: exec1 active.
[exec1: forest ape pelt]
[exec1: tapir snout]
--- Lich: exec1 has exited.

>drop pelt
You drop a dark brown forest ape pelt.
>drop snout
You drop a bristly tapir snout.

;e GameObj.loot.each { |o| echo o.name }
--- Lich: exec1 active.
[exec1: bristly tapir snout]
[exec1: dark brown forest ape pelt]
--- Lich: exec1 has exited.
```

Both of these skins have the "different name on ground vs in hand" thing hence the double entry.