### PR TITLE
Defect - change initialize method to public

### DIFF
--- a/scripts/invoker.lic
+++ b/scripts/invoker.lic
@@ -50,7 +50,7 @@ if Settings[:debug] == nil
 end
 
 class Invoker
-  def self.initialize(auto=false)
+  def initialize(auto=false)
     if auto == true
       @auto = true
     else


### PR DESCRIPTION
Removing the `self.` def that causes method `initialize` to be private.  Making it public seems to allow the script to run but requires testing.