### PR TITLE
Update Oleani-Lib for INVENTORY FULL Change

### DIFF
--- a/scripts/oleani-lib.lic
+++ b/scripts/oleani-lib.lic
@@ -699,7 +699,7 @@ module Oleani
 
       lines = Oleani::Helpers.quiet_command(
           command,
-          /^(?:You are carrying nothing at this time|You are currently (?:wearing and )?carrying)/,
+          /^(?:You are carrying nothing at this time|You are currently (?:wearing)|(?:wearing and carrying))/,
           /(?:<prompt)|(?:.*items? displayed\.\)$)/,
           # /(?:<prompt)|(?:items displayed.\)\b)/,
           true,

--- a/scripts/oleani-lib.lic
+++ b/scripts/oleani-lib.lic
@@ -15,12 +15,15 @@ require "forwardable"
   Roadmap:
     Documentation and examples
 
-     author: elanthia-online
-       game: Gemstone
-       tags: library
-    version: 0.0.11
+             author: Elanthia-Online
+               game: Gemstone
+               tags: library, lich,
+           required: Lich > 5.0.1
+            version: 1.0
 
    changelog:
+      1.0 (2021-12-09):
+        Updated to account for inventory verb changes
       0.0.11 (2021-01-04):
         Add method for looking in boxes
       0.0.10:


### PR DESCRIPTION
A change to inventory full this morning broke the starting capture. The change to the regex fixes it (There may be a more regex-ish way to fix it but this has been tested to work).