### PR TITLE
Fix - infomon deduplicate spell from cooldown

### DIFF
--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -9,13 +9,15 @@
           game: Gemstone
           tags: core
       required: Lich > 4.6.10
-       version: 1.18.10
+       version: 1.18.11
         Source: https://github.com/elanthia-online/jinx
     Alt Source: https://github.com/elanthia-online/lich-5
 
   Version Control:
     Major_change.feature_addition.bugfix
-    
+
+  1.18.11 (2021-12-03):
+    Bugfix for duplicate names between Spell and Cooldown
   1.18.10 (2021-09-10):
     Bugfix for regex Cloak of Shadows with Retribution (CoS - spell)
     Bugfix for regex Raise Dead (Raise Dead Link)
@@ -1396,14 +1398,29 @@ while line = get
       $infomon_cutthroat = true
     elsif line =~ /^\s*The horrible pain in your vocal cords subsides as you spit out the last of the blood clogging your throat\.$/
       $infomon_cutthroat = false
+      #
+      # monitoring for spell active and true up spell durations
+      #
     elsif line == "You currently have the following active effects:"
       while (line = get)
-        if line =~ /\s+([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)$/
+        case line
+        when /Spells:/
+          next
+        when /Cooldowns:/
+          cooldown_list = true
+          next
+        when /Buffs:/
+          cooldown_list = false
+          next
+        when /Debuffs:/
+          next
+        when /\s+([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)$/
           spell_name = $1.dup
-          if $2 == 'Indefinite'
+          spell_name = spell_name+' Cooldown' if cooldown_list
+          if $2.dup == 'Indefinite'
             spell_time = 599.0
           else
-            spell_time = ($3.to_i * 60) + $4.to_i + ($5.to_i / 60.0)
+            spell_time = ($3.dup.to_i * 60) + $4.dup.to_i + ($5.dup.to_i / 60.0)
           end
           if spell_name == 'Raise Dead Link'
             spell_name = 'Raise Dead Cooldown'
@@ -1418,12 +1435,10 @@ while line = get
           else
             echo "no spell matches #{spell_name}" if $infomon_debug
           end
-        elsif line =~ /^ [.]{40}|^(?:Spells|Cooldowns|Buffs|Debuffs):|^  No (?:spells|cooldowns|buffs|debuffs) found\./
+        when /^ [.]{40}|^  No (?:spells|cooldowns|buffs|debuffs) found\./
           next
-        elsif line
-          script.downstream_buffer.unshift(line)
-          break
         else
+          script.downstream_buffer.unshift(line) if line
           break
         end
       end


### PR DESCRIPTION
Infomon change to add ' - Cooldown' to Spell name to differentiate between Spell effect and Cooldown effect while spell-list.xml remains in play.

Resolves #567 