### PR TITLE
Update spell-list.xml

### DIFF
--- a/scripts/spell-list.xml
+++ b/scripts/spell-list.xml
@@ -2135,7 +2135,6 @@
    <spell availability='all' name='MStrike Cooldown' number='9005' type='timer'>
       <duration>1</duration>
       <message type='start'>Your (?:flurry|series) of (?:strikes|rapid shots)(?: and (?:ripostes|maneuvers))? leaves you (?:off-balance|winded) and out of position\.</message>
-      <message type='end'>You feel recovered from your whirlwind flurry of strikes\.</message>
    </spell>
    <spell availability='all' name='Lichbane' number='9006' type='defense'>
       <duration>10</duration>
@@ -2634,5 +2633,28 @@
       <duration>30/60.0</duration>
       <message type='start'>You open yourself to the ravenous void at the core of your being, allowing it to surface\.  Muted veins of metallic grey ripple just beneath your skin\.</message>
       <message type='end'>Something within you loosens, and you can once again feel the hunger of the void within\.</message>
+   </spell>
+   <spell availability="self-cast" name="Focused" number="2001" type="utility">
+      <duration span="refreshable" max="2">2</duration>
+      <message type="start">You focus intently on your picking and disarm skill.</message>
+      <message type="end">You no longer appear focused.</message>
+   </spell>
+   <spell availability="self-cast" name="Weapon Flurry" number="9657" type="timer">
+      <duration>20</duration>
+      <message type="start">You rotate your wrist, your .+ executing a casual spin to establish your flow as you advance upon .+!</message>
+      <message type="end">The mesmerizing sway of body and blade glides to its inevitable end with one final twirl of your .+\.</message>
+      <message type="end">Distracted, you hesitate, and your assault is broken\. You give the blade of your .+ a quick, sweeping flick of annoyance as you lower it\.</message>
+   </spell>
+   <spell availability="self-cast" name="Weapon Thrash" number="9658" type="timer">
+      <duration>20</duration>
+      <message type="start">You rush .+, raising your .+ high to deliver a sound thrashing!</message>
+      <message type="end">With a final, explosive breath, you pull your .+ back to a ready position\.</message>
+      <message type="end">Distracted, you hesitate, and in doing so lose the rhythm of your assault\. You pull your .+ back to a ready position with a wary eye to your environs\.</message>
+   </spell>
+   <spell availability="self-cast" name="Weapon Guardant Thrusts" number="9659" type="timer">
+      <duration>20</duration>
+      <message type="start">Retaining a defensive profile, you raise your .+ in a hanging guard and prepare to unleash a barrage of guardant thrusts upon a .+!</message>
+      <message type="end">You complete your assault, your weight on your rear foot as you snap your .+ back to a defensive angle\.</message>
+      <message type="end">Distracted, you hesitate, and in doing so lose the rhythm of your assault\. You shift your grip on your .+ to a more neutral position and watch for new opportunities\.</message>
    </spell>
 </list>


### PR DESCRIPTION
-Adding support for Lockmaster Focus
-Adding support for active assaults (flurry, thrash, guardant thrusts)
   -TODO: Add support for the other assaults (e.g. barrage)
-Removing "end" messaging tracking for 9005 [mstrike cooldown]
   -The actual mstrike cooldown is now tracked via an effect, so this tracks the 60 seconds PSM3 freeze-out