### PR TITLE
Update bigshot animates, blessing and standing while loot script running

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.7.3
+       version: 4.7.4
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -17,8 +17,13 @@
   Version Control:
     Major_change.feature_addition.bugfix
 
+  v4.7.4 (2022-01-29)
+    Updated target logic to ignore socerer animates.
+    Updated loot subroutine to flag looting active - prevent BS from forcing stand
+
   v4.7.3 (2022-01-25)
-    Updated bless routines to current text and provide option to continue hunt. Also disbaled default startup sound value. Uncomment out print "\a" unless $bigshot_quick if function is desired.
+    Updated bless routines to current text and provide option to continue hunt.
+    Disabled default startup sound value. Uncomment print "\a" unless $bigshot_quick if function is desired.
 
   v4.7.2 (2021-12-14)
     Updated GTK version detection for proper display in dark-mode
@@ -102,7 +107,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.7.3'
+BIGSHOT_VERSION = '4.7.4'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -134,6 +139,7 @@ $current_room_npcs = GameObj.npcs
 $familiar = ""
 $grouplist = []
 $last_loot = nil
+$looting_inactive = true
 $not_hunting_reason = nil
 $rest_reason = nil
 $room_npcs_last_check = []
@@ -1549,6 +1555,7 @@ class Bigshot
 
   def GameObjNpcCheck()
     npcs = GameObj.npcs.find_all { |i| i.status !~ /dead|gone/ }
+    npcs.delete_if { |npc| npc.name =~ /animated/ }
     npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
     npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
     return npcs.size.to_i
@@ -2111,13 +2118,21 @@ class Bigshot
 
   def display_items_for_blessing()
     echo "display_items_for_blessing" if $bigshot_debug
+    $bigshot_bless = $bigshot_bless - ["", nil]
+    bless_bundles = false
     if $bigshot_bless.count > 0
       message(sprintf("Bigshot: The following items should be blessed before next hunt"))
       $bigshot_bless.each { |id|
         noun = GameObj.inv.find { |obj| obj.id == "#{id}" }
+        if noun.nil? or noun.empty?
+          bless_bundles = true
+        else
         message(sprintf("Bigshot: #{noun}"))
+        end
       }
+      message(sprintf("Bigshot: arrows or other bundled weapon-type"))
     end
+    bless_bundles = false
   end
 
   def room_id()
@@ -2216,6 +2231,11 @@ class Bigshot
     echo " false if target.noun.... (not last one)" if $bigshot_debug
     return false if target.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && target.name !~ /ethereal|celestial|unworldly/i
 
+    echo " false if target.name =~ /animated/ #{ target.name =~ /animated/ }" if $bigshot_debug
+    if target.name =~ /animated/
+      CharSettings['untargetable'].push(target.name) if target.status !~ /dead|gone/
+      return false
+    end
     if (!CharSettings['targetable'].include?(target.name) && !CharSettings['untargetable'].include?(target.name) && target.status !~ /dead|gone/)
       result = dothistimeout("target ##{target.id}", 3, /^You are now targeting|^You can't target/)
       if (result =~ /^You are now targeting/)
@@ -2610,6 +2630,7 @@ class Bigshot
         if $last_loot.nil?
           $last_loot = Time.now + 15
         elsif $last_loot <= Time.now
+          $looting_inactive = false
           dead_npcs.each { |i|
             $last_loot = nil
             use_lte_boost()
@@ -2623,8 +2644,10 @@ class Bigshot
               bs_put "loot room"
             end
           }
+          $looting_inactive = true
         end
       else
+        $looting_inactive = false
         dead_npcs.each { |i|
           $last_loot = nil
           use_lte_boost()
@@ -2638,6 +2661,7 @@ class Bigshot
             bs_put "loot room"
           end
         }
+        $looting_inactive = true
       end
     end
   end
@@ -3373,7 +3397,7 @@ elsif (script.vars[1] =~ /tail|follow|link/i)
   while (!dead?)
     begin
       bs.change_stance('defensive')
-      bs.stand() if !standing?
+      bs.stand() if !standing? && $looting_inactive
       sleep(0.25)
 
       # grab event


### PR DESCRIPTION
Updates to BS bring rev to 4.7.4

Ignore animates as NPCs
Do not stand if looting (or loot script) is active
Update bless methods to stop if checked, hunt if not but register a bless would benefit

Concepts - Rinualdo