### PR TITLE
Update bless logic to reduce false positives

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.7.4
+       version: 4.7.5
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -16,6 +16,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+
+  v4.7.5 (2022-02-02)
+    Updated needs bless logic to to remove false positives (most cases)
 
   v4.7.4 (2022-01-29)
     Updated target logic to ignore sorcerer animates.
@@ -520,8 +523,13 @@ class Bigshot
         $bigshot_archery_location = $1
       elsif server_string =~ /You're now no longer aiming at anything in particular/i
         $bigshot_archery_location = nil
-      elsif server_string =~ /The <a exist="(.*?)" noun=".*?">.*?<\/a> strikes? true.* shrugs off some of the damage!/i
-        $bigshot_bless.push($1) if !$bigshot_bless.include?($1)
+      elsif server_string =~ /The <a exist="(.*?)" noun="(.*?)">.*?<\/a> strikes? true.* shrugs off some of the damage!/i
+        my_id = $1.dup
+        my_noun = $2.dup
+        my_item = GameObj.inv.find { |i| i.id == "#{my_id}" }
+        if @AMMO == "#{my_noun}" || my_item || (checkright || checkleft ) == "#{my_noun}"
+          $bigshot_bless.push(my_id) if !$bigshot_bless.include?(my_id)
+        end
       elsif server_string =~ /Your <a exist="(.*?)" noun=".*?">.*?<\/a> returns? to normal\./i
         $bigshot_bless.push($1)
       elsif server_string =~ /^You bolt/i
@@ -2002,7 +2010,7 @@ class Bigshot
     run_scripts(@RESTING_SCRIPTS, true)
 
     if ($rest_reason =~ /No blessing on weapon|Ammo had no effect \(need blessed or magical\)/i)
-      echo "Need a blessing on weapon to continue hunting"
+      message("Need a blessing on weapon to continue hunting")
       Script.self.kill
     end
 
@@ -2130,7 +2138,7 @@ class Bigshot
         message(sprintf("Bigshot: #{noun}"))
         end
       }
-      message(sprintf("Bigshot: arrows or other bundled weapon-type"))
+      message(sprintf("Bigshot: arrows or other bundled weapon-type")) if bless_bundles
     end
     bless_bundles = false
   end


### PR DESCRIPTION
in crowded hunting areas, previous bless needed detect logic would not discern between Char.name and other hunters.  Most false positives addressed, but there may still be occasional observations.