### PR TITLE
Add sloot features

### DIFF
--- a/scripts/sloot.lic
+++ b/scripts/sloot.lic
@@ -144,6 +144,8 @@ setup = proc {
     gtk_locals["enable_close_sacks"].active = (settings["enable_close_sacks"] ||= false)
     gtk_locals["overflowsack"] = Gtk::Entry.new
     gtk_locals["overflowsack"].text = (settings["overflowsack"] ||= '')
+    gtk_locals["no_sell_sacks"] = Gtk::Entry.new
+    gtk_locals["no_sell_sacks"].text = (settings["no_sell_sacks"] ||= '')
     gtk_locals["loot_exclude"] = Gtk::Entry.new
     gtk_locals["loot_exclude"].text = (settings["loot_exclude"] ||= '')
     gtk_locals["critter_exclude"] = Gtk::Entry.new
@@ -631,8 +633,14 @@ setup = proc {
 
 #    hb = Gtk::HBox.new(false, 1)
 	hb = Gtk::Box.new(:horizontal, 1)
-    hb.pack_start(Gtk::Alignment.new(1, 0, 0, 1).add(Gtk::Label.new("(?) Exclude loot:")).set_width_request(100), false)
+    hb.pack_start(Gtk::Alignment.new(1, 0, 0, 1).add(Gtk::Label.new("(?) Exclude loot:")).set_width_request(225), false)
     hb.pack_start(Gtk::Alignment.new(0, 0, 0, 1).add(gtk_locals["sell_exclude"].set_width_request(419)))
+    # hb.pack_start(Gtk::Alignment.new(0, 0, 0, 1).add(gtk_locals["enable_no_sell_overflow_except_boxes"]), false)
+    vb_pg4_1.pack_start(hb, false)
+
+  hb = Gtk::Box.new(:horizontal, 1)
+    hb.pack_start(Gtk::Alignment.new(1, 0, 0, 1).add(Gtk::Label.new("(?) Exclude containers (except boxes):")).set_width_request(225), false)
+    hb.pack_start(Gtk::Alignment.new(0, 0, 0, 1).add(gtk_locals["no_sell_sacks"].set_width_request(419)))
     vb_pg4_1.pack_start(hb, false)
 
 #    hb = Gtk::HBox.new(false, 1)
@@ -772,7 +780,6 @@ setup = proc {
         echo "error: unknown local widget #{option} [#{widget.class}]"
       end
     }
-
     echo "settings saved"
     $lootable = nil
   else
@@ -1797,7 +1804,17 @@ sell = proc {
     end
   }
 
-  found_sacks.each { |sack|
+  selling_sacks = Array.new
+
+  no_sell_sacks = settings["no_sell_sacks"].split(",").to_a
+  
+  found_sacks.each { |sack| 
+    unless no_sell_sacks.include?(sack.noun)
+      selling_sacks.push(sack)
+    end
+  }
+  
+  selling_sacks.each { |sack|
     unless sack.contents
       dothistimeout "look in ##{sack.id}", 5, /In the .*?/
       unless sack.contents
@@ -1846,27 +1863,31 @@ sell = proc {
   sell_item = proc { |item|
     if get_item.call(item, nil)
       dothistimeout "sell ##{item.id}", 5, /ask|offer/
-
-      if checkleft == item.noun or checkright == item.noun
-        unless put_item.call(item, UserVars.send("#{item.type.split(",").first}sack"))
-          dothistimeout "drop ##{item.id}", 5, /drop/
-        end
-      end
-    else
-      msg.call("-- failed to find #{item.name}")
-      exit
     end
+
+    if checkleft == item.noun or checkright == item.noun
+      unless put_item.call(item, UserVars.send("#{item.type.split(",").first}sack"))
+        dothistimeout "drop ##{item.id}", 5, /drop/
+      end
+    end
+    # else
+    #   msg.call("-- failed to find #{item.name}")
+    #   exit
+    # end
   }
 
   if selling.size == 0
     msg.call("-- nothing to sell")
   else
     empty_hands
-
     selling.each_pair { |location, items|
       start_silvers = checksilvers.call
 
-      location = location.split(",").first
+      if location.include? "gemshop"
+        location = "gemshop"
+      else
+        location = location.split(",").first
+      end
       go2.call(location)
       items.each { |item| sell_item.call(item) }
 

--- a/scripts/sloot.lic
+++ b/scripts/sloot.lic
@@ -635,7 +635,6 @@ setup = proc {
 	hb = Gtk::Box.new(:horizontal, 1)
     hb.pack_start(Gtk::Alignment.new(1, 0, 0, 1).add(Gtk::Label.new("(?) Exclude loot:")).set_width_request(225), false)
     hb.pack_start(Gtk::Alignment.new(0, 0, 0, 1).add(gtk_locals["sell_exclude"].set_width_request(419)))
-    # hb.pack_start(Gtk::Alignment.new(0, 0, 0, 1).add(gtk_locals["enable_no_sell_overflow_except_boxes"]), false)
     vb_pg4_1.pack_start(hb, false)
 
   hb = Gtk::Box.new(:horizontal, 1)
@@ -1693,6 +1692,7 @@ locker_boxes = proc { |boxes|
 sell = proc {
   cur_room = Room.current.id
   found_sacks = Array.new
+  selling_sacks = Array.new
   selling = Hash.new
   silver_breakdown = Hash.new
   types = Array.new
@@ -1804,8 +1804,6 @@ sell = proc {
     end
   }
 
-  selling_sacks = Array.new
-
   no_sell_sacks = settings["no_sell_sacks"].split(",").to_a
   
   found_sacks.each { |sack| 
@@ -1863,23 +1861,23 @@ sell = proc {
   sell_item = proc { |item|
     if get_item.call(item, nil)
       dothistimeout "sell ##{item.id}", 5, /ask|offer/
-    end
 
-    if checkleft == item.noun or checkright == item.noun
-      unless put_item.call(item, UserVars.send("#{item.type.split(",").first}sack"))
-        dothistimeout "drop ##{item.id}", 5, /drop/
+      if checkleft == item.noun or checkright == item.noun
+        unless put_item.call(item, UserVars.send("#{item.type.split(",").first}sack"))
+          dothistimeout "drop ##{item.id}", 5, /drop/
+        end
       end
+    else
+      msg.call("-- failed to find #{item.name}")
+      exit
     end
-    # else
-    #   msg.call("-- failed to find #{item.name}")
-    #   exit
-    # end
   }
 
   if selling.size == 0
     msg.call("-- nothing to sell")
   else
     empty_hands
+    
     selling.each_pair { |location, items|
       start_silvers = checksilvers.call
 

--- a/scripts/sloot.lic
+++ b/scripts/sloot.lic
@@ -1877,7 +1877,6 @@ sell = proc {
     msg.call("-- nothing to sell")
   else
     empty_hands
-    
     selling.each_pair { |location, items|
       start_silvers = checksilvers.call
 


### PR DESCRIPTION
There are two additions to sloot:

1. Any items that can be sold at either the gemshop or the pawnshop will attempt to be sold at the gemshop
2. Added a config option for sacks to exclude from selling. The rationale here is that users might, for example, want their scrolls stored in a bag, but don't want that bag sold. Or, maybe, they don't want their overflow container(s) to be sold.

I've never done a PR from a fork before. I'm happy to resubmit if I've missed a step or five.