### PR TITLE
[spell-list] fix typo for cast-proc of sigil of power

### DIFF
--- a/scripts/spell-list.xml
+++ b/scripts/spell-list.xml
@@ -1859,7 +1859,7 @@
    </spell>
    <spell availability='self-cast' name='Sigil of Power' number='9718' type='utility'>
       <cost type='stamina'>50</cost>
-      <cast-proc>dothistimeout &apos;sigil of power&apos;, 3, /^As you concentrate on the signal, you feel exceptionally tired as your physical energy rapidly transforms into magical energy\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
+      <cast-proc>dothistimeout &apos;sigil of power&apos;, 3, /^As you concentrate on your sigil, you feel exceptionally tired as your physical energy rapidly transforms into magical energy\.$|^Your muscles ache much too badly to even think about attempting this maneuver\.$|^The power from your sigil dissipates into the air\.$/</cast-proc>
    </spell>
    <spell availability='self-cast' name='Sigil of Major Protection' number='9719' type='defense'>
       <duration max='3.0' span='stackable'>1</duration>


### PR DESCRIPTION
the dothistimeout in the cast proc is wrong.

old: "As you concentrate on **the signal**"
correct: "As you concentrate on **your sigil**"