### PR TITLE
Fix bug that caused bigshot to think a room was occupied if the disk …

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3004,14 +3004,29 @@ class Bigshot
     return @followers.nil?
   end
 
+  def find_disk_names_in_room()
+    player_disk_names = []
+    room_disks = GameObj.loot.find_all { |obj| obj.noun == 'disk'}
+    room_disks.each do |disk|
+      disk_name_parts = disk.name.split
+      player_name_index = disk_name_parts.rindex('disk') - 1
+      player_disk_names.push(disk_name_parts[player_name_index])
+    end
+    return player_disk_names
+  end
+
+  def room_contains_disks_of_non_group_members()
+    allowed_disk_names = $grouplist + [Char.name]
+    return !(find_disk_names_in_room() - allowed_disk_names).empty?
+  end
+
   def no_players()
     echo "no_players" if $bigshot_debug
     if ((checkpcs - $grouplist).count > 0)
       return false
       echo "no_players: checkpcs present" if $bigshot_debug
-    elsif GameObj.loot.find { |obj| obj.noun == 'disk' and obj.name !~ /#{Char.name}/ }
-      # This can cause poaching if you walk into a room with your disk already present.  Need to find a workaround
-      echo "no_players: GameObj disk present" if $bigshot_debug
+    elsif room_contains_disks_of_non_group_members()
+      echo "no_players: Disk is present from someone not in group" if $bigshot_debug
       return false
     elsif $ambusher_here
       echo "no_players: Ambusher here" if $bigshot_debug

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3023,8 +3023,8 @@ class Bigshot
   def no_players()
     echo "no_players" if $bigshot_debug
     if ((checkpcs - $grouplist).count > 0)
-      return false
       echo "no_players: checkpcs present" if $bigshot_debug
+      return false
     elsif room_contains_disks_of_non_group_members()
       echo "no_players: Disk is present from someone not in group" if $bigshot_debug
       return false


### PR DESCRIPTION
…it finds is that of a groupmate.

Before this change, if a head entered a room that was otherwise huntable but contained the disk of a group member (like a tail in a head/tail situation) bigshot would reject that room.

I've tested this for a few days and the fix seems to resolve the issue without introducing any poaching.