### PR TITLE
fixes to standard lockers, entry, added help

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -117,7 +117,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.7.6'
+BIGSHOT_VERSION = '4.7.7'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -117,7 +117,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.7.7'
+BIGSHOT_VERSION = '4.7.6'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []

--- a/scripts/shoard.lic
+++ b/scripts/shoard.lic
@@ -6,11 +6,18 @@ Shoard- a gem hoarding script
 	game: Gemstone
 	tags: gem, hoarding 
 	required: Lich > 5.0.1
-	version: 1.0
+	version: 1.1
 
   changelog:
+   version 1.1
+    Adds support for standard (not-Premium) lockers
+    Adds HELP. See ;shoard help
+    Locker add/delete: Changed logic to use current room if no room specified
+    Locker add/delete: Removed "locker" mapdb tag check due to unreliable/incomplete tagging
+    Entry fixed for locker entry rooms that don't expose the "opening" or "curtain" in the loot or room description
+   
     version 1.0
-	 * Iniital release
+	 * Initial release
 
 =end
 
@@ -56,7 +63,32 @@ module Hoard
   end
 
   def self.help
-    echo 'Help message'
+    print_option =
+    proc do |option, msg, eg = '', pad = 2|
+      msg = format("%-40s #{$lich_char}#{script.name} #{eg}", msg) if eg != ''
+
+      respond(format('  %<pad>s%<option>-25s %<msg>s', {
+        pad: ' ' * pad,
+        option: option,
+        msg: msg
+      }))
+    end
+
+  respond('shoard originally by spiffyjr maintained by elanthia-online')
+  respond('')
+  respond('shoard is a gem hoarding script designed to make hoarding gems in lockers as fast and easy as possible.')
+  respond('')
+  respond('Gem hoarding:')
+  print_option.call('add [room number]', 'adds locker of current or optionally defined [room number] as hoarding location. For reliability this should be set to the room OUTSIDE the booth (ie: before you enter the curtained opening)')
+  print_option.call('bounty ', 'Attempts to raid hoard for bounty gems')
+  print_option.call('delete [room number]', 'deletes locker of current or optionally defined [room number] as hoarding location.')
+  print_option.call('get # <gem name>', 'get gems from closest locker hoard')
+  print_option.call('go2', 'go2 the nearest locker')
+  #print_option.call('forget <room#|all>', 'forget the index for the room (or all)')
+  print_option.call('index', 'index the nearest locker')
+  print_option.call('list [alpha|gem name]', 'list locker contents')
+  print_option.call('store', 'store gems in the nearest locker')
+  respond('')
   end
 
   def self.error(msg)
@@ -69,7 +101,7 @@ module Hoard
   end
 
   def self.closest_locker
-    Room.current.find_nearest(@data.settings[:lockers].keys)
+    Room.current.find_nearest(@data.settings[:lockers].keys)  
   end
 
   def self.go2(place)
@@ -77,16 +109,21 @@ module Hoard
   end
 
   def self.go2_locker(id = closest_locker)
-    return if Room.current.tags.any? { |tag| tag =~ /^locker:/ }
+  
+    # check if in locker booth
+    return if (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:locker|counter)$/ }
 
     go2(id)
 
-    return if Room.current.tags.any? { |tag| tag =~ /^locker:/ }
+    return if (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:locker|counter)$/ }
 
-    if (way_in = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain)$/ })
+    if (way_in = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain|tapestry)$/ })
+      # handle CHE locker opening hidden behind tapestry
+      way_in.noun = "opening" if way_in.noun == "tapestry"
+
       current = Room.current.id
+      
       move("go #{way_in.noun}")
-
       # You'll have to wait, Kimsy is presently using that locker booth.
       if current == Room.current.id
         info("Someone is using that locker. Waiting until they're done...")
@@ -98,23 +135,26 @@ module Hoard
   end
 
   def self.leave_locker
-    return if Room.current.tags.none? { |tag| tag =~ /^locker:/ }
+    return if Room.current.tags.none? { |tag| tag =~ /locker/ }
 
     if (way_out = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain)$/ })
+      # handle CHE locker opening hidden behind tapestry
+      way_out.noun = "opening" if way_out.noun == "tapestry"
+
       current = Room.current.id
       move("go #{way_out.noun}")
       wait_while { current == Room.current.id }
     else
-      error('Failed to find locker entrance.')
+      error('Failed to find locker exit.')
     end
   end
 
   def self.open_locker
-    dothistimeout('open locker', 3, /As you open the|That is already/)
+    dothistimeout('open locker', 3, /As you open the|That is already|You open the/)
   end
 
   def self.close_locker
-    dothistimeout('close locker', 3, /You hear the faint creak|That is already/)
+    dothistimeout('close locker', 3, /You hear the faint creak|That is already|You close the/)
   end
 
   def self.normalize_gem(gem_name)
@@ -143,7 +183,7 @@ module Hoard
     gems_needed -= gems_on_hand.length
 
     gemshop = Room.list.find { |r| r.tags.include?('gemshop') && r.location =~ /#{realm}/i }
-    error('Failed to find the gemshop to turn into; send this to SpiffyJr') unless gemshop
+    error('Failed to find the gemshop to turn in to') unless gemshop
 
     info("Checking for #{gem} in #{realm}. Need: #{gems_needed}, Have: #{gems_on_hand.length}.")
 
@@ -293,7 +333,7 @@ module Hoard
         jar = locker.contents.find do |obj|
           obj.noun =~ /^(?:jar|bottle|beaker)$/i && obj.after_name.nil?
         end
-        error("Failed to find empty jar for #{gem_name}: this shouldn't happen!") unless jar
+        error("Failed to find empty jar for #{gem_name}: put some empty jars to your locker, run ;shoard index then rerun ;shoard store") unless jar
 
         fput("get ##{jar.id} from ##{locker.id}")
 
@@ -349,7 +389,7 @@ module Hoard
   def self.list(input)
     @data.settings[:lockers].each_pair do |room_id, data|
       room = Room[room_id]
-      _respond("<b>#{room.location} - #{room.title.first} (#{data[:jars].length} jars, #{data[:empty]} empty)</b>")
+      _respond("<b>#{room.location} - #{room.title.first} - Lich Room #: #{room.id} (#{data[:jars].length} jars, #{data[:empty]} empty)</b>")
       respond('Name                                   Count  Full')
       respond('-------------------------------------- -----  ----')
 
@@ -377,6 +417,20 @@ module Hoard
   def self.locker
     locker = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:chest|locker)$/i }
 
+    if locker.nil?
+      #echo "checking counter"
+      #locker = GameObj.room_desc.each { |counter|  counter.contents.each { |obj| obj.noun =~ /locker/   }}
+      #echo "first locker ID: #{locker.id}"
+      counter = GameObj.room_desc.to_a.find { |counter| counter.noun =~ /counter/ }
+      #echo "counter id: #{counter.id}"
+      fput "look on ##{counter.id}"
+      sleep 0.1
+      locker = counter.contents.find { |obj| obj.noun =~ /locker/   }
+      #counter.contents.count { |obj| echo "obj id: #{obj.id}"   }
+      #echo "locker ID: #{locker.id}"
+      dothistimeout("look in ##{locker.id}", 3, /In the|There is nothing/)
+    end
+        
     error('failed to find jar storage') unless locker
 
     if locker.contents.nil?
@@ -425,22 +479,27 @@ module Hoard
 
     case command
     when 'add'
-      unless vars[2]
-        error('You must specify a locker to add.')
-        return
-      end
+      # unless vars[2]
+      #   error('You must specify a locker to add.')
+      #   return
+      #end
 
-      id = vars[2].to_i
+      if vars[2].nil?
+        id = Room.current.id.to_i
+      else
+        id = vars[2].to_i
+      end
 
       if settings[:lockers][id]
         error('Locker already exists.')
         return
       end
 
-      unless Room[id].tags.any? { |t| t =~ /^locker:/ }
-        error('That does not appear to be a valid locker room.')
-        return
-      end
+      # Overly optimistic check assumed locker areas are tagged. They're not (see Clovertooth in IMT for example)
+      #unless Room[id].tags.any? { |t| t =~ /locker/ }
+      #  error('That does not appear to be a valid locker room.')
+      #  return
+      #end
 
       settings[:lockers][id] = { empty: 0, jars: [] }
       load(settings, { force: true })
@@ -456,12 +515,16 @@ module Hoard
       end
       load(settings, { force: true })
     when 'delete'
-      unless vars[2]
-        error('You must specify a locker to delete.')
-        return
+      # unless vars[2]
+      #   error('You must specify a locker to delete.')
+      #   return
+      # end
+      
+      if vars[2].nil?
+        id = Room.current.id.to_i
+      else
+        id = vars[2].to_i
       end
-
-      id = vars[2].to_i
 
       unless settings[:lockers][id]
         error('You have not added that locker.')

--- a/scripts/shoard.lic
+++ b/scripts/shoard.lic
@@ -6,18 +6,11 @@ Shoard- a gem hoarding script
 	game: Gemstone
 	tags: gem, hoarding 
 	required: Lich > 5.0.1
-	version: 1.1
+	version: 1.0
 
   changelog:
-   version 1.1
-    Adds support for standard (not-Premium) lockers
-    Adds HELP. See ;shoard help
-    Locker add/delete: Changed logic to use current room if no room specified
-    Locker add/delete: Removed "locker" mapdb tag check due to unreliable/incomplete tagging
-    Entry fixed for locker entry rooms that don't expose the "opening" or "curtain" in the loot or room description
-   
     version 1.0
-	 * Initial release
+	 * Iniital release
 
 =end
 
@@ -63,32 +56,7 @@ module Hoard
   end
 
   def self.help
-    print_option =
-    proc do |option, msg, eg = '', pad = 2|
-      msg = format("%-40s #{$lich_char}#{script.name} #{eg}", msg) if eg != ''
-
-      respond(format('  %<pad>s%<option>-25s %<msg>s', {
-        pad: ' ' * pad,
-        option: option,
-        msg: msg
-      }))
-    end
-
-  respond('shoard originally by spiffyjr maintained by elanthia-online')
-  respond('')
-  respond('shoard is a gem hoarding script designed to make hoarding gems in lockers as fast and easy as possible.')
-  respond('')
-  respond('Gem hoarding:')
-  print_option.call('add [room number]', 'adds locker of current or optionally defined [room number] as hoarding location. For reliability this should be set to the room OUTSIDE the booth (ie: before you enter the curtained opening)')
-  print_option.call('bounty ', 'Attempts to raid hoard for bounty gems')
-  print_option.call('delete [room number]', 'deletes locker of current or optionally defined [room number] as hoarding location.')
-  print_option.call('get # <gem name>', 'get gems from closest locker hoard')
-  print_option.call('go2', 'go2 the nearest locker')
-  #print_option.call('forget <room#|all>', 'forget the index for the room (or all)')
-  print_option.call('index', 'index the nearest locker')
-  print_option.call('list [alpha|gem name]', 'list locker contents')
-  print_option.call('store', 'store gems in the nearest locker')
-  respond('')
+    echo 'Help message'
   end
 
   def self.error(msg)
@@ -101,7 +69,7 @@ module Hoard
   end
 
   def self.closest_locker
-    Room.current.find_nearest(@data.settings[:lockers].keys)  
+    Room.current.find_nearest(@data.settings[:lockers].keys)
   end
 
   def self.go2(place)
@@ -109,21 +77,16 @@ module Hoard
   end
 
   def self.go2_locker(id = closest_locker)
-  
-    # check if in locker booth
-    return if (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:locker|counter)$/ }
+    return if Room.current.tags.any? { |tag| tag =~ /^locker:/ }
 
     go2(id)
 
-    return if (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:locker|counter)$/ }
+    return if Room.current.tags.any? { |tag| tag =~ /^locker:/ }
 
-    if (way_in = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain|tapestry)$/ })
-      # handle CHE locker opening hidden behind tapestry
-      way_in.noun = "opening" if way_in.noun == "tapestry"
-
+    if (way_in = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain)$/ })
       current = Room.current.id
-      
       move("go #{way_in.noun}")
+
       # You'll have to wait, Kimsy is presently using that locker booth.
       if current == Room.current.id
         info("Someone is using that locker. Waiting until they're done...")
@@ -135,26 +98,23 @@ module Hoard
   end
 
   def self.leave_locker
-    return if Room.current.tags.none? { |tag| tag =~ /locker/ }
+    return if Room.current.tags.none? { |tag| tag =~ /^locker:/ }
 
     if (way_out = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:opening|curtain)$/ })
-      # handle CHE locker opening hidden behind tapestry
-      way_out.noun = "opening" if way_out.noun == "tapestry"
-
       current = Room.current.id
       move("go #{way_out.noun}")
       wait_while { current == Room.current.id }
     else
-      error('Failed to find locker exit.')
+      error('Failed to find locker entrance.')
     end
   end
 
   def self.open_locker
-    dothistimeout('open locker', 3, /As you open the|That is already|You open the/)
+    dothistimeout('open locker', 3, /As you open the|That is already/)
   end
 
   def self.close_locker
-    dothistimeout('close locker', 3, /You hear the faint creak|That is already|You close the/)
+    dothistimeout('close locker', 3, /You hear the faint creak|That is already/)
   end
 
   def self.normalize_gem(gem_name)
@@ -183,7 +143,7 @@ module Hoard
     gems_needed -= gems_on_hand.length
 
     gemshop = Room.list.find { |r| r.tags.include?('gemshop') && r.location =~ /#{realm}/i }
-    error('Failed to find the gemshop to turn in to') unless gemshop
+    error('Failed to find the gemshop to turn into; send this to SpiffyJr') unless gemshop
 
     info("Checking for #{gem} in #{realm}. Need: #{gems_needed}, Have: #{gems_on_hand.length}.")
 
@@ -333,7 +293,7 @@ module Hoard
         jar = locker.contents.find do |obj|
           obj.noun =~ /^(?:jar|bottle|beaker)$/i && obj.after_name.nil?
         end
-        error("Failed to find empty jar for #{gem_name}: put some empty jars to your locker, run ;shoard index then rerun ;shoard store") unless jar
+        error("Failed to find empty jar for #{gem_name}: this shouldn't happen!") unless jar
 
         fput("get ##{jar.id} from ##{locker.id}")
 
@@ -389,7 +349,7 @@ module Hoard
   def self.list(input)
     @data.settings[:lockers].each_pair do |room_id, data|
       room = Room[room_id]
-      _respond("<b>#{room.location} - #{room.title.first} - Lich Room #: #{room.id} (#{data[:jars].length} jars, #{data[:empty]} empty)</b>")
+      _respond("<b>#{room.location} - #{room.title.first} (#{data[:jars].length} jars, #{data[:empty]} empty)</b>")
       respond('Name                                   Count  Full')
       respond('-------------------------------------- -----  ----')
 
@@ -417,20 +377,6 @@ module Hoard
   def self.locker
     locker = (GameObj.loot.to_a + GameObj.room_desc.to_a).find { |obj| obj.noun =~ /^(?:chest|locker)$/i }
 
-    if locker.nil?
-      #echo "checking counter"
-      #locker = GameObj.room_desc.each { |counter|  counter.contents.each { |obj| obj.noun =~ /locker/   }}
-      #echo "first locker ID: #{locker.id}"
-      counter = GameObj.room_desc.to_a.find { |counter| counter.noun =~ /counter/ }
-      #echo "counter id: #{counter.id}"
-      fput "look on ##{counter.id}"
-      sleep 0.1
-      locker = counter.contents.find { |obj| obj.noun =~ /locker/   }
-      #counter.contents.count { |obj| echo "obj id: #{obj.id}"   }
-      #echo "locker ID: #{locker.id}"
-      dothistimeout("look in ##{locker.id}", 3, /In the|There is nothing/)
-    end
-        
     error('failed to find jar storage') unless locker
 
     if locker.contents.nil?
@@ -479,27 +425,22 @@ module Hoard
 
     case command
     when 'add'
-      # unless vars[2]
-      #   error('You must specify a locker to add.')
-      #   return
-      #end
-
-      if vars[2].nil?
-        id = Room.current.id.to_i
-      else
-        id = vars[2].to_i
+      unless vars[2]
+        error('You must specify a locker to add.')
+        return
       end
+
+      id = vars[2].to_i
 
       if settings[:lockers][id]
         error('Locker already exists.')
         return
       end
 
-      # Overly optimistic check assumed locker areas are tagged. They're not (see Clovertooth in IMT for example)
-      #unless Room[id].tags.any? { |t| t =~ /locker/ }
-      #  error('That does not appear to be a valid locker room.')
-      #  return
-      #end
+      unless Room[id].tags.any? { |t| t =~ /^locker:/ }
+        error('That does not appear to be a valid locker room.')
+        return
+      end
 
       settings[:lockers][id] = { empty: 0, jars: [] }
       load(settings, { force: true })
@@ -515,16 +456,12 @@ module Hoard
       end
       load(settings, { force: true })
     when 'delete'
-      # unless vars[2]
-      #   error('You must specify a locker to delete.')
-      #   return
-      # end
-      
-      if vars[2].nil?
-        id = Room.current.id.to_i
-      else
-        id = vars[2].to_i
+      unless vars[2]
+        error('You must specify a locker to delete.')
+        return
       end
+
+      id = vars[2].to_i
 
       unless settings[:lockers][id]
         error('You have not added that locker.')

--- a/scripts/shoard.lic
+++ b/scripts/shoard.lic
@@ -1,26 +1,24 @@
 =begin
 Shoard- a gem hoarding script
 
-	maintainer: Elanthia-Online
-	author: SpiffyJr
-	game: Gemstone
-	tags: gem, hoarding 
-	required: Lich > 5.0.1
-	version: 1.1
+  maintainer: Elanthia-Online
+      author: SpiffyJr
+        game: Gemstone
+        tags: gem, hoarding 
+    required: Lich > 5.0.1
+     version: 1.1.0
 
   changelog:
-   version 1.1
-    Adds support for standard (not-Premium) lockers
-    Adds HELP. See ;shoard help
-    Locker add/delete: Changed logic to use current room if no room specified
-    Locker add/delete: Removed "locker" mapdb tag check due to unreliable/incomplete tagging
-    Entry fixed for locker entry rooms that don't expose the "opening" or "curtain" in the loot or room description
+    v1.1.0 (2022-03-13)
+      Adds support for standard (not-Premium) lockers
+      Adds HELP. See ;shoard help
+      Locker add/delete: Changed logic to use current room if no room specified
+      Locker add/delete: Removed "locker" mapdb tag check due to unreliable/incomplete tagging
+      Entry fixed for locker entry rooms that don't expose the "opening" or "curtain" in the loot or room description
    
-    version 1.0
-	 * Initial release
-
+    v1.0.0 (2021-10-11)
+      Initial release
 =end
-
 
 # frozen_string_literal: true
 


### PR DESCRIPTION
Adds support for standard (not-Premium) lockers
Adds HELP. See ;shoard help
Locker add/delete: Changed logic to use current room if no room specified
Locker add/delete: Removed "locker" mapdb tag check due to unreliable/incomplete tagging
Entry fixed for locker entry rooms that don't expose the "opening" or "curtain" in the loot or room description