### PR TITLE
Adding a check for DR / dependency runs

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.53
+       version: 0.54
       required: Lich >= 4.6.58
 
   changelog:
+    0.54 (2022-03-15):
+      Added logic to welcome Dragonrealms.
     0.53 (2021-07-27):
       Fixed defect where autostart would error if a completely new / fresh install with no lich.db3 existing.
     0.52 (2021-05-10):
@@ -76,6 +78,27 @@ def lich_no_update
 	end
 end
 
+if XMLData.game =~ /^DR/
+  begin
+    did_dependency_install = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_dependency_install';")
+  rescue SQLite3::BusyException
+    sleep 0.1
+    retry
+  end
+  if did_dependency_install.nil?
+    unless File.exist?("#{SCRIPT_DIR}/bootstrap.lic") && File.exist?("#{SCRIPT_DIR}/drinfomon.lic")
+      Script.run('repository', 'download dependency')
+      sleep 0.5
+      Script.run('dependency', 'install')
+    end
+    begin
+      Lich.db.execute("INSERT INTO lich_settings(name,value) VALUES('did_dependency_install', 'yes');")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+  end
+end
 
 if script.vars.empty?
   sleep 0.5


### PR DESCRIPTION
Adding a check for DR, and putting in play a method to automatically download / run the DR script dependency if it hasn't been recorded as run and if two key files cannot be found.

Needs DR specific testing on both existing installs and brand new installs.