### PR TITLE
Adding a check for DR / dependency runs

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.53
+       version: 0.54
       required: Lich >= 4.6.58
 
   changelog:
+    0.54 (2022-03-15):
+      Added logic to welcome Dragonrealms.
     0.53 (2021-07-27):
       Fixed defect where autostart would error if a completely new / fresh install with no lich.db3 existing.
     0.52 (2021-05-10):
@@ -76,6 +78,27 @@ def lich_no_update
 	end
 end
 
+if XMLData.game =~ /^DR/
+  begin
+    did_dependency_install = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_dependency_install';")
+  rescue SQLite3::BusyException
+    sleep 0.1
+    retry
+  end
+  if did_dependency_install.nil?
+    unless File.exist?("#{SCRIPT_DIR}/bootstrap.lic") && File.exist?("#{SCRIPT_DIR}/drinfomon.lic")
+      Script.run('repository', 'download dependency')
+      sleep 0.5
+      Script.run('dependency', 'install')
+    end
+    begin
+      Lich.db.execute("INSERT INTO lich_settings(name,value) VALUES('did_dependency_install', 'yes');")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+  end
+end
 
 if script.vars.empty?
   sleep 0.5

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -87,8 +87,11 @@ if XMLData.game =~ /^DR/
     retry
   end
   if did_dependency_install.nil?
-    unless File.exist?("#{SCRIPT_DIR}/bootstrap.lic") && File.exist?("#{SCRIPT_DIR}/drinfomon.lic")
+    unless File.exist?("#{SCRIPT_DIR}/dependency.lic")
       Script.run('repository', 'download dependency')
+      sleep 1
+    end
+    unless File.exist?("#{SCRIPT_DIR}/bootstrap.lic") && File.exist?("#{SCRIPT_DIR}/drinfomon.lic") && File.exist?("#{SCRIPT_DIR}/common.lic") && File.exist?("#{SCRIPT_DIR}/dependency.lic")
       sleep 0.5
       Script.run('dependency', 'install')
     end
@@ -98,6 +101,9 @@ if XMLData.game =~ /^DR/
       sleep 0.1
       retry
     end
+  else
+    Script.start('dependency')
+    sleep 1
   end
 end
 
@@ -113,11 +119,9 @@ if script.vars.empty?
     if script_list.class == Array
       if run_info == false
         # Run infomon
-        if XMLData.game =~ /^DR/
-          Script.start("drinfomon") if Script.exists?("drinfomon")
-        else
+        unless XMLData.game =~ /^DR/
           Script.start("infomon")
-        end
+	end
         run_info = true
         sleep 0.5
       end

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -15,6 +15,8 @@
   changelog:
     0.54 (2022-03-15):
       Added logic to welcome Dragonrealms.
+      DragonRealms/GemstoneIV infomon detection
+      Removed xnarost from default autostarting
     0.53 (2021-07-27):
       Fixed defect where autostart would error if a completely new / fresh install with no lich.db3 existing.
     0.52 (2021-05-10):
@@ -51,7 +53,6 @@ end
 
 if Settings['scripts'].nil?
   Settings['scripts'] = Array.new
-  Settings['scripts'].push(:name => 'xnarost', :args => [])
   Settings['scripts'].push(:name => 'alias', :args => [])
   Settings['scripts'].push(:name => 'lnet', :args => [])
 end
@@ -112,7 +113,11 @@ if script.vars.empty?
     if script_list.class == Array
       if run_info == false
         # Run infomon
-        start_script 'infomon'
+        if XMLData.game =~ /^DR/
+          Script.start("drinfomon") if Script.exists?("drinfomon")
+        else
+          Script.start("infomon")
+        end
         run_info = true
         sleep 0.5
       end


### PR DESCRIPTION

Adding a check for DR, and putting in play a method to automatically download / run the DR script dependency if it hasn't been recorded as run and if two key files cannot be found.

Needs DR specific testing on both existing installs and brand new installs.

(Remade due to workflows not able to update in a PR after started, see #626 for original)