### PR TITLE
stance perfection, assume aspect, briar weapons support and dhurl fix.

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3006,8 +3006,8 @@ class Bigshot
 	  new_stance = "advance" if perfect_stance =~ /10|20/i
 	  new_stance = "forward" if perfect_stance =~ /30|40/i
 	  new_stance = "neutral" if perfect_stance =~ /50|60/i
-	  new_stance = "advance" if perfect_stance =~ /70|80/i
-	  new_stance = "advance" if perfect_stance =~ /90|100/i
+	  new_stance = "guarded" if perfect_stance =~ /70|80/i
+	  new_stance = "defensive" if perfect_stance =~ /90|100/i
 	end				 
     if (stance() =~ /#{new_stance}/)
       return

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.8.8
+       version: 4.9.0
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,11 +17,11 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
-   v4.8.8 (2022-03-24)
+  v4.9.0 (2022-03-24)
     Added support for briar weapons. Will check for buff and check status of weapons charge.
-	Added support for assume aspect. Will alternate between aspects or evoke for one aspect.
-	Added support for cman stance perfection. Put 10,20,30,ect in attack stance box.
-	Fixed dhurl command knowing weapon auto returned from bond.		
+    Added support for assume aspect. Will alternate between aspects or evoke for one aspect.
+    Added support for cman stance perfection. Put 10,20,30,ect in attack stance box.
+    Fixed dhurl command knowing weapon auto returned from bond.		
 	
   v4.8.7 (2022-03-12)
     Fixed mstrike cooldown and debuff checks.
@@ -204,7 +204,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.8.7'
+BIGSHOT_VERSION = '4.9.0'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -20,7 +20,9 @@
    v4.8.8 (2022-03-15)
     Added support for briar weapons. Will check for buff and check status of weapons charge.
 	Added support for assume aspect. Will alternate between aspects or evoke for one aspect.
-	Fixed dhurl command knowing weapon auto returned from bond.				 
+	Added support for cman stance perfection. Put 10,20,30,ect in attack stance box.
+	Fixed dhurl command knowing weapon auto returned from bond.		
+	
   v4.8.7 (2022-03-12)
     Fixed mstrike cooldown and debuff checks.
     Added Barkskin cooldown support. Add 605 to your society abilities box.
@@ -653,7 +655,7 @@ class Bigshot
 	  elsif server_string =~ /^You no longer look stronger\./i
 	    $bigshot_briars = false
 	  elsif server_string =~ /^A[n]? (.*) rises out of the shadows and flies back to your waiting hand!/i
-	    $bigshot_bond_return = true				
+	    $bigshot_bond_return = true
       end
       server_string
     }
@@ -1862,7 +1864,7 @@ class Bigshot
 	return if !Weapon.available?("Pin Down")
 	waitrt?
 	waitcastrt?	
-	result = dothistimeout("weapon pindown ##{npc.id}", 2, /take quick assessment and raise your|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+	result = dothistimeout("weapon pindown ##{npc.id}", 2, /take quick assessment and raise your|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|You can't|Could not find|seconds/i)
     if (result == false)
  	  $bigshot_should_rest = true
       $rest_reason = "Unknown result from pindown routine: #{result}"
@@ -2998,15 +3000,26 @@ class Bigshot
   def change_stance(new_stance, force = true)
     return if Spell[216].active? || dead?
 
+	perfect_stance = nil
+	if new_stance =~ /10|20|30|40|50|60|70|80|90|100/i
+	  perfect_stance = new_stance
+	  new_stance = "advance" if perfect_stance =~ /10|20/i
+	  new_stance = "forward" if perfect_stance =~ /30|40/i
+	  new_stance = "neutral" if perfect_stance =~ /50|60/i
+	  new_stance = "advance" if perfect_stance =~ /70|80/i
+	  new_stance = "advance" if perfect_stance =~ /90|100/i
+	end				 
     if (stance() =~ /#{new_stance}/)
       return
     elsif (checkcastrt() > 0 && new_stance =~ /def/)
       return if stance() == 'guarded'
     end
 
-    if (force)
-      result = dothistimeout("stance #{new_stance}", 3, /You are now in an?|You move into an?|You fall back into a|Cast Roundtime in effect|You are unable to change/)
-    else
+    if ((force) && (perfect_stance != nil) && (CMan.known?("Stance Perfection")))
+      result = dothistimeout("cman stance #{perfect_stance}", 3, /You are now in an?|You move into an?|You fall back into a|Cast Roundtime in effect|You are unable to change/)
+    elsif (force)
+	  result = dothistimeout("stance #{new_stance}", 3, /You are now in an?|You move into an?|You fall back into a|Cast Roundtime in effect|You are unable to change/)
+	else
       fput "stance #{new_stance}"
     end
   end

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -123,7 +123,7 @@ if $SAFE > 0
 end
 
 # Check version of Lich for compatibility
-LICH_GEM_REQUIRES = '5.4.0'
+LICH_GEM_REQUIRES = '5.5.0'
 INFOMON_GEM_REQUIRES = '1.18.11'
 INFOMON_VERSION = '0.0.0'
 infomon_data = open("#{SCRIPT_DIR}/infomon.lic", 'r').read

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,8 +8,8 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.8.7
-      requires: Lich >= 5.4.0, infomon >= 1.18.11
+       version: 4.8.8
+      requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
   To help contribute: https://github.com/elanthia-online/scripts
@@ -17,7 +17,7 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
-   v4.8.8 (2022-03-15)
+   v4.8.8 (2022-03-24)
     Added support for briar weapons. Will check for buff and check status of weapons charge.
 	Added support for assume aspect. Will alternate between aspects or evoke for one aspect.
 	Added support for cman stance perfection. Put 10,20,30,ect in attack stance box.

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,7 +17,10 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
- 
+   v4.8.8 (2022-03-15)
+    Added support for briar weapons. Will check for buff and check status of weapons charge.
+	Added support for assume aspect. Will alternate between aspects or evoke for one aspect.
+	Fixed dhurl command knowing weapon auto returned from bond.				 
   v4.8.7 (2022-03-12)
     Fixed mstrike cooldown and debuff checks.
     Added Barkskin cooldown support. Add 605 to your society abilities box.
@@ -213,6 +216,8 @@ $bigshot_archery_stuck_location = []
 $bigshot_archery_location = nil
 $bigshot_bandits = false
 $bigshot_bless = []
+$bigshot_bond_return = false
+$bigshot_briars = false							
 $bigshot_debug = false
 $bigshot_flee = false
 $bigshot_lte_boost_counter = 0
@@ -643,6 +648,12 @@ class Bigshot
         $bigshot_reaction = nil
       elsif server_string =~ /#{UserVars.op["flee_message"]}/i && UserVars.op["flee_message"] != ""
         $bigshot_flee = true
+	  elsif server_string =~ /The vines lose all crimson hues, and strength courses through your blood\.$/i
+	    $bigshot_briars = true
+	  elsif server_string =~ /^You no longer look stronger\./i
+	    $bigshot_briars = false
+	  elsif server_string =~ /^A[n]? (.*) rises out of the shadows and flies back to your waiting hand!/i
+	    $bigshot_bond_return = true				
       end
       server_string
     }
@@ -990,7 +1001,7 @@ class Bigshot
           elsif ($1 == '!outside')
             commandcheckreturn = true if outside?
         #Check for buffs to perform actions. May have delay due to the way updates are sent but should only be noticed on fast paced buffs like arcane reflex.
-		  elsif ($1 == 'barrage')
+	  elsif ($1 == 'barrage')
 		    commandcheckreturn = true if !Effects::Buffs.active?("Enh. Dexterity (+10)")
 		  elsif ($1 == '!barrage')
 		    commandcheckreturn = true if Effects::Buffs.active?("Enh. Dexterity (+10)")
@@ -1283,7 +1294,11 @@ class Bigshot
 	  cmd_1040()
 	elsif (command =~ /^dhurl/i)
 	  cmd_dhurl()
-    else
+	elsif (command =~ /briar\s?(\w+)/i)
+	  cmd_briar($1)
+	elsif (command =~ /^assume\s?(\w+)?\s?(\w+)?\s?(evoke)?/i)
+	  cmd_assume($1, $2, $3)								
+	else
       return if $ambusher_here
       return if $obvious_hiding_player
 
@@ -1428,6 +1443,66 @@ class Bigshot
     end
   end
 
+  def cmd_assume(aspect, extra)
+    echo "cmd_assume" if $bigshot_debug
+    return if !Spell[650].known?
+  
+	timer = (Time.now - 240)
+	CharSettings['jackal']		=	timer if CharSettings['jackal'].nil?
+	CharSettings['wolf']		=	timer if CharSettings['wolf'].nil?
+	CharSettings['lion']		=	timer if CharSettings['lion'].nil?
+	CharSettings['panther']		=	timer if CharSettings['panther'].nil?
+	CharSettings['hawk']		=	timer if CharSettings['hawk'].nil?
+	CharSettings['owl']			=	timer if CharSettings['owl'].nil?
+	CharSettings['porcupine']	=	timer if CharSettings['porcupine'].nil?
+	CharSettings['rat']			=	timer if CharSettings['rat'].nil?
+	CharSettings['bear']		=	timer if CharSettings['bear'].nil?
+	CharSettings['burgee']		=	timer if CharSettings['burgee'].nil?
+	CharSettings['mantis']		=	timer if CharSettings['mantis'].nil?
+	CharSettings['serpent']		=	timer if CharSettings['serpent'].nil?
+	CharSettings['spider']		=	timer if CharSettings['spider'].nil?
+	CharSettings['yierka']		=	timer if CharSettings['yierka'].nil?
+	aspect_timer = CharSettings.to_hash
+	
+    waitrt?
+    waitcastrt?
+    if !Effects::Buffs.active?("Assume Aspect")
+      Spell[650].force_evoke if ((extra =~ /evoke/i) && Spell[650].affordable?)
+      Spell[650].cast if ((extra !~ /evoke/i) && Spell[650].affordable?)
+      first_aspect = true
+      waitcastrt?
+    end
+	return if !Effects::Buffs.active?("Assume Aspect")
+	
+    if (!Effects::Buffs.active?("Aspect of the #{aspect.capitalize()}") && !Effects::Buffs.active?("Aspect of the #{extra.capitalize()}"))
+      if ((Time.now > aspect_timer[aspect]) && ((first_aspect == true) || (checkmana >= 25)))
+	    dothistimeout "assume #{aspect}", 1, /^You concentrate your focus upon the Aspect|^You feel that you will not be able to fully concentrate upon the Aspect/i
+        first_aspect = false
+        CharSettings[aspect] = (Time.now + 240)
+		echo CharSettings[aspect]
+      elsif ((Time.now > aspect_timer[extra]) && ((first_aspect == true) || (checkmana >= 25)))
+	    dothistimeout "assume #{extra}", 1, /^You concentrate your focus upon the Aspect|^You feel that you will not be able to fully concentrate upon the Aspect/i
+        first_aspect = false
+        CharSettings[extra] = (Time.now + 240)
+		echo CharSettings[extra]
+      end
+    end
+  end
+
+  def cmd_briar(weapon)
+    echo "cmd_briar" if $bigshot_debug
+    return if (weapon.nil? || $bigshot_briars)
+    return if (weapon != (GameObj.right_hand.to_s || GameObj.left_hand.to_s))
+    ready = false
+    silence_me
+    res = Lich::Util.quiet_command_xml("look #{weapon}", /You gaze intently|You see/, /<prompt time=/)
+    if res.any?{ |line| line =~ /to be about (\d+) percent./i }
+ 	  ready = true if $1.to_i == 100
+	  sleep(0.2)
+    end
+    silence_me
+    fput "raise #{weapon}" if ready == true
+  end
   def cmd_throw(npc)
     echo "cmd_throw" if $bigshot_debug
     unless npc.status == 'lying down'
@@ -1703,6 +1778,7 @@ class Bigshot
   def cmd_recover(weapon_lost = true)
     echo "cmd_recover" if $bigshot_debug
     until weapon_lost == false
+	  break if $bigshot_bond_return = true
       waitrt?
       res = dothistimeout "recover hurl", 1, Regexp.union(
         /You know (.*) is around here somewhere, but you don't see it./,
@@ -1713,9 +1789,9 @@ class Bigshot
       )
       if res =~ /You know (.*) is around here somewhere, but you don't see it./
         sleep(0.5)
-      elsif res =~ /You spy a (.*) and recover it|A (.*) rises out of the shadows and flies back to your waiting hand!/
+      elsif res =~ /You spy a (.*) and recover it|(.*) rises out of the shadows and flies back to your waiting hand!/
         weapon_lost = false
-      elsif res =~ /In order to recover your hurled weapon, you'll need to have a free hand./
+      elsif res =~ /In order to recover your hurled weapon, you'll need to have a free hand.|You find nothing recoverable./
         weapon_lost = false
       end
     end
@@ -3966,9 +4042,13 @@ class Bigshot
 		renewal_cost = $1.to_i
 	  end
 	  silence_me
-	end				
+	end
 
     @SIGNS.each do |i|
+	  if i =~ /650\s?(\w+)?\s?(\w+)?\s?/ 
+		cmd_assume($1.to_s, $2.to_s)
+		next
+	  end
       i = i.to_i
       next if [9903, 9904, 9905, 9906, 9907, 9908, 9909, 9910, 9912, 9913, 9914, 9918].include?(i) and Spell[9012].active?
       next if i == 9918


### PR DESCRIPTION
cman stance perfection - use 10,20,30,ect in attack stance box to use stance perfection if you know it.
assume aspect - use '650 lion wolf' '650 lion evoke' in society box or 'assume lion wolf' 'assume lion evoke' in hunting commands.
briar weapons - 'briar \<weapon\>' 'briar bow' 'briarbow' in hunting commands to activate +AS buff.

dhurl fix - added weapon bond return message to monitor so dhurl/recover can see if a weapon auto returns from bonding and doesn't end up in a recover loop. Warriors rejoice.