### PR TITLE
Update forgery.lic

### DIFF
--- a/scripts/forgery.lic
+++ b/scripts/forgery.lic
@@ -19,8 +19,31 @@
 
  Category: Artisan
  Tags: forging, forge, craft, artisan, perfect
- Version: 18
+ Version: 19
 
+ v19 2022-03-29
+   Bugfix for maeterial_oil typo
+ v18 2021-10-12
+   Updated to support GTK3
+ v17 2018-12-01
+   Fixed a dumb oil bug. Again?
+ v16 2018-04-01
+   Fixed a dumb bug where average pieces were mixed in the container with keepers
+ v15 2017-03-01
+  Killed the gift/trash options for lumnis change(v15)
+
+=end
+=begin
+ Pre-Gnomad changelog:
+  UPDATES:
+  Early 2011 -> heavily modified Dalem's dforge script.
+  Sept 2011  -> fixed measuring the stand-alone hammerhead glyph for forging hammer heads.
+  Jan 2012   -> fixed citizenship buying bug
+  Mar 2012   -> fixed forging-hammer hang bugs.  thanks to Kuirit
+       -> broke buying for non-citizens by accident when i fixed it for citizens.  error gone now and should work fine.  my bad!
+       -> fixed a problem with the oil section of the script, and cleaned it up a little bit.  also added the oil type for rare metal slabs...props to Gizmo!
+       -> fixed more bugs.  thanks to Gizmo for pointin em out.
+  Mar 2012 -> fixed and reworked the scrap-selling part which I dont think many people actually used because it only activates if the scrap_container fills up.
  October 2015: Forked by Gnomad
  December 2015: Various bugfixes, began internal testing (v2, internal)
  January 2016: MARK perfect items as unsellable (v3, internal) forged perfect hammer, began OHE work
@@ -31,27 +54,7 @@
  April 2016: Addes some internal features (v9), had a baby (v9.5), fixed a spear-forging bug and migrated settings,
        to be per-character (v10), a hang when your glyph runs out (v11), added results tracking and some internal changes (v12)
  May 2016: AFK tweaks (v13)
- LOL March 2017: (See the had a baby thing) Bugfixes(v14, v15), killed the gift/trash options for lumnis change(v15)
- July 2017: Quit Gemstone, probably for good. Sorry. My health won't let me play much any more.
- April 2018: Fixed a dumb bug where average pieces were mixed in the container with keepers (v16).
- December 2018: Fixed a dumb oil bug. Again? (v17)
- Updated to support GTK3 (v18)
-
-
 =end
-
-# Pre-Gnomad changelog:
-#  UPDATES:
-#  Early 2011 -> heavily modified Dalem's dforge script.
-#  Sept 2011  -> fixed measuring the stand-alone hammerhead glyph for forging hammer heads.
-#  Jan 2012   -> fixed citizenship buying bug
-#  Mar 2012   -> fixed forging-hammer hang bugs.  thanks to Kuirit
-#       -> broke buying for non-citizens by accident when i fixed it for citizens.  error gone now and should work fine.  my bad!
-#       -> fixed a problem with the oil section of the script, and cleaned it up a little bit.  also added the oil type for rare metal slabs...props to Gizmo!
-#       -> fixed more bugs.  thanks to Gizmo for pointin em out.
-#  03/29/12 -> fixed and reworked the scrap-selling part which I dont think many people actually used because it only activates if the scrap_container fills up.
-
-
 
 # #Attuning to hammer: You feel as if you've become accustomed to the balance and heft of this forging-hammer.
 
@@ -752,7 +755,7 @@ class << forger
   def oil
     waitrt?
     fput "wear forging" if checkright =~ /forging-hammer/ && !(checkleft and checkright).nil?
-    oil = Material_oil[@material_name]
+    oil = material_oil[@material_name]
     res = dothistimeout "look in trough", 10, /In the trough/
     unless res =~ /#{oil_trough[oil]}/    #ie.. unless you already have the oil you need in the trough
       if res =~ /oil|water/


### PR DESCRIPTION
v19 fix for material_oil spelling typo