### PR TITLE
[eherbs.lic] Small correction to remove 'an' where appropriate

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -14,10 +14,13 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 5.5.0
-           version: 1.1.1
+           version: 1.1.2
 
   Version Control:
     Major_change.feature_addition.bugfix
+  1.1.2 (2022-04-06):
+    Fix for a/an ordering from menus
+
   1.1.1 (2022-04-04):
     Add LICH_VERSION check
 

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -592,7 +592,7 @@ read_menu = proc {
 
   while (line = get) and (line !~ /ORDER|BUY/)
     for item in line.scan(/<d.*?cmd="order ([0-9]+).*?>(.*?)<\/d>/)
-      @menu[item[1].sub(/^a /, '')] = item[0]
+      @menu[item[1].sub(/^a |^an /, '')] = item[0]
     end
   end
   status_tags(onoff = "off")


### PR DESCRIPTION
User reported defect - `an earthworm potion`

Logic corrected to strike `an` in the menu to match and order the potion.