### PR TITLE
fixed bug in cast_signs() for bards not singing

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4091,7 +4091,7 @@ class Bigshot
 	renewal_cost = 0
 	if Char.prof == "Bard"
 	  silence_me unless undo_silence = silence_me
-	  song_renewal_cost = Lich::Util.quiet_command_xml("song status", /currently singing:/, /<prompt time=/)
+	  song_renewal_cost = Lich::Util.quiet_command_xml("song status", /currently singing:|not singing/, /<prompt time=/)
 	  if song_renewal_cost.any?{ |line| line =~ /Your current renewal cost is (\d+) mana./i }
 		renewal_cost = $1.to_i
 	  end


### PR DESCRIPTION
added not singing to the start prompt for the quiet command to fix a pretty glaring bug reported by Doug.