### PR TITLE
[resource.lic] add explicit grit numbers for hybrid weapons

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -29,10 +29,10 @@
        name: resource
        tags: resource, tears, 330, santify, grit, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic, grit, wps, devotion, jesus juice, sanctify, 330, permabless, 620, ranger, druid fluid, grace
    requires: Lich > 5.4.0
-    version: 1.7
+    version: 1.7.0
 
     changelog:
-        1.7 (2022-04-29)
+        1.7.0 (2022-04-29)
             Add explicit grit numbers for hybrid weapons
         1.6.1 (2022-04-08)
             Fix to save monk/warrior bonus titles to file

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -29,9 +29,11 @@
        name: resource
        tags: resource, tears, 330, santify, grit, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic, grit, wps, devotion, jesus juice, sanctify, 330, permabless, 620, ranger, druid fluid, grace
    requires: Lich > 5.4.0
-    version: 1.6.1
+    version: 1.7
 
     changelog:
+        1.7 (2022-04-29)
+            Add explicit grit numbers for hybrid weapons
         1.6.1 (2022-04-08)
             Fix to save monk/warrior bonus titles to file
         1.6.0 (2022-04-08)
@@ -229,6 +231,8 @@ class Resource
                     "Thrown" => bonus[5],
                     "Polearm" => bonus[6],
                     "Brawling" => bonus[7],
+                    "Katars" => bonus[8],
+                    "Bastard Swords / Katanas" => bonus[9]
                 }
             }
         elsif Char.prof == "Monk"
@@ -256,24 +260,24 @@ class Resource
         all_bonuses = Resource.load_bonuses
         unless all_bonuses.nil?
             all_bonuses = all_bonuses.sort
-            _respond "-" * 89
+            _respond "-" * 117
             headers = ['Game', 'Character', 'Profession', 'Bonus']
-            rowout(headers, true, 19)
-            _respond "-" * 89
+            rowout(headers, true, 26)
+            _respond "-" * 117
             all_bonuses.each { |character|
                 if character[1][:prof] == "Warrior"
                     character[1][:bonus].each { |title, bonusValue|
-                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 19)
+                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 26)
                     }
                 elsif character[1][:prof] == "Monk"
                     character[1][:bonus].each { |title, bonusValue|
-                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 19)
+                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 26)
                     }
                 else
-                    rowout([character[1][:game], character[1][:name], character[1][:prof], character[1][:bonus]], false, 19)
+                    rowout([character[1][:game], character[1][:name], character[1][:prof], character[1][:bonus]], false, 26)
                 end
             }
-            _respond "-" * 89
+            _respond "-" * 117
         else
             echo "No characters currently found."
         end
@@ -530,7 +534,9 @@ class Resource
         end
 
         gritSkills = Hash.new
-        
+        gritSkillHybrids = {"Katars" => ["Edged Weapons", "Brawling Weapons"],
+                            "Bastard Swords / Katanas" => ["Edged Weapons", "Two-Handed Weapons"]}
+
         res = Lich::Util.quiet_command_xml("skills full", /your current skill bonuses and ranks/, /Further information can be found in the/, 8)
         res.each{ |line|
             line = line.gsub('<pushBold/>', '').gsub('<popBold/>', '')
@@ -603,7 +609,10 @@ class Resource
                 harnesspower = $2.to_i
             end
         }
-        
+        gritSkillHybrids.each { |weapons, skills|
+            gritSkills[weapons] = skills.map { |s| gritSkills[s] }.sum / 2
+        }
+         
         res = Lich::Util.quiet_command_xml("info", /^Name: /)
         res.each { |line|
             line = line.gsub('<pushBold/>', '').gsub('<popBold/>', '')
@@ -760,7 +769,9 @@ class Resource
                 respond "+ Secondary Skills:"
                 respond "    Weapons (specific to weapon type being serviced):"
                 gritSkills.each { |title, weaponValue|
-                    sortedGritSkills = gritSkills.sort_by { |k,v| v }.reject { |k,v| k == title }
+                    sortedGritSkills = gritSkills.sort_by { |k,v| v }.reject { |k,v| k == title or
+                                                                                     gritSkillHybrids.has_key? k or
+                                                                                     gritSkillHybrids.fetch(title, []).include? k }
                     secondaryWeaponRanks = sortedGritSkills.pop(2).reduce(0) { |sum, skillArray| sum += skillArray[1] }
                     respond "      #{(secondaryWeaponRanks / 2).to_s.rjust(3)} : #{title}"
                 }
@@ -772,7 +783,9 @@ class Resource
             respond "      #{gritCommonBase + ((armoruse > (level + 1) ? (level + 1)*2 + (armoruse - (level + 1)) : armoruse * 2)) + (shielduse / 3)} : Armor" if show_chart
             grit_bonuses = [(gritCommonBase + ((armoruse > (level + 1) ? (level + 1)*2 + (armoruse - (level + 1)) : armoruse * 2)) + (shielduse / 3))]
             gritSkills.each { |title, weaponValue|
-                sortedGritSkills = gritSkills.sort_by { |k,v| v }.reject { |k,v| k == title }
+                sortedGritSkills = gritSkills.sort_by { |k,v| v }.reject { |k,v| k == title or
+                                                                                 gritSkillHybrids.has_key? k or
+                                                                                 gritSkillHybrids.fetch(title, []).include? k }
                 secondaryWeaponRanks = sortedGritSkills.pop(2).reduce(0) { |sum, skillArray| sum += skillArray[1] }
                 respond "      #{gritCommonBase + ((weaponValue > (level + 1) ? (level + 1)*2 + (weaponValue - (level + 1)) : weaponValue * 2)) + (secondaryWeaponRanks / 2)} : #{title}" if show_chart
                 grit_bonuses.push(gritCommonBase + ((weaponValue > (level + 1) ? (level + 1)*2 + (weaponValue - (level + 1)) : weaponValue * 2)) + (secondaryWeaponRanks / 2))

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -63,9 +63,6 @@
 
 silence_me
 
-require 'yaml'
-require 'terminal-table'
-
 LICH_GEM_REQUIRES = '5.4.0'
 
 if Gem::Version.new(LICH_VERSION) < Gem::Version.new(LICH_GEM_REQUIRES)
@@ -88,6 +85,9 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(LICH_GEM_REQUIRES)
    end
    exit
 end
+
+require 'yaml'
+require 'terminal-table'
 
 class Resource
     COST_ESSENCE = ["0", "312", "625", "937", "1250", "1562", "1875", "2187", "2500", "2812", "3125", "3437", "3750", "4062", "4375", "4687", "5000", "5312", "5625", "5937", "6250", "6562", "6875", "7187", "7500", "15000", "22500", "30000", "37500", "45000", "52500", "60000", "67500", "75000", "82500", "90000", "97500", "105000", "112500", "120000", "127500", "135000", "142500", "150000", "157500", "165000", "172500", "180000", "187500", "195000"]

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -64,6 +64,7 @@
 silence_me
 
 require 'yaml'
+require 'terminal-table'
 
 LICH_GEM_REQUIRES = '5.4.0'
 
@@ -260,24 +261,36 @@ class Resource
         all_bonuses = Resource.load_bonuses
         unless all_bonuses.nil?
             all_bonuses = all_bonuses.sort
-            _respond "-" * 117
-            headers = ['Game', 'Character', 'Profession', 'Bonus']
-            rowout(headers, true, 26)
-            _respond "-" * 117
+            
+            headers = %i[Game Character Profession Bonus]
+            table_rows = []
+                              
             all_bonuses.each { |character|
                 if character[1][:prof] == "Warrior"
                     character[1][:bonus].each { |title, bonusValue|
-                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 26)
+                        table_rows.push([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"])
                     }
                 elsif character[1][:prof] == "Monk"
                     character[1][:bonus].each { |title, bonusValue|
-                        rowout([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"], false, 26)
+                        table_rows.push([character[1][:game], character[1][:name], character[1][:prof], "#{bonusValue} #{title}"])
                     }
                 else
-                    rowout([character[1][:game], character[1][:name], character[1][:prof], character[1][:bonus]], false, 26)
+                    table_rows.push([character[1][:game], character[1][:name], character[1][:prof], character[1][:bonus]])
                 end
             }
-            _respond "-" * 117
+            
+            table = Terminal::Table.new(
+                headings: headers,
+                rows: table_rows
+            )
+            table = table.to_s
+            if table =~ /\n\|([\w\s\|]+)\|\n/
+              header = $1
+              headerbold = Lich::Messaging.monsterbold(header)
+              table = table.gsub(header, headerbold)
+            end
+            _respond "<output class=\"mono\"/>\n" + table + "\n<output class=\"\"/>"
+            
         else
             echo "No characters currently found."
         end
@@ -428,10 +441,10 @@ class Resource
         _respond "Calculating essence needed to take an item from #{starting_bonus} to #{ending_bonus}"
         _respond ""
 
-        _respond "-" * PAD
+                          
         headers = ['Current', 'New', 'Cost (ess)', 'Cost (wks)', 'Total (ess)', 'Total (wks)']
-        rowout(headers, true)
-        _respond "-" * PAD
+        table_rows = []
+                          
 
         current_bonus = starting_bonus
         running_total_ess = 0
@@ -448,24 +461,44 @@ class Resource
                               (step_cost / WEEKLY_RESOURCE).round(2), 
                               running_total_ess, 
                               (running_total_ess / WEEKLY_RESOURCE).round(2)]
-            rowout(response_array)
+            table_rows.push(response_array)
             current_bonus += 1
         end
-        _respond "-" * PAD
-        _respond ""
-        _respond "-" * 96
+        table = Terminal::Table.new(
+            headings: headers,
+            rows: table_rows
+        )
+        table = table.to_s
+        if table =~ /\n\|([\w\d\s\|\$\/\(\)]+)\|\n/
+          header = $1
+          headerbold = Lich::Messaging.monsterbold(header)
+          table = table.gsub(header, headerbold)
+        end
+        _respond "<output class=\"mono\"/>\n" + table + "\n<output class=\"\"/>"
+        respond ""
+        
         headers = ['Cost per Essence', 'Old Cost per Ess', 'Total Cost', '$4/1m Silver', '$5/1m Silver']
-        rowout(headers, true, 16)
-        _respond "-" * 96
+        table_rows = []
+                         
         if variable[4]
-            rowout(calc_rate_row(tears_rate, running_total_ess), false, 16)
+            table_rows.push(calc_rate_row(tears_rate, running_total_ess))
         else
             (4..10).to_a.each { |rate_multi|
                 rate = 16 * rate_multi
-                rowout(calc_rate_row(rate, running_total_ess), false, 16)
+                table_rows.push(calc_rate_row(rate, running_total_ess))
             }
         end
-        _respond "-" * 96
+        table = Terminal::Table.new(
+            headings: headers,
+            rows: table_rows
+        )
+        table = table.to_s
+        if table =~ /\n\|([\w\d\s\|\$\/\(\)]+)\|\n/
+          header = $1
+          headerbold = Lich::Messaging.monsterbold(header)
+          table = table.gsub(header, headerbold)
+        end
+        _respond "<output class=\"mono\"/>\n" + table + "\n<output class=\"\"/>"
     end
     
     def self.chart


### PR DESCRIPTION
adds explicit numbers for grit for hybrid weapon types by defining the hybrid (katar, bastard sword / katana) and the associated weapon types that make up it's skill (have to make sure to skip the "hybrid" skill as a secondary number for all weapons, and define ignore the hybrid's own sub-skills so they don't get counted twice. hence the more complex reject logic)