### PR TITLE
[bigshot.lic] cmd_spell waitrt? missing

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.11.1
+       version: 4.11.2
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -18,6 +18,9 @@
   Version Control:
     Major_change.feature_addition.bugfix
   
+  v4.11.2 (2022-04-29)
+    Added a waitrt? to cmd_spell routine.
+
   v4.11.1 (2022-04-23)
     Fixed bug with cast_signs() assuming bards are always singing.
     Cleaned up RoaterEscape(), it will now open containers to look for dagger type weapon.
@@ -222,7 +225,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.11.1'
+BIGSHOT_VERSION = '4.11.2'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -1618,6 +1621,7 @@ class Bigshot
       $rest_reason = "out of mana"
     end
 
+    waitrt?
     waitcastrt?
 
     if incant.nil?


### PR DESCRIPTION
Issue with cmd_spell failing due to hard RT as no waitrt? in the command.