### PR TITLE
[eforgery.lic] variables not defined in class

### DIFF
--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -382,7 +382,7 @@ class << forger
     }
   }
 
-  oil_trough = {
+  Oil_Trough = {
     "water" => "some water",
     "tempering oil" => "some oil",
     "enchanted oil" => "some iridescent oil",
@@ -390,7 +390,7 @@ class << forger
     "ensorcelled oil" => "some dimly glowing oil"
   }
 
-  material_oil = {
+  Material_Oil = {
     "bronze" => "water",
     "iron" => "water",
     "steel" => "tempering oil",
@@ -415,7 +415,7 @@ class << forger
     "golvern" => "ensorcelled oil"
   }
 
-  oil_order = {
+  Oil_Order = {
     "tempering oil" => 5,
     "enchanted oil" => 6,
     "twice-enchanted oil" => 7,
@@ -692,7 +692,7 @@ class << forger
     fput "wear forging" if checkright =~ /forging-hammer/ && !(checkleft and checkright).nil?
     multimove "go door", "out"
     if @oil_container
-      buy(oil_order[material_oil[@material_name]])
+      buy(Oil_Order[Material_Oil[@material_name]])
       you_put("oil", @oil_container)
       rent
       move "go door"
@@ -705,9 +705,9 @@ class << forger
   def oil
     waitrt?
     fput "wear forging" if checkright =~ /forging-hammer/ && !(checkleft and checkright).nil?
-    oil = material_oil[@material_name]
+    oil = Material_Oil[@material_name]
     res = dothistimeout "look in trough", 10, /In the trough/
-    unless res =~ /#{oil_trough[oil]}/    #ie.. unless you already have the oil you need in the trough
+    unless res =~ /#{Oil_Trough[oil]}/    #ie.. unless you already have the oil you need in the trough
       if res =~ /oil|water/
         fput "pull plug"
         if @oil_container and (checkright =~ /oil/ or checkleft =~ /oil/)

--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -18,11 +18,13 @@
  Contributors: Moredin, Tillek, Gnomad, Tysong
      Category: Artisan
          Tags: forging, forge, craft, artisan, perfect
-      Version: 1.0.2
+      Version: 1.0.3
 
   Version Control:
     Major_change.feature_addition.bugfix
 
+  v1.0.3 (2022-05-03)
+    Bugfix for variables outside of class.
   v1.0.2 (2022-05-02)
     Bugfix for regex match
   v1.0.1 (2022-04-29)
@@ -93,46 +95,6 @@ if Settings.to_hash.size > 0  and CharSettings.to_hash.size == 0
     CharSettings[setting] = value
   end
 end
-
-oil_trough = {
-  "water" => "some water",
-  "tempering oil" => "some oil",
-  "enchanted oil" => "some iridescent oil",
-  "twice-enchanted oil" => "some opalescent oil",
-  "ensorcelled oil" => "some dimly glowing oil"
-}
-
-material_oil = {
-  "bronze" => "water",
-  "iron" => "water",
-  "steel" => "tempering oil",
-  "invar" => "tempering oil",
-  "faenor" => "enchanted oil",
-  "mithril" =>  "enchanted oil",
-  "ora" => "enchanted oil",
-  "drakar" => "enchanted oil",
-  "gornar" => "enchanted oil",
-  "rhimar" => "enchanted oil",
-  "zorchar" => "enchanted oil",
-  "kelyn" => "enchanted oil",
-  "imflass" => "twice-enchanted oil",
-  "razern" => "twice-enchanted oil",
-  "eahnor" => "ensorcelled oil",
-  "mithglin" => "ensorcelled oil",
-  "vaalorn" => "ensorcelled oil",
-  "vultite" => "ensorcelled oil",
-  "rolaren" => "ensorcelled oil",
-  "veil iron" => "ensorcelled oil",
-  "eonake" => "ensorcelled oil",
-  "golvern" => "ensorcelled oil"
-}
-
-oil_order = {
-  "tempering oil" => 5,
-  "enchanted oil" => 6,
-  "twice-enchanted oil" => 7,
-  "ensorcelled oil" => 8
-}
 
 CharSettings.load
 before_dying { CharSettings.save }
@@ -418,6 +380,46 @@ class << forger
       'town'    =>  3519,
       'wastebin'  => 'bin'
     }
+  }
+
+  oil_trough = {
+    "water" => "some water",
+    "tempering oil" => "some oil",
+    "enchanted oil" => "some iridescent oil",
+    "twice-enchanted oil" => "some opalescent oil",
+    "ensorcelled oil" => "some dimly glowing oil"
+  }
+
+  material_oil = {
+    "bronze" => "water",
+    "iron" => "water",
+    "steel" => "tempering oil",
+    "invar" => "tempering oil",
+    "faenor" => "enchanted oil",
+    "mithril" =>  "enchanted oil",
+    "ora" => "enchanted oil",
+    "drakar" => "enchanted oil",
+    "gornar" => "enchanted oil",
+    "rhimar" => "enchanted oil",
+    "zorchar" => "enchanted oil",
+    "kelyn" => "enchanted oil",
+    "imflass" => "twice-enchanted oil",
+    "razern" => "twice-enchanted oil",
+    "eahnor" => "ensorcelled oil",
+    "mithglin" => "ensorcelled oil",
+    "vaalorn" => "ensorcelled oil",
+    "vultite" => "ensorcelled oil",
+    "rolaren" => "ensorcelled oil",
+    "veil iron" => "ensorcelled oil",
+    "eonake" => "ensorcelled oil",
+    "golvern" => "ensorcelled oil"
+  }
+
+  oil_order = {
+    "tempering oil" => 5,
+    "enchanted oil" => 6,
+    "twice-enchanted oil" => 7,
+    "ensorcelled oil" => 8
   }
 
   def find_wastebin


### PR DESCRIPTION
Moved `oil_trough`, `material_oil`, and `oil_order` to be inside the `forger` class as only used inside of it and was causing not found issues.