### PR TITLE
[go2.lic] v1.35 exit if not enough silvers

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -1165,14 +1165,14 @@ loop {
                   fput "withdraw #{needed_silvers - Lich::Util.silver_count} silvers"
                end
                if Lich::Util.silver_count < needed_silvers
-                  echo 'You are too poor to make this trip.'
-                  echo 'Not enough silver in current area\'s bank.'
+                  echo "You are too poor to make this trip."
+                  echo "Not enough silver in current area's bank."
                   exit
                end
             else
-               echo 'You are too poor to make this trip.'
-               echo 'To give go2 permission to take your monies, type ;go2 getsilvers=on'
-               echo 'Continuing anyway in 10 seconds...'
+               echo "You are too poor to make this trip."
+               echo "To give go2 permission to take your monies, type ;go2 getsilvers=on"
+               echo "Continuing anyway in 10 seconds..."
                sleep 10
             end
          end

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.34
+           version: 1.35
           required: Lich >= 5.4.2
 
    changelog:
+      1.35 (2022-05-12):
+        exit if get-silvers fails to get enough silver from bank.
       1.34 (2022-03-31):
         For DR: add support for yaml-based map stringproc overrides
       1.33 (2022-03-31):
@@ -1161,6 +1163,11 @@ loop {
                   fput "ask banker for #{[(needed_silvers - Lich::Util.silver_count), 20].max} silvers"
                else
                   fput "withdraw #{needed_silvers - Lich::Util.silver_count} silvers"
+               end
+               if Lich::Util.silver_count < needed_silvers
+                  echo 'You are too poor to make this trip.'
+                  echo 'Not enough silver in current area\'s bank.'
+                  exit
                end
             else
                echo 'You are too poor to make this trip.'


### PR DESCRIPTION
Fix for using go2 with getsilvers enabled and not having enough at bank. Will exit with an echo statement stating such. Addresses #673