### PR TITLE
[gameobj] ensure that all of the Sanctum gems are also gemshop sellable

### DIFF
--- a/spec/gameobj-data/gem_spec.rb
+++ b/spec/gameobj-data/gem_spec.rb
@@ -520,9 +520,20 @@ describe GameObj do
 
     describe "Sanctum of Scales" do
       [
-        %[oblong blue goldstone],
+        %[age-darkened ivory crescent],
+        %[blackish blue idocrase],
+        %[cloudy alexandrite shard],
         %[dull grey crystal],
+        %[faceted blood red sandruby],
+        %[formation of rainbowed bismuth],
+        %[oblong blue goldstone],
+        %[piece of striated fluorite],
         %[pink salt crystal],
+        %[radiant green cinderstone],
+        %[square of shale rock],
+        %[swirled lightning glass shard],
+        %[variegated violet tanzanite],
+        %[twisted iron spiral],
       ].each do |gem|
         it "recognizes #{gem} as a gem" do
           expect(GameObjFactory.item_from_name(gem).type).to eq "gem"

--- a/type_data/migrations/7_sos.rb
+++ b/type_data/migrations/7_sos.rb
@@ -15,6 +15,21 @@ migrate :gem, :gemshop do
   insert(:name, %[oblong blue goldstone])
   insert(:name, %[dull grey crystal])
   insert(:name, %[pink salt crystal])
+  insert(:name, %[twisted iron spiral])
+end
+
+migrate :gemshop do
+  insert(:name, %[age-darkened ivory crescent])
+  insert(:name, %[blackish blue idocrase])
+  insert(:name, %[cloudy alexandrite shard])
+  insert(:name, %[faceted blood red sandruby])
+  insert(:name, %[fossilized bessho lizard spur])
+  insert(:name, %[formation of rainbowed bismuth])
+  insert(:name, %[piece of striated fluorite])
+  insert(:name, %[radiant green cinderstone])
+  insert(:name, %[square of shale rock])
+  insert(:name, %[swirled lightning glass shard])
+  insert(:name, %[variegated violet tanzanite])
 end
 
 migrate :skin, :furrier do


### PR DESCRIPTION
Some of these were recognized as gems but didn't have sellable values.

 - age-darkened ivory crescent
 - blackish blue idocrase
 - cloudy alexandrite shard
 - faceted blood red sandruby
 - fossilized bessho lizard spur
 - formation of rainbowed bismuth
 - piece of striated fluorite
 - radiant green cinderstone
 - square of shale rock
 - swirled lightning glass shard
 - variegated violet tanzanite

Also `twisted iron spiral` wasn't recognize as a gem at all, so I updated the migration to include that as well.