### PR TITLE
[eloot.lic] uncommon disk proper fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -13,9 +13,12 @@
       contributers: SpiffyJr, Athias, Demandred, Tysong, Deysh
               game: Gemstone
               tags: loot
-           version: 1.4.0
+           version: 1.4.1
   Improvements:
   
+  v1.4.1 (2022-06-15)
+    - bug fix for disks
+
   v1.4.0 (2022-06-10)
     - added support for shroud and glamour
     - added check in valid loot routine to exclude disks
@@ -222,7 +225,7 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(LICH_GEM_REQUIRES) || Gem::
    exit
 end
 
-ELoot_version = '1.4.0'
+ELoot_version = '1.4.1'
 ELootUI_version = '1.1.4'
 
 elootUI_VERSION = nil
@@ -2105,7 +2108,7 @@ module ELoot
         obj.name =~ /\bsevered\b/i ||
         obj.id.to_i.negative? ||
         (obj.type =~ /weapon|armor/i && obj.type !~ /uncommon/i) ||
-        obj.name =~ /#{Char.name} (?:disk|coffin)$/ ||
+        obj.noun =~ /^(?:disk|coffin)$/ ||
         ELoot.data.settings[:crumbly].index(obj.name) > -1          
       end
     end
@@ -2114,7 +2117,6 @@ module ELoot
       if !ELoot.data.settings[:loot_types].nil?
         objs.reject do |obj|
           obj.type !~ Regexp.union(ELoot.data.settings[:loot_types]) ||
-            obj.name =~ /#{Char.name} (?:disk|coffin)$/ ||
             (ELoot.data.settings[:loot_exclude].length.positive? &&
              obj.name =~ Regexp.union(ELoot.data.settings[:loot_exclude]))
         end


### PR DESCRIPTION
Remove change from self.valid_objs(objs) and corrected proper spot in self.reject_invalid_loot(objs) call.