### PR TITLE
[bigshot.lic] Update dead man's switch to only work in GSF

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.12.2
+       version: 4.12.3
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.12.3 (2022-07-01)
+    Add check to deadman's switch to only work in Shattered.
 
   v4.12.2 (2022-06-08)
     Add checks for Divergence cooldown spells for hunting tab abilities/spells/cmans
@@ -250,7 +252,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.12.2'
+BIGSHOT_VERSION = '4.12.3'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -2969,7 +2971,7 @@ class Bigshot
 
   def dead_man_switch()
     echo "dead_man_switch" if $bigshot_debug
-    if @DEAD_MAN_SWITCH
+    if @DEAD_MAN_SWITCH && XMLData.game =~ /GSF/
       Thread.new {
         while (running?($current_script_name))
           if (dead? || percenthealth < 40)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4690,7 +4690,7 @@ class Bigshot
 
     Gtk.queue do
       # General
-      add_checkbox(@OP_TABLE1,  0, "Engage deadmans switch", 'dead_man_switch')
+      add_checkbox(@OP_TABLE1,  0, "Engage deadmans switch (Shattered Only)", 'dead_man_switch')
       add_checkbox(@OP_TABLE1,  1, "Flee from clouds", 'flee_clouds')
       add_checkbox(@OP_TABLE1,  0, "Depart/rerun if dead", 'depart_switch')
       add_checkbox(@OP_TABLE1,  1, "Flee from vines", 'flee_vines')


### PR DESCRIPTION
Since it is considered slamming to log out in an attempt to prevent your death. Would hate for someone to get banned from something they are unaware of.