### PR TITLE
[ebestiary] adds ebestiary

### DIFF
--- a/scripts/ebestiary.lic
+++ b/scripts/ebestiary.lic
@@ -1,0 +1,163 @@
+#   Tries to parse the "creatures by level page" on the wiki to mimic the old
+#   behavior from ;beastiary
+#
+#   for usage info:
+#     ;ebestiary help
+#
+#     author: elanthia-online
+#     game: Gemstone
+#     tags: info, play.net, wiki, bestiary, monsters, critters, help, bestiary, elanthia-online
+#     version: 1.0
+#
+#   changelog:
+#     1.0 - initial release as ebestiary (formerly wikibeast)
+
+require 'net/https'
+require 'terminal-table'
+require 'uri'
+require 'rexml/document'
+
+class EBestiary
+  include REXML
+
+  def initialize(args, charsettings)
+    @base_url = 'https://gswiki.play.net/List_of_creatures_by_level'
+    @disarm_url = 'https://gswiki.play.net/List_of_creatures_that_can_cause_item_loss'
+    @script_name = 'ebestiary'
+    @args = args
+    @charsettings = charsettings
+    # bug fix for old version
+    @charsettings['creatures_by_level'] ||= Hash.new
+    @output = Terminal::Table.new headings: ['Level', 'Creature', 'Types', 'Wiki Link']
+    parse_args
+  end
+
+  def get_page(url)
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    req = Net::HTTP::Get.new(uri.request_uri)
+    begin
+      resp = http.request(req)
+      http_code = "HTTP: #{resp.code}"
+    rescue StandardError
+      http_code = 'DNS or connection error'
+    end
+    echo "Error retrieving #{uri} (#{http_code})" unless resp.is_a? Net::HTTPSuccess
+    [http_code, resp.body]
+  end
+
+  def get_level_from_main(tab, level)
+    url_root = 'https://gswiki.play.net'
+    lvl_list = XPath.first(tab, "//td/b/a[@title=\"Category:Level #{level} Creatures\"]").parent.parent
+    lvl_list = XPath.match(lvl_list, './/li/a')
+    @charsettings['creatures_by_level'][level] = []
+    lvl_list.each do |m|
+      @charsettings['creatures_by_level'][level].push({ "name": m.text.capitalize, "link": "#{url_root}#{m['href']}" })
+    end
+  end
+
+  def pretty_print_level(lvl, type_filter = nil)
+    add_sep = false
+    @charsettings['creatures_by_level'][lvl].each do |mob|
+      add_sep = true
+      fake_mobj = fake_obj(mob[:name])
+      types = get_types(fake_mobj)
+      unless (type_filter == '') || types =~ (/#{type_filter}/) || (types == 'UNKNOWN') || mob[:name] =~ (/#{type_filter}/i)
+        next
+      end
+
+      @output.add_row [lvl, mob[:name], types, mob[:link]]
+    end
+    @output.add_separator if add_sep && (@output.to_s.split("\n").last =~ /\d/)
+  end
+
+  # makes a fake creature game obj to check type
+  def fake_obj(creature)
+    fakeobj = GameObj.new(666_999, creature.split(' ').last, creature.downcase)
+    fakeobj = GameObj.new(666_999, creature.split(' ').last, creature) if fakeobj.type.nil?
+    fakeobj
+  end
+
+  def get_types(fakeobj)
+    types = fakeobj.type
+    types = 'UNKNOWN' if types.nil? || types.empty?
+    types = types.split(',')
+    types.reject! { |t| t == 'aggressive npc' }
+    types.join(',')
+  end
+
+  def search_mobs
+    _respond "Loading local cache of creature list from wiki (last updated: #{@charsettings['updated_at']})"
+    levels = @args[0].scan(/(\d+)/)
+    type_filter = @args[0].scan(/([a-z-']+)/i).join('|')
+    if !levels.nil? && !levels.empty?
+      if levels.length > 2
+        echo 'Too many things that look like levels in your arguments'
+        exit
+      elsif levels.length == 2
+        lvl_range = [levels[0][0].to_i, levels[1][0].to_i].sort
+        lvl_range = (lvl_range[0]..lvl_range[1])
+      else
+        lvl_range = [levels[0][0].to_i]
+      end
+    elsif levels.nil? || levels.empty?
+      lvl_range = ((Char.level.to_i - 5)..(Char.level.to_i + 5)).to_a
+    end
+
+    lvl_range.each do |lvl|
+      if lvl.nil?
+        echo 'Error parsing given level range'
+        exit
+      end
+      next if lvl < 1
+
+      pretty_print_level(lvl, type_filter)
+    end
+    _respond @output
+  end
+
+  def refresh_cache
+    _respond "Updating local cache of creature list from wiki (last updated: #{@charsettings['updated_at']})..."
+    http_code, resp = get_page(@base_url)
+    @charsettings['page_cache'] = resp
+    @charsettings['updated_at'] = Time.now
+    @page = Document.new(resp)
+    @creature_table = XPath.first(@page, '//table')
+    max_level = resp.scan(/Category:Level ([0-9]+) Creatures/).flatten.map(&:to_i).max
+    echo 'Building cache by level...'
+    (1..max_level).each do |l|
+      echo "level #{l}" if l.modulo(10).zero? || l == max_level
+      get_level_from_main(@creature_table, l)
+    end
+    echo 'Done!'
+  end
+
+  def parse_args
+    if @args.include? 'help'
+      _respond 'usage:'
+      _respond "    ;#{@script_name} refresh                              - refresh local cache of the 'creatures by level' page"
+      _respond '                                                      this happens automatically if you have not run this script previously'
+      respond "    ;#{@script_name} <start level> <end level (optional)> - show creatures between start and end level"
+      _respond '                                                      if end level is omitted, only shows creatures of <start level>'
+      _respond "    ;#{@script_name}                                      - show creatures that are +/-5 from your current level"
+      _respond ''
+      _respond ' any other non-numeric argument will filter results that have that as a name or creature type'
+      _respond " i.e. ;#{@script_name} 20 undead             - show level 20 undead"
+      _respond "      ;#{@script_name} 5 10 orc              - show orcs between levels 5 and 10"
+      _respond '      note: any mob with an UNKNOWN type will always be displayed'
+      _respond '            these mobs are not being parsed correctly from the gameobj-data file'
+      exit
+    elsif @args.any? { |ar| ar =~ /refresh|reload/ }
+      refresh_cache
+      exit
+    elsif !@charsettings['updated_at'] || ((Time.now.to_i - @charsettings['updated_at'].to_i) > 2_592_000)
+      respond "Automatically refreshing the creature cache. This happens on first run and once every 30 days thereafter."
+      refresh_cache
+    end
+  end
+end
+
+eb = EBestiary.new(script.vars, CharSettings.to_hash)
+eb.search_mobs


### PR DESCRIPTION
- on initial run pulls down the Creatures By Level page from the wiki in order to build a list of creatures and their level
- this then happens only once manually invoked, or once every 30 days to ensure new creatures are brought in
- can then list creatures by a level range, filtering by a search term that mathces on creature TYPE (as defined by gameobj-data) or name
- creatures with no valid type will display as UNKNOWN and always come back in a search (likely needs fix in gameobj-data)
- default is to level by +/- 5 of your current level if no level arguments passed