### PR TITLE
[bigshot.lic] added tailwind command check

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.12.3
+       version: 4.12.4
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,11 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.13.1 (2022-07-01)
+	Add command check for tailwind.
+	Fixed briar command with briar weapon in off hand of twc.
+	Fixed bigshot quick standing around waiting for mana.
+
   v4.12.3 (2022-07-01)
     Add check to deadman's switch to only work in Shattered.
 
@@ -252,7 +257,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.12.3'
+BIGSHOT_VERSION = '4.12.4'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -969,7 +974,7 @@ class Bigshot
 	
     # check mana/stamina/health(percentage)/encumbrance/unarmed tiering/mobs in room/target not prone/target undead
     # ! means the inverse/opposite effect
-    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice).*?)\)$/i)
+    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice|tailwind|!tailwind).*?)\)$/i)
       command = $1
       commandcheckreturn = false
       $2.split(" ").each { |s|
@@ -1025,7 +1030,7 @@ class Bigshot
 			  commandcheckreturn = true if !( Effects::Buffs.time_left("Tangleweed Vigor") <= ($2.to_f / 60.to_f) )
 			end
           end
-         elsif s =~ /((?:prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice))/i
+         elsif s =~ /((?:prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice|tailwind|!tailwind))/i
           if ($1 == 'prone')
             commandcheckreturn = true if npc.status =~ PRONE
           elsif ($1 == '!prone')
@@ -1063,7 +1068,7 @@ class Bigshot
           elsif ($1 == '!outside')
             commandcheckreturn = true if outside?
         #Check for buffs to perform actions. May have delay due to the way updates are sent but should only be noticed on fast paced buffs like arcane reflex.
-	  elsif ($1 == 'barrage')
+		  elsif ($1 == 'barrage')
 		    commandcheckreturn = true if !Effects::Buffs.active?("Enh. Dexterity (+10)")
 		  elsif ($1 == '!barrage')
 		    commandcheckreturn = true if Effects::Buffs.active?("Enh. Dexterity (+10)")
@@ -1087,6 +1092,10 @@ class Bigshot
 		    commandcheckreturn = true if !Effects::Buffs.active?("Forceful Blows")
 		  elsif ($1 == '!thrash')
 		    commandcheckreturn = true if Effects::Buffs.active?("Forceful Blows")
+		  elsif ($1 == 'tailwind')
+		    commandcheckreturn = true if !Effects::Buffs.active?("Breeze Archery Tailwind")
+		  elsif ($1 == '!tailwind')
+		    commandcheckreturn = true if Effects::Buffs.active?("Breeze Archery Tailwind")
 		  elsif ($1 == 'reflex')
 			commandcheckreturn = true if !$bigshot_arcane_reflex
 		  elsif ($1 == '!reflex')
@@ -1554,7 +1563,7 @@ class Bigshot
   def cmd_briar(weapon)
     echo "cmd_briar" if $bigshot_debug
     return if (weapon.nil? || $bigshot_briars)
-    return if (weapon != (GameObj.right_hand.to_s || GameObj.left_hand.to_s))
+    return if (weapon != GameObj.right_hand.to_s && weapon != GameObj.left_hand.to_s)
     ready = false
     silence_me unless undo_silence = silence_me
     res = Lich::Util.quiet_command_xml("look #{weapon}", /You gaze intently|You see/, /<prompt time=/)
@@ -1650,7 +1659,7 @@ class Bigshot
       $bigshot_should_rest = true
       $rest_reason = "out of mana"
     end
-
+	return if !Spell[id].affordable? && $bigshot_quick
     waitrt?
     waitcastrt?
 
@@ -2015,7 +2024,7 @@ class Bigshot
 	return if !Weapon.available?("Barrage")
     waitrt?
     waitcastrt?
-    result = dothistimeout("weapon barrage ##{npc.id}", 10, /Upon firing|Distracted|last arrow|Your satisfying display|awkward proposition|little bit late|still stunned|too injured|You cannot|Could not find|seconds|what?/i)
+    result = dothistimeout("weapon barrage ##{npc.id}", 10, /Upon firing|Distracted|last arrow|Your satisfying display|awkward proposition|little bit late|still stunned|too injured|You cannot|Could not find|seconds|what?|You don't seem to be able to move your legs to do that/i)
 	if (result =~ /You cannot fire/)
 	  unless GameObj.right_hand.id.nil?
 	    line = dothistimeout "stow ##{GameObj.right_hand.id}", 3, /put|closed/
@@ -4215,6 +4224,7 @@ class Bigshot
 
         break if single_cast
       end
+	  sleep(0.2)		 
     end
   end
 


### PR DESCRIPTION
fixed briar <weapon> to work when briar weapon in off hand of twc.
bigshot quick will not skip spells when out of mana instead of standing aroud waiting.