### PR TITLE
[bigshot.lic] fixed shield bash for semi's (typo free this time)

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.12.4
+       version: 4.12.5
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,10 +17,16 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
-  v4.13.1 (2022-07-01)
-	Add command check for tailwind.
-	Fixed briar command with briar weapon in off hand of twc.
-	Fixed bigshot quick standing around waiting for mana.
+  v4.12.5 (2022-07-21)
+    Fixed shield bash to work for both shield and cman skills.
+    1040 now has a checkbox to auto shout if you or group member could benefit.
+    Will no longer pull kneeling people to their feet.
+    Will no longer attempt to pull the dead to their feet.
+	
+  v4.12.4 (2022-07-01)
+    Add command check for tailwind.
+    Fixed briar command with briar weapon in off hand of twc.
+    Fixed bigshot quick standing around waiting for mana.
 
   v4.12.3 (2022-07-01)
     Add check to deadman's switch to only work in Shattered.
@@ -56,12 +62,12 @@
   v4.11.1 (2022-04-23)
     Fixed bug with cast_signs() assuming bards are always singing.
     Cleaned up RoaterEscape(), it will now open containers to look for dagger type weapon.
-	Roater's and Rift Crawlers are pretty much identical in this aspect. No changes needed to work for both.
+    Roater's and Rift Crawlers are pretty much identical in this aspect. No changes needed to work for both.
     Added waitrt? to command checks to prevent check from clearing while in rt from previous move.
     
   v4.11.0 (2022-04-15)
     Adjusted hide to specify number of attempts to try and hide if failing: hide 2   
-	Added Swift Justice tracking command check: (justice) (!justice) to use skill when swift justice has charges or has no charges.
+    Added Swift Justice tracking command check: (justice) (!justice) to use skill when swift justice has charges or has no charges.
 	
   v4.10.1 (2022-04-04)
     Update consecrate to not return from hunt if blessing a sanctified weapon
@@ -257,7 +263,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.12.4'
+BIGSHOT_VERSION = '4.12.5'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -633,7 +639,7 @@ class Bigshot
     :event_stack, :followers, :BLESS, :AIM, :TIER3, :QUIET_FOLLOWERS,
     :MSTRIKE_COOLDOWN, :MSTRIKE_STAMINA_COOLDOWN, :MSTRIKE_MOB,
     :MSTRIKE_QUICKSTRIKE, :MSTRIKE_STAMINA_QUICKSTRIKE,
-    :UAC_MSTRIKE, :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY,
+    :UAC_MSTRIKE, :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY, :TROUBADOURS_RALLY,
     :QUICKHUNT_TARGETS, :UAC_SMITE, :FOG_RETURN, :FOG_OPTIONAL, :LOOT_STANCE,
     :DELAY_LOOT, :PULL, :OVERKILL, :LTE_BOOST, :HELP_GROUP_KILL, :WEAPON_REACTION, :DEADER
 
@@ -862,6 +868,7 @@ class Bigshot
     set_value('fog_optional',                 '',          false)
     set_value('loot_stance',                  '',          false)
     set_value('delay_loot',                   '',          false)
+    set_value('troubadours_rally',			  '',		   false)
     set_value('pull',                         '',          true)
     set_value('deader',                         '',        true)
     set_value('overkill',                     'to_i',      0)
@@ -938,7 +945,19 @@ class Bigshot
 
   def cmd(command, npc = nil, stance_dance = true)
     echo "cmd #{command}" if $bigshot_debug
-    GameObj.pcs.each { |s| if s.status =~ /kneeling|sitting|^lying|prone/; fput "pull #{s.noun}"; end; } if GameObj.targets.any? { |s| s.type =~ /aggressive npc/ } && @PULL
+    GameObj.pcs.each { |s| if s.status =~ /sitting|^lying|prone/ && s.status !~ /dead/; fput "pull #{s.noun}"; end; } if GameObj.targets.any? { |s| s.type =~ /aggressive npc/ } && @PULL
+    
+    if @TROUBADOURS_RALLY && Spell[1040].known?
+      if Char.status =~ /webbed|sleeping|stunned|frozen|immobilized|held in place|horrified|staggered/i
+        cmd_1040(Char.name)
+      end
+      GameObj.pcs.each { |s|
+	if s.status =~ /webbed|sleeping|stunned|frozen|immobilized|held in place|horrified|staggered/i && $grouplist.include?(s.noun)
+	  cmd_1040(s.noun)
+	  break
+	end
+      }
+    end
     
     if GameObj.pcs.any? { |s| s.status =~ /dead/ } && @DEADER
       puts "#{monsterbold_start} Found a deader! #{monsterbold_end}"
@@ -1357,8 +1376,6 @@ class Bigshot
       unarmed($1, npc, $2)
     elsif (command =~ /^smite/i)
       volnsmite(npc)
-    elsif (command =~ /^1040/i)
-      cmd_1040()
     elsif (command =~ /^stomp/i)
       cmd_stomp()
     elsif (command =~ /^leech/i)
@@ -1385,7 +1402,6 @@ class Bigshot
       if res =~ /^What were you referring to\?$/i
         break
       end
-
       sleep(1)
     end
   end
@@ -1574,6 +1590,7 @@ class Bigshot
     silence_me if undo_silence
     fput "raise #{weapon}" if ready == true
   end
+  
   def cmd_throw(npc)
     echo "cmd_throw" if $bigshot_debug
     unless npc.status == 'lying down'
@@ -1838,25 +1855,34 @@ class Bigshot
     end
   end
 
-  def cmd_1040()
-	echo "cmd_1040" if $bigshot_debug
-	return if !Spell[1040].known?
-	waitrt?
-	waitcastrt?
-	fput "shout 1040" if Spell[1040].affordable?
+  def cmd_1040(target)
+    echo "cmd_1040 #{target}" if $bigshot_debug
+    CharSettings['last_rally'] = (Time.now - 5) if CharSettings['last_rally'].nil?
+    return if !Spell[1040].known?
+    return if (Time.now < CharSettings['last_rally'])
+    waitrt?
+    waitcastrt?
+    if !Spell[1040].affordable?
+      fput "mana pulse"
+      waitcastrt?
+    end
+    if Spell[1040].affordable?
+      Spell[1040].cast
+      CharSettings['last_rally'] = (Time.now + 5)
+    end
   end
-
+  
   def cmd_dhurl()
     echo "cmd_dhurl" if $bigshot_debug
     waitrt?
     waitcastrt?
     res = dothistimeout "hurl", 1, Regexp.union(
-        /^Roundtime/,
-        /^What were you referring to\?$/,
-        /^You throw/,
-		/^You take aim and throw/,
-        /That's not going to do much.  Try using a weapon/,
-        /You find nothing recoverable/
+      /^Roundtime/,
+      /^What were you referring to\?$/,
+      /^You throw/,
+      /^You take aim and throw/,
+      /That's not going to do much.  Try using a weapon/,
+      /You find nothing recoverable/
     )
     if res =~ /You take aim and throw|You throw/
       weapon_hurled_room = Room.current.id
@@ -1876,7 +1902,7 @@ class Bigshot
   def cmd_recover(weapon_lost = true)
     echo "cmd_recover" if $bigshot_debug
     until weapon_lost == false
-	  break if $bigshot_bond_return = true
+      break if $bigshot_bond_return = true
       waitrt?
       res = dothistimeout "recover hurl", 1, Regexp.union(
         /You know (.*) is around here somewhere, but you don't see it./,
@@ -1956,925 +1982,928 @@ class Bigshot
   end
 
   def cmd_pindown(npc)
-	echo "cmd_pindown" if $bigshot_debug
-	return if !Weapon.available?("Pin Down")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon pindown ##{npc.id}", 2, /take quick assessment and raise your|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|You can't|Could not find|seconds/i)
+    echo "cmd_pindown" if $bigshot_debug
+    return if !Weapon.available?("Pin Down")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon pindown ##{npc.id}", 2, /take quick assessment and raise your|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|You can't|Could not find|seconds/i)
     if (result == false)
- 	  $bigshot_should_rest = true
+      $bigshot_should_rest = true
       $rest_reason = "Unknown result from pindown routine: #{result}"
-	elsif (result =~ /but it has no effect/)
+    elsif (result =~ /but it has no effect/)
       $bigshot_should_rest = true
       $rest_reason = "Ammo had no effect (need blessed or magical)"
-	end
+    end
   end
 
   def cmd_cripple(npc)
-	echo "cmd_cripple" if $bigshot_debug
-	return if !Weapon.available?("Cripple")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon cripple ##{npc.id}", 2, /You reverse your grip|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from cripple routine: #{result}"
-	end  
+    echo "cmd_cripple" if $bigshot_debug
+    return if !Weapon.available?("Cripple")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon cripple ##{npc.id}", 2, /You reverse your grip|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from cripple routine: #{result}"
+    end  
   end
 
   def cmd_charge(npc)
-	echo "cmd_charge" if $bigshot_debug
-	return if !Weapon.available?("Charge")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon charge ##{npc.id}", 2, /attempt a charge|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from charge routine: #{result}"
-	end  
+    echo "cmd_charge" if $bigshot_debug
+    return if !Weapon.available?("Charge")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon charge ##{npc.id}", 2, /attempt a charge|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from charge routine: #{result}"
+    end  
   end
 
   def cmd_twinhammer(npc)
-	echo "cmd_twinhammer" if $bigshot_debug
-	return if !Weapon.available?("Twin Hammerfists")
-	return if npc.status =~ PRONE
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon twinhammer ##{npc.id}", 2, /raise your hands high|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You (cannot|can't)|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from twinhammer routine: #{result}"
-	end
+    echo "cmd_twinhammer" if $bigshot_debug
+    return if !Weapon.available?("Twin Hammerfists")
+    return if npc.status =~ PRONE
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon twinhammer ##{npc.id}", 2, /raise your hands high|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You (cannot|can't)|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from twinhammer routine: #{result}"
+    end
   end
 
   def cmd_dizzyingswing(npc)
-	echo "cmd_dizzyingswing" if $bigshot_debug
-	return if !Weapon.available?("Dizzying Swing")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon dizzyingswing ##{npc.id}", 2, /lash out in a strike|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from dizzyingswing routine: #{result}"
-	end  
+    echo "cmd_dizzyingswing" if $bigshot_debug
+    return if !Weapon.available?("Dizzying Swing")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon dizzyingswing ##{npc.id}", 2, /lash out in a strike|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from dizzyingswing routine: #{result}"
+    end  
   end
 
   def cmd_barrage(npc)
     echo "cmd_barrage" if $bigshot_debug
-	return if !Weapon.available?("Barrage")
+    return if !Weapon.available?("Barrage")
     waitrt?
     waitcastrt?
     result = dothistimeout("weapon barrage ##{npc.id}", 10, /Upon firing|Distracted|last arrow|Your satisfying display|awkward proposition|little bit late|still stunned|too injured|You cannot|Could not find|seconds|what?|You don't seem to be able to move your legs to do that/i)
-	if (result =~ /You cannot fire/)
-	  unless GameObj.right_hand.id.nil?
-	    line = dothistimeout "stow ##{GameObj.right_hand.id}", 3, /put|closed/
-        if line =~ /closed/
-          container = GameObj.inv.find { |obj| obj.name =~ /#{@AMMO_CONTAINER}/ } #Probably need to change this?
-          fput "open my ##{container.id}"
-          fput "put ##{GameObj.right_hand.id} in my ##{container.id}"
-        end
-	  end
-	elsif (result =~ /but it has no effect/)
+    if (result =~ /You cannot fire/)
+      unless GameObj.right_hand.id.nil?
+        line = dothistimeout "stow ##{GameObj.right_hand.id}", 3, /put|closed/
+	if line =~ /closed/
+	  container = GameObj.inv.find { |obj| obj.name =~ /#{@AMMO_CONTAINER}/ } #Probably need to change this?
+	  fput "open my ##{container.id}"
+	  fput "put ##{GameObj.right_hand.id} in my ##{container.id}"
+	end
+      end
+    elsif (result =~ /but it has no effect/)
       $bigshot_should_rest = true
       $rest_reason = "Ammo had no effect (need blessed or magical)"
     elsif (result == false)
       $bigshot_should_rest = true
       $rest_reason = "Unknown result from barrage routine: #{result}"
     end
-	sleep(0.2)
+    sleep(0.2)
   end
 
   def cmd_flurry(npc)
-	echo "cmd_flurry" if $bigshot_debug
-	return if !Weapon.available?("Flurry")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon flurry ##{npc.id}", 10, /Distracted|inevitable end|ready position|You watch for openings|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from flurry routine: #{result}"
-	end
-	sleep(0.2)
+    echo "cmd_flurry" if $bigshot_debug
+    return if !Weapon.available?("Flurry")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon flurry ##{npc.id}", 10, /Distracted|inevitable end|ready position|You watch for openings|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from flurry routine: #{result}"
+    end
+    sleep(0.2)
   end
 
   def cmd_thrash(npc)
     echo "cmd_thrash" if $bigshot_debug
-	return if !Weapon.available?("Thrash")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon thrash ##{npc.id}", 10, /Distracted|inevitable end|ready position|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from thrash routine: #{result}"
-	end
-	sleep(0.2)
+    return if !Weapon.available?("Thrash")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon thrash ##{npc.id}", 10, /Distracted|inevitable end|ready position|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from thrash routine: #{result}"
+    end
+    sleep(0.2)
   end
 
   def cmd_pummel(npc)
     echo "cmd_pummel" if $bigshot_debug
-	return if !Weapon.available?("Pummel")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon pummel ##{npc.id}", 10, /Distracted|your assault complete|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from pummel routine: #{result}"
-	end
-	sleep(0.2)
+    return if !Weapon.available?("Pummel")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon pummel ##{npc.id}", 10, /Distracted|your assault complete|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from pummel routine: #{result}"
+    end
+    sleep(0.2)
   end
 
   def cmd_fury(npc)
     echo "cmd_fury" if $bigshot_debug
-	return if !Weapon.available?("Fury")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon fury ##{npc.id}", 10, /Distracted|recentering yourself|Your furious assault|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from fury routine: #{result}"
-	end
-	sleep(0.2)
+    return if !Weapon.available?("Fury")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon fury ##{npc.id}", 10, /Distracted|recentering yourself|Your furious assault|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from fury routine: #{result}"
+    end
+    sleep(0.2)
   end
 
   def cmd_gthrusts(npc)
     echo "cmd_gthrusts" if $bigshot_debug
-	return if !Weapon.available?("Guardant Thrusts")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon gthrusts ##{npc.id}", 10, /Distracted|inevitable end|complete your assault|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from gthrusts routine: #{result}"
-	end
-	sleep(0.2)
+    return if !Weapon.available?("Guardant Thrusts")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon gthrusts ##{npc.id}", 10, /Distracted|inevitable end|complete your assault|awkward proposition|little bit late|still stunned|too injured|what?|already dead|little bit late|could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from gthrusts routine: #{result}"
+    end
+    sleep(0.2)
   end
 
   def cmd_clash(npc)
-	echo "cmd_clash" if $bigshot_debug
-	return if !Weapon.available?("Clash")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon clash ##{npc.id}", 2, /you plunge into the fray|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from clash routine: #{result}"
-	end
+    echo "cmd_clash" if $bigshot_debug
+    return if !Weapon.available?("Clash")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon clash ##{npc.id}", 2, /you plunge into the fray|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from clash routine: #{result}"
+    end
   end
 
   def cmd_volley(npc)
-	echo "cmd_volley" if $bigshot_debug
-	return if !Weapon.available?("Volley")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon volley ##{npc.id}", 2, /filling the sky with a volley of deadly projectiles|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-  	  $bigshot_should_rest = true
+    echo "cmd_volley" if $bigshot_debug
+    return if !Weapon.available?("Volley")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon volley ##{npc.id}", 2, /filling the sky with a volley of deadly projectiles|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
       $rest_reason = "Unknown result from volley routine: #{result}"
-	elsif (result =~ /but it has no effect/)
+    elsif (result =~ /but it has no effect/)
       $bigshot_should_rest = true
       $rest_reason = "Ammo had no effect (need blessed or magical)"
-	end
+    end
   end
 
   def cmd_pulverize(npc)
-	echo "cmd_pulverize" if $bigshot_debug
-	return if !Weapon.available?("Pulverize")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon pulverize ##{npc.id}", 2, /pulverize your foes|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from pulverize routine: #{result}"
-	end
+    echo "cmd_pulverize" if $bigshot_debug
+    return if !Weapon.available?("Pulverize")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon pulverize ##{npc.id}", 2, /pulverize your foes|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from pulverize routine: #{result}"
+    end
   end
 
   def cmd_cyclone(npc)
-	echo "cmd_cyclone" if $bigshot_debug
-	return if !Weapon.available?("Cyclone")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("weapon cyclone ##{npc.id}", 2, /a blurred cyclone|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from cyclone routine: #{result}"
-	end
+    echo "cmd_cyclone" if $bigshot_debug
+    return if !Weapon.available?("Cyclone")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("weapon cyclone ##{npc.id}", 2, /a blurred cyclone|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from cyclone routine: #{result}"
+    end
   end
 
   def cmd_whirlwind(npc)
-	echo "cmd_whirlwind" if $bigshot_debug
-	return if !Weapon.available?("Whirlwind")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon whirlwind ##{npc.id}", 2, /Twisting and spinning|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from whirlwind routine: #{result}"
-	end
+    echo "cmd_whirlwind" if $bigshot_debug
+    return if !Weapon.available?("Whirlwind")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon whirlwind ##{npc.id}", 2, /Twisting and spinning|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from whirlwind routine: #{result}"
+    end
   end
 
   def cmd_wblade(npc)
-	echo "cmd_wblade" if $bigshot_debug
-	return if !Weapon.available?("Whirling Blade")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("weapon wblade ##{npc.id}", 2, /With a broad flourish|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from wblade routine: #{result}"
-	end
+    echo "cmd_wblade" if $bigshot_debug
+    return if !Weapon.available?("Whirling Blade")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("weapon wblade ##{npc.id}", 2, /With a broad flourish|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from wblade routine: #{result}"
+    end
   end
 
   def cmd_shieldthrow(npc)
-	echo "cmd_shieldthrow" if $bigshot_debug
-	return if !Shield.available?("Shield Throw")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield throw ##{npc.id}", 2, /You snap your arm|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shieldthrow routine: #{result}"
-	end    
+    echo "cmd_shieldthrow" if $bigshot_debug
+    return if !Shield.available?("Shield Throw")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("shield throw ##{npc.id}", 2, /You snap your arm|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shieldthrow routine: #{result}"
+    end    
   end
 
-  def cmd_shieldbash(npc)
-	echo "cmd_shieldbash" if $bigshot_debug
-	return if !Shield.available?("Shield Bash")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield bash ##{npc.id}", 2, /attempt a shield bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield bash routine: #{result}"
-	end  
+   def cmd_shieldbash(npc)
+     echo "cmd_shieldbash" if $bigshot_debug
+       if Shield.known?("Shield Bash")
+       return if !Shield.available?("Shield Bash")
+       waitrt?
+       waitcastrt?
+       result = dothistimeout("shield bash ##{npc.id}", 2, /attempt a shield bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+       if (result == false)
+         $bigshot_should_rest = true
+         $rest_reason = "Unknown result from shield bash routine: #{result}"
+       end 
+     elsif CMan.known?("Shield Bash")
+       return if !CMan.available?("Shield Bash")
+       waitrt?
+       waitcastrt?
+       result = dothistimeout("cman sbash ##{npc.id}", 2, /attempt a shield bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+       if (result == false)
+         $bigshot_should_rest = true
+	 $rest_reason = "Unknown result from shield bash routine: #{result}"
+       end
+     end
   end
 
   def cmd_shieldcharge(npc)
-	echo "cmd_shieldcharge" if $bigshot_debug
-	return if !Shield.available?("Shield Charge")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("shield charge ##{npc.id}", 2, /attempt a shield charge|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield charge routine: #{result}"
-	end  
+    echo "cmd_shieldcharge" if $bigshot_debug
+    return if !Shield.available?("Shield Charge")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("shield charge ##{npc.id}", 2, /attempt a shield charge|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shield charge routine: #{result}"
+    end  
   end
 
   def cmd_shieldstrike(npc)
-	echo "cmd_shieldstrike" if $bigshot_debug
-	return if !Shield.available?("Shield Strike")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield strike ##{npc.id}", 2, /launch a quick bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield strike routine: #{result}"
-	end  
+    echo "cmd_shieldstrike" if $bigshot_debug
+    return if !Shield.available?("Shield Strike")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("shield strike ##{npc.id}", 2, /launch a quick bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shield strike routine: #{result}"
+    end  
   end
 
   def cmd_shieldpin(npc)
-	echo "cmd_shieldpin" if $bigshot_debug
-	return if !Shield.available?("Shield Pin")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield pin ##{npc.id}", 2, /diversionary shield bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield pin routine: #{result}"
-	end  
+    echo "cmd_shieldpin" if $bigshot_debug
+    return if !Shield.available?("Shield Pin")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("shield pin ##{npc.id}", 2, /diversionary shield bash|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shield pin routine: #{result}"
+    end  
   end
 
   def cmd_shieldtrample(npc)
-	echo "cmd_shieldtrample" if $bigshot_debug
-	return if !Shield.available?("Shield Trample")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield trample ##{npc.id}", 2, /charge headlong towards|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield trample routine: #{result}"
-	end  
+    echo "cmd_shieldtrample" if $bigshot_debug
+    return if !Shield.available?("Shield Trample")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("shield trample ##{npc.id}", 2, /charge headlong towards|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shield trample routine: #{result}"
+    end  
   end
 
   def cmd_shieldpush(npc)
-	echo "cmd_shieldpush" if $bigshot_debug
-	return if !Shield.available?("Shield Push")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("shield push ##{npc.id}", 2, /attempt to push|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shield push routine: #{result}"
-	end  
+    echo "cmd_shieldpush" if $bigshot_debug
+    return if !Shield.available?("Shield Push")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("shield push ##{npc.id}", 2, /attempt to push|awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shield push routine: #{result}"
+    end  
   end
 
   def cmd_shout()
-	echo "cmd_shout" if $bigshot_debug
-	return if ((checkstamina < 21) || Effects::Debuffs.active?("Overexerted"))
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("warcry shout", 2, /You let loose an echoing shout!|Your fighting spirit is bolstered!|round(time)?|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shout routine: #{result}"
-	end
-	sleep(0.5)
+    echo "cmd_shout" if $bigshot_debug
+    return if ((checkstamina < 21) || Effects::Debuffs.active?("Overexerted"))
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("warcry shout", 2, /You let loose an echoing shout!|Your fighting spirit is bolstered!|round(time)?|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shout routine: #{result}"
+    end
+    sleep(0.5)
   end
 
   def cmd_yowlp()
-	echo "cmd_yowlp" if $bigshot_debug
-	return if ((checkstamina < 11) || Effects::Debuffs.active?("Overexerted"))
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("warcry yowlp", 2, /You throw back your shoulders and let out a resounding yowlp!|Your fighting spirit is emboldened!|round(time)?|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from yowlp routine: #{result}"
-	end  
+    echo "cmd_yowlp" if $bigshot_debug
+    return if ((checkstamina < 11) || Effects::Debuffs.active?("Overexerted"))
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("warcry yowlp", 2, /You throw back your shoulders and let out a resounding yowlp!|Your fighting spirit is emboldened!|round(time)?|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from yowlp routine: #{result}"
+    end  
   end
 
   def cmd_holler()
-	echo "cmd_holler" if $bigshot_debug
-	return if ((checkstamina < 31) || Effects::Debuffs.active?("Overexerted"))
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("warcry holler", 2, /You throw back your head and let out a thundering holler!|You throw back your head and holler your war cry!|Your fighting spirit is bolstered to heroic proportions!|round(time)?|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from holler routine: #{result}"
-	end  
+    echo "cmd_holler" if $bigshot_debug
+    return if ((checkstamina < 31) || Effects::Debuffs.active?("Overexerted"))
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("warcry holler", 2, /You throw back your head and let out a thundering holler!|You throw back your head and holler your war cry!|Your fighting spirit is bolstered to heroic proportions!|round(time)?|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from holler routine: #{result}"
+    end  
   end
 
   def cmd_bellow(target,npc)
-	echo "cmd_bellow" if $bigshot_debug
-	return if Effects::Debuffs.active?("Overexerted")
-	waitrt?
-	waitcastrt?
+    echo "cmd_bellow" if $bigshot_debug
+    return if Effects::Debuffs.active?("Overexerted")
+    waitrt?
+    waitcastrt?
     if (target == 'all') && (checkstamina > 21)
-	  result = dothistimeout("warcry bellow all",2, /nerve-shattering bellow!|round(time)?|seconds/i)
-	  if (result == false)
-	    $bigshot_should_rest = true
-	    $rest_reason = "Unknown result from bellow routine: #{result}"
-	  end  
-	elsif (checkstamina > 11)
-	  result = dothistimeout("warcry bellow ##{npc.id}", 2, /nerve-shattering bellow!|round(time)?|seconds/i)
-	  if (result == false)
-	    $bigshot_should_rest = true
-	    $rest_reason = "Unknown result from bellow routine: #{result}"
-	  end  
-	end
+      result = dothistimeout("warcry bellow all",2, /nerve-shattering bellow!|round(time)?|seconds/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from bellow routine: #{result}"
+      end
+    elsif (checkstamina > 11)
+      result = dothistimeout("warcry bellow ##{npc.id}", 2, /nerve-shattering bellow!|round(time)?|seconds/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from bellow routine: #{result}"
+      end
+    end
   end
 
   def cmd_growl(target,npc)
-	echo "cmd_growl" if $bigshot_debug
-	return if Effects::Debuffs.active?("Overexerted")
-	waitrt?
-	waitcastrt?
-	if (target == 'all') && (checkstamina > 15)
+    echo "cmd_growl" if $bigshot_debug
+    return if Effects::Debuffs.active?("Overexerted")
+    waitrt?
+    waitcastrt?
+    if (target == 'all') && (checkstamina > 15)
       result = dothistimeout("warcry growl all",2, /nerve-shattering bellow!|round(time)?|seconds/i)
-	  if (result == false)
-	    $bigshot_should_rest = true
-	    $rest_reason = "Unknown result from bellow routine: #{result}"
-	  end  
-	elsif (checkstamina > 8)
-	  result = dothistimeout("warcry growl ##{npc.id}", 2, /nerve-shattering bellow!|round(time)?|seconds/i)
-	  if (result == false)
-	    $bigshot_should_rest = true
-	    $rest_reason = "Unknown result from growl routine: #{result}"
-	  end  
-	end
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from bellow routine: #{result}"
+      end  
+    elsif (checkstamina > 8)
+      result = dothistimeout("warcry growl ##{npc.id}", 2, /nerve-shattering bellow!|round(time)?|seconds/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from growl routine: #{result}"
+      end
+    end
   end
 
   def cmd_cry(target,npc)
-	echo "cmd_cry" if $bigshot_debug
-	return if Effects::Debuffs.active?("Overexerted")
-	waitrt?
-	waitcastrt?
-	if (target == 'all') && (checkstamina > 31)
-	    result = dothistimeout("warcry cry all",2, /eerie, modulating cry|round(time)?|seconds/i)
-	    if (result == false)
-	      $bigshot_should_rest = true
-	      $rest_reason = "Unknown result from bellow routine: #{result}"
-	    end  
-	elsif (checkstamina > 16)
-	    result = dothistimeout("warcry cry ##{npc.id}", 2, /eerie, modulating cry|round(time)?|seconds/i)
-	    if (result == false)
-	      $bigshot_should_rest = true
-	      $rest_reason = "Unknown result from cry routine: #{result}"
-	    end  
-	end
+    echo "cmd_cry" if $bigshot_debug
+    return if Effects::Debuffs.active?("Overexerted")
+    waitrt?
+    waitcastrt?
+    if (target == 'all') && (checkstamina > 31)
+      result = dothistimeout("warcry cry all",2, /eerie, modulating cry|round(time)?|seconds/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from bellow routine: #{result}"
+      end
+    elsif (checkstamina > 16)
+      result = dothistimeout("warcry cry ##{npc.id}", 2, /eerie, modulating cry|round(time)?|seconds/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from cry routine: #{result}"
+      end
+    end
   end
 
   def cmd_bearhug(npc)
-	echo "cmd_bearhug" if $bigshot_debug
-	return if !CMan.available?("Bearhug") # "Enh. Strength (+10)"
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman bearhug ##{npc.id}", 9, /release your grip|feat of strength empowers|avoids your grasp|fend off your grasp|leaving you flailing|awkward proposition|completely miss|unable to complete|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from bearhug routine: #{result}"
-	end 
+    echo "cmd_bearhug" if $bigshot_debug
+    return if !CMan.available?("Bearhug") # "Enh. Strength (+10)"
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman bearhug ##{npc.id}", 9, /release your grip|feat of strength empowers|avoids your grasp|fend off your grasp|leaving you flailing|awkward proposition|completely miss|unable to complete|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from bearhug routine: #{result}"
+    end 
   end
 
   def cmd_bullrush(npc)
-	echo "cmd_bullrush" if $bigshot_debug
-	return if !CMan.available?("Bull Rush")
-	return if npc.status =~ PRONE
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman bullrush ##{npc.id}", 2, /dip your shoulder and rush|You can't reach|little bit late|awkward proposition|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from bullrush routine: #{result}"
-	end 
+    echo "cmd_bullrush" if $bigshot_debug
+    return if !CMan.available?("Bull Rush")
+    return if npc.status =~ PRONE
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman bullrush ##{npc.id}", 2, /dip your shoulder and rush|You can't reach|little bit late|awkward proposition|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from bullrush routine: #{result}"
+    end 
   end
 
   def cmd_coupdegrace(npc)
-	echo "cmd_coupdegrace" if $bigshot_debug
-	return if !CMan.available?("Coup de Grace") # "Enh. Strength (+10)"
-	waitrt?
-	waitcastrt?
+    echo "cmd_coupdegrace" if $bigshot_debug
+    return if !CMan.available?("Coup de Grace") # "Enh. Strength (+10)"
+    waitrt?
+    waitcastrt?
 #need success messaging and maybe more failure messaging.
-	result = dothistimeout("cman coupdegrace ##{npc.id}", 2, /intending to finish|isn't injured enough|thwarts your attempt|awkward proposition|unable to complete|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from coupdegrace routine: #{result}"
-	end 
+    result = dothistimeout("cman coupdegrace ##{npc.id}", 2, /intending to finish|isn't injured enough|thwarts your attempt|awkward proposition|unable to complete|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from coupdegrace routine: #{result}"
+    end 
   end
 
   def cmd_cpress(npc)
-	echo "cmd_cpress" if $bigshot_debug
-	return if !CMan.available?("Crowd Press")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman cpress ##{npc.id}", 2, /You approach|You maneuver in close|try to maneuver|can't manage to do that right now|awkward proposition|rooted in place|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from cpress routine: #{result}"
-	end 
+    echo "cmd_cpress" if $bigshot_debug
+    return if !CMan.available?("Crowd Press")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman cpress ##{npc.id}", 2, /You approach|You maneuver in close|try to maneuver|can't manage to do that right now|awkward proposition|rooted in place|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from cpress routine: #{result}"
+    end 
   end
 
   def cmd_dirtkick(npc)
-	echo "cmd_dirtkick" if $bigshot_debug
-	return if !CMan.available?("Dirtkick")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman dirtkick ##{npc.id}", 2, /foot and let it fly|clump of dust|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from dirtkick routine: #{result}"
-	end 
+    echo "cmd_dirtkick" if $bigshot_debug
+    return if !CMan.available?("Dirtkick")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman dirtkick ##{npc.id}", 2, /foot and let it fly|clump of dust|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from dirtkick routine: #{result}"
+    end 
   end
 
   def cmd_dislodge(npc)
-	echo "cmd_dislodge" if $bigshot_debug
-	return if !CMan.available?("Dislodge")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman dislodge ##{npc.id}", 2, /attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from dislodge routine: #{result}"
-	end 
+    echo "cmd_dislodge" if $bigshot_debug
+    return if !CMan.available?("Dislodge")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman dislodge ##{npc.id}", 2, /attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from dislodge routine: #{result}"
+    end 
   end
   
   def cmd_exsanguinate(npc)
-	echo "cmd_exsanguinate" if $bigshot_debug
-	return if !CMan.available?("Exsanguinate")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman exsanguinate ##{npc.id}", 2, /blur of steel in your eagerness|slows to a trickle and finally stops|is not bleeding|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from exsanguinate routine: #{result}"
-	end 
+    echo "cmd_exsanguinate" if $bigshot_debug
+    return if !CMan.available?("Exsanguinate")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman exsanguinate ##{npc.id}", 2, /blur of steel in your eagerness|slows to a trickle and finally stops|is not bleeding|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from exsanguinate routine: #{result}"
+    end 
   end
 
   def cmd_feint(npc)
-	echo "cmd_feint" if $bigshot_debug
-	return if !CMan.available?("Feint")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman feint ##{npc.id}", 2, /You feint|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from feint routine: #{result}"
-	end 
+    echo "cmd_feint" if $bigshot_debug
+    return if !CMan.available?("Feint")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman feint ##{npc.id}", 2, /You feint|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from feint routine: #{result}"
+    end 
   end
 
   def cmd_gkick(npc)
-	echo "cmd_gkick" if $bigshot_debug
-	return if !CMan.available?("Groin Kick")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman gkick ##{npc.id}", 2, /deliver a kick|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from gkick routine: #{result}"
-	end 
+    echo "cmd_gkick" if $bigshot_debug
+    return if !CMan.available?("Groin Kick")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman gkick ##{npc.id}", 2, /deliver a kick|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from gkick routine: #{result}"
+    end 
   end
 
   def cmd_hamstring(npc)
-	echo "cmd_hamstring" if $bigshot_debug
-	return if !CMan.available?("Hamstring")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman hamstring ##{npc.id}", 2, /try to hamstring|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from hamstring routine: #{result}"
-	end 
+    echo "cmd_hamstring" if $bigshot_debug
+    return if !CMan.available?("Hamstring")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman hamstring ##{npc.id}", 2, /try to hamstring|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from hamstring routine: #{result}"
+    end 
   end
   
   def cmd_haymaker(npc)
-	echo "cmd_haymaker" if $bigshot_debug
-	return if !CMan.available?("Haymaker")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman haymaker ##{npc.id}", 2, /roundhouse punch|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from haymaker routine: #{result}"
-	end 
+    echo "cmd_haymaker" if $bigshot_debug
+    return if !CMan.available?("Haymaker")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman haymaker ##{npc.id}", 2, /roundhouse punch|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from haymaker routine: #{result}"
+    end 
   end
 
   def cmd_headbutt(npc)
-	echo "cmd_headbutt" if $bigshot_debug
-	return if !CMan.available?("Headbutt")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman headbutt ##{npc.id}", 2, /attempt to headbutt|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from headbutt routine: #{result}"
-	end 
+    echo "cmd_headbutt" if $bigshot_debug
+    return if !CMan.available?("Headbutt")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman headbutt ##{npc.id}", 2, /attempt to headbutt|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from headbutt routine: #{result}"
+    end 
   end
 
   def cmd_leapattack(npc)
-	echo "cmd_leapattack" if $bigshot_debug
-	return if !CMan.available?("Leap Attack")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman leapattack ##{npc.id}", 2, /leap into the air|low enough for you to attack|isn't flying|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from leapattack routine: #{result}"
-	end 
+    echo "cmd_leapattack" if $bigshot_debug
+    return if !CMan.available?("Leap Attack")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman leapattack ##{npc.id}", 2, /leap into the air|low enough for you to attack|isn't flying|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from leapattack routine: #{result}"
+    end 
   end
   
   def cmd_mblow(npc)
-	echo "cmd_mblow" if $bigshot_debug
-	return if !CMan.available?("Mighty Blow")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman mblow ##{npc.id}", 2, /with all your might|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from mblow routine: #{result}"
-	end 
+    echo "cmd_mblow" if $bigshot_debug
+    return if !CMan.available?("Mighty Blow")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman mblow ##{npc.id}", 2, /with all your might|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from mblow routine: #{result}"
+    end 
   end
   
   def cmd_sblow(npc)
-	echo "cmd_sblow" if $bigshot_debug
-	return if !CMan.available?("Staggering Blow")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman sblow ##{npc.id}", 2, /with staggering might|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sblow routine: #{result}"
-	end 
+    echo "cmd_sblow" if $bigshot_debug
+    return if !CMan.available?("Staggering Blow")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman sblow ##{npc.id}", 2, /with staggering might|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sblow routine: #{result}"
+    end 
   end
   
   def cmd_scleave(npc)
-	echo "cmd_scleave" if $bigshot_debug
-	return if !CMan.available?("Spell Cleave")
-	return if Effects::Cooldowns.active?("Spell Cleave")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman scleave ##{npc.id}", 2, /concentrate on the magical wards|anti-magical equipment|out of reach|You can't reach||little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from scleave routine: #{result}"
-	end 
+    echo "cmd_scleave" if $bigshot_debug
+    return if !CMan.available?("Spell Cleave")
+    return if Effects::Cooldowns.active?("Spell Cleave")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman scleave ##{npc.id}", 2, /concentrate on the magical wards|anti-magical equipment|out of reach|You can't reach||little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from scleave routine: #{result}"
+    end 
   end 
   
   def cmd_sattack(npc)
-	echo "cmd_sattack" if $bigshot_debug
-	return if !CMan.available?("Spin Attack")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman sattack ##{npc.id}", 2, /spinning leap towards|out of reach|You can't reach||little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sattack routine: #{result}"
-	end 
+    echo "cmd_sattack" if $bigshot_debug
+    return if !CMan.available?("Spin Attack")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman sattack ##{npc.id}", 2, /spinning leap towards|out of reach|You can't reach||little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sattack routine: #{result}"
+    end 
   end
 
   def cmd_sunder(npc)
-	echo "cmd_sunder" if $bigshot_debug
-	return if !CMan.available?("Sunder Shield")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman sunder ##{npc.id}", 2, /split it asunder|holding a shield|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sunder routine: #{result}"
-	end 
+    echo "cmd_sunder" if $bigshot_debug
+    return if !CMan.available?("Sunder Shield")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman sunder ##{npc.id}", 2, /split it asunder|holding a shield|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sunder routine: #{result}"
+    end 
   end
   
   def cmd_surge()
     echo "cmd_surge" if $bigshot_debug
-	return if !CMan.known?("Surge of Strength")
-	return if (Effects::Buffs.active?("Enh. Strength (+32)") || Effects::Buffs.active?("Enh. Strength (+28)") || Effects::Buffs.active?("Enh. Strength (+24)") || Effects::Buffs.active?("Enh. Strength (+20)") || Effects::Buffs.active?("Enh. Strength (+16)"))
-	waitrt?
-	waitcastrt?
-	if (checkstamina >= 30 && !Effects::Cooldowns.active?("Surge of Strength"))
-	  result = dothistimeout("cman surge", 1, /You feel a great deal stronger.|untapped sources of strength|still recent prior attempt|come from your muscles|ache much too badly/i)
-	  if (result == false)
-		$bigshot_should_rest = true
-		$rest_reason = "Unknown result from surge routine: #{result}"
-	  end
-	elsif (checkstamina >= 60 && Effects::Cooldowns.active?("Surge of Strength"))
-	  result = dothistimeout("cman surge", 1, /You feel a great deal stronger.|untapped sources of strength|still recent prior attempt|come from your muscles|ache much too badly/i)
-	  if (result == false)
-		$bigshot_should_rest = true
-		$rest_reason = "Unknown result from surge routine: #{result}"
-	  end
-	end
+    return if !CMan.known?("Surge of Strength")
+    return if (Effects::Buffs.active?("Enh. Strength (+32)") || Effects::Buffs.active?("Enh. Strength (+28)") || Effects::Buffs.active?("Enh. Strength (+24)") || Effects::Buffs.active?("Enh. Strength (+20)") || Effects::Buffs.active?("Enh. Strength (+16)"))
+    waitrt?
+    waitcastrt?
+    if (checkstamina >= 30 && !Effects::Cooldowns.active?("Surge of Strength"))
+      result = dothistimeout("cman surge", 1, /You feel a great deal stronger.|untapped sources of strength|still recent prior attempt|come from your muscles|ache much too badly/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from surge routine: #{result}"
+      end
+    elsif (checkstamina >= 60 && Effects::Cooldowns.active?("Surge of Strength"))
+      result = dothistimeout("cman surge", 1, /You feel a great deal stronger.|untapped sources of strength|still recent prior attempt|come from your muscles|ache much too badly/i)
+      if (result == false)
+        $bigshot_should_rest = true
+	$rest_reason = "Unknown result from surge routine: #{result}"
+      end
+    end
   end
   
   def cmd_tackle(npc)
-	echo "cmd_tackle" if $bigshot_debug
-	return if !CMan.available?("Tackle")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman tackle ##{npc.id}", 2, /You hurl yourself|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from tackle routine: #{result}"
-	end 
+    echo "cmd_tackle" if $bigshot_debug
+    return if !CMan.available?("Tackle")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman tackle ##{npc.id}", 2, /You hurl yourself|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from tackle routine: #{result}"
+    end 
   end
 
   def cmd_trip(npc)
-	echo "cmd_trip" if $bigshot_debug
-	return if !CMan.available?("Trip")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman trip ##{npc.id}", 2, /jerk the weapon sharply sideways|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from trip routine: #{result}"
-	end 
+    echo "cmd_trip" if $bigshot_debug
+    return if !CMan.available?("Trip")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman trip ##{npc.id}", 2, /jerk the weapon sharply sideways|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from trip routine: #{result}"
+    end 
   end
 
   def cmd_truestrike(npc)
-	echo "cmd_truestrike" if $bigshot_debug
-	return if !CMan.available?("True Strike")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman truestrike ##{npc.id}", 2, /will strike true|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from truestrike routine: #{result}"
-	end 
+    echo "cmd_truestrike" if $bigshot_debug
+    return if !CMan.available?("True Strike")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman truestrike ##{npc.id}", 2, /will strike true|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from truestrike routine: #{result}"
+    end 
   end
 
   def cmd_vaultkick(npc)
-	echo "cmd_vaultkick" if $bigshot_debug
-	return if !CMan.available?("Vault Kick")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman vaultkick ##{npc.id}", 2, /vaulting kick|is lying down|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from vaultkick routine: #{result}"
-	end 
+    echo "cmd_vaultkick" if $bigshot_debug
+    return if !CMan.available?("Vault Kick")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman vaultkick ##{npc.id}", 2, /vaulting kick|is lying down|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from vaultkick routine: #{result}"
+    end 
   end
 
   def cmd_cutthroat(npc)
-	echo "cmd_cutthroat" if $bigshot_debug
-	return if !CMan.available?("Cutthroat")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman cutthroat ##{npc.id}", 2, /attempt to slit|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from cutthroat routine: #{result}"
-	end 
+    echo "cmd_cutthroat" if $bigshot_debug
+    return if !CMan.available?("Cutthroat")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman cutthroat ##{npc.id}", 2, /attempt to slit|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from cutthroat routine: #{result}"
+    end 
   end
   
   def cmd_shroud(npc)
-	echo "cmd_shroud" if $bigshot_debug
-	return if !CMan.available?("Dust Shroud")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman shroud ##{npc.id}", 1, /kicking up as much dirt|you're already out of sight|awkward proposition|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from shroud routine: #{result}"
-	end 
+    echo "cmd_shroud" if $bigshot_debug
+    return if !CMan.available?("Dust Shroud")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman shroud ##{npc.id}", 1, /kicking up as much dirt|you're already out of sight|awkward proposition|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from shroud routine: #{result}"
+    end 
   end
   
   def cmd_divert(npc)
-	echo "cmd_divert" if $bigshot_debug
-	return if !CMan.available?("Divert")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman divert ##{npc.id}", 2, /Try hiding first|prepare your diversion|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from divert routine: #{result}"
-	end 
+    echo "cmd_divert" if $bigshot_debug
+    return if !CMan.available?("Divert")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman divert ##{npc.id}", 2, /Try hiding first|prepare your diversion|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from divert routine: #{result}"
+    end 
   end
 
   def cmd_eviscerate(npc)
-	echo "cmd_eviscerate" if $bigshot_debug
-	return if !CMan.available?("Eviscerate")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman eviscerate ##{npc.id}", 2, /poised to eviscerate|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from eviscerate routine: #{result}"
-	end 
+    echo "cmd_eviscerate" if $bigshot_debug
+    return if !CMan.available?("Eviscerate")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman eviscerate ##{npc.id}", 2, /poised to eviscerate|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from eviscerate routine: #{result}"
+    end 
   end
   
   def cmd_eyepoke(npc)
-	echo "cmd_eyepoke" if $bigshot_debug
-	return if !CMan.available?("Eyepoke")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman eyepoke ##{npc.id}", 2, /finger at the eye|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from eyepoke routine: #{result}"
-	end 
+    echo "cmd_eyepoke" if $bigshot_debug
+    return if !CMan.available?("Eyepoke")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman eyepoke ##{npc.id}", 2, /finger at the eye|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from eyepoke routine: #{result}"
+    end 
   end
   
   def cmd_footstomp(npc)
-	echo "cmd_footstomp" if $bigshot_debug
-	return if !CMan.available?("Footstomp")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman footstomp ##{npc.id}", 2, /attempting to footstomp|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from footstomp routine: #{result}"
-	end 
+    echo "cmd_footstomp" if $bigshot_debug
+    return if !CMan.available?("Footstomp")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman footstomp ##{npc.id}", 2, /attempting to footstomp|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from footstomp routine: #{result}"
+    end 
   end
 
   def cmd_garrote(npc)
-	echo "cmd_garrote" if $bigshot_debug
-	return if !CMan.available?("Garrote")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman garrote ##{npc.id}", 2, /fling your wire around|damage to yourself|other hand clear|holding a garrote|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from garrote routine: #{result}"
-	end 
+    echo "cmd_garrote" if $bigshot_debug
+    return if !CMan.available?("Garrote")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman garrote ##{npc.id}", 2, /fling your wire around|damage to yourself|other hand clear|holding a garrote|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from garrote routine: #{result}"
+    end 
   end
 
   def cmd_kneebash(npc)
-	echo "cmd_kneebash" if $bigshot_debug
-	return if !CMan.available?("Kneebash")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman kneebash ##{npc.id}", 2, /down at the knee|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from kneebash routine: #{result}"
-	end 
+    echo "cmd_kneebash" if $bigshot_debug
+    return if !CMan.available?("Kneebash")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman kneebash ##{npc.id}", 2, /down at the knee|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from kneebash routine: #{result}"
+    end 
   end
   
   def cmd_mug(npc)
-	echo "cmd_mug" if $bigshot_debug
-	return if !CMan.available?("Mug")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman mug ##{npc.id}", 2, /boldly accost|won't fall for that again|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from mug routine: #{result}"
-	end 
+    echo "cmd_mug" if $bigshot_debug
+    return if !CMan.available?("Mug")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman mug ##{npc.id}", 2, /boldly accost|won't fall for that again|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from mug routine: #{result}"
+    end 
   end
 
   def cmd_nosetweak(npc)
-	echo "cmd_nosetweak" if $bigshot_debug
-	return if !CMan.available?("Nosetweak")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman nosetweak ##{npc.id}", 2, /reach out and grab|stand up first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from nosetweak routine: #{result}"
-	end 
+    echo "cmd_nosetweak" if $bigshot_debug
+    return if !CMan.available?("Nosetweak")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman nosetweak ##{npc.id}", 2, /reach out and grab|stand up first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from nosetweak routine: #{result}"
+    end 
   end
 
   def cmd_sbash(npc)
-	echo "cmd_shieldbash" if $bigshot_debug
-	return if !CMan.available?("Shield Bash")
-	waitrt?
-	waitcastrt?	
-	result = dothistimeout("cman sbash ##{npc.id}", 2, /attempt a shield bash|awkward proposition|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sbash routine: #{result}"
-	end  
+    echo "cmd_shieldbash" if $bigshot_debug
+    return if !CMan.available?("Shield Bash")
+    waitrt?
+    waitcastrt?	
+    result = dothistimeout("cman sbash ##{npc.id}", 2, /attempt a shield bash|awkward proposition|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sbash routine: #{result}"
+    end  
   end
   
   def cmd_subdue(npc)
-	echo "cmd_subdue" if $bigshot_debug
-	return if !CMan.available?("Subdue")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman subdue ##{npc.id}", 2, /spring from hiding|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from subdue routine: #{result}"
-	end 
+    echo "cmd_subdue" if $bigshot_debug
+    return if !CMan.available?("Subdue")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman subdue ##{npc.id}", 2, /spring from hiding|Try hiding first|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from subdue routine: #{result}"
+    end 
   end
   
   def cmd_sthieve(npc)
-	echo "cmd_sthieve" if $bigshot_debug
-	return if !CMan.available?("Spell Thieve")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman sthieve ##{npc.id}", 2, /concentrate on the magic|anti-magical equipment|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sthieve routine: #{result}"
-	end 
+    echo "cmd_sthieve" if $bigshot_debug
+    return if !CMan.available?("Spell Thieve")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman sthieve ##{npc.id}", 2, /concentrate on the magic|anti-magical equipment|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sthieve routine: #{result}"
+    end 
   end
 
   def cmd_spunch(npc)
-	echo "cmd_spunch" if $bigshot_debug
-	return if !CMan.available?("Sucker Punch")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman spunch ##{npc.id}", 2, /You swing|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from spunch routine: #{result}"
-	end 
+    echo "cmd_spunch" if $bigshot_debug
+    return if !CMan.available?("Sucker Punch")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman spunch ##{npc.id}", 2, /You swing|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from spunch routine: #{result}"
+    end 
   end
   
   def cmd_sweep(npc)
-	echo "cmd_sweep" if $bigshot_debug
-	return if !CMan.available?("Sweep")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman sweep ##{npc.id}", 2, /crouch and sweep|out of reach|awkward proposition|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from sweep routine: #{result}"
-	end 
+    echo "cmd_sweep" if $bigshot_debug
+    return if !CMan.available?("Sweep")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman sweep ##{npc.id}", 2, /crouch and sweep|out of reach|awkward proposition|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from sweep routine: #{result}"
+    end 
   end
 
   def cmd_swiftkick(npc)
-	echo "cmd_swiftkick" if $bigshot_debug
-	return if !CMan.available?("Swiftkick")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman swiftkick ##{npc.id}", 2, /attempting a swiftkick|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from swiftkick routine: #{result}"
-	end 
+    echo "cmd_swiftkick" if $bigshot_debug
+    return if !CMan.available?("Swiftkick")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman swiftkick ##{npc.id}", 2, /attempting a swiftkick|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from swiftkick routine: #{result}"
+    end 
   end
 
   def cmd_templeshot(npc)
-	echo "cmd_templeshot" if $bigshot_debug
-	return if !CMan.available?("Templeshot")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman templeshot ##{npc.id}", 2, /swing the blunt end|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from templeshot routine: #{result}"
-	end 
+    echo "cmd_templeshot" if $bigshot_debug
+    return if !CMan.available?("Templeshot")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman templeshot ##{npc.id}", 2, /swing the blunt end|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from templeshot routine: #{result}"
+    end 
   end
 
   def cmd_throatchop(npc)
-	echo "cmd_throatchop" if $bigshot_debug
-	return if !CMan.available?("Throatchop")
-	waitrt?
-	waitcastrt?
-	result = dothistimeout("cman throatchop ##{npc.id}", 2, /You chop|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result == false)
-	  $bigshot_should_rest = true
-	  $rest_reason = "Unknown result from throatchop routine: #{result}"
-	end 
-  end
-
-  def cmd_checker()
-	echo "cmd_checker" if $bigshot_debug
-	echo " ************ "
-	echo "barrage buff #{Effects::Buffs.active?("Enh. Dexterity (+10)")}" 
-	echo "arcane reflex #{Effects::Buffs.active?("Nature's Touch Arcane Ref")}" 
-	echo " ************ "
+    echo "cmd_throatchop" if $bigshot_debug
+    return if !CMan.available?("Throatchop")
+    waitrt?
+    waitcastrt?
+    result = dothistimeout("cman throatchop ##{npc.id}", 2, /You chop|out of reach|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+    if (result == false)
+      $bigshot_should_rest = true
+      $rest_reason = "Unknown result from throatchop routine: #{result}"
+    end 
   end
 
   def cmd_berserk()
@@ -4713,6 +4742,7 @@ class Bigshot
       add_checkbox(@OP_TABLE4,  1, "Use sign of wracking/sigil of power/symbol of mana", 'use_wracking')
       add_checkbox(@OP_TABLE4,  0, "Delay looting", 'delay_loot')
       add_checkbox(@OP_TABLE4,  1, "Defensive stance before looting", 'loot_stance')
+	  add_checkbox(@OP_TABLE4,  0, "Troubadour's Rally", 'troubadours_rally')
       add_checkbox(@OP_TABLE4,  1, "Pull players to feet", 'pull')
       add_checkbox(@OP_TABLE4,  1, "Stop for dead players", 'deader')
       # Attacking
@@ -4784,7 +4814,9 @@ class Bigshot
 
       priority_tip = "Priority is based on order of valid targets box on hunting tab. Will switch to highest priority in room when attacking."
       @OP_ENTRY['priority'].set_tooltip_text(priority_tip)
-
+	  
+	  troubadours_rally_tip = "Shout 1040 when you or your group members are incapacitated."
+	  @OP_ENTRY['troubadours_rally'].set_tooltip_text(troubadours_rally_tip)
       smite_tip = "Will SMITE a non-corporeal undead when tier is excellent during UAC Combat"
       @OP_ENTRY['uac_smite'].set_tooltip_text(smite_tip)
 


### PR DESCRIPTION
Changed 1040 to have a checkbox. When enabled will check self and group members for status ailments, and shout 1040 to attempt to clear them. 5 second timeout to keep from multiple casts back to back. This may need to be adjusted. 1040 seems to be RNG without heavy lores. Will need to find the balance between effective and blowing all your mana, or maybe this is just left up to the user.
Pull players to feet will no longer pull kneeling players.

Don't fix white space issues in the middle of the night right before bed.