### PR TITLE
[bigshot.lic] expanded dislodge command

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1620,6 +1620,8 @@ class Bigshot
           return
         elsif (line =~ /^Your magic fizzles ineffectually\./)
           return
+	elsif (line =~ /^You are (?:still )?stunned\./ || muckled?)
+	  return
         end
       }
       if (force_this =~ /^(\d+) / && !Spell[$1.to_i].affordable?)

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.12.6 (2022-07-24)
+    Gave frozen it's own command check
+	Expanded support for dislodge activating only on specific locations.				 
   v4.12.5 (2022-07-21)
     Fixed shield bash to work for both shield and cman skills.
     1040 now has a checkbox to auto shout if you or group member could benefit.
@@ -275,6 +278,8 @@ $bigshot_arcane_reflex = false
 $bigshot_archery_aim = 0
 $bigshot_archery_stuck_location = []
 $bigshot_archery_location = nil
+$bigshot_dislodge_target = nil
+$bigshot_dislodge_location = nil
 $bigshot_bandits = false
 $bigshot_bless = []
 $bigshot_bond_return = false
@@ -679,8 +684,10 @@ class Bigshot
         $bigshot_1614_list.push($1)
       elsif server_string =~ /<pushBold\/>.*?<a exist="(.*?)" noun=".*?">.*?<\/a><popBold\/>.*?recovers from being rebuked/i
         $bigshot_1614_list.delete($1)
-      elsif server_string =~ /The.*sticks in.*\'s (.*)\!/i
-        $bigshot_archery_stuck_location.push($1)
+      elsif server_string =~ /The.*sticks in <pushBold\/>an? <a exist="(\d+)" noun="[^"]+">[^<]+<\/a><popBold\/>'s (?:left |right )?(.*)!/i
+        $bigshot_archery_stuck_location.push($2)
+		$bigshot_dislodge_target = $1
+		$bigshot_dislodge_location = $2
       elsif server_string =~ /You're now aiming at the (.*) of/i
         $bigshot_archery_location = $1
       elsif server_string =~ /You're now no longer aiming at anything in particular/i
@@ -981,7 +988,7 @@ class Bigshot
 	
     # check mana/stamina/health(percentage)/encumbrance/unarmed tiering/mobs in room/target not prone/target undead
     # ! means the inverse/opposite effect
-    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice|tailwind|!tailwind).*?)\)$/i)
+    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|tier|!tier|mob|!mob|prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice|tailwind|!tailwind).*?)\)$/i)
       command = $1
       commandcheckreturn = false
       $2.split(" ").each { |s|
@@ -1042,6 +1049,10 @@ class Bigshot
             commandcheckreturn = true if npc.status =~ PRONE
           elsif ($1 == '!prone')
             commandcheckreturn = true if npc.status !~ PRONE
+		  elsif ($1 == 'frozen')
+            commandcheckreturn = true if npc.status =~ /frozen/i
+		  elsif ($1 == '!frozen')
+            commandcheckreturn = true if npc.status !~ /frozen/i
           elsif ($1 == 'undead')
             commandcheckreturn = true if !npc.type.split(',').any? { |a| a == "undead" }
           elsif ($1 == '!undead')
@@ -1273,8 +1284,8 @@ class Bigshot
       cmd_cpress(npc)
     elsif (command =~ /^dirtkick/i)
       cmd_dirtkick(npc)
-    elsif (command =~ /^dislodge/i)
-      cmd_dislodge(npc)
+    elsif (command =~ /dislodge\s?(.*)/i)
+      cmd_dislodge(npc, $1)
     elsif (command =~ /^exsanguinate/i)
       cmd_exsanguinate(npc)
     elsif (command =~ /^feint/i)
@@ -1594,8 +1605,8 @@ class Bigshot
     start = Time.now
     loop {
       cmd(force_this, npc)
-	  sleep(0.1)	 
-      buffer = reget(35)
+	  sleep(0.1)
+	  buffer = reget(35)
       buffer.each_with_index { |line, i|
         if (line =~ /^You.*(#{checknpcs.join('|')})|^You feint (high|low|(to the (left|right)))/)
           if (buffer[i + 1] && buffer[i + 1] =~ /== \+(\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /== \+(\d+)/)
@@ -2452,13 +2463,19 @@ class Bigshot
     end 
   end
 
-  def cmd_dislodge(npc)
+  def cmd_dislodge(npc,location)
     echo "cmd_dislodge" if $bigshot_debug
     return if !CMan.available?("Dislodge")
+	return if npc.id != $bigshot_dislodge_target
+	location = location.split(/ /,9)
+	return if !location.include?($bigshot_dislodge_location)
     waitrt?
     waitcastrt?
-    result = dothistimeout("cman dislodge ##{npc.id}", 2, /attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-    if (result == false)
+    result = dothistimeout("cman dislodge ##{npc.id} #{$bigshot_dislodge_location}", 2, /You manage to dislodge|attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+	if (result =~ /You manage to dislodge/ || npc.status =~ /dead|gone/)
+	  $bigshot_dislodge_location = nil
+	  $bigshot_dislodge_target = nil
+	elsif (result == false)
       $bigshot_should_rest = true
       $rest_reason = "Unknown result from dislodge routine: #{result}"
     end 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,7 +19,7 @@
     Major_change.feature_addition.bugfix
   v4.12.6 (2022-07-24)
     Gave frozen it's own command check
-	Expanded support for dislodge activating only on specific locations.				 
+	Expanded support for dislodge firing only on specific locations.
   v4.12.5 (2022-07-21)
     Fixed shield bash to work for both shield and cman skills.
     1040 now has a checkbox to auto shout if you or group member could benefit.
@@ -279,7 +279,7 @@ $bigshot_archery_aim = 0
 $bigshot_archery_stuck_location = []
 $bigshot_archery_location = nil
 $bigshot_dislodge_target = nil
-$bigshot_dislodge_location = nil
+$bigshot_dislodge_location = []
 $bigshot_bandits = false
 $bigshot_bless = []
 $bigshot_bond_return = false
@@ -686,8 +686,8 @@ class Bigshot
         $bigshot_1614_list.delete($1)
       elsif server_string =~ /The.*sticks in <pushBold\/>an? <a exist="(\d+)" noun="[^"]+">[^<]+<\/a><popBold\/>'s (?:left |right )?(.*)!/i
         $bigshot_archery_stuck_location.push($2)
+		$bigshot_dislodge_location.push($2)									 
 		$bigshot_dislodge_target = $1
-		$bigshot_dislodge_location = $2
       elsif server_string =~ /You're now aiming at the (.*) of/i
         $bigshot_archery_location = $1
       elsif server_string =~ /You're now no longer aiming at anything in particular/i
@@ -973,13 +973,13 @@ class Bigshot
       stance_dance = false if command.any? { |j| j =~ /stance/ }
       command.each do |i|
         break if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }
-
         echo i if $bigshot_debug
         cmd(i, npc, stance_dance)
       end
       return
     end
-   
+	$bigshot_dislodge_location = [] if npc.status =~ /dead|gone/   
+	
     # waitrt/waitcastrt
     unless (command =~ /^nudgeweapons?/)
       waitrt?
@@ -2464,17 +2464,26 @@ class Bigshot
   end
 
   def cmd_dislodge(npc,location)
-    echo "cmd_dislodge" if $bigshot_debug
+    echo "cmd_dislodge #{npc} #{location}" if $bigshot_debug
     return if !CMan.available?("Dislodge")
 	return if npc.id != $bigshot_dislodge_target
-	location = location.split(/ /,9)
-	return if !location.include?($bigshot_dislodge_location)
+	target = nil
+    location = location.split(/ /,9) #[bigshot: ["eye", "head", "neck", "chest", "back", "abdomen", "arm", "leg", "hand"]]
+	location.each{ |location| 
+	  if $bigshot_dislodge_location.include?(location)
+	    target = location; break
+	  end
+	  }
+	return if target.nil?
     waitrt?
     waitcastrt?
-    result = dothistimeout("cman dislodge ##{npc.id} #{$bigshot_dislodge_location}", 2, /You manage to dislodge|attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-	if (result =~ /You manage to dislodge/ || npc.status =~ /dead|gone/)
-	  $bigshot_dislodge_location = nil
+    result = dothistimeout("cman dislodge ##{npc.id} #{target}", 2, /attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
+	if (result =~ /You manage to dislodge|You skillfully wrench/ && npc.status =~ /dead|gone/)
+	  $bigshot_dislodge_location = []
 	  $bigshot_dislodge_target = nil
+	elsif (result =~ /You manage to dislodge|You skillfully wrench/)
+	  $bigshot_dislodge_location.delete(target)
+	  target = nil
 	elsif (result == false)
       $bigshot_should_rest = true
       $rest_reason = "Unknown result from dislodge routine: #{result}"
@@ -4096,6 +4105,7 @@ class Bigshot
     $bigshot_ambush = 0
     $bigshot_archery_aim = 0
     $bigshot_archery_stuck_location = []
+	$bigshot_dislodge_location = []							
     $bigshot_unarmed_tier = 1
     $bigshot_unarmed_followup = false
     $bigshot_unarmed_followup_attack = ""

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -20,6 +20,7 @@
   v4.12.6 (2022-07-24)
     Gave frozen it's own command check
 	Expanded support for dislodge firing only on specific locations.
+	Commented out ammo gathering.
   v4.12.5 (2022-07-21)
     Fixed shield bash to work for both shield and cman skills.
     1040 now has a checkbox to auto shout if you or group member could benefit.
@@ -359,7 +360,7 @@ def spell_is_selfcast?(spell_id)
 end
 
 before_dying { unspam() }
-before_dying { $bigshot.gather_ammo }
+#before_dying { $bigshot.gather_ammo }#Not needed since archery updates.
 
 class Bigshot
   class Event
@@ -686,7 +687,7 @@ class Bigshot
         $bigshot_1614_list.delete($1)
       elsif server_string =~ /The.*sticks in <pushBold\/>an? <a exist="(\d+)" noun="[^"]+">[^<]+<\/a><popBold\/>'s (?:left |right )?(.*)!/i
         $bigshot_archery_stuck_location.push($2)
-		$bigshot_dislodge_location.push($2)									 
+		$bigshot_dislodge_location.push($2)
 		$bigshot_dislodge_target = $1
       elsif server_string =~ /You're now aiming at the (.*) of/i
         $bigshot_archery_location = $1
@@ -1949,18 +1950,18 @@ class Bigshot
     waitrt?
     waitcastrt?
 
-    if @AMMO
-      result = dothistimeout "get 1 my #{@AMMO.sub(/s$/, '')}", 2, /You remove|Get what\?|You already/
-      if (result =~ /Get what\?/)
-        $bigshot_should_rest = true
-        $rest_reason = "Out of ammo"
-        return
-      end
-    end
+#    if @AMMO
+#      result = dothistimeout "get 1 my #{@AMMO.sub(/s$/, '')}", 2, /You remove|Get what\?|You already/
+#      if (result =~ /Get what\?/)
+#        $bigshot_should_rest = true
+#        $rest_reason = "Out of ammo"
+#        return
+#      end
+#    end
 
     result = dothistimeout("fire ##{npc.id}", 2, /round(time)?|You cannot|Could not find|seconds|Get what?/i)
     if (result =~ /^Could not find/)
-      gather_ammo()
+      #gather_ammo()#Not used since archery updates.
     elsif (result =~ /You cannot fire/)
       unless GameObj.right_hand.id.nil?
         line = dothistimeout "stow ##{GameObj.right_hand.id}", 3, /put|closed/
@@ -2056,7 +2057,7 @@ class Bigshot
       unless GameObj.right_hand.id.nil?
         line = dothistimeout "stow ##{GameObj.right_hand.id}", 3, /put|closed/
 	if line =~ /closed/
-	  container = GameObj.inv.find { |obj| obj.name =~ /#{@AMMO_CONTAINER}/ } #Probably need to change this?
+	  container = GameObj.inv.find { |obj| obj.name =~ /#{@AMMO_CONTAINER}/ }
 	  fput "open my ##{container.id}"
 	  fput "put ##{GameObj.right_hand.id} in my ##{container.id}"
 	end
@@ -3501,7 +3502,7 @@ class Bigshot
       end
       # prepare_for_movement()
       echo "Exiting attack loop" if $bigshot_debug
-      gather_ammo()
+      #gather_ammo()#Not used since archery updates.
 
       if (should_rest?)
         break
@@ -4107,7 +4108,7 @@ class Bigshot
     $bigshot_ambush = 0
     $bigshot_archery_aim = 0
     $bigshot_archery_stuck_location = []
-	$bigshot_dislodge_location = []							
+	$bigshot_dislodge_location = []
     $bigshot_unarmed_tier = 1
     $bigshot_unarmed_followup = false
     $bigshot_unarmed_followup_attack = ""


### PR DESCRIPTION
gave frozen its own command check because PRONE spectral protectors can still reflect arrows while frozen ones cannot. So need it to be more accurate for frozen. It's still part of prone check.

dislodge <location> - would only attempt to dislodge if an arrow sticks in this location (dislodge eye head neck chest back abdomen arm hand leg)

It piggy backs on existing archery tracking. Will record target id and location of latest arrow that lodges. Then dislodge will fire if your current target id matches the lodged target id and location matches one you want to dislodge from. This works great as a lone archer. Could pose a problem with a group of archers as first person/third person messaging is the same. So someone smarter may want to look into it. But for now, this greatly expands the usability of the dislodge command in bigshot.
