### PR TITLE
Updates to script and UI

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -13,8 +13,17 @@
       contributers: SpiffyJr, Athias, Demandred, Tysong, Deysh
               game: Gemstone
               tags: loot
-           version: 1.4.18
+           version: 1.4.19
   Improvements:
+
+  v1.4.19
+    - fixed looting logic when its flagged as two items with one not wanted (eg. uncommon & clothing). It will pick up the item to prevent valuable items getting left behind
+    - additional error checking for empty box's in containers
+    - additional error checking for looting
+    - added support to use left hand for looting
+    - added support for users who don't sell with eloot (full container tracking)
+    - added secondary overflow container
+    - moved UI check only when loading or setup
 
   v1.4.18
     - followup typo fix for default crubmly list
@@ -286,31 +295,12 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(LICH_GEM_REQUIRES) || Gem::
    exit
 end
 
-ELoot_version = '1.4.17'
-ELootUI_version = '1.1.5'
+ELoot_version = '1.4.19'
+ELootUI_version = '1.1.6'
 
 elootUI_VERSION = nil
 
-if File.exist?("#{$data_dir}eloot.ui")
-
-  File.foreach("#{$data_dir}eloot.ui") { |line| 
-    if line =~ /^[\s\t#]*version:[\s\t]*([\w,\s\.\d]+)/i
-          elootUI_VERSION = $1.sub(/\s\(.*?\)/, '').strip
-          break
-    end
-  }
-
-  if elootUI_VERSION != ELootUI_version
-    Lich::Messaging.msg(type = "warn", msg = " Your UI is an old version! ")
-    Lich::Messaging.msg(type = "warn", msg = " Kill script if you don't want to download!")
-    for i in (5).downto(1)
-      Lich::Messaging.msg(type = "warn", msg = " Downloading in...#{i} ")
-      sleep 1
-    end
-    
-    Script.run("jinx", "data update eloot.ui --force")
-  end
-else
+if !File.exist?("#{$data_dir}eloot.ui")
   Lich::Messaging.msg(type = "warn", msg = " Your UI is missing or its a first install. ")
   Lich::Messaging.msg(type = "warn", msg = " Kill script if you don't want to download!")
   for i in (5).downto(1)
@@ -321,6 +311,7 @@ else
     Script.run("jinx", "data install eloot.ui")
 end
 
+#Probably can remove this
 #move an existing profile from the old directory structure and save it to new one
 old_dir = "#{$data_dir}eloot/#{XMLData.game}/"
 new_dir = "#{$data_dir}#{XMLData.game}/#{Char.name}/"
@@ -348,6 +339,29 @@ module ELoot
   
   ##### Data & Setup Start #####
   
+  def self.check_ui()
+  
+    elootUI_VERSION = nil
+    File.foreach("#{$data_dir}eloot.ui") { |line| 
+      if line =~ /^[\s\t#]*version:[\s\t]*([\w,\s\.\d]+)/i
+            elootUI_VERSION = $1.sub(/\s\(.*?\)/, '').strip
+            break
+      end
+    }
+
+    if elootUI_VERSION != ELootUI_version
+      Lich::Messaging.msg(type = "warn", msg = " Your UI is an old version! ")
+      Lich::Messaging.msg(type = "warn", msg = " Kill script if you don't want to download!")
+      for i in (5).downto(1)
+        Lich::Messaging.msg(type = "warn", msg = " Downloading in...#{i} ")
+        sleep 1
+      end
+      
+      Script.run("jinx", "data update eloot.ui --force")
+    end
+   
+  end
+  
   def self.load_defaults()
     
     default_hash = {
@@ -359,6 +373,7 @@ module ELoot
       :coin_hand=>false,
       :coin_hand_name=>"",
       :overflow_container=>"",
+      :secondary_overflow=>"",
       :sell_loot_types=>["alchemy", "armor", "clothing", "food", "gem", "jewelry", "lockpick", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand", "box"],
       :sell_container=>["default","overflow","box","collectible","forageable","gem","herb","lockpick","potion","reagent","scroll","skin","treasure","trinket","wand"],
       :sell_exclude=>[],
@@ -389,7 +404,9 @@ module ELoot
       :debug=>false,
       :unskinnable=>[],
       :crumbly=> [],
-      :keep_closed=>false
+      :keep_closed=>false,
+      :track_full_sacks=>true,
+      :favor_left=>false,
     }
     Dir.mkdir("#{$data_dir}#{XMLData.game}") unless File.exist?("#{$data_dir}#{XMLData.game}")
     Dir.mkdir("#{$data_dir}#{XMLData.game}/#{Char.name}") unless File.exist?("#{$data_dir}#{XMLData.game}/#{Char.name}")
@@ -427,6 +444,8 @@ module ELoot
     ELoot.data.settings[:display_box_contents] = false unless ELoot.data.settings.has_key?(:display_box_contents)
     ELoot.data.settings[:use_disk] = true unless ELoot.data.settings.has_key?(:use_disk)
     ELoot.data.settings[:keep_closed] = false unless ELoot.data.settings.has_key?(:keep_closed)
+    ELoot.data.settings[:track_full_sacks] = true unless ELoot.data.settings.has_key?(:track_full_sacks)
+    ELoot.data.settings[:favor_left] = false unless ELoot.data.settings.has_key?(:favor_left)
     
     #Remove overflow container name from settings. We don't need to save it
     default_settings = ["default","overflow","box","collectible","forageable","gem","herb","lockpick","potion","reagent","scroll","skin","treasure","trinket","wand"]
@@ -484,19 +503,21 @@ module ELoot
       end
     }
   
-    #Add the overflow sack 
-    ELoot.data.sacks.store(ELoot.data.settings[:overflow_container].to_s, GameObj.inv.find { |i| i.name =~ /#{ELoot.data.settings[:overflow_container]}/ })
-    ELoot.data.sacks.delete("")
-    
-    ELoot.data.settings[:sell_container].push(ELoot.data.settings[:overflow_container].to_s) if ELoot.data.settings[:sell_container].include?("overflow")
-    ELoot.data.settings[:sell_container].delete("")
-    
     #Bail if default container isn't set
     if ELoot.data.sacks['default'].nil?
       ELoot.msg("error", " Set stow container using STOW SET before using this script") 
       exit
     end
   
+    #Add the overflow sacks 
+    ELoot.data.sacks.store(ELoot.data.settings[:overflow_container].to_s, GameObj.inv.find { |i| i.name =~ /#{ELoot.data.settings[:overflow_container]}/ })
+    ELoot.data.sacks.store(ELoot.data.settings[:secondary_overflow].to_s, GameObj.inv.find { |i| i.name =~ /#{ELoot.data.settings[:secondary_overflow]}/ })
+    ELoot.data.sacks.delete("")
+    
+    ELoot.data.settings[:sell_container].push(ELoot.data.settings[:overflow_container].to_s) if ELoot.data.settings[:sell_container].include?("overflow")
+    ELoot.data.settings[:sell_container].push(ELoot.data.settings[:secondary_overflow].to_s) if ELoot.data.settings[:sell_container].include?("overflow")
+    ELoot.data.settings[:sell_container].delete("")
+     
     #Add the skin sheathes if set
     ELoot.data.ready_list.store("skin_sheath", GameObj.inv.find { |i| i.name =~ /#{ELoot.data.settings[:skin_sheath]}\b/ if !ELoot.data.settings[:skin_sheath].empty? && !ELoot.data.settings[:skin_sheath].nil?})
     ELoot.data.ready_list.store("skin_sheath_blunt", GameObj.inv.find { |i| i.name =~ /#{ELoot.data.settings[:skin_sheath_blunt]}\b/ if !ELoot.data.settings[:skin_sheath_blunt].empty? && !ELoot.data.settings[:skin_sheath_blunt].nil?})          
@@ -867,6 +888,7 @@ module ELoot
     box_sacks.push(ELoot.data.sacks["box"]) if ELoot.data.settings[:sell_container].include?("box")
     box_sacks.push(ELoot.data.sacks["default"]) if ELoot.data.settings[:sell_container].include?("default")
     box_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) if ELoot.data.settings[:sell_container].include?("overflow")
+    box_sacks.push(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]]) if ELoot.data.settings[:sell_container].include?("overflow")
     
     ELoot.msg("debug", " box_sacks: #{box_sacks}")
     
@@ -893,9 +915,19 @@ module ELoot
 
     box_list.dup.each{|box|
       lines = ELoot.silent_command("look in ##{box.id}",/There is nothing|In the(.*?)#{box.noun}|That is closed|You see the shifting form/)
-      box_list.delete(box) if lines.any?{ |line| line =~ /There is nothing|In the/i }
+      if lines.any?{ |line| line =~ /In the|There is nothing/i }
+        if box.contents.length.positive?
+          unless [GameObj.left_hand.type, GameObj.right_hand.type].include?("box")
+            Inventory.drag(box)
+          end
+          Loot.box_loot(box) 
+        end
+        box_list.delete(box) 
+      
+      end
+      
     }
-  
+ 
     return box_list
 
   end
@@ -1125,6 +1157,8 @@ module ELoot
       @settings[:crumbly] ||= []
       @settings[:crumbly] = (default_crumbly + @settings[:crumbly]).uniq
       
+      @settings[:unskinnable] = @settings[:unskinnable].uniq
+      
       @settings[:sell_container] ||= ["default","overflow","box","collectible","forageable","gem","herb","lockpick","potion","reagent","scroll","skin","treasure","trinket","wand"]
 
       @look_regex = Regexp.union(
@@ -1231,9 +1265,13 @@ module ELoot
         use_disk: { default: true },
         loot_defensive: { default: false },
         overflow_container: { default: '' },
+        secondary_overflow: { default: '' },
         coin_hand: { default: false },
         coin_hand_name: { default: '' },
-        keep_closed: { default: false }
+        keep_closed: { default: false },
+        track_full_sacks: { default: true },
+        favor_left: { default: false },
+        
       },
       sell: {
         sell_loot_types: {
@@ -1666,14 +1704,28 @@ module ELoot
    
     def self.free_hand 
       unless (GameObj.right_hand.id.nil? and ([Wounds.rightArm, Wounds.rightHand, Scars.rightArm, Scars.rightHand].max < 3)) or (GameObj.left_hand.id.nil? and ([Wounds.leftArm, Wounds.leftHand, Scars.leftArm, Scars.leftHand].max < 3))
-        if GameObj.right_hand.id and ([Wounds.rightArm, Wounds.rightHand, Scars.rightArm, Scars.rightHand].max < 3 or [Wounds.leftArm, Wounds.leftHand, Scars.leftArm, Scars.leftHand].max = 3)
-          waitrt?
-          Inventory.free_hands(right: true)
+        
+        if ELoot.data.settings[:favor_left]
+          if GameObj.left_hand.id and ([Wounds.leftArm, Wounds.leftHand, Scars.leftArm, Scars.leftHand].max < 3 or [Wounds.rightArm, Wounds.rightHand, Scars.rightArm, Scars.rightHand].max = 3)
+            waitrt?
+            Inventory.free_hands(left: true)
+          else
+            waitrt?
+            Inventory.free_hands(right: true)
+          end
         else
-          waitrt?
-          Inventory.free_hands(left: true)
+          if GameObj.right_hand.id and ([Wounds.rightArm, Wounds.rightHand, Scars.rightArm, Scars.rightHand].max < 3 or [Wounds.leftArm, Wounds.leftHand, Scars.leftArm, Scars.leftHand].max = 3)
+            waitrt?
+            Inventory.free_hands(right: true)
+          else
+            waitrt?
+            Inventory.free_hands(left: true)
+          end
         end
       end
+      
+      #Fixme: Add toggle in UI to favor the left instead of the right
+      
     end
 
     def self.free_hands(right: false, left: false, both: false)
@@ -1706,6 +1758,7 @@ module ELoot
     
       Inventory.open_single_container(ELoot.data.sacks["default"])
       Inventory.open_single_container(ELoot.data.settings[:overflow_container])
+      Inventory.open_single_container(ELoot.data.settings[:secondary_overflow])
       
       containers = Array.new 
       item.each{ |loot|
@@ -1845,7 +1898,23 @@ module ELoot
           ELoot.box_phase(item) if phase_thing
           return
         end    
-        ELoot.msg("info", " Your OVERFLOW container cannot hold this item.")
+      end
+      
+      #inform user it didn't fit
+      ELoot.msg("info", " The #{item} won't fit in the #{ELoot.data.sacks[ELoot.data.settings[:overflow_container]]}. Trying secondary overflow container.")
+      
+      #try secondary overflow
+      if ELoot.data.settings[:secondary_overflow].empty?
+        ELoot.msg("info", " You have not set a Secondary OVERFLOW container.")
+        ELoot.msg("info", " You're carrying too much stuff. Unload a bit! Exiting...")
+        exit
+      else
+        result = Inventory.store_item(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]], item)
+        if result
+          ELoot.box_phase(item) if phase_thing
+          return
+        end    
+        ELoot.msg("info", " Your Secondary OVERFLOW container cannot hold this item.")
         ELoot.msg("info", " You're carrying too much stuff. Unload a bit! Exiting...")
         exit
       end
@@ -1873,7 +1942,21 @@ module ELoot
         sleep 0.1
       }
 
-      ELoot.silent_command("look in ##{ELoot.data.sacks[item.type].id}", ELoot.data.look_regex)
+      #Bag might be closed...lets check
+      if ELoot.data.sacks[item.type] && !ELoot.data.sacks_full.include?(ELoot.data.sacks[item.type])
+        lines = ELoot.silent_command("look in ##{ELoot.data.sacks[item.type].id}", ELoot.data.look_regex)
+        bag = ELoot.data.sacks[item.type]
+      else
+        lines = ELoot.silent_command("look in ##{ELoot.data.sacks["default"].id}", ELoot.data.look_regex)
+        bag = ELoot.data.sacks["default"]
+      end
+      
+      if lines.any?{ |line| line =~ /That is closed|is shut too tightly to see its contents/i }
+        #open the bag
+        ELoot.msg("debug", "Inventory.single_loot: opening bag")
+        Inventory.open_single_container(bag)
+      end
+      
       10.times {
         return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) and ELoot.data.sacks[item.type].contents.to_a.map(&:id).include?(item.id))
         return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) and ELoot.data.sacks["default"].contents.to_a.map(&:id).include?(item.id))
@@ -1891,7 +1974,23 @@ module ELoot
       else
         result = Inventory.store_item(ELoot.data.sacks[ELoot.data.settings[:overflow_container]], item)
         return if result      
-        ELoot.msg("info", " Your OVERFLOW container cannot hold this item.")
+      end
+      
+      #inform user it didn't fit
+      ELoot.msg("info", " The #{item} won't fit in the #{ELoot.data.sacks[ELoot.data.settings[:overflow_container]]}. Trying secondary overflow container.")
+      
+      #try secondary overflow
+      if ELoot.data.settings[:secondary_overflow].empty?
+        ELoot.msg("info", " You have not set a Secondary OVERFLOW container.")
+        ELoot.msg("info", " You're carrying too much stuff. Unload a bit! Exiting...")
+        exit
+      else
+        result = Inventory.store_item(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]], item)
+        if result
+          ELoot.box_phase(item) if phase_thing
+          return
+        end    
+        ELoot.msg("info", " Your Secondary OVERFLOW container cannot hold this item.")
         ELoot.msg("info", " You're carrying too much stuff. Unload a bit! Exiting...")
         exit
       end
@@ -1936,6 +2035,13 @@ module ELoot
       }
   
       ELoot.silent_command("look in ##{bag.id}", ELoot.data.look_regex)
+           
+      if lines.any?{ |line| line =~ /That is closed|is shut too tightly to see its contents/i }
+        #open the bag
+        ELoot.msg("debug", "Inventory.single_loot: opening bag")
+        Inventory.open_single_container(bag)
+      end
+          
       10.times {
         return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && bag.contents.to_a.map(&:id).include?(item.id))
         sleep 0.1
@@ -2203,8 +2309,8 @@ module ELoot
       if !ELoot.data.settings[:loot_types].nil?
         objs.reject do |obj|
           obj.type !~ Regexp.union(ELoot.data.settings[:loot_types]) ||
-            (ELoot.data.settings[:loot_exclude].length.positive? &&
-             obj.name =~ Regexp.union(ELoot.data.settings[:loot_exclude]))
+          (ELoot.data.settings[:loot_exclude].length.positive? &&
+             obj.name =~ Regexp.union(ELoot.data.settings[:loot_exclude]))         
         end
       end
     end
@@ -2212,7 +2318,7 @@ module ELoot
     def self.invalid_objs(objs) #finds non-valid loot    
         invalid_categories = ELoot.data.all_loot_categories - ELoot.data.settings[:loot_types]
         objs.find_all do |obj|
-          next if obj.nil? || obj.empty?
+          next if obj.nil? || obj.empty? || obj.type =~ Regexp.union(ELoot.data.settings[:loot_types])
           obj.type =~ Regexp.union(invalid_categories)  \
           || (ELoot.data.settings[:loot_exclude].length.positive? && obj.name =~ Regexp.union(ELoot.data.settings[:loot_exclude]))          
         end     
@@ -2229,18 +2335,20 @@ module ELoot
  
         # Boxes go first. If handled, we reject them since they're already looted.
         types = ["box", "clothing", "collectible", "cursed", "jewelry", "food"]
+       
         objs = objs.reject do |thing|
-    
           Loot.bag_loot(thing) if thing.type =~ /clothing/ 
-          next false if ELoot.data.settings[:loot_exclude].length.positive? && thing.name =~ Regexp.union(ELoot.data.settings[:loot_exclude])     
-          unless thing.type =~ Regexp.union(ELoot.data.settings[:loot_types].reject { |x| !types.include?(x)}) \
+          next false if ELoot.data.settings[:loot_exclude].length.positive? && thing.name =~ Regexp.union(ELoot.data.settings[:loot_exclude]) 
+         
+           unless thing.type =~ Regexp.union(ELoot.data.settings[:loot_types]) && thing.type =~ Regexp.union(types) \
+            || thing.type =~ /cursed/i && ELoot.data.settings[:loot_types].include?("cursed") \
             || (thing.type =~ /weapon/i && thing.type =~ /uncommon/ ) && ELoot.data.settings[:loot_types].include?("weapon") \
             || (thing.type =~ /armor/i && thing.type =~ /uncommon/ ) && ELoot.data.settings[:loot_types].include?("armor") \
             || thing.name =~ /orb/ && thing.type =~ /magic/ && ELoot.data.settings[:loot_types].include?("magic") \
             || thing.name =~ /silver coin/ && ELoot.data.settings[:loot_types].include?("coins")
             next false       
           end
-    
+ 
           if thing.name =~ /silver coin/
             ELoot.silent_command("get coin",/you gather/i,true)
           else
@@ -2325,6 +2433,7 @@ module ELoot
               Inventory.open_single_container(ELoot.data.sacks["gem"])
               Inventory.open_single_container(ELoot.data.sacks["skin"])
               Inventory.open_single_container(ELoot.data.settings[:overflow_container])
+              Inventory.open_single_container(ELoot.data.settings[:secondary_overflow])             
             end  
            
             Inventory.single_drag(check_hand, false)
@@ -2419,7 +2528,7 @@ module ELoot
       objs.each do |obj|
         res = dothistimeout("skin ##{obj.id} #{skinner_hand}", 2, skin_match)
         if res =~ /You cannot skin/
-          ELoot.data.settings[:unskinnable].push(obj.name)
+          ELoot.data.settings[:unskinnable].push(obj.name) 
           ELoot.save_profile()
         elsif res =~ break_match
           fput "stow gem ##{GameObj.left_hand.id}"
@@ -2449,7 +2558,7 @@ module ELoot
       
 
         objs = objs.reject do |obj|
-          (ELoot.data.settings[:unskinnable].index(obj.name) > -1 && !Loot.occassional_skinner(obj))||
+          (ELoot.data.settings[:unskinnable].include?(obj.name) && !Loot.occassional_skinner(obj))||
             obj.type =~ /bandit/ ||
             obj.name =~ /(?:ethereal|ghostly|unwordly|Grimswarm)/ ||
             ELoot.data.settings[:skin_exclude].length.positive? && obj.name =~ Regexp.union(ELoot.data.settings[:skin_exclude])
@@ -2804,7 +2913,7 @@ module ELoot
  
       #Do we have anything to dump?
       dump_items = Array.new
-      sacks = [ELoot.data.sacks["default"], ELoot.data.sacks[ELoot.data.settings[:overflow_container]]]      
+      sacks = [ELoot.data.sacks["default"], ELoot.data.sacks[ELoot.data.settings[:overflow_container]], ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]]]      
       sacks.each{ |sack| 
         Inventory.check_sell_container(sack) if @sell_containers.include?(sack) && ELoot.data.settings[:keep_closed]
         sack.contents.each{ |item|
@@ -3042,7 +3151,10 @@ module ELoot
       unless npc.nil?
         chrono_sacks = Array.new
         chrono_sacks.push(ELoot.data.sacks["default"]) if ELoot.data.settings[:sell_container].include?("default")
-        chrono_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) if ELoot.data.settings[:sell_container].include?("overflow")
+        if ELoot.data.settings[:sell_container].include?("overflow")
+          chrono_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) 
+          chrono_sacks.push(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]]) 
+        end
         
         chrono_sacks.each{ |sack| Inventory.open_single_container(sack) }        
              
@@ -3118,7 +3230,10 @@ module ELoot
       skin_sacks = Array.new
       skin_sacks.push(ELoot.data.sacks["skin"]) if ELoot.data.settings[:sell_container].include?("skin")
       skin_sacks.push(ELoot.data.sacks["default"]) if ELoot.data.settings[:sell_container].include?("default")
-      skin_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) if ELoot.data.settings[:sell_container].include?("overflow")
+      if ELoot.data.settings[:sell_container].include?("overflow")
+        skin_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) 
+        skin_sacks.push(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]])
+      end
          
       ELoot.msg("debug", " skin_sacks: #{skin_sacks}")
       skin_sacks.each{ |sack|
@@ -3189,7 +3304,10 @@ module ELoot
       gem_sacks = Array.new
       gem_sacks.push(ELoot.data.sacks["gem"]) if ELoot.data.settings[:sell_container].include?("gem")
       gem_sacks.push(ELoot.data.sacks["default"]) if ELoot.data.settings[:sell_container].include?("default")
-      gem_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) if ELoot.data.settings[:sell_container].include?("overflow")
+      if ELoot.data.settings[:sell_container].include?("overflow")
+        gem_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) 
+        gem_sacks.push(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]])
+      end
      
       gem_sacks.each{ |sack|
         next if sack.nil?
@@ -3243,8 +3361,10 @@ module ELoot
       consignment_sacks = Array.new
       consignment_sacks.push(ELoot.data.sacks["reagent"]) if ELoot.data.settings[:sell_container].include?("reagent")
       consignment_sacks.push(ELoot.data.sacks["default"]) if ELoot.data.settings[:sell_container].include?("default")
-      consignment_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]]) if ELoot.data.settings[:sell_container].include?("overflow")
-      
+      if ELoot.data.settings[:sell_container].include?("overflow")
+        consignment_sacks.push(ELoot.data.sacks[ELoot.data.settings[:overflow_container]])
+        consignment_sacks.push(ELoot.data.sacks[ELoot.data.settings[:secondary_overflow]]) 
+      end
       consignment_sacks.each{ |sack|
         next if sack.nil?
         next if sack.contents.find_all { |obj| obj.sellable.include?("consignment") }.empty?  
@@ -3457,7 +3577,7 @@ module ELoot
           selling.push("gemshop") unless selling.include?("gemshop")
         elsif thing.type == "collectible" && ELoot.data.settings[:sell_collectibles]
           selling.push("collectibles") unless selling.include?("collectibles")
-        elsif ELoot.data.settings[:sell_loot_types].include?("box") && thing.name =~ /gold|mithril|silver/ && thing.type == "box"
+        elsif ELoot.data.settings[:sell_loot_types].include?("box") && thing.type == "box"
           selling.push("pawnshop") unless selling.include?("pawnshop")
         elsif !thing.sellable.nil? && thing.type.split(',').any? { |type| type =~ /^#{ELoot.data.settings[:sell_loot_types].join('|')}$/ } 
           thing.sellable.to_s.split(',').each{ |location|
@@ -3530,7 +3650,8 @@ if script.vars.any? { |var| var =~ /^--debug=(on|off|true|false|yes|no)$/i }
 end
 
 if script.vars[1] =~ /ver/i
-  echo " Eloot Version: #{ELoot_version}"
+  echo "   Eloot Version: #{ELoot_version}"
+  echo " Eloot UI Version: #{ELootUI_version}"
   exit
 end
   
@@ -3546,10 +3667,15 @@ silence_me if ELoot.data.settings[:silence]
 
 # Initialize default settings
 unless ELoot.data
+  ELoot.check_ui
   ELoot.load(ELoot.load_profile())
   ELoot.set_inventory
 end
 
+if !ELoot.data.settings[:track_full_sacks]
+  ELoot.data.sacks_full = Array.new
+  ELoot.data.disk_full = false
+end  
     
 #Sorter shows inventory checks so we kill it and restart
 ELoot.manage_sorter
@@ -3605,10 +3731,12 @@ when 'sell'
 when 'pool'
   ELoot::Sell.pool
 when 'setup'
+  ELoot.check_ui
   ELoot::Setup.new(ELoot.data.settings).start
   ELoot.load(ELoot.load_profile())
   ELoot.set_inventory
 when 'load'
+  ELoot.check_ui
   ELoot.load(ELoot.load_profile)
   ELoot.set_inventory
 when 'deposit'

--- a/scripts/eloot.ui
+++ b/scripts/eloot.ui
@@ -5,9 +5,14 @@ original author: SpiffyJr (sloot)
         maintainer: elanthia-online
       contributers: SpiffyJr, Athias, Demandred, Tysong, Deysh
               game: Gemstone  
-           version: 1.1.5
+           version: 1.1.6
              
     Improvements:
+    
+    v1.1.6 (2022-09-05)
+      - added toggle to prioritize left
+      - added toggle to turn off full container monitoring to support those not selling with eloot
+      - added secondary overflow container
     
     v1.1.5 (2022-08-02)
       - added toggle to loot silver on the ground
@@ -48,12 +53,12 @@ original author: SpiffyJr (sloot)
     </columns>
   </object>
   <object class="GtkAdjustment" id="sell_appraise_gemshop_adjustment">
-    <property name="upper">100000</property>
+    <property name="upper">1000000</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="sell_appraise_gemshop_pawnshop">
-    <property name="upper">100000</property>
+    <property name="upper">1000000</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
@@ -490,7 +495,7 @@ original author: SpiffyJr (sloot)
                             <property name="border-width">5</property>
                             <property name="label-xalign">0</property>
                             <child>
-                              <!-- n-columns=5 n-rows=4 -->
+                              <!-- n-columns=4 n-rows=3 -->
                               <object class="GtkGrid">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -515,42 +520,6 @@ original author: SpiffyJr (sloot)
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Overflow container:</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkEntry" id="overflow_container">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="tooltip-text" translatable="yes">Enter the name of your overflow container.  This container will be used when the targeted STOW container is full.</property>
-                                    <property name="width-chars">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">3</property>
-                                    <property name="width">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
                                   <object class="GtkCheckButton" id="loot_phase">
                                     <property name="label" translatable="yes">Phase boxes(?)</property>
                                     <property name="visible">True</property>
@@ -558,11 +527,12 @@ original author: SpiffyJr (sloot)
                                     <property name="receives-default">False</property>
                                     <property name="tooltip-text" translatable="yes">Phases boxes if you are able to.</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
                                     <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -576,8 +546,64 @@ original author: SpiffyJr (sloot)
                                     <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">2</property>
+                                    <property name="left-attach">1</property>
                                     <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="label" translatable="yes">Coin Hand Name:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="coin_hand_name">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="track_full_sacks">
+                                    <property name="label" translatable="yes">Track Full Containers(?)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Eloot will try to keep track of full sacks (turn off if not selling with eloot)</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="favor_left">
+                                    <property name="label" translatable="yes">Favor Left(?)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Will favor left hand to stow for looting (defaults to right)</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -588,11 +614,12 @@ original author: SpiffyJr (sloot)
                                     <property name="receives-default">True</property>
                                     <property name="tooltip-text" translatable="yes">Will keep sacks closed (Performance hit!)</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
                                     <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">3</property>
-                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -601,53 +628,13 @@ original author: SpiffyJr (sloot)
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
+                                    <property name="halign">start</property>
                                     <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">4</property>
+                                    <property name="left-attach">2</property>
                                     <property name="top-attach">0</property>
                                   </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Coin Hand Name:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">3</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkEntry" id="coin_hand_name">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">3</property>
-                                    <property name="top-attach">3</property>
-                                    <property name="width">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                                 <child>
                                   <placeholder/>
@@ -682,6 +669,110 @@ original author: SpiffyJr (sloot)
                               <object class="GtkGrid">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xpad">5</property>
+                                    <property name="ypad">5</property>
+                                    <property name="label" translatable="yes">Primary Overflow:</property>
+                                    <property name="xalign">0</property>
+                                    <property name="yalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="overflow_container">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Enter the name of your overflow container.  This container will be used when the targeted STOW container is full.</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">10</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="hexpand">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="xpad">5</property>
+                                    <property name="ypad">5</property>
+                                    <property name="label" translatable="yes">Secondary Overflow:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="secondary_overflow">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Enter the name of your secondary overflow container.  This container will be used when the primary overflow container is full.</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="vexpand">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Overflow Containers</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="label-xalign">0</property>
+                            <child>
+                              <!-- n-columns=3 n-rows=3 -->
+                              <object class="GtkGrid">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-top">5</property>
                                 <property name="margin-bottom">5</property>
@@ -695,6 +786,7 @@ original author: SpiffyJr (sloot)
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -709,6 +801,7 @@ original author: SpiffyJr (sloot)
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">end</property>
+                                    <property name="margin-end">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
@@ -734,6 +827,10 @@ original author: SpiffyJr (sloot)
                                     <property name="height-request">80</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="shadow-type">in</property>
                                     <child>
@@ -798,7 +895,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -825,6 +922,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -839,6 +937,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">end</property>
+                                    <property name="margin-end">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
@@ -864,6 +963,10 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="height-request">80</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="shadow-type">in</property>
                                     <child>
@@ -928,7 +1031,7 @@ Enter "(?:big ugly|mongrel) kobold" and "Vvrael destroyer" as separate entries.<
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>
@@ -1625,6 +1728,7 @@ Enter "(?:big ugly|mongrel) kobold" and "Vvrael destroyer" as separate entries.<
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -1639,6 +1743,7 @@ Enter "(?:big ugly|mongrel) kobold" and "Vvrael destroyer" as separate entries.<
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">end</property>
+                                    <property name="margin-end">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
@@ -1664,6 +1769,10 @@ Enter "(?:big ugly|mongrel) kobold" and "Vvrael destroyer" as separate entries.<
                                     <property name="height-request">80</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="shadow-type">in</property>
                                     <child>
@@ -1755,6 +1864,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -1769,6 +1879,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">end</property>
+                                    <property name="margin-end">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
@@ -1794,6 +1905,10 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="height-request">80</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="shadow-type">in</property>
                                     <child>
@@ -1946,6 +2061,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                     <property name="label" translatable="yes">Pawnshop Limit</property>
                                   </object>
                                   <packing>
@@ -1958,6 +2074,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                     <property name="adjustment">sell_appraise_gemshop_pawnshop</property>
                                   </object>
                                   <packing>
@@ -2555,6 +2672,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                     <property name="label" translatable="yes">Skin Sheath (edged)</property>
                                   </object>
                                   <packing>
@@ -2566,6 +2684,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                   <object class="GtkEntry" id="skin_sheath">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
                                     <property name="width-chars">20</property>
                                   </object>
                                   <packing>
@@ -2611,6 +2730,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                     <property name="label" translatable="yes">Skin Sheath (blunt)</property>
                                   </object>
                                   <packing>
@@ -2622,6 +2742,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                   <object class="GtkEntry" id="skin_sheath_blunt">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
                                     <property name="width-chars">20</property>
                                   </object>
                                   <packing>
@@ -2722,6 +2843,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">start</property>
+                                    <property name="margin-start">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -2736,6 +2858,7 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
                                     <property name="halign">end</property>
+                                    <property name="margin-end">5</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
@@ -2761,6 +2884,10 @@ Enter "(?:aquamarine|gold) wand" and "gold ring" as separate entries.</property>
                                     <property name="height-request">80</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
                                     <property name="hexpand">True</property>
                                     <property name="shadow-type">in</property>
                                     <child>


### PR DESCRIPTION
v1.4.19
    - fixed looting logic when its flagged as two items with one not wanted (eg. uncommon & clothing). It will pick up the item to prevent valuable items getting left behind
    - additional error checking for empty box's in containers
    - additional error checking for looting
    - added support to use left hand for looting
    - added support for users who don't sell with eloot (full container tracking)
    - added secondary overflow container
    - moved UI check only when loading or setup

v1.1.6 (2022-09-05) UI
      - added toggle to prioritize left
      - added toggle to turn off full container monitoring to support those not selling with eloot
      - added secondary overflow container