### PR TITLE
[bigshot.lic] properly kill hunting scripts started with args

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.12.9
+       version: 4.12.11
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.12.11 (2022-09-18)
+    Fixed calls to kill hunting scripts started with args
+
   v4.12.10 (2022-08-21)
     Added tumbleweed to list of tangleweed nouns
     
@@ -808,9 +811,11 @@ class Bigshot
 
     # this is mainly for azbounty:
     before_dying {
-      @HUNTING_SCRIPTS.each { |i|
-        echo "Cleaning up hunting scripts: #{i}."
-        stop_script(i) if running?(i)
+      @HUNTING_SCRIPTS.each { |hs|
+        # check for scripts with args passed
+        hs_name = hs.split(/\s+/).first
+        echo "Cleaning up hunting scripts: #{hs_name}."
+        stop_script(hs_name) if running?(hs_name)
       }
     }
   end
@@ -3269,6 +3274,8 @@ class Bigshot
 
   def croak_script(name)
     echo "croak_script" if $bigshot_debug
+    # check for script name string with args
+    name = name.split(/\s+/).first
     kill_script(name) if running?(name)
   end
 


### PR DESCRIPTION
currently hunting scripts started with arguments (i.e. hunting scripts of: `spellactive,my_hunting_script optional args here,helppeople`) are not properly terminated because the calls to stop all active hunting scripts use the entire entry without splitting on space to account for the args (the script START works as expected). This orphans active scripts that are invoked with arguments as it attempts to `kill_script("my_hunting_script optional args here")` and not `kill_script("my_hunting_script")`