### PR TITLE
[CombatLog.lic] Creation. Alpha Stage.

### DIFF
--- a/scripts/CombatLog.lic
+++ b/scripts/CombatLog.lic
@@ -1,0 +1,567 @@
+=begin
+  CombatLog.lic is a damage meter.
+  
+  IN ALPHA STAGE. IN ALPHA STAGE. IN ALPHA STAGE. IN ALPHA STAGE. IN ALPHA STAGE.
+  
+        author: Nisugi
+		  game: Gemstone
+		  tags: hunting, data collection
+	   version: 0.0.1 alpha
+	   
+  Version Control:
+    Major_chage.feature_addition.bugfix
+  v1.0.0 alpha
+    Initial creation.
+	Supports fire, barrage, volley, spikethorn, tangleweed, feline companions.
+	Tracks damage and flares for each attack. Reports on death.
+	Make an alias ;alias add dps = CombatLog.report_kill('\?')
+	then just 'dps <target_id>' to report on them.
+	
+  Need to do:
+    EVERYTHING
+	Integrate all attacks/flares/dot type damage
+	Integrate a proper report.
+	Need ;logxml of various combat types to parse.
+	
+=end
+
+
+
+
+
+
+
+
+
+module CombatLog
+  require 'yaml'
+  status_tags
+  
+  def self.initialize
+    @death_cry_regexp = Regexp.union(
+      /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> falls back into a heap and dies/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> screams up at the heavens, then collapses and dies/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (screams|screeches) one last time and dies/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> falls to the ground and dies/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> rolls over and dies/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up/,
+	  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> lets out a final agonized squeal and dies/,
+      /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies/
+	  )
+
+	@death_cry =  /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+
+    @rotflare_dot_regexp = Regexp.union(
+ 	  /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>, leaking ooze leaks from the fresh wounds/,
+	  /<pushBold\/>\w <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> skin cracks open and oozes an inky black ichor/,
+	  /Rotting ulcers spread across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/,
+	  /Abscesses drain a bloody yellow fluid across <pushBold\/>a <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/,
+	  /<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> loses <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> balance/,
+	  /Skin peels off <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body, exposing rotting flesh/,
+	  /A fierce rash spreads across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/,
+	  /Rotting skin falls from <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body in large flakes/
+	  ) 
+  end
+	
+  def self.load
+    Dir.mkdir("#{$data_dir}#{XMLData.game}") unless File.exist?("#{$data_dir}#{XMLData.game}")
+    Dir.mkdir("#{$data_dir}#{XMLData.game}/#{Char.name}") unless File.exist?("#{$data_dir}#{XMLData.game}/#{Char.name}")
+    @filename = "#{$data_dir}#{XMLData.game}/#{Char.name}/combat_log.yaml"
+	if !File.exists?("#{@filename}")
+      @combat_log = Hash.new { |h,k| h[k] = {} }
+      File.write(@filename,@combat_log.to_yaml)
+	else
+	  @combat_log = YAML.load_file(@filename)
+	end
+	before_dying { File.write(@filename,@combat_log.to_yaml) }
+  end
+  
+  def self.save
+	File.write(@filename,@combat_log.to_yaml)
+  end
+  
+  def self.report_kill(id)
+	echo "#{id} : #{@combat_log[id]}"
+	CombatLog.save
+  end
+    
+  def self.new_target(id,name)
+	@combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+  end
+  
+  def self.companion_process(id,name,cbuffer)
+    @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+	@combat_log[id]['c_attack'] += 1
+	cbuffer.to_enum.with_index.reverse_each { |cline,i|
+	  case cline
+	  when /SMR result:/
+	    case cbuffer[i+1]
+		when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/
+		  break
+		end
+	  when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> emerges from the shadows/
+		@combat_log[id]['c_ambush'] += 1
+	  #Dead
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    @combat_log[id]['death_time'] = Time.now
+		@combat_log[id]['dead'] = true
+		@combat_log[id]['c_kill'] = true
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    c_damage = $1.to_i
+		case cbuffer[i-1]
+	    when /The murky haze surrounding <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> seems to intensify the slashing attack/
+	      @combat_log[id]['c_damage'] += c_damage
+		  @combat_log[id]['c_debuff'] += 1
+		when /The <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> takes the opportunity to slash <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> claws at the <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> chest/
+		  @combat_log[id]['c_damage'] += c_damage
+		  @combat_log[id]['c_double'] += 1  
+		when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/
+		  @combat_log[id]['c_damage'] += c_damage
+		end
+	  end
+	}
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+  
+  def self.tangleweed_process(id,name,tbuffer)
+    @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+	@combat_log[id]['t_attack'] += 1
+	tbuffer.to_enum.with_index.reverse_each { |tline,i|
+	  case tline
+	  when /SMR result:/
+	    case tbuffer[i+1]
+	  when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+		  break
+		end
+	  when /You notice a number of the <a exist="\d+" noun="\w+">[^<]+<\/a> widgeonweed mass scrape into <pushBold\/>a <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> skin\.  <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> suddenly looks very weak/
+	    @combat_log[id]['t_poison'] += 1
+	  #Dead
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    #@combat_log[id]['death_time'] = Time.now
+		@combat_log[id]['dead'] = true
+	    @combat_log[id]['t_kill'] = true
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    t_damage = $1.to_i
+	    case tbuffer[i-1]
+	    when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+	      @combat_log[id]['t_damage'] += t_damage
+	    end
+	  end
+	}
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+  
+  def self.spikethorn_process(id,name,sbuffer)
+    @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+	@combat_log[id]['spike_thorn'] += 1
+    sbuffer.to_enum.with_index.reverse_each { |sline,i|
+	  case sline
+	  #Dead
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    #@combat_log[id]['death_time'] = Time.now
+		@combat_log[id]['dead'] = true
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    damage = $1.to_i
+		case sbuffer[i-1]
+		when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+		  damage = 0 #Zero out Tangleweed damage.
+		when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/
+		  damage = 0 #Zero out Companion damage.
+		when /The <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> takes the opportunity to slash <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> claws at the <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> chest/
+		  damage = 0 #Zero out Companion double strike damage.
+		when /The murky haze surrounding <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> seems to intensify the slashing attack/
+		  damage = 0 #Zero out Companion buffed damage. 
+		when /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, leaking ooze leaks from the fresh wounds./
+		  damage = 0 #Zero out rot dot ticks.
+		when /<pushBold\/>\w <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> skin cracks open and oozes an inky black ichor/
+		  damage = 0 #Zero out rot dot ticks.
+		end
+		@combat_log[id]['spikethorn_damage'] += damage
+	  when /Dozens of long thorns suddenly grow out from the ground underneath <pushBold\/>a <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>/
+	    @combat_log[id]['cast_round_time'] = checkcastrt
+		break
+	  end
+	}
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+  
+  def self.fire_process(id,name,fbuffer)
+    @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+	@combat_log[id]['fire'] += 1
+	@combat_log[id]['tw_fire'] += 1 if Effects::Buffs.active?("Breeze Archery Tailwind")
+    fbuffer.to_enum.with_index.reverse_each { |fline,i|
+	  case fline
+	  #Dead
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    #@combat_log[id]['death_time'] = Time.now
+		@combat_log[id]['dead'] = true
+		@combat_log[id]['round_time'] = checkrt
+	  #Flares
+	  when /(?:A gust of wind shoves )?<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: is buffeted by a (?:burst|sudden gust) of wind(?: and pushed back)?)/
+		@combat_log[id]['breeze_flare'] += 1
+	  when /(?:(?:An|The) earthy, sweet aroma (?:wafts from |clings to |clinging to )|Soot brown specks of leaf mold trail in the wake of )<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: in a murky haze| grows more pervasive| movements, distorted by a murky haze| in a murky haze, accompanied by soot brown specks of leaf mold)/
+		@combat_log[id]['wild_entropy_flare'] += 1
+	  when /A sickly green aura radiates from a <a exist="\d+" noun="\w+">[^<]+<\/a> .*? and seeps into <pushBold\/>an? <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> wounds/
+		@combat_log[id]['rot_flare'] += 1
+	  when /Your <a exist="\d+" noun="\w+">[^<]+<\/a> bursts alight with leaping tongues of holy fire/
+		@combat_log[id]['holy_fire_flare'] += 1
+	  when /A wave of wicked power surges forth from your <a exist="\d+" noun="\w+">[^<]+<\/a> and fills <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> with terror, <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> form trembling with unmitigated fear/
+		@combat_log[id]['terror_flare'] += 1
+	  when /Cords of plasma-veined grey mist seep from your <a exist="\d+" noun="\w+">[^<]+<\/a> and entangle <pushBold\/>the <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, causing <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> to tremble violently/
+		@combat_log[id]['ghezyte_flare'] += 1
+	  #Buffs
+	  when /Vital energy infuses you, hastening your arcane reflexes/
+		@combat_log[id]['arcane_reflex'] += 1
+	  when /The vitality of nature bestows you with a burst of strength/
+		@combat_log[id]['physical_prowess'] += 1
+	  when /A favorable tailwind springs up behind you|The wind turns in your favor|You shift position, taking advantage of a favorable tailwind/
+		@combat_log[id]['tailwind'] += 1
+	  when /Necrotic energy from your <a exist="\d+" noun="(\w+)">[^<]+<\/a> overflows into you/
+		@combat_log[id]['ensorcell_flare'] += 1
+	  when /You feel healed/
+	    @combat_log[id]['ensorcell_heal'] += 1
+	  when /You feel empowered/
+	    @combat_log[id]['ensorcell_mana'] += 1
+	  when /You feel rejuvenated/
+	    @combat_log[id]['ensorcell_spirit'] += 1
+	  when /You feel reinvigorated/
+	    @combat_log[id]['ensorcell_stamina'] += 1
+	  when /You feel energized/
+	    @combat_log[id]['ensorcell_acuity'] += 1
+	  when /You feel the unnatural surge of necrotic power wane away/
+	    @combat_log[id]['ensorcell_acuity_consumed'] += 1
+	  #Damage
+	  when /Consumed by the hallowed flames, <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> is ravaged for (\d+) points? of damage!/
+		@combat_log[id]['fire_damage'] += damage
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    damage = $1.to_i
+		case fbuffer[i-1]
+		when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+		  damage = 0 #Zero out Tangleweed damage.
+		when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/
+		  damage = 0 #Zero out Companion damage.
+		when /The <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> takes the opportunity to slash <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> claws at the <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> chest/
+		  damage = 0 #Zero out Companion double strike damage.
+		when /The murky haze surrounding <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> seems to intensify the slashing attack/
+		  damage = 0 #Zero out Companion buffed damage. 
+		when /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, leaking ooze leaks from the fresh wounds./
+		  damage = 0 #Zero out rot dot ticks.
+		when /<pushBold\/>\w <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> skin cracks open and oozes an inky black ichor/
+		  damage = 0 #Zero out rot dot ticks.
+		end
+		@combat_log[id]['fire_damage'] += damage
+	  end
+	}
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+  
+  def self.barrage_process(bbuffer)
+    id = name = dead = death_time = nil
+    target_line = bbuffer.find { |l| l =~ /^The arrow sticks in <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>/ }
+	if target_line =~ /^The arrow sticks in <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>/
+	  id = $1
+	  name = $2
+	  @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+	  @combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+	  @combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+	  @combat_log[id]['barrage_hit'] += 1
+	else
+	  echo "ERROR: That didn't work."
+	end
+    bbuffer.to_enum.with_index.reverse_each { |bline,i|
+	  case bline
+	  when /The arrow streaks off into the distance/
+	    if bline[i-1] =~ /(?:.*)?<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>(?:.*?)/
+		  id = $1
+		  name = $2
+		  @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+		  @combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+		  @combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+		  @combat_log[id]['barrage_miss'] += 1
+		end		  
+	  #Dead
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    death_time = Time.now
+		dead = true
+	  #Flares
+	  when /(?:A gust of wind shoves )?<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: is buffeted by a (?:burst|sudden gust) of wind(?: and pushed back)?)/
+		@combat_log[id]['breeze_flare'] += 1
+	  when /(?:(?:An|The) earthy, sweet aroma (?:wafts from |clings to |clinging to )|Soot brown specks of leaf mold trail in the wake of )<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: in a murky haze| grows more pervasive| movements, distorted by a murky haze| in a murky haze, accompanied by soot brown specks of leaf mold)/
+		@combat_log[id]['wild_entropy_flare'] += 1
+	  when /A sickly green aura radiates from a <a exist="\d+" noun="\w+">[^<]+<\/a> .*? and seeps into <pushBold\/>an? <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> wounds/
+		@combat_log[id]['rot_flare'] += 1
+	  when /Your <a exist="\d+" noun="\w+">[^<]+<\/a> bursts alight with leaping tongues of holy fire/
+		@combat_log[id]['holy_fire_flare'] += 1
+	  when /A wave of wicked power surges forth from your <a exist="\d+" noun="\w+">[^<]+<\/a> and fills <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> with terror, <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> form trembling with unmitigated fear/
+		@combat_log[id]['terror_flare'] += 1
+	  when /Cords of plasma-veined grey mist seep from your <a exist="\d+" noun="\w+">[^<]+<\/a> and entangle <pushBold\/>the <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, causing <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> to tremble violently/
+		@combat_log[id]['ghezyte_flare'] += 1
+	  #Buffs
+	  when /Vital energy infuses you, hastening your arcane reflexes/
+		@combat_log[id]['arcane_reflex'] += 1
+	  when /The vitality of nature bestows you with a burst of strength/
+		@combat_log[id]['physical_prowess'] += 1
+	  when /A favorable tailwind springs up behind you|The wind turns in your favor|You shift position, taking advantage of a favorable tailwind/
+		@combat_log[id]['tailwind'] += 1
+	  when /Necrotic energy from your <a exist="\d+" noun="(\w+)">[^<]+<\/a> overflows into you/
+		@combat_log[id]['ensorcell_flare'] += 1
+	  when /You feel healed/
+	    @combat_log[id]['ensorcell_heal'] += 1
+	  when /You feel empowered/
+	    @combat_log[id]['ensorcell_mana'] += 1
+	  when /You feel rejuvenated/
+	    @combat_log[id]['ensorcell_spirit'] += 1
+	  when /You feel reinvigorated/
+	    @combat_log[id]['ensorcell_stamina'] += 1
+	  when /You feel energized/
+	    @combat_log[id]['ensorcell_acuity'] += 1
+	  when /You feel the unnatural surge of necrotic power wane away/
+	    @combat_log[id]['ensorcell_acuity_consumed'] += 1
+	  #Damage
+	  when /Consumed by the hallowed flames, <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> is ravaged for (\d+) points? of damage!/
+		@combat_log[id]['barrage_damage'] += damage
+	  when /... (?:and hit for )?(\d+) points? of damage!/
+	    damage = $1.to_i
+		case bbuffer[i-1]
+		when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+		  damage = 0 #Zero out Tangleweed damage.
+		when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/
+		  damage = 0 #Zero out Companion damage.
+		when /The <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> takes the opportunity to slash <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> claws at the <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> chest/
+		  damage = 0 #Zero out Companion double strike damage.
+		when /The murky haze surrounding <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> seems to intensify the slashing attack/
+		  damage = 0 #Zero out Companion buffed damage. 
+		when /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, leaking ooze leaks from the fresh wounds./
+		  damage = 0 #Zero out rot dot ticks.
+		when /<pushBold\/>\w <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> skin cracks open and oozes an inky black ichor/
+		  damage = 0 #Zero out rot dot ticks.
+		end
+		@combat_log[id]['barrage_damage'] += damage
+ 	  when /Nocking another arrow to your bowstring, you swiftly draw back and loose again/
+	    if dead
+		  @combat_log[id]['death_time'] = death_time unless @combat_log[id].has_key?('death_time')
+		  @combat_log[id]['dead'] = true
+		  @combat_log[id]['round_time'] = checkrt
+		end
+		dead = false
+	    echo "break"
+		break
+	  end
+	}
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+  
+  def self.volley_process(vbuffer)
+	id = name = dead = nil
+	damage = ghezyte_flare = terror_flare = holy_fire = rot_flare = wild_entropy_flare = breeze_flare = 0
+	vbuffer.to_enum.with_index.reverse_each { |vline,i|
+	#  echo vline
+	  case vline
+	  when /The arrow breaks into tiny fragments/
+	    damage = ghezyte_flare = terror_flare = holy_fire = rot_flare = wild_entropy_flare = breeze_flare = 0
+		id = name = dead = nil
+	  when /An ominous shadow falls over your surroundings as a whistling hail of arrows arcs down from above/
+	    break
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    death_time = Time.now
+		dead = $1
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    damage += $1.to_i
+	  #Grab our targets
+	  when /(?:The|<pushBold\/>\w+) <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> is struck by a falling arrow/
+	    id = $1
+		name = $2
+	  when /An arrow (?:pierces|skewers) <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>/
+	    id = $1
+		name = $2
+	  when /(?:The|<pushBold\/>\w+) <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> is transfixed by an arrow\'s descent/
+	    id = $1
+		name = $2
+	  when /An arrow finds its mark!  <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> is hit/
+	    id = $1
+		name = $2
+	  when /SMR result:/
+	    sleep(0.1)
+	    @combat_log[id] = Hash.new if !@combat_log.has_key?(id)
+		@combat_log[id]['name'] = name unless @combat_log[id].has_key?('name')
+		@combat_log[id]['start_time'] = Time.now unless @combat_log[id].has_key?('start_time')
+		@combat_log[id]['volley_hit'] += 1
+		@combat_log[id]['volley_damage'] += damage
+		@combat_log[id]['holy_fire_flare'] += holy_fire if (holy_fire > 0)
+		@combat_log[id]['breeze_flare'] += breeze_flare if (breeze_flare > 0)
+		@combat_log[id]['wild_entropy_flare'] += wild_entropy_flare if (wild_entropy_flare > 0)
+		@combat_log[id]['rot_flare'] += rot_flare if (rot_flare > 0)
+		@combat_log[id]['terror_flare'] += terror_flare if (terror_flare > 0)
+		@combat_log[id]['ghezyte_flare'] += ghezyte_flare if (ghezyte_flare > 0)
+		@combat_log[dead]['death_time'] = Time.now unless @combat_log[dead].has_key?('death_time')
+		@combat_log[dead]['dead'] = true if !dead.nil?
+		CombatLog.report_kill(id) if @combat_log[id]['dead']
+
+	  #Flares
+	  when /(?:A gust of wind shoves )?<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: is buffeted by a (?:burst|sudden gust) of wind(?: and pushed back)?)/
+		breeze_flare += 1
+	  when /(?:(?:An|The) earthy, sweet aroma (?:wafts from |clings to |clinging to )|Soot brown specks of leaf mold trail in the wake of )<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>(?: in a murky haze| grows more pervasive| movements, distorted by a murky haze| in a murky haze, accompanied by soot brown specks of leaf mold)/
+		wild_entropy_flare += 1
+	  when /A sickly green aura radiates from a <a exist="\d+" noun="\w+">[^<]+<\/a> .*? and seeps into <pushBold\/>an? <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> wounds/
+		rot_flare += 1
+	  when /Your <a exist="\d+" noun="\w+">[^<]+<\/a> bursts alight with leaping tongues of holy fire/
+		holy_fire += 1
+	  when /A wave of wicked power surges forth from your <a exist="\d+" noun="\w+">[^<]+<\/a> and fills <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> with terror, <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> form trembling with unmitigated fear/
+		terror_flare += 1
+	  when /Cords of plasma-veined grey mist seep from your <a exist="\d+" noun="\w+">[^<]+<\/a> and entangle <pushBold\/>the <a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/>, causing <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> to tremble violently/
+		ghezyte_flare += 1
+	  end
+	}
+  end
+  
+  def self.rot_process(id,name,rbuffer)
+    damage = nil
+	@combat_log[id] = Hash.new if @combat_log[id].nil?
+	@combat_log[id]['name'] = name if @combat_log[id]['name'].nil?
+	@combat_log[id]['rot_dot'] += 1 if !@combat_log[id].nil?
+	rbuffer.to_enum.with_index.reverse_each { |rline,i|
+	  case rline
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    @combat_log[$1]['death_time'] = Time.now
+		@combat_log[$1]['dead'] = $1
+	  when /... (?:and )?(?:hits? for )?(\d+) points? of damage/
+	    damage = $1.to_i
+		case rbuffer[i-1]
+		when /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>, leaking ooze leaks from the fresh wounds/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /<pushBold\/>\w <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> skin cracks open and oozes an inky black ichor/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /Rotting ulcers spread across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /Abscesses drain a bloody yellow fluid across <pushBold\/>a <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> loses <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> balance/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /Skin peels off <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body, exposing rotting flesh/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /A fierce rash spreads across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /Rotting skin falls from <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body in large flakes/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		when /<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> breathing appears to be labored/
+		  @combat_log[id]['rot_dot_damage'] += damage
+		  break
+		end
+	  end
+    }
+	CombatLog.report_kill(id) if @combat_log[id]['dead']
+  end
+   
+  def self.combat_watch_xml
+	while string = get
+	  case string
+	  #Death
+	  when /The(?: spectral form of the)? <pushBold\/><a exist="(\d+)" noun="\w+">[^<]+<\/a><popBold\/> (?:collapses, gurgling once with a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face before expiring|gurgles once and goes still, a wrathful look on <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> face|face begins to hideously contort as ribbons of essence begin to wend away from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> and into nothingness|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tenses in agony as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> begins to dissolve from the bottom up|tail twitches feebly as <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> dies|falls back into a heap and dies|screams up at the heavens, then collapses and dies|(screams|screeches) one last time and dies|falls to the ground and dies|rolls over and dies|lets out a final agonized squeal and dies)/
+	    @combat_log[$1]['death_time'] = Time.now unless @combat_log[$1].has_key?('death_time')
+	  #Companion Misses
+	    #Yep let's add that here.
+	  #Companion Hits
+	  when /<pushBold\/>A <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:pounces on|charges forward and slashes <pushBold\/><a exist="\d+" noun="\w+">her<\/a><popBold\/> claws at) <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>(?: faster than <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> can react)?/ 
+		companion_buffer = reget(30)
+		companion_process($1,$2,companion_buffer)
+	  #Tangleweed Misses
+	  when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>, but is unable to grasp <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>/
+		CombatLog.new_target($1,$2)
+		@combat_log[$1]['t_attack'] += 1
+		@combat_log[$1]['t_miss'] += 1
+	  #Tangleweed Hits
+	  when /The <a exist="\d+" noun="\w+">[^<]+<\/a> lashes out (?:violently )?at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>, (?:dragging|wraps itself around) <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> (?:body and entangles <pushBold\/><a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> )?(?:on|to) the ground/
+		tangleweed_buffer = reget(30)
+		tangleweed_process($1,$2,tangleweed_buffer)
+	  #Moonbeam Misses
+	  when /The (?:coruscating|ruddy|scarlet-sparked|swirling) light appears to crack and shatter, disintegrating into the air without effect/
+		CombatLog.new_target($1,$2)
+		@combat_log[$1]['moonbeam_failed'] += 1
+	  #Moonbeam
+	  when /<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> is caught fast, the light of (?:Liabo|Lornon|the moon) arresting <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> movements/
+	    CombatLog.new_target($1,$2)
+		@combat_log[$1]['moonbeam'] += 1
+	  #Spikethorn Hits
+	  when /Dozens of long thorns suddenly grow out from the ground underneath <pushBold\/>a <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>/
+	    sleep(0.1)
+		spikethorn_buffer = reget(30)
+		spikethorn_process($1,$2,spikethorn_buffer)
+	  #Ranged Misses
+	  when /You(?: take aim and)? fire your <a exist="\d+" noun="\w+">[^<]+<\/a> at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> but the shot flies wide of the target/
+		CombatLog.new_target($1,$2)
+		@combat_log[$1]['shots_missed'] += 1
+		@combat_log[$1]['tw_shots_missed'] += 1 if Effects::Buffs.active?("Breeze Archery Tailwind")
+	  #Ranged Hits
+	  when /You(?: take aim and)? fire .*? at <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>/
+	    sleep(0.1)
+		fire_buffer = reget(30)
+		fire_process($1,$2,fire_buffer)
+	  #Barrage
+	  when /Nocking another arrow to your bowstring, you swiftly draw back and loose again/
+	    sleep(0.1)
+	    barrage_buffer = reget(30)
+		barrage_process(barrage_buffer)
+	  #Volley
+	  when /An ominous shadow falls over your surroundings as a whistling hail of arrows arcs down from above/
+	    sleep(0.1)
+	    volley_buffer = reget(50)
+		volley_process(volley_buffer)
+	  
+	  #Rot Dot Ticks
+	  when /Darkened sores form all over <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/>, leaking ooze leaks from the fresh wounds/
+		rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /<pushBold\/>\w <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> skin cracks open and oozes an inky black ichor/
+		rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /Rotting ulcers spread across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /Abscesses drain a bloody yellow fluid across <pushBold\/>a <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /<pushBold\/>\w+ <a exist="\d+" noun="\w+">([^<]+)<\/a><popBold\/> loses <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> balance/
+		rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /Skin peels off <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body, exposing rotting flesh/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /A fierce rash spreads across <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /Rotting skin falls from <pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> body in large flakes/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  when /<pushBold\/>\w+ <a exist="(\d+)" noun="\w+">([^<]+)<\/a><popBold\/> breathing appears to be labored/
+	    rot_buffer = reget(20)
+		rot_process($1,$2,rot_buffer)
+	  end
+	end
+  end
+  
+end
+
+CombatLog.load
+CombatLog.combat_watch_xml

--- a/scripts/CombatLog.lic
+++ b/scripts/CombatLog.lic
@@ -6,7 +6,7 @@
         author: Nisugi
 		  game: Gemstone
 		  tags: hunting, data collection
-	   version: 0.0.1 alpha
+	   version: 1.0.0 alpha
 	   
   Version Control:
     Major_chage.feature_addition.bugfix


### PR DESCRIPTION
Will track damage->target and report on death. Currently tracks fire, barrage, volley, spikethorn, tangleweed, feline companion, flares, rot dot damage, moonbeam. Flares supported are ghezyte, terror, rot, holy fire (doesn't tag damage as holyfire damage, need expanded to track both damage numbers and assign to holy fire. assigns to total damage at this time.) breeze, wild entropy, tailwind, arcane reflex, physical prowess, ensorcell.  Saves to combat_log.yaml