### PR TITLE
[repository.lic] v2.40 remove Lich update function

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -16,6 +16,7 @@
                       
     2.40 (2022-10-06):
       remove lich update function ability
+      remove ability to overwrite Lich5 version of infomon/waggle/xnarost
     2.39 (2022-05-29):
       change default list of updateable scripts
     2.38 (2022-04-03):
@@ -1373,7 +1374,10 @@ elsif (cmd[0] =~ /^download$/i)
   else
     echo "downloading #{list[0][fi]} in 3 seconds... (;k #{script.name} to cancel)"
     sleep 3
-    if download_file.call(list[0][fi], list[0][gi], cmd_version)
+    if list[0][fi] =~ /^(infomon|waggle|xnarost)\.lic$/i)
+      echo "#{list[0][fi]} no longer updatable via ;repository."
+      echo "Please use ;lich5-update --script=#{list[0][fi]}"
+    elsif list[0][fi] !~ download_file.call(list[0][fi], list[0][gi], cmd_version)
       echo 'done'
     end
   end
@@ -1408,6 +1412,9 @@ elsif (cmd[0] =~ /^download-?update[ds]$/i)
       no_updates = true
       for local_info in (Settings['updatable'][:scripts])
         next if (LICH_VERSION =~ /^4\.4/) and (local_info[:filename] =~ /^(alias|vars|autostart|infomon)\.lic$/i)
+        
+        #bypass auto update of following scripts if on Lich5.
+        next if (LICH_VERSION =~ /^5\./) and (local_info[:filename] =~ /^(infomon|waggle|xnarost)\.lic$/i)
         if remote_info = list.find { |rinfo| (rinfo[fi] == local_info[:filename]) and (rinfo[gi] == local_info[:game]) }
           if (local_info[:filename] =~ /\.xml$/i) and (LICH_VERSION.split('.').collect { |n| n.rjust(5,'0') }.join('.') >= '00004.00006.00000')
             updated = !File.exists?("#{$data_dir}#{local_info[:filename]}") || (File.mtime("#{$data_dir}#{local_info[:filename]}").to_i < remote_info[lui].to_i)
@@ -2410,7 +2417,7 @@ elsif cmd[0] =~ /^help$/i
     output.concat "   upload FILENAME           upload a file to the server\n"
     output.concat "   delete FILENAME           delete a file from the server\n"
     output.concat "   change-password NEWPASS   change your repository password\n"
-    output.concat "   download-lich             download the latest version of Lich\n"
+#    output.concat "   download-lich             download the latest version of Lich\n"
     output.concat "   download-mapdb            download the latest map database\n"
     output.concat "   checkout-mapdb            must be done before editing the map database\n"
     output.concat "   release-mapdb             if you checkout-mapdb and change your mind\n"
@@ -2419,10 +2426,10 @@ elsif cmd[0] =~ /^help$/i
     output.concat "                             if set as updatable with the set-updatable commands\n"
     output.concat "   show-updatable            shows your current settings for download-updates\n"
     output.concat "   set-updatable FILENAME    download updates for FILENAME (when using download-updates)\n"
-    output.concat "   set-lich-updatable        download updates for Lich (download-updates)\n"
+#    output.concat "   set-lich-updatable        download updates for Lich (download-updates)\n"
     output.concat "   set-mapdb-updatable       download updates for the map database (download-updates)\n"
     output.concat "   unset-updatable FILENAME  ignore updates to FILENAME\n"
-    output.concat "   unset-lich-updatable      ignore updates to Lich\n"
+#    output.concat "   unset-lich-updatable      ignore updates to Lich\n"
     output.concat "   unset-mapdb-updatable     ignore updates to the map database\n"
     output.concat "\n"
     output.concat "options:\n"

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -1377,7 +1377,7 @@ elsif (cmd[0] =~ /^download$/i)
     if list[0][fi] =~ /^(infomon|waggle|xnarost)\.lic$/i)
       echo "#{list[0][fi]} no longer updatable via ;repository."
       echo "Please use ;lich5-update --script=#{list[0][fi]}"
-    elsif list[0][fi] !~ download_file.call(list[0][fi], list[0][gi], cmd_version)
+    elsif download_file.call(list[0][fi], list[0][gi], cmd_version)
       echo 'done'
     end
   end

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -1374,7 +1374,7 @@ elsif (cmd[0] =~ /^download$/i)
   else
     echo "downloading #{list[0][fi]} in 3 seconds... (;k #{script.name} to cancel)"
     sleep 3
-    if list[0][fi] =~ /^(infomon|waggle|xnarost)\.lic$/i)
+    if list[0][fi] =~ /^(infomon|waggle|xnarost)\.lic$/i
       echo "#{list[0][fi]} no longer updatable via ;repository."
       echo "Please use ;lich5-update --script=#{list[0][fi]}"
     elsif download_file.call(list[0][fi], list[0][gi], cmd_version)

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -1,7 +1,7 @@
 =begin
 
   This script allows you to connect to the Lich server to upload and download scripts,
-  the map database, and Lich.
+  and the map database.
 
   ;repository help
 
@@ -1523,6 +1523,7 @@ elsif (cmd[0] =~ /^unset-?updat(?:e|able)$/i)
   else
     echo "could not find #{cmd[1]} in the updatable list"
   end
+=begin
 elsif (cmd[0] =~ /^set-?lich-?updat(?:e|able)$|^set-?updat(?:e|able)-?lich$/i)
   if cmd[1]
     echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
@@ -1539,6 +1540,7 @@ elsif (cmd[0] =~ /^unset-?lich-?updat(?:e|able)$|^unset-?updat(?:e|able)-?lich$/
   Settings['updatable'] ||= Hash.new
   Settings['updatable'][:lich] = false
   echo 'the download-updates command will ignore updates for Lich'
+=end
 elsif (cmd[0] =~ /^set-?map(?:db)?-?updat(?:e|able)$|^set-?updat(?:e|able)-?map(?:db)?$/i)
   if cmd[1]
     echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
@@ -2422,7 +2424,7 @@ elsif cmd[0] =~ /^help$/i
     output.concat "   checkout-mapdb            must be done before editing the map database\n"
     output.concat "   release-mapdb             if you checkout-mapdb and change your mind\n"
     output.concat "   upload-mapdb              upload your changes to the map database\n"
-    output.concat "   download-updates          downloads any available updates to scripts/lich/mapdb\n"
+    output.concat "   download-updates          downloads any available updates to scriptsmapdb\n"
     output.concat "                             if set as updatable with the set-updatable commands\n"
     output.concat "   show-updatable            shows your current settings for download-updates\n"
     output.concat "   set-updatable FILENAME    download updates for FILENAME (when using download-updates)\n"

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,10 +10,12 @@
   contributors: SpiffyJr (theman@spiffyjr.me)
           game: any
           tags: core
-       version: 2.39
+       version: 2.40
 
   changelog:
                       
+    2.40 (2022-10-06):
+      remove lich update function ability
     2.39 (2022-05-29):
       change default list of updateable scripts
     2.38 (2022-04-03):
@@ -1392,7 +1394,7 @@ elsif (cmd[0] =~ /^download-?update[ds]$/i)
   Settings['updatable'][:scripts] ||= Array.new
   Settings['updatable'][:mapdb] ||= Hash.new
   if Settings['updatable'][:lich]
-    download_lich.call
+    #download_lich.call
   end
   if Settings['updatable'][:mapdb][XMLData.game]
     download_mapdb.call
@@ -2204,7 +2206,10 @@ elsif (cmd[0] =~ /^download-?lich$/i)
     echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
     exit
   end
-  download_lich.call
+  #download_lich.call
+  echo "Lich is no longer updatable via ;repository"
+  echo "Please see ;lich5-update --help"
+  echo "For info on updating Lich5"
 
 
 #


### PR DESCRIPTION
remove lich update function ability and point to `;lich5-update` instead.