### PR TITLE
Update go2.lic

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,15 +10,16 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.0.1
+           version: 2.0.2
           required: Lich >= 4.6.14 
-          required: Lich >= 5.4.1 for ;go2 setup and menu functions
+              note: Lich >= 5.4.1 for ;go2 setup and menu functions
 
    changelog:
+      2.0.2 (2022-10-20): Xanlin:
+        adjusted wait before exiting 
       2.0.1 (2022-10-08)
         bug fix for non-Gtk users
         backward compatibility for Lich4
-   
       2.0 (2022-10-08): Deysh:
         added setup gui
         added color options to help output
@@ -34,6 +35,8 @@
       1.36.0 (2022-06-16):
         fix for urchins runners not recognized as command option
         add sos caravan options.
+=end
+=begin
       1.35 (2022-05-12):
         exit if get-silvers fails to get enough silver from bank.
       1.34 (2022-03-31):
@@ -61,8 +64,6 @@
         Fix DragonRealms auto drag feature (Sarvatt)
       1.24 (2019-03-03):
          Updated formatting for ";go2 list" in GSPlat and GSF
-=end
-=begin
       1.23 (2019-03-03):
          add setting for using GSPlat old portal system
       1.22 (2019-02-10):
@@ -2017,7 +2018,10 @@ module Go2
      break unless $go2_restart
   }
 
-  sleep 0.1 if Room.current.id != destination.id
+  timeout = Time.now + 1
+  while Room.current.id != destination.id and Time.now < time
+    sleep 0.05 if Room.current.id != destination.id
+  end
   end_time = Time.now
   travel_time = (end_time.to_r - start_time.to_r).to_f / 60
   echo "travel time: #{sprintf("%d:%02d:%06.3f", travel_time.truncate, travel_time.truncate % 60, ((travel_time % 1) * 60).round(3))}"


### PR DESCRIPTION
adjusted wait before exiting to wait up to 1 second to match the current room to the destination room, impacts chaining scripts