### PR TITLE
eloot: Add CLI for updating settings

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -375,53 +375,62 @@ module ELoot
     end
    
   end
+
+  def self.launch_settings_ui
+    check_ui
+    Setup.new(data.settings).start
+    ELoot.load(load_profile)
+    set_inventory
+  end
+
+  DEFAULT_SETTINGS ={
+    :loot_types=>["alchemy", "armor", "box", "clothing", "collectible", "food", "gem", "jewelry", "lockpick", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand"],
+    :loot_exclude=>["black ora", "urglaes"],
+    :loot_phase=>false,
+    :use_disk=>true,
+    :loot_defensive=>false,
+    :coin_hand=>false,
+    :coin_hand_name=>"",
+    :overflow_container=>"",
+    :secondary_overflow=>"",
+    :sell_loot_types=>["alchemy", "armor", "clothing", "food", "gem", "jewelry", "lockpick", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand", "box"],
+    :sell_container=>["default","overflow","box","collectible","forageable","gem","herb","lockpick","potion","reagent","scroll","skin","treasure","trinket","wand"],
+    :sell_exclude=>[],
+    :sell_keep_scrolls=>[],
+    :sell_appraise_types=>["jewelry", "magic", "uncommon", "valuable"],
+    :sell_appraise_gemshop=>14999,
+    :sell_appraise_pawnshop=>34999,
+    :sell_collectibles=>true,
+    :sell_gold_rings=>false,
+    :sell_locksmith=>false,
+    :sell_locksmith_pool=>true,
+    :display_box_contents=>false,
+    :sell_locksmith_pool_tip=>15,
+    :sell_locksmith_pool_tip_percent=>true,
+    :sell_share_silvers=>false,
+    :sell_fwi=>false,
+    :sell_shroud=>false,
+    :sell_keep_silver=>0,
+    :skin_enable=>false,
+    :skin_kneel=>false,
+    :skin_604=>false,
+    :skin_resolve=>false,
+    :skin_sheath=>"",
+    :skin_weapon=>"",
+    :skin_sheath_blunt=>"",
+    :skin_weapon_blunt=>"",
+    :silence=>true,
+    :debug=>false,
+    :unskinnable=>[],
+    :crumbly=> [],
+    :keep_closed=>false,
+    :track_full_sacks=>true,
+    :favor_left=>false,
+  }
   
   def self.load_defaults()
     
-    default_hash = {
-      :loot_types=>["alchemy", "armor", "box", "clothing", "collectible", "food", "gem", "jewelry", "lockpick", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand"],
-      :loot_exclude=>["black ora", "urglaes"],
-      :loot_phase=>false,
-      :use_disk=>true,
-      :loot_defensive=>false,
-      :coin_hand=>false,
-      :coin_hand_name=>"",
-      :overflow_container=>"",
-      :secondary_overflow=>"",
-      :sell_loot_types=>["alchemy", "armor", "clothing", "food", "gem", "jewelry", "lockpick", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand", "box"],
-      :sell_container=>["default","overflow","box","collectible","forageable","gem","herb","lockpick","potion","reagent","scroll","skin","treasure","trinket","wand"],
-      :sell_exclude=>[],
-      :sell_keep_scrolls=>[],
-      :sell_appraise_types=>["jewelry", "magic", "uncommon", "valuable"],
-      :sell_appraise_gemshop=>14999,
-      :sell_appraise_pawnshop=>34999,
-      :sell_collectibles=>true,
-      :sell_gold_rings=>false,
-      :sell_locksmith=>false,
-      :sell_locksmith_pool=>true,
-      :display_box_contents=>false,
-      :sell_locksmith_pool_tip=>15,
-      :sell_locksmith_pool_tip_percent=>true,
-      :sell_share_silvers=>false,
-      :sell_fwi=>false,
-      :sell_shroud=>false,
-      :sell_keep_silver=>0,
-      :skin_enable=>false,
-      :skin_kneel=>false,
-      :skin_604=>false,
-      :skin_resolve=>false,
-      :skin_sheath=>"",
-      :skin_weapon=>"",
-      :skin_sheath_blunt=>"",
-      :skin_weapon_blunt=>"",
-      :silence=>true,
-      :debug=>false,
-      :unskinnable=>[],
-      :crumbly=> [],
-      :keep_closed=>false,
-      :track_full_sacks=>true,
-      :favor_left=>false,
-    }
+    default_hash = DEFAULT_SETTINGS.dup
     Dir.mkdir("#{$data_dir}#{XMLData.game}") unless File.exist?("#{$data_dir}#{XMLData.game}")
     Dir.mkdir("#{$data_dir}#{XMLData.game}/#{Char.name}") unless File.exist?("#{$data_dir}#{XMLData.game}/#{Char.name}")
 
@@ -438,7 +447,7 @@ module ELoot
       elsif !File.exist?("#{filename}") && name != Char.name
         ELoot.msg("error", " ELoot.load_profile: Attempt to load a profile that does not exist.")
       elsif !File.exist?("#{filename}") && name == Char.name
-        ELoot.msg("info", " No current settings found.  Loading defaults for configurtion.")
+        ELoot.msg("info", " No current settings found.  Loading defaults for configuration.")
         ELoot.msg("info", " Suggest you configure to your needs with ;eloot setup")
         settings_hash = ELoot.load_defaults()
       else
@@ -497,6 +506,57 @@ module ELoot
 
   def self.data
     @@data
+  end
+
+  def self.update_setting(input)
+    ELoot.load(ELoot.load_profile()) unless ELoot.data
+
+    setting_to_update = normalize_setting_name(input.first)
+    ELoot.msg("debug", "Normalized #{input.first} as #{setting_to_update}")
+
+    if DEFAULT_SETTINGS.keys.include?(setting_to_update)
+      default_value = DEFAULT_SETTINGS[setting_to_update].dup
+      ELoot.msg("debug", "recognized #{setting_to_update} as as valid #{default_value.class} setting")
+      new_value = coerce_setting_value(setting_to_update, default_value, input[1..-1])
+      ELoot.msg("debug", "Normalized #{input[1..-1]} as #{new_value.inspect}")
+
+      data.settings[setting_to_update] = new_value
+      ELoot.msg("info", "Updated #{setting_to_update} to #{new_value}")
+      ELoot.save_profile()
+    else
+      ELoot.msg("error", "#{setting_to_update} is not a recognized setting. Recognized setting names:")
+      ELoot.msg("error", DEFAULT_SETTINGS.keys.sort.join("\n"))
+    end
+  end
+
+  def self.coerce_setting_value(setting_name, default, input)
+    case default
+    when TrueClass, FalseClass
+      fix_option = { 'on' => true, 'true' => true, 'yes' => true, 'off' => false, 'false' => false, 'no' => false }
+      fix_option.fetch(input[0]) do |v|
+        ELoot.msg("error", %{Expected a boolean (true/false/yes/no) value for "#{setting_name} but got "#{v}"})
+        exit
+      end
+    when Array
+      input
+    when Integer
+      v = input[0]
+      if v =~ /\A[+-]?\d+\z/
+        v.to_i
+      else
+        ELoot.msg("error", %{Expected an integer value for #{setting_name} value but got "#{v}"})
+        exit
+      end
+    when String
+      input.join(" ")
+    else
+      ELoot.msg("error", "Recognized #{setting_name} but don't know how to normalize a #{default.class} type setting")
+      exit
+    end
+  end
+
+  def self.normalize_setting_name(input)
+    input.downcase.tr('-', '_').to_sym
   end
 
   def self.get_lines(command, regex, loud = false)
@@ -3806,7 +3866,7 @@ end
 
 # This allows partial matches the same way Gemstone works.
 # e.g., ;eloot sel would match ;eloot sell
-command = '^box^help^setup^sell^pool^load^list^test^deposit^start'
+command = '^box^help^settings^setup^sell^pool^load^list^test^deposit^start'
 
 # No match - show help message
 unless (index = (command =~ /\^#{script.vars[1]}/))
@@ -3842,16 +3902,19 @@ when 'sell'
 when 'pool'
   deposit = script.vars[2] =~ /depo/ ? true : false
   ELoot::Sell.pool(deposit)
-when 'setup'
-  ELoot.check_ui
-  ELoot::Setup.new(ELoot.data.settings).start
-  ELoot.load(ELoot.load_profile())
-  ELoot.set_inventory
 when 'load'
   waitrt?
   ELoot.check_ui
   ELoot.load(ELoot.load_profile)
   ELoot.set_inventory
+when 'settings'
+  if Script.current.vars[2]
+    ELoot.update_setting(script.vars[2..-1])
+  else
+    ELoot.launch_settings_ui
+  end
+when 'setup'
+  ELoot.launch_settings_ui
 when 'deposit'
   ELoot.silver_deposit
   ELoot.go2(room)


### PR DESCRIPTION
This PR updates ;eloot to add a text-based interface for updating settings:

```
;eloot set <setting name> <setting value>
```

```xml
;eloot set sell_locksmith_pool_tip 12
<preset id='whisper'>Updated sell_locksmith_pool_tip to 12</preset>
<preset id='whisper'> Settings saved to file: /home/charlie/lich/data/GSIV/Monit/eloot.yaml.</preset>
```

Because the first few letters of the new command overlap with the command to launch the GUI, `set` will also launch the GUI if not given a setting name to update, e.g.

```
;eloot set
;eloot settings
```

It uses the default settings to recognize valid setting names and to validate the new settings value. Currently, this includes:

```
;eloot set help

<b>help is not a recognized setting. Recognized setting names:</b>
coin_hand
coin_hand_name
crumbly
debug
display_box_contents
favor_left
keep_closed
loot_defensive
loot_exclude
loot_phase
loot_types
overflow_container
secondary_overflow
sell_appraise_gemshop
sell_appraise_pawnshop
sell_appraise_types
sell_collectibles
sell_container
sell_exclude
sell_fwi
sell_gold_rings
sell_keep_scrolls
sell_keep_silver
sell_locksmith
sell_locksmith_pool
sell_locksmith_pool_tip
sell_locksmith_pool_tip_percent
sell_loot_types
sell_share_silvers
sell_shroud
silence
skin_604
skin_enable
skin_kneel
skin_resolve
skin_sheath
skin_sheath_blunt
skin_weapon
skin_weapon_blunt
track_full_sacks
unskinnable
use_disk
```

If there are valid settings that are not included in the default settings, I would like to add a default both to make the CLI work but also to better document how ;eloot works out of the box for everyone.

It looks like there are currently boolean, integer (are any of these floats?), string, and array of string settings values. Strings and arrays of strings are straightforward to take directly as input, but I added some validation for integer and boolean settings:

```xml
;eloot set sell_locksmith_pool_tip purple

<b>Expected an integer value for sell_locksmith_pool_tip value but got "purple"</b>
```

```xml
> ;eloot set sell_locksmith_pool_tip_percent purple

<b>Expected a boolean (true/false/yes/no) value for "sell_locksmith_pool_tip_percent but got "purple"</b>
```

I didn't update the version or changelog yet because I see that a [v1.5.0 release of eloot](https://github.com/elanthia-online/scripts/pull/852) is being prepped. I will rebase this PR against master when that lands but wanted to get this up so folks can take a look at what I have.