### PR TITLE
[bigshot.lic] waitcastrt? change in def cmd()

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor
           game: Gemstone
           tags: hunting
-       version: 4.12.11
+       version: 4.12.12
       requires: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,10 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.12.12 (2022-10-28)
+    Fix for waitcastrt? before commands unless command can be executed during castrt
+    Fix for quickhunt targets when given an attack routine
+
   v4.12.11 (2022-09-18)
     Fixed calls to kill hunting scripts started with args
 
@@ -285,7 +289,7 @@ require 'yaml'
 require 'drb'
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.12.9'
+BIGSHOT_VERSION = '4.12.12'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1005,7 +1005,8 @@ class Bigshot
     # waitrt/waitcastrt
     unless (command =~ /^nudgeweapons?/)
       waitrt?
-      waitcastrt? if command =~ /^\d+|incant/
+      #waitcastrt? if command =~ /^\d+|incant/
+      waitcastrt? unless command =~ /hide|cock/da
     end
 	
     # check mana/stamina/health(percentage)/encumbrance/unarmed tiering/mobs in room/target not prone/target undead
@@ -3343,7 +3344,7 @@ class Bigshot
         routine_letter = @TARGETS[key]
       end
 
-      if routine_letter == 'quick' || $bigshot_quick
+      if routine_letter == 'quick' || ($bigshot_quick && key.nil?)
         return @QUICK_COMMANDS unless @QUICK_COMMANDS.size == 0
       elsif routine_letter == 'j'
         return @HUNTING_COMMANDS_J unless @HUNTING_COMMANDS_J.size == 0


### PR DESCRIPTION
Currently bigshot only respects cast rt if you're casting a spell. It immediately tries any other command triggering the game to tell you to wait for your rt. Changed the logic to waitcastrt unless the command doesn't care about cast rt. Like Hide or Cocking your crossbow. Probably are some other commands that will need to be added but I'm unsure what they are.

Made a small change to make bigshot quick respect routines when specified versus only using the quick routine.