### PR TITLE
[Bigshot.lic] Typo fixes for cman regex

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -18,6 +18,8 @@
   Version Control:
     Major_change.feature_addition.bugfix
     
+  v4.13.1 (2022-11-03)
+    Typo fixes in cman regex
   v4.13.0 (2022-10-29)
     Added profile support to UI
     ***************************
@@ -1596,7 +1598,7 @@ class Bigshot
     echo "cmd_cmans - npc: #{npc} cmd: #{cmd}" if $bigshot_debug
  
     result_regex = Regexp.union(     
-      /awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find||seconds/i,
+      /awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i,
       /attempt a shield bash/i,
       /release your grip/i,
       /feat of strength empowers/i,
@@ -1671,7 +1673,7 @@ class Bigshot
   
     return if !CMan.available?(commands[cmd])
     return unless CMan.affordable?(commands[cmd])
-    return if Effects::Cooldowns.active?("Bearhub") && cmd == "bearhug"
+    return if Effects::Cooldowns.active?("Bearhug") && cmd == "bearhug"
     return if npc.status =~ PRONE && cmd == "bullrush"
     return if Effects::Cooldowns.active?("Spell Cleave") && cmd == "scleave"
     return if Effects::Cooldowns.active?("Spell Thieve") && cmd == "sthieve"
@@ -1691,7 +1693,7 @@ class Bigshot
     echo "cmd_rogue_cmans - npc: #{npc} cmd: #{cmd}" if $bigshot_debug
     
     result_regex = Regexp.union(
-      /awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find||seconds/i,
+      /awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i,
       /attempt to slit/i,
       /Try hiding first/i,
       /kicking up as much dirt/i,


### PR DESCRIPTION
bearhug was matching on /round(time)?/ causing bigshot to not wait. Removed the extra | as well. Fixed typo in Bearhug cooldown check.