### PR TITLE
[bigshot.lic] v4.13.4 command check tweak

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1384,7 +1384,7 @@ class Bigshot
           }
              
           echo "command_check section 1 #{s} #{split_check[split_item]}" if $bigshot_debug
-          return split_check[split_item] if split_check[split_item] != false
+          return split_check[split_item] if split_check[split_item]
         end
     
         if s =~ /((?:buff))(\d+)/i
@@ -1403,7 +1403,7 @@ class Bigshot
           }
           
           echo "command_check section 2 #{s} #{buff_check[command]}" if $bigshot_debug
-          return buff_check[command] if buff_check[command] != false
+          return buff_check[command] if buff_check[command]
         end
       
         if s =~ /((?:prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice|tailwind|!tailwind))/i
@@ -1472,7 +1472,7 @@ class Bigshot
             end       
           else     
             echo "command_check section 3 #{s} #{other_checks[item]}" if $bigshot_debug
-            return other_checks[item] if other_checks[item] != false
+            return other_checks[item] if other_checks[item]
           end
       
         end

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1384,7 +1384,7 @@ class Bigshot
           }
              
           echo "command_check section 1 #{s} #{split_check[split_item]}" if $bigshot_debug
-          return split_check[split_item] if split_check[split_item] == true
+          return split_check[split_item] if split_check[split_item] != false
         end
     
         if s =~ /((?:buff))(\d+)/i
@@ -1403,7 +1403,7 @@ class Bigshot
           }
           
           echo "command_check section 2 #{s} #{buff_check[command]}" if $bigshot_debug
-          return buff_check[command] if buff_check[command] == true
+          return buff_check[command] if buff_check[command] != false
         end
       
         if s =~ /((?:prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice|tailwind|!tailwind))/i
@@ -1472,7 +1472,7 @@ class Bigshot
             end       
           else     
             echo "command_check section 3 #{s} #{other_checks[item]}" if $bigshot_debug
-            return other_checks[item] if other_checks[item] == true
+            return other_checks[item] if other_checks[item] != false
           end
       
         end

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh
           game: Gemstone
           tags: hunting
-       version: 4.13.3
+       version: 4.13.4
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup instructions: https://gswiki.play.net/Script_Bigshot
@@ -18,6 +18,9 @@
   Version Control:
     Major_change.feature_addition.bugfix
   
+  v4.13.4 (2022-11-7)
+    - bug fix for split, buff, and other checks
+
   v4.13.3 (2022-11-7)
     - bug fix for censure command
   
@@ -349,7 +352,7 @@ Dir.mkdir("#{$data_dir}#{XMLData.game}/#{Char.name}") unless File.exist?("#{$dat
 Dir.mkdir("#{$data_dir}#{XMLData.game}/#{Char.name}/bigshot_profiles") unless File.exist?("#{$data_dir}#{XMLData.game}/#{Char.name}/bigshot_profiles")
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.13.3'
+BIGSHOT_VERSION = '4.13.4'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []


### PR DESCRIPTION
The command checks don't always return true/false. They can return 0 and possibly other results. The only sure thing we have is that if the result is false, it returns false. 

So I changed the returns back to `!= false` from `== true` due to `prone` returns `0` for `true`