### PR TITLE
[Infomon.lic] Updates for 620 tracking

### DIFF
--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -16,8 +16,7 @@
     Major_change.feature_addition.bugfix
 
   1.18.17 (2022-12-05):
-    Fix for Resist Nature to show as active with new changes
-    Fix for CoL timers
+    Fix for more missing XML spells and Resist Nature
   1.18.16 (2022-08-15):
     Fix for spell cleanup for missing XML spells/buffs/etc
   1.18.15 (2022-05-19):
@@ -446,7 +445,7 @@ unless Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.0.16')
         end
 
         existing_spell_names = []
-        ignore_spells = ["Berserk", "Council Task", "Council Punishment"]
+        ignore_spells = ["Berserk", "Council Task", "Council Punishment", "Briar Betrayer"]
         Spell.active.each { |s| existing_spell_names << s.name }
         inactive_spells = existing_spell_names - ignore_spells - update_spell_names
         inactive_spells.each { |s| badspell = Spell[s].num; Spell[badspell].putdown if Spell[s].active?}

--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -385,6 +385,10 @@ unless Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.0.16')
             @makeychange << k
             update_spell_names.push("Mage Armor")
             next
+          elsif k =~ /(?:Resist Nature|620)(?: \-)?/
+            @makeychange << k
+            update_spell_names.push("Resist Nature")
+            next
           elsif k =~ /(?:CoS|712) \- /
             @makeychange << k
             update_spell_names.push("Cloak of Shadows")
@@ -418,6 +422,8 @@ unless Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.0.16')
             case changekey
             when /(?:Mage Armor|520) \- /
               update_spell_durations['Mage Armor'] = update_spell_durations.delete changekey
+            when /(?:Resist Nature|620)/
+              update_spell_durations['Resist Nature'] = update_spell_durations.delete changekey
             when /(?:CoS|712) \- /
               update_spell_durations['Cloak of Shadows'] = update_spell_durations.delete changekey
             when /Enh\. Strength/

--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -9,12 +9,14 @@
           game: Gemstone
           tags: core
       required: Lich > 5.0.16
-       version: 1.18.16
+       version: 1.18.17
         Source: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
 
+  1.18.17 (2022-12-05):
+    Fix for Resist Nature to show as active with new changes
   1.18.16 (2022-08-15):
     Fix for spell cleanup for missing XML spells/buffs/etc
   1.18.15 (2022-05-19):

--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -17,6 +17,7 @@
 
   1.18.17 (2022-12-05):
     Fix for Resist Nature to show as active with new changes
+    Fix for CoL timers
   1.18.16 (2022-08-15):
     Fix for spell cleanup for missing XML spells/buffs/etc
   1.18.15 (2022-05-19):
@@ -445,7 +446,7 @@ unless Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.0.16')
         end
 
         existing_spell_names = []
-        ignore_spells = ["Berserk"]
+        ignore_spells = ["Berserk", "Council Task", "Council Punishment"]
         Spell.active.each { |s| existing_spell_names << s.name }
         inactive_spells = existing_spell_names - ignore_spells - update_spell_names
         inactive_spells.each { |s| badspell = Spell[s].num; Spell[badspell].putdown if Spell[s].active?}


### PR DESCRIPTION
Updated so ;magic will track 620 properly when it is an element other than nature.
Preventing ;waggle from casting 620 when it's already at max duration.