### PR TITLE
Ebounty

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -11,7 +11,7 @@
   Improvements:
 
   v1.0.8 (2022-12-06)
-    - moved post hunt routine to after forage turin to avoid trashing foraged item 
+    - moved post hunt routine to after forage turnin to avoid trashing foraged item 
 
   v1.0.7 (2022-12-05)
     - bug fix for hunting sequence resting

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -11,7 +11,7 @@
   Improvements:
 
   v1.0.8 (2022-12-06)
-    - moved post hunt routine to after forage turnin to avoid trashing foraged item 
+    - moved post hunt routine to after forage turn-in to avoid trashing foraged item 
 
   v1.0.7 (2022-12-05)
     - bug fix for hunting sequence resting

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,6 +10,9 @@
            
   Improvements:
 
+  v1.0.8 (2022-12-06)
+    - moved post hunt routine to after forage turin to avoid trashing foraged item 
+
   v1.0.7 (2022-12-05)
     - bug fix for hunting sequence resting
 
@@ -2125,9 +2128,7 @@ module EBounty
       EBounty.fog
     
       EBounty.go2(EBounty.data.settings[:resting_room])
-      
-      Hunting.post_hunt
-      
+         
       if checkbounty =~ /The.*is working on a concoction that requires (?:a|an|some) (.*) found/     
         herb = $1
       end
@@ -2164,6 +2165,8 @@ module EBounty
         sleep 0.2 until checkbounty != original_checkbounty || Time.now > end_wait
       
       end
+      
+      Hunting.post_hunt
       
       if checkbounty =~ /The.*is working on a concoction that requires (?:a|an|some) (.*) found/ && recover_room
         EBounty.go2_rest


### PR DESCRIPTION
v1.0.8 (2022-12-06)
    - moved post hunt routine to after forage turn-in to avoid trashing foraged item 