### PR TITLE
ebounty.lic

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,13 +9,15 @@
   contributers: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-       version: 1.0.15
+       version: 1.0.16
            
   Improvements:
-  v1.0.15 (2022-12-22)
-    - bugfix for herbalist rooms using UID's
+  v1.0.16 (2022-12-22)
+    - typo fix for the bugfix for herbalist rooms using UID's
 =end
 =begin
+  v1.0.15 (2022-12-22)
+    - bugfix for herbalist rooms using UID's
   v1.0.14 (2022-12-20)
     - updated herbalist rooms to use UID's for instance compatibility
   v1.0.13 (2022-12-19)
@@ -64,7 +66,7 @@ require 'yaml'
 
 module EBounty
 
-  EBounty_version = '1.0.15'
+  EBounty_version = '1.0.16'
   @@data ||= nil
  
    ##### Data & Setup Start #####
@@ -728,7 +730,7 @@ module EBounty
       
       @herbalist_rooms = []
   
-      EBounty.data.herbalist_rooms_uid.each{ |room|
+      herbalist_rooms_uid.each{ |room|
         @herbalist_rooms.push(Room[room].id) if Room[room].id.positive?
       }
       


### PR DESCRIPTION
v1.0.16 (2022-12-22)
    - typo fix for the bugfix for herbalist rooms using UID's