### PR TITLE
ebounty.lic

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,13 +9,15 @@
   contributers: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-       version: 1.0.16
+       version: 1.0.17
            
   Improvements:
-  v1.0.16 (2022-12-22)
-    - typo fix for the bugfix for herbalist rooms using UID's
+  v1.0.17 (2022-12-27)
+    - ensuring following scripts are stopped before starting ebounty: go2, echild, ego2, bigshot
 =end
 =begin
+  v1.0.16 (2022-12-22)
+    - typo fix for the bugfix for herbalist rooms using UID's
   v1.0.15 (2022-12-22)
     - bugfix for herbalist rooms using UID's
   v1.0.14 (2022-12-20)
@@ -66,7 +68,7 @@ require 'yaml'
 
 module EBounty
 
-  EBounty_version = '1.0.16'
+  EBounty_version = '1.0.17'
   @@data ||= nil
  
    ##### Data & Setup Start #####
@@ -2554,11 +2556,15 @@ if script.vars[1].nil?
   EBounty.deadmans_switch
   EBounty.set_variables
   
+  kill_scripts = ["go2", "echild", "ego2", "bigshot"]
+    
+  kill_scripts.each{ |script|
+    kill_script(script) if running?(script)   
+  }
+  
   before_dying { 
     UserVars.op = current_settings
     EBounty.go2(EBounty.data.start_room) if EBounty.data.settings[:basic]
-    
-    kill_scripts = ["go2", "echild", "ego2"]
     
     kill_scripts.each{ |script|
       kill_script(script) if running?(script)   


### PR DESCRIPTION
v1.0.17 (2022-12-27)
    - ensuring following scripts are stopped before starting ebounty: go2, echild, ego2, bigshot