### PR TITLE
[Bigshot.lic] Check for targets after wander_wait

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4079,7 +4079,6 @@ class Bigshot
       $wander_rooms.push(next_room)
       way = room.wayto[next_room]
       if way.class == String
-        pause @WANDER_WAIT
         move(way)
       else
         way.call
@@ -4102,6 +4101,9 @@ class Bigshot
       npcs.delete_if { |npc| (npc.status =~ /dead|gone/) }
       sort_npcs.each { |i| return i if valid_target?(i, true) and no_players == true and (GameObjNpcCheck() > 0) }
       return if should_rest?
+      
+      pause @WANDER_WAIT
+      return if (GameObj.targets.any? { |npc| UserVars.op["targets"].include?(npc.noun) } && no_players_hunt && !should_flee? && !poaching?)
 
       set_obvious_hiding_player(false)
       wander.call

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 4.13.16
+       version: 4.13.17
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.13.17 (2023-01-23)
+    - move wander_wait to prevent poaching
   v4.13.16 (2023-01-21)
     - added support to rest for debuffs: Wall of Thorn Poison, Confusion, Creeping Dread, and Crushing Dread
   v4.13.15 (2023-01-12)
@@ -161,7 +163,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.13.16'
+BIGSHOT_VERSION = '4.13.17'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []


### PR DESCRIPTION
Bigshot has a wait before moving rooms setting that literally just waits then moves.  Let's make it useful. We enter a room, check for targets, wait the amount of time you set (defaults to .3s), check for targets again, then leaves if no target. Allowing bigshot to handle hidden creatures, creatures walking in, and creatures spawning.

Relocated the pause @WANDER_WAIT outside of the wander proc and added a check for targets.