### PR TITLE
[script][go2] - Support custom target room arrays

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,11 +10,13 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.0.5
+           version: 2.0.6
           required: Lich >= 5.4.1
 
    changelog:
-      2.0.5 (2022-11-29): Tysong
+      2.0.6 (2023-02-04): Gildaren:
+        Add support for custom named targets with an array of roomnumbers. Finds nearest.
+      2.0.5 (2022-11-29): Tysong:
         Fix for variable name syntax
       2.0.4 (2022-11-28): Gildaren:
         Add support to "goback" to the room go2 last started in
@@ -740,7 +742,9 @@ module Go2
      output << "   other commands:"
      output << ""
      output << "      #{$lich_char}#{Script.current.name} save new name=<target>      <Saves> a custom target.  target can be the same"
-     output << "      #{''.rjust($lich_char.length + Script.current.name.length)}                                as before, or \"current\" for your current room"
+     output << "      #{''.rjust($lich_char.length + Script.current.name.length)}                                as before, or \"current\" for your current room.\n"
+     output << "      #{''.rjust($lich_char.length + Script.current.name.length)}                                Can also be an array of rooms, separated by commas.\n"
+     output << "      #{''.rjust($lich_char.length + Script.current.name.length)}                                If the target exists, will append the room to array.\n"
      output << "      #{$lich_char}#{Script.current.name} delete custom target        Deletes a saved custom target."
      output << "      #{$lich_char}#{Script.current.name} list                          Shows your settings and custom targets."
      output << "      #{$lich_char}#{Script.current.name} targets                       Shows the built-in targets."
@@ -774,49 +778,54 @@ module Go2
 
   }
 
-  # For Dragonrealms only
-  # A change in behavior from Lich4 to Lich5 caused certain ;go2 map wayto movements to fail.
-  # This is because of the way the map stringprocs are structured, and the method used to evaluate
-  # certain map moves, which involved an arguably dubious overloading of FalseClass on Lich4.
-  # The transition to Lich5 makes it necessary to fix some stringprocs as an interim solution, at
-  # least until the map can be divested from current owner control and handled appropriately. This code
-  # also allows the flexibility to pull custom map wayto overrides from the standard yaml hierarchy.
+  # For Dragonrealms
+  # Allows map wayto and timeto overrides in base.yaml and a user's yaml
+  # Allows custom map targets defined via yaml
   if XMLData.game =~ /^DR/
-   # Get yaml settings
-   settings = get_settings
+    # Get yaml settings
+    settings = get_settings
 
-   # Get base and personal wayto overrides
-   base_wayto_overrides = settings.base_wayto_overrides
-   personal_wayto_overrides = settings.personal_wayto_overrides
+    # Get base and personal wayto overrides
+    base_wayto_overrides = settings.base_wayto_overrides
+    personal_wayto_overrides = settings.personal_wayto_overrides
 
-   # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
-   wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
+    # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
+    wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
 
-   # Iterate through the aggregated map wayto overrides from above and set new stringprocs
-   wayto_overrides.each do | key, values |
-     start_room_id = values['start_room'].to_i
-     end_room_id = values['end_room'].to_i
+    # Iterate through the aggregated map wayto overrides from above and set new stringprocs
+    wayto_overrides.each do | key, values |
+      start_room_id = values['start_room'].to_i
+      end_room_id = values['end_room'].to_i
 
-     start_room = Map.list[start_room_id]
+      start_room = Map.list[start_room_id]
 
-     old_wayto = start_room.wayto["#{end_room_id}"]
-     old_timeto = start_room.timeto["#{end_room_id}"]
+      old_wayto = start_room.wayto["#{end_room_id}"]
+      old_timeto = start_room.timeto["#{end_room_id}"]
 
-     new_wayto = old_wayto
-     new_timeto = old_timeto
+      new_wayto = old_wayto
+      new_timeto = old_timeto
 
-     if values['str_proc']
-       new_wayto = StringProc.new("#{values['str_proc']}")
-     end
+      if values['str_proc']
+        new_wayto = StringProc.new("#{values['str_proc']}")
+      end
 
-     if values['travel_time']
-       new_timeto = values['travel_time'].to_f
-     end
+      if values['travel_time']
+        new_timeto = values['travel_time'].to_f
+      end
 
-     start_room.wayto["#{end_room_id}"] = new_wayto
-     start_room.timeto["#{end_room_id}"] = new_timeto
-   end
- end
+      start_room.wayto["#{end_room_id}"] = new_wayto
+      start_room.timeto["#{end_room_id}"] = new_timeto
+    end
+
+    # Pull personal map custom targets, if any
+    personal_map_targets = settings.personal_map_targets
+
+    if personal_map_targets
+      custom_targets = (GameSettings['custom targets'] || Hash.new)
+      custom_targets.merge!(personal_map_targets)
+      GameSettings['custom targets'] = custom_targets
+    end
+  end
 
   change_map_vaalor_shortcut = proc { |use_shortcut|
      unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
@@ -926,19 +935,19 @@ module Go2
      end
      output << ""
      output << "                 delay: #{CharSettings['delay']}"
-     output << "           get silvers: #{CharSettings['get silvers'] ? 'on' : 'off'}"
-     output << "    get return silvers: #{CharSettings['get return trip silvers'] ? 'on' : 'off'}"
-     output << "              ice mode: #{UserVars.mapdb_ice_mode}"
-     output << "           use seeking: #{CharSettings['use seeking'] ? 'on' : 'off'}"
-     output << "           use urchins: #{UserVars.mapdb_use_urchins ? 'on' : 'off'}"
-     output << "       use portmasters: #{UserVars.mapdb_use_portmasters ? 'on' : 'off'}"
-     output << "          use day pass: #{UserVars.mapdb_use_day_pass ? 'on' : 'off'}"
-     output << "          buy day pass: #{UserVars.mapdb_buy_day_pass ? 'on' : 'off'}"
-     output << "    day pass container: #{UserVars.day_pass_sack.nil? ? '(not set)' : UserVars.day_pass_sack}"
-     output << "hide room descriptions: #{CharSettings['hide_room_descriptions'] ? 'on' : 'off'}"
-     output << "      hide room titles: #{CharSettings['hide_room_titles'] ? 'on' : 'off'}"
-     output << "            echo input: #{CharSettings['echo_input'] ? 'on' : 'off'}"
      if XMLData.game =~ /^GS/
+        output << "           get silvers: #{CharSettings['get silvers'] ? 'on' : 'off'}"
+        output << "    get return silvers: #{CharSettings['get return trip silvers'] ? 'on' : 'off'}"
+        output << "              ice mode: #{UserVars.mapdb_ice_mode}"
+        output << "           use seeking: #{CharSettings['use seeking'] ? 'on' : 'off'}"
+        output << "           use urchins: #{UserVars.mapdb_use_urchins ? 'on' : 'off'}"
+        output << "       use portmasters: #{UserVars.mapdb_use_portmasters ? 'on' : 'off'}"
+        output << "          use day pass: #{UserVars.mapdb_use_day_pass ? 'on' : 'off'}"
+        output << "          buy day pass: #{UserVars.mapdb_buy_day_pass ? 'on' : 'off'}"
+        output << "    day pass container: #{UserVars.day_pass_sack.nil? ? '(not set)' : UserVars.day_pass_sack}"
+        output << "hide room descriptions: #{CharSettings['hide_room_descriptions'] ? 'on' : 'off'}"
+        output << "      hide room titles: #{CharSettings['hide_room_titles'] ? 'on' : 'off'}"
+        output << "            echo input: #{CharSettings['echo_input'] ? 'on' : 'off'}"
         output << "         stop for dead: #{CharSettings['stop for dead'] ? 'on' : 'off'}"
         output << "       vaalor shortcut: #{CharSettings['vaalor shortcut'] ? 'on' : 'off'}"
         output << "           FWI trinket: #{UserVars.mapdb_fwi_trinket ? UserVars.mapdb_fwi_trinket : '(not set)'}"
@@ -957,40 +966,71 @@ module Go2
      output << ""
      output << "custom targets:"
      output << ""
-     for target_name,target_num in GameSettings['custom targets'].sort
-        output << "   #{target_name.ljust(20)} = #{target_num.to_s.rjust(5)}   #{Map[target_num].title.first}"
-     end
+     GameSettings['custom targets'].sort_by {|key| key}.to_h.each do |target_name, target_nums|
+        if target_nums.is_a?(Array)
+          target_nums.uniq!
+          if target_nums.length == 1
+            output << "   #{target_name.ljust(15)} = #{target_nums.to_s} - #{Map[target_nums[0]].title.first}"
+          else
+            output << "   #{target_name.ljust(15)} = #{target_nums.sort.to_s}"
+          end
+        else
+          output << "   #{target_name.ljust(15)} = [#{target_nums.to_s}] - #{Map[target_nums].title.first}"
+        end
+        output << ""
+      end
      output << ""
      respond output
      exit
   elsif Script.current.vars[1] =~ /^save/i
-     unless Script.current.vars[0] =~ /^save (.+?)=(.+)$/
-        echo "error: You're doing it wrong."
+     unless script.vars[0] =~ /^save ([a-zA-Z0-9!@#$%_-]+)\s?=\s?(current|\d+)$/ || script.vars[0] =~ /^save ([a-zA-Z0-9!@#$%_-]+)\s?=\s?\[?([current\d,\s]+)\]?$/
+        echo "error: format"
+        echo "error: proper format examples - ;go2 save test=1234 OR ;go2 save test=[1234, 1432] etc."
         exit
      end
-     target_name = $1.strip
-     target = $2.strip
+     target_name = $1
+     target = $2.split(',')
+                .collect(&:strip)
+
      if target_name =~ /^\d+$/
         echo "error: target name can't be just a number."
         exit
      end
-     if target =~ /^current$/i
-        unless target_room = Map.current
-           echo 'error: your current room was not found in the map database.'
-           exit
-        end
-     else
-        unless target =~ /^\d+$/ and (target_room = Map[target.to_i])
-           unless target_room = Map[target]
-              echo "error: could not identify the target room"
-              exit
-           end
+
+     # User included current room as a custom target. Verify exists.
+     if target.include?(/current/i)
+        unless Map.current.id
+          echo 'error: your current room was not found in the map database.'
+          exit
         end
      end
+
+     target.map! {|element| element == "current" ? Map.current.id : element}
+           .map!(&:to_i)
+
+     target_holder = []
+     target.each do |element|
+        unless target_room = Map[element]
+          target_holder.append(element)
+        end
+     end
+
+     unless target_holder.empty?
+        echo "error: the following rooms were not found in the map - #{target_holder}"
+        exit
+     end
+
      custom_targets = (GameSettings['custom targets'] || Hash.new)
-     custom_targets[target_name] = target_room.id
+
+     if custom_targets[target_name]
+        echo "Custom target #{target_name} exists. Appending this roomnumber(s)."
+        custom_targets[target_name] = (custom_targets[target_name] + target).uniq
+     else
+        custom_targets[target_name] = target
+     end
      GameSettings['custom targets'] = custom_targets
-     echo "custom target saved (#{target_name}->#{target_room.id})"
+     echo "custom target saved (#{target_name} => #{custom_targets[target_name]})"
+     echo GameSettings['custom targets']
      exit
   elsif Script.current.vars[1] =~ /^delete$/i
      delkey = Script.current.vars[0].sub(/\s*delete\s*/i, '')
@@ -1628,11 +1668,12 @@ module Go2
         end
      end
   elsif (custom_targets = GameSettings['custom targets']) and (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}$/i }) or (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}/i })
-     destination_id = custom_targets[target]
+     destination_id = Room[room.id].find_nearest(custom_targets[target].to_a.uniq)
      unless destination = Map[destination_id]
         echo "error: custom target (#{destination_id}) was not found in the map database"
         exit
      end
+     echo "nearest room for custom target: #{target} is #{destination_id} #{Map[destination_id].title.first}"
      confirm = false
   elsif Map.list.any? { |r| r.tags.include?(target_search_string) }
      target_list = Map.list.find_all { |room| room.tags.include?(target_search_string) }.collect { |room| room.id }


### PR DESCRIPTION
This will need some testing since I don't play GS and DR's and GS's go2 are quite different.

Cross-PR'd the changes from my work on DR's `go2`. Allows command-line custom target saving of multiple rooms for a single target. It will then go2 the nearest.

If the target name exists, it appends the roomnumber to the existing target room list. Delete still functions the same way. 

Example from command line, all formats below should work:
```
;go2 save custom=1234
;go2 save custom=[1234, 5678]
;go2 save custom=1234, 5678
;go2 save custom = 5555
```

![image](https://user-images.githubusercontent.com/6467969/216783652-6167c1d1-06f3-4927-8316-2e40278a4c9a.png)

