### PR TITLE
[infomon.lic] update

### DIFF
--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -9,11 +9,13 @@
           game: Gemstone
           tags: core
       required: Lich > 5.0.16
-       version: 1.18.19
+       version: 1.18.20
         Source: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  1.18.20 (2023-02-20):
+    Fix premature silence end for psm skills with text after <output class="">
   1.18.19 (2023-01-26):
     Fixed bad PSM evaluations on partial regex match (shield_strike bug)
     Remove code for ;banks and alias to just sending BANK ACCOUNT
@@ -227,7 +229,7 @@ need_psm.each { |get_ability|
   hide_lines = @done = false
   action = proc { |server_string|
     if hide_lines
-      if server_string =~ /<output class=""\/>|<prompt/
+      if server_string =~ /<prompt/
           DownstreamHook.remove('psmmon_finder')
           @done = true
       end


### PR DESCRIPTION
Fix premature silence end for psm skills with text after <output class="">

turns:

--- Lich: infomon active.
[infomon: checking Feat...]

H>
[infomon: checking Armor...]

Available Armor Specializations Points: 4
H>
[infomon: checking Weapon...]

H>
[infomon: checking Shield...]

H>
[infomon: checking CMan...]

H>
[infomon: done]

into: 
--- Lich: infomon active.
[infomon: checking Feat...]
[infomon: checking Armor...]
[infomon: checking Weapon...]
[infomon: checking Shield...]
[infomon: checking CMan...]
[infomon: done]