### PR TITLE
chore: fixup netlify jinxp

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,7 @@
 [build]
 publish = "dist"
 command = """
-  curl --version && \
-  curl -s --retry 5 --retry-connrefused https://api.github.com/repos/elanthia-online/jinxp/releases/latest \
-  | grep browser_download_url \
-  | grep jinxp \
-  | cut -d '"' -f 4 \
-  | wget --tries=5 --retry-connrefused --retry-on-host-error -qi - \
+  wget --tries=5 --retry-connrefused --retry-on-host-error https://github.com/elanthia-online/jinxp/releases/download/v0.4.0/jinxp \
   && chmod +x jinxp \
   && cp mapdb/* scripts/ \
   && ./jinxp -i scripts


### PR DESCRIPTION
Use specific version without CURL to avoid netlify job failures