### PR TITLE
[bigshot.lic] v4.15.2 bugfix for various cmds

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 4.15.1
+       version: 4.15.2
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,12 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.15.2 (2023-03-01)
+    - bugfix to allow cmd_weapons to work if using more than base Mnemonic
+    - bugfix to allow cmd_shields to work if using more than base Mnemonic
+    - bugfix to allow cmd_cmans to work if using more than base Mnemonic
+    - bugfix to allow cmd_bearhug to work if using more than base Mnemonic
+    - bugfix to allow cmd_rogue_cmans to work if using more than base Mnemonic
   v4.15.1 (2023-02-18)
     - initial bugfix(s) for Ruby 3.x compliance
     - fix for exiting cmd_force if command check fails on cmd
@@ -180,7 +186,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.15.1'
+BIGSHOT_VERSION = '4.15.2'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -1454,9 +1460,11 @@ class Bigshot
       "whirlwind" =>      "Whirlwind",          
     }  
   
-    return if !Weapon.available?(commands[cmd])
-    return unless Weapon.affordable?(commands[cmd])
+    cmd_clean = cmd.split(' ').first
+    return if !Weapon.available?(commands[cmd_clean])
+    return unless Weapon.affordable?(commands[cmd_clean])
     return if npc.status =~ PRONE && commands[cmd] =~ /Charge|Twin Hammerfists/
+    
     waitrt?
     waitcastrt?	
      
@@ -1516,8 +1524,9 @@ class Bigshot
         return unless CMan.affordable?("Shield Bash")
         cmd = "cman sbash"     
     else
-      return if !Shield.available?(commands[cmd])
-      return unless Shield.affordable?(commands[cmd])
+      cmd_clean = cmd.split(' ').first
+      return if !Shield.available?(commands[cmd_clean])
+      return unless Shield.affordable?(commands[cmd_clean])
     end
     
     waitrt?
@@ -1619,11 +1628,12 @@ class Bigshot
       "vaultkick" =>      "Vault Kick",
     }
   
-    return if !CMan.available?(commands[cmd])
-    return unless CMan.affordable?(commands[cmd])
-    return if npc.status =~ PRONE && cmd == "bullrush"
-    return if Effects::Cooldowns.active?("Spell Cleave") && cmd == "scleave"
-    return if Effects::Cooldowns.active?("Spell Thieve") && cmd == "sthieve"
+    cmd_clean = cmd.split(' ').first
+    return if !CMan.available?(commands[cmd_clean])
+    return unless CMan.affordable?(commands[cmd_clean])
+    return if npc.status =~ PRONE && cmd =~ /^bullrush/i
+    return if Effects::Cooldowns.active?("Spell Cleave") && cmd =~ /^scleave/i
+    return if Effects::Cooldowns.active?("Spell Thieve") && cmd =~ /^sthieve/i
     
     waitrt?
     waitcastrt?	
@@ -1669,8 +1679,9 @@ class Bigshot
       "bearhug" =>        "Bearhug"    
     }  
   
-    return if !CMan.available?(commands[cmd])
-    return unless CMan.affordable?(commands[cmd])
+    cmd_clean = cmd.split(' ').first
+    return if !CMan.available?(commands[cmd_clean])
+    return unless CMan.affordable?(commands[cmd_clean])
     
     waitrt?
     waitcastrt?	
@@ -1744,10 +1755,13 @@ class Bigshot
       
     }
     
-    return if !CMan.available?(commands[cmd]) 
-    return unless CMan.affordable?(commands[cmd])
+    cmd_clean = cmd.split(' ').first
+    return if !CMan.available?(commands[cmd_clean]) 
+    return unless CMan.affordable?(commands[cmd_clean])
+    
     waitrt?
     waitcastrt?	
+    
     result = dothistimeout("cman #{cmd} ##{npc.id}", 2, result_regex)
     if (result == false)
       $bigshot_should_rest = true


### PR DESCRIPTION
    - bugfix to allow cmd_weapons to work if using more than base Mnemonic
    - bugfix to allow cmd_shields to work if using more than base Mnemonic
    - bugfix to allow cmd_cmans to work if using more than base Mnemonic
    - bugfix to allow cmd_bearhug to work if using more than base Mnemonic
    - bugfix to allow cmd_rogue_cmans to work if using more than base Mnemonic