### PR TITLE
[ecleanse.lic] v1.0.13 Ruby 3.2 bugfix

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -5,13 +5,15 @@
   contributers: Tysong
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
-       version: 1.0.12
+       version: 1.0.13
 
   Improvements:
-  v1.0.12 (2023-03-27)
-    - added standing check for "channel open" casting
+  v1.0.13 (2023-04-06)
+    - Bugfix for regex comparison of an integer in Ruby 3.2+, force convert .to_s
 =end
 =begin
+  v1.0.12 (2023-03-27)
+    - added standing check for "channel open" casting
   v1.0.11 (2023-03-11)
     - added multiple searches for recover item
   v1.0.10 (2023-03-07)
@@ -46,7 +48,7 @@
 =end
 
 module Ecleanse
-  Ecleanse_version = '1.0.12'
+  Ecleanse_version = '1.0.13'
 
   @@data ||= nil
   @did_something = false
@@ -912,11 +914,11 @@ module Ecleanse
         Ecleanse.remove_web_bound
       end
 
-      if Effects::Debuffs.to_h.any? { |debuff| debuff[0] =~ /Rooted|Pressed/ }
+      if Effects::Debuffs.to_h.any? { |debuff| debuff[0].to_s =~ /Rooted|Pressed/ }
         Ecleanse.remove_grounded
       end
 
-      if Effects::Debuffs.to_h.any? { |debuff| debuff[0] =~ /Confusion|Vertigo|Sounds|Thought Lash|Mindwipe|Pious Trial|Powersink/ }
+      if Effects::Debuffs.to_h.any? { |debuff| debuff[0].to_s =~ /Confusion|Vertigo|Sounds|Thought Lash|Mindwipe|Pious Trial|Powersink/ }
         Ecleanse.remove_magical
       end
 


### PR DESCRIPTION
Bugfix for regex comparison of an integer in Ruby 3.2+, force convert .to_s