### PR TITLE
[spell-list.xml] fix typo for sign of darkness

### DIFF
--- a/scripts/spell-list.xml
+++ b/scripts/spell-list.xml
@@ -2143,7 +2143,7 @@
    </spell>
    <spell availability='self-cast' name='Sign of Darkness' number='9919' type='utility'>
       <cost type='spirit'>6</cost>
-      <cast-proc>dothistimeout &apos;sign of darkness&apos; 3, /^Darkness enfolds and surrounds you\.\.\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
+      <cast-proc>dothistimeout &apos;sign of darkness&apos;, 3, /^Darkness enfolds and surrounds you\.\.\.$|^Your punishment does not end for another [0-9]+ minutes?\.$|^The power from your sign dissipates into the air\.$|^You realize your powers would be useless here, and cease your action\.$|^I don&apos;t think so\.$/</cast-proc>
    </spell>
    <spell availability='self-cast' name='Sign of Hopelessness' number='9920' type='utility'>
       <cost type='spirit'>11</cost>


### PR DESCRIPTION
was missing a comma in the DOTHISTIMEOUT in the cast-proc

```
>;e echo Spell['Sign of Dark'].cast
[exec1]>sign of darkness
Darkness enfolds and surrounds you...
[Council, Misty Void]
You are totally surrounded by dense mist.  All directions are the same, yet all directions hold different possibilities.
Obvious exits: north, northeast, east, southeast, south, southwest, west, northwest, up, down, out
You feel drained!
[exec1: Darkness enfolds and surrounds you...]
```