### PR TITLE
[Bigshot.lic] Add sneaking support (#2)

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 4.17.2
+       version: 4.17.3
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.17.3 (2023-06-24)
+    - Added support for sneaking while hunting.
   v4.17.2 (2023-06-21)
     - Added missing regex for fury completion.
   v4.17.1 (2023-06-13)
@@ -213,7 +215,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.17.2'
+BIGSHOT_VERSION = '4.17.3'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -258,6 +260,7 @@ $room_npcs_last_check = []
 $mstrike_taken = false
 $bigshot_single = false
 $bigshot_room_claimed = []
+$bigshot_sneaky_hunt = false
 
 def spell_is_selfcast?(spell_id)
   [
@@ -581,7 +584,7 @@ class Bigshot
                 :event_stack, :followers, :BLESS, :AIM, :TIER3, :QUIET_FOLLOWERS,
                 :MSTRIKE_COOLDOWN, :MSTRIKE_STAMINA_COOLDOWN, :MSTRIKE_MOB,
                 :MSTRIKE_QUICKSTRIKE, :MSTRIKE_STAMINA_QUICKSTRIKE, :UAC_MSTRIKE,
-                :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY, :TROUBADOURS_RALLY,
+                :WANDER_WAIT, :QUICK_COMMANDS, :PRIORITY, :TROUBADOURS_RALLY, :SNEAKY_SNEAKY,
                 :QUICKHUNT_TARGETS, :UAC_SMITE, :FOG_RETURN, :FOG_OPTIONAL, :LOOT_STANCE,
                 :DELAY_LOOT, :PULL, :OVERKILL, :LTE_BOOST, :HELP_GROUP_KILL, :WEAPON_REACTION, :DEADER, :CORRECT_PERCENT_MIND, :MA_LOOTER
 
@@ -745,6 +748,7 @@ class Bigshot
         echo "Cleaning up hunting scripts: #{hs_name}."
         stop_script(hs_name) if running?(hs_name)
       }
+      fput("movement autosneak off") if $bigshot_sneaky_hunt
     }
   end
 
@@ -796,6 +800,7 @@ class Bigshot
     set_value('loot_stance',                  '',          false)         # defensive stance before looting
     set_value('pull',                         '',          true)          # pull players to feet
     set_value('deader',                       '',          true)          # stop for dead players
+    set_value('sneaky_sneaky',                '',          false)         # sneak during hunts
 
     # Attacking Tab
     set_value('ambush',                       'split',     Array.new)     # ambush aiming locations
@@ -2033,6 +2038,7 @@ class Bigshot
     end
 
     unless Effects::Buffs.active?("Aspect of the #{aspect.capitalize()}") || Effects::Buffs.active?("Aspect of the #{extra.capitalize()}")
+
       if (checkprep != "None" and checkprep != "Assume Aspect")
         fput 'release'
       end
@@ -3111,6 +3117,12 @@ class Bigshot
     if !$bigshot_quick && !manually_walking
       goto(@HUNTING_ROOM_ID)
     end
+    # set autosneak on if we're sneaking
+    if @SNEAKY_SNEAKY
+      fput("movement autosneak on")
+      $bigshot_sneaky_hunt = true
+    end
+
     if (!solo? && leading?)
       @followers.add_event(:FOLLOW_NOW) # trigger rubber band
       while (!@followers.all_present?)
@@ -3221,6 +3233,12 @@ class Bigshot
     stop_watch()
 
     # prep/go
+    # set autosneak off if we're sneaking
+    if @SNEAKY_SNEAKY
+      fput("movement autosneak off")
+      $bigshot_sneaky_hunt = false
+    end
+
     prepare_for_movement()
     set_obvious_hiding_player(false)
     if (@FOG_RETURN.to_i != 0 && @FOG_OPTIONAL == false) || (@FOG_RETURN.to_i != 0 && @FOG_OPTIONAL == true && $rest_reason =~ /wounded|encumbered/)
@@ -4284,6 +4302,12 @@ class Bigshot
         sort_npcs.each { |i| return i if valid_target?(i, false) and no_players_hunt == true and (GameObjNpcCheck() > 0) }
       end
 
+      # make sure we're hiding if we're sneaking
+      if $bigshot_sneaky_hunt
+        cmd_hide(1) unless hidden
+        waitrt?
+      end
+
       set_obvious_hiding_player(false)
       wander.call
       sleep(0.1)
@@ -4468,6 +4492,7 @@ class Bigshot
         priority: { default: false },
         delay_loot: { default: false },
         troubadours_rally: { default: false },
+        sneaky_sneaky: { default: false },
         use_wracking: { default: false },
         loot_stance: { default: false },
         pull: { default: true },
@@ -4634,6 +4659,7 @@ class Bigshot
       </object><packing><property name="left-attach">2</property><property name="top-attach">5</property></packing></child><child><object class="GtkCheckButton" id="priority"><property name="label" translatable="yes">Priority Hunt</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">30</property><property name="margin-end">20</property><property name="margin-top">20</property><property name="draw-indicator">True</property>
       </object><packing><property name="left-attach">2</property><property name="top-attach">6</property></packing></child><child><object class="GtkCheckButton" id="delay_loot"><property name="label" translatable="yes">Delay Looting</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">30</property><property name="margin-end">20</property><property name="draw-indicator">True</property>
       </object><packing><property name="left-attach">2</property><property name="top-attach">7</property></packing></child><child><object class="GtkCheckButton" id="troubadours_rally"><property name="label" translatable="yes">Troubadour\'s Rally</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">30</property><property name="margin-end">20</property><property name="draw-indicator">True</property>
+	  </object><packing><property name="left-attach">2</property><property name="top-attach">9</property></packing></child><child><object class="GtkCheckButton" id="sneaky_sneaky"><property name="label" translatable="yes">Sneaky Sneaky</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">30</property><property name="margin-end">20</property><property name="draw-indicator">True</property>
       </object><packing><property name="left-attach">2</property><property name="top-attach">8</property></packing></child><child><object class="GtkCheckButton" id="use_wracking"><property name="label" translatable="yes">Use sign of wracking/sigil of power/symbol of mana</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">10</property><property name="margin-end">20</property><property name="margin-top">20</property><property name="draw-indicator">True</property>
       </object><packing><property name="left-attach">3</property><property name="top-attach">6</property></packing></child><child><object class="GtkCheckButton" id="loot_stance"><property name="label" translatable="yes">Defensive stance before looting</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">10</property><property name="margin-end">20</property><property name="draw-indicator">True</property>
       </object><packing><property name="left-attach">3</property><property name="top-attach">7</property></packing></child><child><object class="GtkCheckButton" id="pull"><property name="label" translatable="yes">Pull players to feet</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">10</property><property name="margin-end">20</property><property name="draw-indicator">True</property>
@@ -4922,6 +4948,8 @@ class Bigshot
       self['wracking_spirit'].tooltip_text = ''
       # Priority Hunt
       self['priority'].tooltip_text = "Priority is based on order of valid targets box on hunting tab.\nWill switch to highest priority in room when attacking."
+      # SNEAKY_SNEAKY
+      self['sneaky_sneaky'].tooltip_text = "Sneak around while hunting."
       # Delay Looting
       self['delay_loot'].tooltip_text = ''
       # Troubadour's Rally


### PR DESCRIPTION
* [Bigshot.lic] Add sneaking support

When you toggle sneaky sneaky checkbox on the hunting tab. Will enable autosneak movement when it arrives at the hunting area. Will disable autosneak movement when it leaves the hunting area. Will hide before changing rooms during hunt, if you are not hidden. Will disable autosneak movement upon exiting bigshot if it was turned on. feel free to change the names .. hah

* Update bigshot.lic

rubocop fixes

* Update bigshot.lic

more rubocop fixes