### PR TITLE
[eforgery.lic] Fix a couple bugs, and add ClimateWear/pocket messaging support.

### DIFF
--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -979,7 +979,8 @@ class << forger
         done = true
         waitrt?
         tongs
-      elsif line =~ /Roundtime: 30 sec./ # didn't glance at the grinder or the door; time to do this manually
+      elsif line =~ /Roundtime:/ # didn't glance at the grinder or the door; time to do this manually.
+        # Note from trisscar1212: This is most likely happening when the glyph degrades ("then the glyph turns a dull grey and crumbles to dust")
         done = true
         waitrt?
         if @make_hammers

--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -18,11 +18,15 @@
  Contributors: Moredin, Tillek, Gnomad, Tysong
      Category: Artisan
          Tags: forging, forge, craft, artisan, perfect
-      Version: 1.0.4
+      Version: 1.0.5
 
   Version Control:
     Major_change.feature_addition.bugfix
 
+  v1.0.5 (2023-06-26)
+    Fix for ClimateWear containers
+    Fix for missing glyph
+    Fix for grind/tongs RT check
   v1.0.4 (2023-06-03)
     Fix for vaalor material oil
     Rubocop cleanup

--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -799,16 +799,16 @@ class << forger
       line = nil
       until line && !(line =~ /It's closed/)
         fput "get #{item} from #{container}"
-        line = waitfor "You remove", "It's closed", "Get what"
+        line = waitfor "You remove", "You grab", "It's closed", "Get what"
         closed = closed || line =~ /It's closed./
       end
       fput "close #{container}" if closed
     else
       echo "container doesn't exist" if @DEBUG
       fput "get my #{item}"
-      line = waitfor "You remove", "It's closed", "Get what"
+      line = waitfor "You remove", "You grab", "It's closed", "Get what"
     end
-    return line =~ /You remove/
+    return line =~ /You remove/ || line =~ /You grab/
   end
 
   def measure
@@ -833,9 +833,9 @@ class << forger
   def you_put(item, container)
     closed = false
     line = nil
-    until line =~ /You put/
+    until line =~ /You put/ || line =~ /You tuck/
       fput "put #{item} in #{container}"
-      line = waitfor "You put", "It's closed.", "won't fit"
+      line = waitfor "You put", "You tuck", "It's closed.", "won't fit"
       exit if line =~ /won't fit/
       closed = closed || line =~ /It's closed./
       fput "open #{container}" if closed
@@ -1143,7 +1143,7 @@ class << forger
       until donescrapping == true
         line = nil
         fput "put ##{item.id} in #{@scrap_container}"
-        line = waitfor "You put", "It's closed", "won't fit"
+        line = waitfor "You put", "You tuck", "It's closed", "won't fit"
         if line =~ /fit/
           fput "look in my #{@scrap_container}"
           unless checkroom =~ /Workshop/
@@ -1170,7 +1170,7 @@ class << forger
         elsif line =~ /closed/
           closed = true
           fput "open my #{@scrap_container}"
-        elsif line =~ /You put/
+        elsif line =~ /You put/ || line =~ /You tuck/
           donescrapping = true
         end
       end

--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -998,7 +998,7 @@ class << forger
         done = true
         waitrt?
         trash(checkleft)
-      elsif line =~ /What were you referring to/
+      elsif line =~ /What were you referring to/ || line =~ /You stare at nothing in particular/
         done = true
         waitrt?
         you_put(@material_noun, @block_container)


### PR DESCRIPTION
Noted a couple of these bugs when using eforgery and fixed them, namely, a catch for when the script should manually go to the door or grinder, and when a glyph was missing.

In addition, I have a ClimateWear cloak, and the messaging for interacting with this container is a little different, so I added those success keywords to the you_get and you_put methods.