### PR TITLE
[Bigshot.lic] UCS follow up attack fix

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 4.17.3
+       version: 4.17.4
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.17.4 (2023-06-28)
+    - relocated ucs followup attack tracking to hunt monitor so it supports weapon skills
   v4.17.3 (2023-06-24)
     - Added support for sneaking while hunting.
   v4.17.2 (2023-06-21)
@@ -215,7 +217,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.17.3'
+BIGSHOT_VERSION = '4.17.4'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -663,6 +665,14 @@ class Bigshot
         $bigshot_reaction = nil
       elsif server_string =~ /#{UserVars.op["flee_message"]}/i && UserVars.op["flee_message"] != ""
         $bigshot_flee = true
+      elsif line =~ /^\sUAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)$/ && $bigshot_unarmed_followup == true
+        endroll = $1
+        if endroll.to_i > 100
+          $bigshot_unarmed_followup = false
+        end
+      elsif line =~ /Strike leaves foe vulnerable to a followup (.*) attack!/
+        $bigshot_unarmed_followup = true
+        $bigshot_unarmed_followup_attack = $1
       elsif server_string =~ /The vines lose all crimson hues, and strength courses through your blood\.$/i
         $bigshot_briars = true
       elsif server_string =~ /^You no longer look stronger\./i
@@ -1949,14 +1959,6 @@ class Bigshot
         elsif tier =~ /excellent/
           $bigshot_unarmed_tier = 3
         end
-      elsif line =~ /.* = .* d100: .* = \-?(\d+)$/ && $bigshot_unarmed_followup == true
-        endroll = $1
-        if endroll.to_i > 100
-          $bigshot_unarmed_followup = false
-        end
-      elsif line =~ /Strike leaves foe vulnerable to a followup (.*) attack!/
-        $bigshot_unarmed_followup = true
-        $bigshot_unarmed_followup_attack = $1
       elsif line =~ /You fail to find an opening for your strike\./
         $bigshot_aim += 1
       elsif line =~ /You cannot aim that high!|is already missing that!/

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -665,12 +665,12 @@ class Bigshot
         $bigshot_reaction = nil
       elsif server_string =~ /#{UserVars.op["flee_message"]}/i && UserVars.op["flee_message"] != ""
         $bigshot_flee = true
-      elsif line =~ /^\sUAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)$/ && $bigshot_unarmed_followup == true
+      elsif line =~ /^ UAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)$/ && $bigshot_unarmed_followup == true
         endroll = $1
         if endroll.to_i > 100
           $bigshot_unarmed_followup = false
         end
-      elsif line =~ /Strike leaves foe vulnerable to a followup (.*) attack!/
+      elsif line =~ /^  Strike leaves foe vulnerable to a followup (.*) attack!$/
         $bigshot_unarmed_followup = true
         $bigshot_unarmed_followup_attack = $1
       elsif server_string =~ /The vines lose all crimson hues, and strength courses through your blood\.$/i

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -1,0 +1,106 @@
+=begin
+  A simple script to deal with those pesky hiding targets.
+  Will force a creature to populate into GameObj when they are revealed if they're not already present.
+
+        author: elanthia-online
+  contributers: FarFigNewGut, Nisugi
+          game: Gemstone
+          tags: hunting, target, hidden, bandits
+       version: 0.1
+
+  Improvements:
+  v0.1 (2023-06-27)
+    - initial creation
+    - hidden target api OverWatch.hidden_targets will return room number where target was seen hiding
+    - hidden target api OverWatch.hidden_targets will return 0 when room changed, or hidden creature is uncovered
+=end
+
+module OverWatch
+  status_tags
+  @hidden_targets = nil
+  @debug = false
+
+  def self.track_hidden_targets(room_id)
+    @hidden_targets = room_id
+    echo "Target hid." if @debug == true
+  end
+
+  def self.push_revealed_targets(target_id, target_noun, target_name)
+    @hidden_targets = nil
+    echo "Target located." if @debug == true
+    if GameObj.targets.any? { |npc| npc.id == target_id }
+      echo "NPC already included" if @debug == true
+    else
+      GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))
+    end
+    if XMLData.current_target_ids.include?(target_id)
+      echo "ID already in current_target_ids" if @debug == true
+    else
+      XMLData.current_target_ids.unshift(target_id)
+    end
+  end
+
+  def self.room_with_hiders
+    return @hidden_targets
+  end
+
+  def self.hiders?
+    room_with_hiders.eql?(XMLData.room_id)
+  end
+
+  def self.room_with_hiders_reset
+    @hidden_targets = nil
+    return @hidden_targets
+  end
+
+  def self.watch
+    while (line = get)
+      case line
+      when /^You reveal <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> from hiding\!/ # Sunburst
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> is forced from hiding\!/
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> leaps from hiding to attack\!/ # Players, Assassins
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> is revealed from hiding\./ # Players, Bandits, Wardens
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> comes out of hiding\./ # Players, AC, Wardens
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /<pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> leaps suddenly forward, uncovering <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/>, who was hidden\!/ # Cat AC
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /<pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> takes a pointed step forward, revealing <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/>, who was hidden\!/ # Canine AC
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> dives ahead while flapping <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> wings, exposing <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/>, who was hidden\!/ # Avian AC
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> leaps out of <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> hiding place\!/ # Bandit
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> suddenly leaps from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> hiding place\!/ # Bandit Spawn
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> springs upon you from behind and aims a blow to your head\!/ # Subdue?
+        OverWatch.push_revealed_targets($1, $2, $3)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> springs upon you from behind and attempts to grasp you by the chin while bringing <pushBold\/><a exist="\d+" noun=" ?\w+">\w+<\/a><popBold\/> <a exist="\d+" noun="[^"]+">[^<]+<\/a> up to slit your throat\!/ # Cutthroat
+        OverWatch.push_revealed_targets($1, $2, $3)
+
+      # And then let's try to keep tracking of hidden targets
+      when /<nav rm='\d+'\/>/ # Reset our hidden_targets when we change rooms. Hopefully eliminates stale data.
+        OverWatch.room_with_hiders_reset
+      when /^<pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> slips into hiding\./
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /flies out of the shadows toward you\!/ # You being attacked
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /A faint silvery light flickers from the shadows./ # Hidden Bandits
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /Suddenly, a tiny shard of jet black crystal flies from the shadows toward you!/ # Hidden Bandits
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /With a barely audible hiss, <pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> fades into the surroundings\./
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /flies out of the shadows toward <a exist="\-\d+" noun="\w+">[^<]+<\/a>\!/ # Mob or player attacking player
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      when /flies out of the shadows toward <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>\!/ # Player (maybe mob) attacking mob
+        OverWatch.track_hidden_targets(XMLData.room_id)
+      end
+    end
+  end
+end
+
+OverWatch.watch


### PR DESCRIPTION
Relocated the UCS follow up attack tracking out of def_unarmed and into the hunt_monitor. 
This prevents stale info when you gain a follow up from unarmed but consume it with fury and vice versa.

EDIT: Yeah this doesn't work .. matches everyone's ucs attacks.