### PR TITLE
chore: rspec test rename and concurrency cancel

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -1,5 +1,9 @@
-name: Tests
+name: RSpec Tests
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -9,7 +13,7 @@ jobs:
         ruby: ['2.7']
     name: Run tests on Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
Cancel previous rspec tests if a new test queues before it finishes.