### PR TITLE
[Bigshot.lic] v4.17.4 update UCS

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 4.17.3
+       version: 4.17.4
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,14 +17,17 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v4.17.4 (2023-06-29
+    - Expanded UCS followup attack tracking to work with PSM attacks.
+    - Added UCS tier command checks  tier3, !tier3, ect.
   v4.17.3 (2023-06-24)
     - Added support for sneaking while hunting.
   v4.17.2 (2023-06-21)
     - Added missing regex for fury completion.
   v4.17.1 (2023-06-13)
     - Reconfigure assume aspect
-    - removed check that could cause nerves to get blown.
-    - added cman ki focus
+    - Removed check that could cause nerves to get blown.
+    - Added cman ki focus
   v4.17.0 (2023-06-04)
     - Skip infomon.lic check if on newer Lich versions
   v4.16.3 (2023-05-20)
@@ -215,7 +218,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '4.17.3'
+BIGSHOT_VERSION = '4.17.4'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -663,6 +666,22 @@ class Bigshot
         $bigshot_reaction = nil
       elsif server_string =~ /#{UserVars.op["flee_message"]}/i && UserVars.op["flee_message"] != ""
         $bigshot_flee = true
+      elsif server_string =~ /^\s+Strike leaves foe vulnerable to a followup (.*) attack!/
+        $bigshot_unarmed_followup = true
+        $bigshot_unarmed_followup_attack = $1
+      elsif server_string =~ /^You have (decent|good|excellent) positioning against <pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/>\./
+        tier = $1
+        if tier =~ /decent/
+          $bigshot_unarmed_tier = 1
+        elsif tier =~ /good/
+          $bigshot_unarmed_tier = 2
+        elsif tier =~ /excellent/
+          $bigshot_unarmed_tier = 3
+        end
+      elsif server_string =~ /^You (?:make a precise )?attempt to (\w+) <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/>!/
+        if $bigshot_unarmed_followup && ($bigshot_unarmed_followup_attack.to_s == $1.to_s)
+          assess_followup
+        end
       elsif server_string =~ /The vines lose all crimson hues, and strength courses through your blood\.$/i
         $bigshot_briars = true
       elsif server_string =~ /^You no longer look stronger\./i
@@ -1267,7 +1286,7 @@ class Bigshot
     # check mana/stamina/health(percentage)/encumbrance/unarmed tiering/mobs in room/target not prone/target undead
     # ! means the inverse/opposite effect
     original_command = command
-    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|k|!k|tier|!tier|mob|!mob|prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice|tailwind|!tailwind).*?)\)$/i)
+    if (command =~ /(.*)\((.*?(?:s|!s|m|!m|h|!h|e|!e|v|!v|k|!k|tier|!tier|mob|!mob|prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|buff|censer|justice|!justice|tailwind|!tailwind|tier1|!tier1|tier2|!tier2|tier3|!tier3).*?)\)$/i)
       command = $1.strip
 
       $2.split(" ").each { |s|
@@ -1317,7 +1336,7 @@ class Bigshot
           return buff_check[command] if buff_check[command]
         end
 
-        if s =~ /((?:once|prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice|tailwind|!tailwind))/i
+        if s =~ /((?:once|prone|!prone|frozen|!frozen|undead|!undead|flying|!flying|hidden|!hidden|poison|!poison|disease|!disease|noncorporeal|!noncorporeal|pcs|!pcs|outside|!outside|bearhug|!bearhug|barrage|!barrage|fury|!fury|flurry|!flurry|pummel|!pummel|thrash|!thrash|reflex|!reflex|vigor|!vigor|shout|!shout|yowlp|!yowlp|surge|!surge|censer|justice|!justice|tailwind|!tailwind|tier1|!tier1|tier2|!tier2|tier3|!tier3))/i
 
           item = $1.strip
           other_checks = {
@@ -1370,6 +1389,12 @@ class Bigshot
             '!burst'        => Effects::Cooldowns.active?("Burst of Swiftness"),
             'surge'         => Effects::Buffs.active?("Enh. Strength (+32)") || Effects::Buffs.active?("Enh. Strength (+28)") || Effects::Buffs.active?("Enh. Strength (+24)") || Effects::Buffs.active?("Enh. Strength (+20)") || Effects::Buffs.active?("Enh. Strength (+16)"),
             '!surge'        => Effects::Cooldowns.active?("Surge of Strength"),
+            'tier1'         => $bigshot_unarmed_tier != 1,
+            '!tier1'        => $bigshot_unarmed_tier == 1,
+            'tier2'         => $bigshot_unarmed_tier != 2,
+            '!tier2'        => $bigshot_unarmed_tier == 2,
+            'tier3'         => $bigshot_unarmed_tier != 3,
+            '!tier3'        => $bigshot_unarmed_tier == 3,
           }
 
           if (item == 'censer')
@@ -1435,7 +1460,10 @@ class Bigshot
     cmd_clean = cmd.split(' ').first
     return if !Weapon.available?(commands[cmd_clean])
     return unless Weapon.affordable?(commands[cmd_clean])
-
+    if commands[cmd_clean] == "Fury" && $bigshot_unarmed_tier == 3
+      cmd = commands[cmd_clean] + " " + @TIER3
+    end
+    
     waitrt?
     waitcastrt?
 
@@ -1891,6 +1919,15 @@ class Bigshot
     end
   end
 
+  def assess_followup(*lines)
+    follow_up_results = $_SERVERBUFFER_.dup.join("\n")
+    follow_up_results = follow_up_results.split("\n").delete_if { |line| line.nil? or line.empty? or line =~ /^[\r\n\s\t]*$/ }
+    follow_up_results = follow_up_results.find_all { |line| line =~ /UAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)/ }
+    if follow_up_results[-1] =~ /UAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)/
+      $bigshot_unarmed_followup = false if ($1.to_i > 100)
+    end
+  end
+  
   def unarmed(command, npc, manualaim)
     echo "unarmed" if $bigshot_debug
     return if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -1463,7 +1463,7 @@ class Bigshot
     if commands[cmd_clean] == "Fury" && $bigshot_unarmed_tier == 3
       cmd = commands[cmd_clean] + " " + @TIER3
     end
-    
+
     waitrt?
     waitcastrt?
 
@@ -1919,7 +1919,7 @@ class Bigshot
     end
   end
 
-  def assess_followup(*lines)
+  def assess_followup
     follow_up_results = $_SERVERBUFFER_.dup.join("\n")
     follow_up_results = follow_up_results.split("\n").delete_if { |line| line.nil? or line.empty? or line =~ /^[\r\n\s\t]*$/ }
     follow_up_results = follow_up_results.find_all { |line| line =~ /UAF: -?\d+ vs UDF: -?\d+ = [\d\.]+(?: \(capped\))? \* MM: \d+ \+ d100: \d+ = (\d+)/ }
@@ -1927,7 +1927,7 @@ class Bigshot
       $bigshot_unarmed_followup = false if ($1.to_i > 100)
     end
   end
-  
+
   def unarmed(command, npc, manualaim)
     echo "unarmed" if $bigshot_debug
     return if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -6,13 +6,16 @@
   contributers: FarFigNewGut, Nisugi
           game: Gemstone
           tags: hunting, target, hidden, bandits
-       version: 0.1
+       version: 1.0
 
   Improvements:
-  v0.1 (2023-06-27)
+  v1.0 (2023-06-27)
     - initial creation
-    - hidden target api OverWatch.hidden_targets will return room number where target was seen hiding
-    - hidden target api OverWatch.hidden_targets will return 0 when room changed, or hidden creature is uncovered
+    - OverWatch.room_with_hiders will return room number where target was seen hiding
+    - OverWatch.room_with_hiders will return nil when room changed, or hidden creature is uncovered
+    - OverWatch.hiders? will return true/false based off above
+    - Supports Bandits, Triton Assassins, Triton Wardens
+    - Need to know what other creatures hide/ambush.
 =end
 
 module OverWatch


### PR DESCRIPTION
1) Relocated followup and tier tracking out of unarmed method and into hunt_monitor. Allowing cohesion across unarmed and psm UCS attacks. 
2) Added command checks for tier1, !tier1, tier2, !tier2, tier3, !tier3 
3) If you are at tier3 when you initiate fury, it will now use your @TIER3 attack instead of only using jab.

Currently, if you are tier3 with a target and initiate fury, it will only use jab. If you are below tier3, it will start with jab (or a followup attack if you have one) and continue to tier you up.
You can specify an attack for fury to override jabs.
`weapon fury punch target` will use punch instead of jab, while still tiering up for follow up attacks. However if you are tier3 when the fury is started, it will use your @TIER3 instead of punch.