### PR TITLE
[effect-list.xml] fix for CMan ranks

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -1691,7 +1691,7 @@
       <message type='end'>You begin to lose touch with your internal sources of strength\.</message>
    </spell>
    <spell availability='self-cast' name='Surge of Strength Cooldown' number='9606'>
-      <duration>dur = { nil =&gt; 5, 0 =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan.surge_of_strength]; else; 5; end</duration>
+      <duration>dur = { nil =&gt; 5, 0 =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan['surge_of_strength']]; else; 5; end</duration>
       <message type='start'>You feel (?:significantly|a great deal|a fair amount) stronger\.</message>
       <message type='end'>Your internal strength fully recovers from your most recent attempt to tap into it\.</message>
    </spell>
@@ -2436,7 +2436,7 @@
       <message type='end'>You feel your connection to the vitality of nature renew itself once more\.</message>
    </spell>
    <spell availability='self-cast' name='Burst of Swiftness Cooldown' number='9051' type='timer'>
-      <duration>dur = { nil =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan.burst_of_swiftness]; else; 5; end</duration>
+      <duration>dur = { nil =&gt; 5, 1 =&gt; 5, 2 =&gt; 4, 3 =&gt; 3, 4 =&gt; 2.5, 5 =&gt; 2 }; if defined?(CMan); dur[CMan['burst_of_swiftness']]; else; 5; end</duration>
       <message type='start'>You feel (?:significantly|a great deal|a fair amount) more agile\.</message>
       <message type='end'>You feel entirely capable of preparing yourself to once again move swiftly at a moment&apos;s notice\.</message>
    </spell>


### PR DESCRIPTION
Fix `CMan.burst_of_swiftness` and `CMan.surge_of_strength` to be `CMan['burst_of_swiftness']` and `CMan['surge_of_strength']`