### PR TITLE
[autostart.lic] v0.59 update Infomon.get check

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -13,7 +13,7 @@
       required: Lich >= 4.6.58
 
   changelog:
-    0.59 (2023-06-04):
+    0.59 (2023-07-29):
       Update to Infomon.sync db check to prevent race condition against possible XML stream
     0.58 (2023-06-04):
       Change Infomon::CLI.sync to Infomon.sync

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -132,7 +132,7 @@ if script.vars.empty?
     if script_list.class == Array
       if run_info == false
         # Run infomon
-        if XMLData.game !~ /^DR/ && defined?(Infomon) && Infomon.get("society.status").nil?
+        if XMLData.game !~ /^DR/ && defined?(Infomon) && Infomon.get("infomon.last_sync").nil?
           Infomon.sync
         elsif XMLData.game !~ /^DR/ && defined?(Infomon).nil?
           Script.start("infomon")

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.58
+       version: 0.59
       required: Lich >= 4.6.58
 
   changelog:
+    0.59 (2023-06-04):
+      Update to Infomon.sync db check to prevent race condition against possible XML stream
     0.58 (2023-06-04):
       Change Infomon::CLI.sync to Infomon.sync
     0.57 (2023-03-12):
@@ -130,7 +132,7 @@ if script.vars.empty?
     if script_list.class == Array
       if run_info == false
         # Run infomon
-        if XMLData.game !~ /^DR/ && defined?(Infomon) && Infomon.get("stat.race").nil?
+        if XMLData.game !~ /^DR/ && defined?(Infomon) && Infomon.get("society.status").nil?
           Infomon.sync
         elsif XMLData.game !~ /^DR/ && defined?(Infomon).nil?
           Script.start("infomon")


### PR DESCRIPTION
Use `Infomon.get("society.status")` instead of `Infomon.get("stat.race")` to prevent possible false complete sync