### PR TITLE
[eloot]v1.6.1 - extend support for fossil charm (ground coins)

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -12,7 +12,7 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian
               game: Gemstone
               tags: loot
-           version: 1.6.0
+           version: 1.6.1
   Improvements:
   v1.6.1 (2023-08-03)
     - extended support for fossil charm (ground coins)
@@ -229,7 +229,7 @@ end
 
 # eloot is a looter for Gemstone that focuses on performance
 module ELoot
-  ELoot_version = '1.6.0'
+  ELoot_version = '1.6.1'
 
   @@data ||= nil
 


### PR DESCRIPTION
Extended fossil charm logic to also work with coins on the ground