### PR TITLE
[bigshot.lic] fix incorrect mblow regex

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.1.1
+       version: 5.1.2
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.1.2 (2023-08-21)
+    - fix incorrect regex match for mighty blow
   v5.1.1 (2023-08-14)
     - fix missing regex match for censer command check
   v5.1.0 (2023-08-07)
@@ -2567,7 +2569,7 @@ class Bigshot
       /leap into the air/i,
       /low enough for you to attack/i,
       /isn't flying/i,
-      /with all your might/i,
+      /with all(?: of)? your might/i,
       /with staggering might/i,
       /concentrate on the magical wards/i,
       /anti-magical equipment/i,


### PR DESCRIPTION
```
[bigshot]>cman mblow #240939326
Tightening your grip on your cardboard military pick, you strike out at a giant rat with all of your might!

```
not sure if the "all" vs "all of" is variable based on anything so, edited to catch both just in case.