### PR TITLE
[bigshot.lic] v5.1.3 cmd_spell fixes

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.1.2
+       version: 5.1.3
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.1.3 (2023-08-26)
+    - add 335/Divine Wrath cooldown check in cmd_spell to not cast
+    - change cmd_spell to use Spell.force_incant for incanted spells instead of bs_put
   v5.1.2 (2023-08-21)
     - fix incorrect regex match for mighty blow
   v5.1.1 (2023-08-14)
@@ -170,7 +173,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '5.1.1'
+BIGSHOT_VERSION = '5.1.3'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []
@@ -3118,6 +3121,7 @@ class Bigshot
     return if id == 506 and Spell[506].active?
     return if id == 9605 and Effects::Cooldowns.active?("Surge of Strength") # surge cooldown
     return if id == 9625 and Effects::Cooldowns.active?("Burst of Swiftness") # burst cooldown
+    return if id == 335 and Effects::Cooldowns.active?(335) # Divine Wrath cooldown
     return if id == 608 and hiding?
     return if id == 703 and $bigshot_703_list.any? { |s| s == target.id }
     return if id == 1614 and $bigshot_1614_list.any? { |s| s == target.id }
@@ -3153,7 +3157,7 @@ class Bigshot
       end
 
       change_stance('offensive') if Spell[id].stance || (id.to_s =~ /1700/i && extra =~ /evoke/i)
-      bs_put "incant #{id} #{extra}"
+      Spell[id].force_incant(extra) # bs_put "incant #{id} #{extra}"
       change_stance(@HUNTING_STANCE)
 
       if selfcast


### PR DESCRIPTION
Update cmd_spell to skip 335 on cooldown
Update cmd_spell to use Spell.force_incant instead of bs_put for incanted spells