### PR TITLE
Debt collector fixes

### DIFF
--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.3.0
+        version: 1.3.1
    requirements:
     - sequel gem
     - ascii_charts gem

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -230,7 +230,6 @@ module Ledger
           withdraws = $1.delete(',').to_i + $4.delete(',').to_i + $5.delete(',').to_i + $6.delete(',').to_i + $7.delete(',').to_i + $10.delete(',').to_i
           deposits = $2.delete(',').to_i + $3.delete(',').to_i + $8.delete(',').to_i + $9.delete(',').to_i + $11.delete(',').to_i
           if line.include?("I have a bill of ")
-            echo reget 40
             # 5 lines is the min, using 10 for safety. Very unlikely of a false positive
             next unless reget 10, "The local debt collector suddenly enters and walks toward you purposely."
             if match = (reget 10, "The debt collector reminds you that you still owe")[-1].match(/owe ([\d,]+) silver/)

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -33,6 +33,10 @@
     v1.3.0 - 2023-08-01
       - fix for lootcap estimate SQL statement
       - add ability to pass year, month, character, game to Ledger::Character.estimate_loot_cap
+    v1.3.1 - 2023-09-01
+      - fix to prevent other peoples debts from triggering withdrawels
+      - fix to prevent partial debt repayment from triggering withdrawl of entire debt
+      - fix to match depts in mist harbor.
 =end
 
 gems_to_load = ["sequel", "ascii_charts", "terminal-table"]

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -233,16 +233,17 @@ module Ledger
         if line =~ /Very well, a withdrawal of ([\d,]+) silver|That's a total of ([\d,]+) silver|That's ([\d,]+) (?:silver|silvers) to your account|scrip for ([\d,]+) silvers, with a ([\d,]+) silver fee for the scrip|I have a bill of ([\d,]+) silvers? (?:presented by your creditors|that I suggest you pay immediately)|teller carefully records the transaction, (?:and then )?hands you ([\d,]+) silver|You deposit ([\d,]+) (?:silver|silvers) into your account|You deposit your note worth ([\d,]+) into your account|teller scribbles the transaction into a book and hands you ([\d,]+) (?:silver|silvers)|You hand your notes to the teller, who glances over each one and scribbles the amounts in a book.  She says, "They add up to ([\d,]+) (?:silver|silvers)/
           withdraws = $1.delete(',').to_i + $4.delete(',').to_i + $5.delete(',').to_i + $6.delete(',').to_i + $7.delete(',').to_i + $10.delete(',').to_i
           deposits = $2.delete(',').to_i + $3.delete(',').to_i + $8.delete(',').to_i + $9.delete(',').to_i + $11.delete(',').to_i
+
           if line.include?("I have a bill of ")
             # 5 lines is the min, using 10 for safety. Very unlikely of a false positive
             next unless reget 10, "The local debt collector suddenly enters and walks toward you purposely."
-            if match = (reget 10, "The debt collector reminds you that you still owe")[-1].match(/owe ([\d,]+) silver/)
-              # If you deposit but do not have enough to cover dept will take what it can, without this was reocring the full fine amount as withdrawn
-              withdraws = withdraws - $1.delete(',').to_i
-            end
 
+            if (reget 10, "The debt collector reminds you that you still owe")[-1] =~ /owe ([\d,]+) silver/
+              # If you deposit but do not have enough to cover dept will take what it can, without this was reocring the full fine amount as withdrawn
+              withdraws -= $1.delete(',').to_i
+            end
           end
-          
+
           echo "recorded.withdraw : #{withdraws}" if withdraws > 0
           echo "recorded.deposit : #{deposits}" if deposits > 0
           self.record_transaction(amount: deposits - withdraws, type: "silver")

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -238,8 +238,8 @@ module Ledger
             # 5 lines is the min, using 10 for safety. Very unlikely of a false positive
             next unless reget 10, "The local debt collector suddenly enters and walks toward you purposely."
 
-            if (reget 10, "The debt collector reminds you that you still owe")[-1] =~ /owe ([\d,]+) silver/
-              # If you deposit but do not have enough to cover dept will take what it can, without this was reocring the full fine amount as withdrawn
+            if reget(10, "The debt collector reminds you that you still owe").last =~ /owe ([\d,]+) silver/
+              # If you deposit but do not have enough to cover dept will take what it can, without this was recording the full fine amount as withdrawn
               withdraws -= $1.delete(',').to_i
             end
           end

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -226,9 +226,20 @@ module Ledger
     def self.main()
       while (line = get)
         # todo: bloodscrip tracking deposit/withdraw
-        if line =~ /Very well, a withdrawal of ([\d,]+) silver|That's a total of ([\d,]+) silver|That's ([\d,]+) (?:silver|silvers) to your account|scrip for ([\d,]+) silvers, with a ([\d,]+) silver fee for the scrip|I have a bill of ([\d,]+) silvers presented by your creditors|teller carefully records the transaction, (?:and then )?hands you ([\d,]+) silver|You deposit ([\d,]+) (?:silver|silvers) into your account|You deposit your note worth ([\d,]+) into your account|teller scribbles the transaction into a book and hands you ([\d,]+) (?:silver|silvers)|You hand your notes to the teller, who glances over each one and scribbles the amounts in a book.  She says, "They add up to ([\d,]+) (?:silver|silvers)/
+        if line =~ /Very well, a withdrawal of ([\d,]+) silver|That's a total of ([\d,]+) silver|That's ([\d,]+) (?:silver|silvers) to your account|scrip for ([\d,]+) silvers, with a ([\d,]+) silver fee for the scrip|I have a bill of ([\d,]+) silvers? (?:presented by your creditors|that I suggest you pay immediately)|teller carefully records the transaction, (?:and then )?hands you ([\d,]+) silver|You deposit ([\d,]+) (?:silver|silvers) into your account|You deposit your note worth ([\d,]+) into your account|teller scribbles the transaction into a book and hands you ([\d,]+) (?:silver|silvers)|You hand your notes to the teller, who glances over each one and scribbles the amounts in a book.  She says, "They add up to ([\d,]+) (?:silver|silvers)/
           withdraws = $1.delete(',').to_i + $4.delete(',').to_i + $5.delete(',').to_i + $6.delete(',').to_i + $7.delete(',').to_i + $10.delete(',').to_i
           deposits = $2.delete(',').to_i + $3.delete(',').to_i + $8.delete(',').to_i + $9.delete(',').to_i + $11.delete(',').to_i
+          if line.include?("I have a bill of ")
+            echo reget 40
+            # 5 lines is the min, using 10 for safety. Very unlikely of a false positive
+            next unless reget 10, "The local debt collector suddenly enters and walks toward you purposely."
+            if match = (reget 10, "The debt collector reminds you that you still owe")[-1].match(/owe ([\d,]+) silver/)
+              # If you deposit but do not have enough to cover dept will take what it can, without this was reocring the full fine amount as withdrawn
+              withdraws = withdraws - $1.delete(',').to_i
+            end
+
+          end
+          
           echo "recorded.withdraw : #{withdraws}" if withdraws > 0
           echo "recorded.deposit : #{deposits}" if deposits > 0
           self.record_transaction(amount: deposits - withdraws, type: "silver")


### PR DESCRIPTION
Previously if in the bank at the time another players debt was collected it was being tracked as withdrawn form your own account. Also added fix for when you do not have enough to cover the whole fine, without the full fine was being deducted.