### PR TITLE
[ledger.lic] v1.3.4 note tracking

### DIFF
--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -39,7 +39,9 @@
       - fix to match debts in mist harbor.
     v1.3.2 - 2023-09-06
       - Code cleanup, no functional changes
-    v1.3.3 - 2023-09-08
+    v1.3.3 - 2023-09-17
+      - Fix to bounty point tracking (broken in 1.3.2)
+    v1.3.4 - 2023-09-18
       - Add tracking of note withdrawal (Withdrawing 2 or more notes rapidly before first note is tracked will cause notes to be missed)
 =end
 
@@ -314,7 +316,7 @@ module Ledger
           silver += fee
           echo "recorded.withdraw : #{silver}"
           self.record_transaction(amount: -silver, type: "silver")
-        elsif line =~ /\[You have earned (<?amount>[\d,]+) bounty points/
+        elsif /\[You have earned (?<amount>[\d,]+) bounty points/ =~ line
           self.record_transaction(amount: amount.delete(',').to_i, type: "bounty")
         elsif line =~ /inter-town bank transfer options? available/
           self.print()

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -105,20 +105,21 @@ module Ledger
   end
 
   module Utility
-    def self.reget_xml(*lines) # Match original reget
-      status_tags
-      matches = reget lines
-      status_tags
-      return matches
-    end
-
     def self.get_note_value(noteId)
-      # line = dothistimeout "read ##{noteId}", 3, /and reads, "Hold in right hand to use."/
       line = Lich::Util::quiet_command_xml("read ##{noteId}", /has a value of (?:[\d,]+) silver and reads/, /<prompt/, false, 3).last
-      echo line
       if /has a value of (?<silver>[\d,]+) silver/ =~ line
         return silver.delete(',').to_i
       end
+    end
+
+    def self.strip_xml(line) # Copied from reget function
+      line.gsub!(/<pushStream id=["'](?:spellfront|inv|bounty|society)["'][^>]*\/>.*?<popStream[^>]*>/m, '')
+      line.gsub!(/<stream id="Spells">.*?<\/stream>/m, '')
+      line.gsub!(/<(compDef|inv|component|right|left|spell|prompt)[^>]*>.*?<\/\1>/m, '')
+      line.gsub!(/<[^>]+>/, '')
+      line.gsub!('&gt;', '>')
+      line.gsub!('&lt;', '<')
+      return line
     end
   end
 
@@ -131,14 +132,10 @@ module Ledger
       /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
       /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
     )
-    @withdraw_notes_regex = Regexp.union( # Fee currently always 0 but account for it just in case
-      /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/, # Terras, value of note available
-      # Other towns, value of note not available, will require note to be read to check value
-      /The teller purses her lips and says, "Hmm, we will have to give you an? (?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note) for that amount\."  The teller makes some marks on a blank (?:note|chit) and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge\.  Have a nice day."/,
-      # Pine far
-
-    )
-    @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<noteId>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount."/
+    # Terras notes, value of note available
+    @withdraw_notes_regex = /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/ 
+    # Other towns, value of note not imediately available
+    @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<noteId>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount\."  The teller makes some marks on a blank <a exist="(?:\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:chit|note)<\/a> and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge.  Have a nice day\."/
     @deposit_regex = Regexp.union(
       /You deposit (?<silver>[\d,]+) silvers? into your account/,
       /That's a total of (?<silver>[\d,]+) silver/,
@@ -278,8 +275,9 @@ module Ledger
     end
 
     def self.main()
-      notes = Array.new
-      while (line = get)
+      status_tags
+      while (xml_line = get)
+        line = Ledger::Utility.strip_xml(xml_line.dup)
         # todo: bloodscrip tracking deposit/withdraw
         if (match = line.match(@withdraw_silver_regex))
           silver = match[:silver].delete(',').to_i
@@ -299,20 +297,16 @@ module Ledger
           echo "recorded.deposit : #{silver}"
           self.record_transaction(amount: silver, type: "silver")
         elsif (match = line.match(@withdraw_notes_regex))
+          silver = match[:silver].delete(',').to_i
           fee = match[:fee].delete(',').to_i
-          if match[:silver]
-            # Withdraw action tells us amount
-            silver = match[:silver].delete(',').to_i
-          elsif (match = Ledger::Utility.reget_xml(10, "Hmm, we will have to give you").last.match(@withdraw_notes_xml_regex))
-            # Withdraw action does not tell is amount, get note ID and read it.
-            silver = Ledger::Utility.get_note_value(match[:noteId])
-          else
-            # Should not happen as long as regex is correct
-            echo "Failed to get value of note, please provide a log on the Scripting Discord channel"
-            next
-          end
-          unless silver # Could not parse note for some reason
-            echo "Failed to get value or withdrawn note."
+          silver += fee
+          echo "recorded.withdraw : #{silver}"
+          self.record_transaction(amount: -silver, type: "silver")
+        elsif (match = xml_line.match(@withdraw_notes_xml_regex))
+          fee = match[:fee].delete(',').to_i
+          silver = Ledger::Utility.get_note_value(match[:noteId]) # If further notes are withdrawn before this returns they will be missed
+          unless silver && fee # Could not parse note for some reason
+            echo "Failed to get value of withdrawn note."
             next
           end
           silver += fee

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -107,8 +107,8 @@ module Ledger
   end
 
   module Utility
-    def self.get_note_value(noteId)
-      line = Lich::Util::quiet_command_xml("read ##{noteId}", /has a value of (?:[\d,]+) silver and reads/, /<prompt/, false, 3).last
+    def self.get_note_value(note_id)
+      line = Lich::Util::quiet_command_xml("read ##{note_id}", /has a value of (?:[\d,]+) silver and reads/, /<prompt/, false, 3).last
       if /has a value of (?<silver>[\d,]+) silver/ =~ line
         return silver.delete(',').to_i
       end
@@ -137,7 +137,7 @@ module Ledger
     # Terras notes, value of note available
     @withdraw_notes_regex = /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/
     # Other towns, value of note not imediately available
-    @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<noteId>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount\."  The teller makes some marks on a blank <a exist="(?:\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:chit|note)<\/a> and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge.  Have a nice day\."/
+    @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<note_id>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount\."  The teller makes some marks on a blank <a exist="(?:\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:chit|note)<\/a> and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge.  Have a nice day\."/
     @deposit_regex = Regexp.union(
       /You deposit (?<silver>[\d,]+) silvers? into your account/,
       /That's a total of (?<silver>[\d,]+) silver/,
@@ -306,7 +306,7 @@ module Ledger
           self.record_transaction(amount: -silver, type: "silver")
         elsif (match = xml_line.match(@withdraw_notes_xml_regex))
           fee = match[:fee].delete(',').to_i
-          silver = Ledger::Utility.get_note_value(match[:noteId]) # If further notes are withdrawn before this returns they will be missed
+          silver = Ledger::Utility.get_note_value(match[:note_id]) # If further notes are withdrawn before this returns they will be missed
           unless silver && fee # Could not parse note for some reason
             echo "Failed to get value of withdrawn note."
             next

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.3.2
+        version: 1.3.3
    requirements:
     - sequel gem
     - ascii_charts gem
@@ -39,6 +39,8 @@
       - fix to match debts in mist harbor.
     v1.3.2 - 2023-09-06
       - Code cleanup, no functional changes
+    v1.3.3 - 2023-09-08
+      - Add tracking of note withdrawal (Withdrawing 2 or more notes rapidly before first note is tracked will cause notes to be missed)
 =end
 
 # Known issues

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -135,7 +135,7 @@ module Ledger
       /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
     )
     # Terras notes, value of note available
-    @withdraw_notes_regex = /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/ 
+    @withdraw_notes_regex = /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/
     # Other towns, value of note not imediately available
     @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<noteId>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount\."  The teller makes some marks on a blank <a exist="(?:\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:chit|note)<\/a> and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge.  Have a nice day\."/
     @deposit_regex = Regexp.union(

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -34,12 +34,18 @@
       - fix for lootcap estimate SQL statement
       - add ability to pass year, month, character, game to Ledger::Character.estimate_loot_cap
     v1.3.1 - 2023-09-01
-      - fix to prevent other peoples debts from triggering withdrawels
-      - fix to prevent partial debt repayment from triggering withdrawl of entire debt
-      - fix to match depts in mist harbor.
+      - fix to prevent other peoples debts from triggering withdrawals
+      - fix to prevent partial debt repayment from triggering withdrawal of entire debt
+      - fix to match debts in mist harbor.
     v1.3.2 - 2023-09-06
       - Code cleanup, no functional changes
 =end
+
+# Known issues
+# -  If 2 more more rapid note withdrawals only the first will be tracked
+# -  Pinefar depositing/withdrawing money can not be reliably tracked as no messaging
+#      Smiling greedily, Hurshal takes your silvers and says, "Heh, I'll put dese in ye 'Mule bank account right quick."
+#      Hurshal looks at you and says, "Hmm, looks like ye could be a'usin' me services there, lad.  I guarantee I'll get a good bit of ye silver to the 'Mule fer ye.  Ask me about me service if ye interested."
 
 gems_to_load = ["sequel", "ascii_charts", "terminal-table"]
 failed_to_load = []
@@ -98,6 +104,24 @@ module Ledger
     end
   end
 
+  module Utility
+    def self.reget_xml(*lines) # Match original reget
+      status_tags
+      matches = reget lines
+      status_tags
+      return matches
+    end
+
+    def self.get_note_value(noteId)
+      # line = dothistimeout "read ##{noteId}", 3, /and reads, "Hold in right hand to use."/
+      line = Lich::Util::quiet_command_xml("read ##{noteId}", /has a value of (?:[\d,]+) silver and reads/, /<prompt/, false, 3).last
+      echo line
+      if /has a value of (?<silver>[\d,]+) silver/ =~ line
+        return silver.delete(',').to_i
+      end
+    end
+  end
+
   module History
     @file = File.join($data_dir, "ledger.db")
     Self = Sequel.sqlite(@file)
@@ -106,11 +130,15 @@ module Ledger
       /Very well, a withdrawal of (?<silver>[\d,]+) silver/,
       /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
       /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
-      /scrip for (?<silver>[\d,]+) silvers?, with a 0 silver fee for the scrip/, # Terras note withdraw, will be moved to notes regex next release
     )
-    @withdraw_notes_regex = Regexp.union( # Unused till next release
-      /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/, # Terras
+    @withdraw_notes_regex = Regexp.union( # Fee currently always 0 but account for it just in case
+      /scrip for (?<silver>[\d,]+) silvers?, with a (?<fee>[\d,]+) silvers? fee for the scrip/, # Terras, value of note available
+      # Other towns, value of note not available, will require note to be read to check value
+      /The teller purses her lips and says, "Hmm, we will have to give you an? (?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note) for that amount\."  The teller makes some marks on a blank (?:note|chit) and hands it to you, saying "That is a (?<fee>[\d,]+) silvers? surcharge\.  Have a nice day."/,
+      # Pine far
+
     )
+    @withdraw_notes_xml_regex = /The teller purses her lips and says, "Hmm, we will have to give you an? <a exist="(?<noteId>\d+)" noun="(?:note|chit)">(?:\w+(?:'s)? )?(?:promissory note|mining chit|salt-stained kraken chit|City-States promissory note)<\/a> for that amount."/
     @deposit_regex = Regexp.union(
       /You deposit (?<silver>[\d,]+) silvers? into your account/,
       /That's a total of (?<silver>[\d,]+) silver/,
@@ -250,6 +278,7 @@ module Ledger
     end
 
     def self.main()
+      notes = Array.new
       while (line = get)
         # todo: bloodscrip tracking deposit/withdraw
         if (match = line.match(@withdraw_silver_regex))
@@ -269,6 +298,26 @@ module Ledger
           silver = match[:silver].delete(',').to_i
           echo "recorded.deposit : #{silver}"
           self.record_transaction(amount: silver, type: "silver")
+        elsif (match = line.match(@withdraw_notes_regex))
+          fee = match[:fee].delete(',').to_i
+          if match[:silver]
+            # Withdraw action tells us amount
+            silver = match[:silver].delete(',').to_i
+          elsif (match = Ledger::Utility.reget_xml(10, "Hmm, we will have to give you").last.match(@withdraw_notes_xml_regex))
+            # Withdraw action does not tell is amount, get note ID and read it.
+            silver = Ledger::Utility.get_note_value(match[:noteId])
+          else
+            # Should not happen as long as regex is correct
+            echo "Failed to get value of note, please provide a log on the Scripting Discord channel"
+            next
+          end
+          unless silver # Could not parse note for some reason
+            echo "Failed to get value or withdrawn note."
+            next
+          end
+          silver += fee
+          echo "recorded.withdraw : #{silver}"
+          self.record_transaction(amount: -silver, type: "silver")
         elsif line =~ /\[You have earned (<?amount>[\d,]+) bounty points/
           self.record_transaction(amount: amount.delete(',').to_i, type: "bounty")
         elsif line =~ /inter-town bank transfer options? available/

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.3.3
+        version: 1.3.4
    requirements:
     - sequel gem
     - ascii_charts gem
@@ -20,36 +20,37 @@
   Help Contribute: https://github.com/elanthia-online/scripts
   Version Control:
   Major_change.feature_addition.bugfix
-    v1.0.1 - 2023-01-26
-      - Force monospaced output for BANK output
-      - Add safety checks for gem loading
-    v1.1.0 - 2023-02-22
-      - fix reports by game code
-      - add --report-character flag
-    v1.1.1 - 2023-02-23
-      - fix for mono output
-    v1.2.0 - 2023-07-01
-      - add lootcap estimator for --report-character flag
-    v1.3.0 - 2023-08-01
-      - fix for lootcap estimate SQL statement
-      - add ability to pass year, month, character, game to Ledger::Character.estimate_loot_cap
+    v1.3.4 - 2023-09-18
+      - Add tracking of note withdrawal (Withdrawing 2 or more notes rapidly before first note is tracked will cause notes to be missed)
+    v1.3.3 - 2023-09-17
+      - Fix to bounty point tracking (broken in 1.3.2)
+    v1.3.2 - 2023-09-06
+      - Code cleanup, no functional changes
     v1.3.1 - 2023-09-01
       - fix to prevent other peoples debts from triggering withdrawals
       - fix to prevent partial debt repayment from triggering withdrawal of entire debt
       - fix to match debts in mist harbor.
-    v1.3.2 - 2023-09-06
-      - Code cleanup, no functional changes
-    v1.3.3 - 2023-09-17
-      - Fix to bounty point tracking (broken in 1.3.2)
-    v1.3.4 - 2023-09-18
-      - Add tracking of note withdrawal (Withdrawing 2 or more notes rapidly before first note is tracked will cause notes to be missed)
+    v1.3.0 - 2023-08-01
+      - fix for lootcap estimate SQL statement
+      - add ability to pass year, month, character, game to Ledger::Character.estimate_loot_cap
+    v1.2.0 - 2023-07-01
+      - add lootcap estimator for --report-character flag
+    v1.1.1 - 2023-02-23
+      - fix for mono output
+    v1.1.0 - 2023-02-22
+      - fix reports by game code
+      - add --report-character flag
+    v1.0.1 - 2023-01-26
+      - Force monospaced output for BANK output
+      - Add safety checks for gem loading
 =end
-
-# Known issues
-# -  If 2 more more rapid note withdrawals only the first will be tracked
-# -  Pinefar depositing/withdrawing money can not be reliably tracked as no messaging
-#      Smiling greedily, Hurshal takes your silvers and says, "Heh, I'll put dese in ye 'Mule bank account right quick."
-#      Hurshal looks at you and says, "Hmm, looks like ye could be a'usin' me services there, lad.  I guarantee I'll get a good bit of ye silver to the 'Mule fer ye.  Ask me about me service if ye interested."
+=begin
+ Known issues
+ -  If 2 more more rapid note withdrawals only the first will be tracked
+ -  Pinefar depositing/withdrawing money can not be reliably tracked as no messaging
+      Smiling greedily, Hurshal takes your silvers and says, "Heh, I'll put dese in ye 'Mule bank account right quick."
+      Hurshal looks at you and says, "Hmm, looks like ye could be a'usin' me services there, lad.  I guarantee I'll get a good bit of ye silver to the 'Mule fer ye.  Ask me about me service if ye interested."
+=end
 
 gems_to_load = ["sequel", "ascii_charts", "terminal-table"]
 failed_to_load = []


### PR DESCRIPTION
This feature adds tracking of withdrawing notes from the bank, previously this only worked on Terras where gameline includes value of note withdraw:
`The teller nods and says, "Let's see... that's a scrip for 101 silvers, with a 0 silver fee for the scrip. `

In other towns the value is not shown:
`The teller purses her lips and says, "Hmm, we will have to give you a City-States promissory note for that amount."  The teller makes some marks on a blank note and hands it to you, saying "That is a 0 silver surcharge.  Have a nice day."`

This change enables the XML feed to get the ID of note being passed to you and uses `Lich::Util::quiet_command_xml` to read the note and extract the value. Known issue with this approach is if 2 or more notes are withdrawn before the first note can be read will cause notes to be missed.

Possible alternatives to fix known issue:

1. Don't use a quite_command, just read the note 'out loud' (keep track of it's ID) and add an extra if check to the main while loop to read record the result of the read (if note ID matches)
2. Something with down stream hooks might work for keeping the read quiet, not really thought through fully as quickly got messy

Option 1 seems easy but having the read visible might annoy/confuse people? Sure there is a better way though that I am missing which is reason for mentioning it. 