### PR TITLE
[repo] V2.49 - Add wrayth links to repo output

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -13,9 +13,11 @@
        version: 2.48
 
   changelog:
-    2.48 (2023-09-012):
+    2.49 (2023-09-012):
       Added clickable wrayth links to any command that list script names (works even if duplicate script names)
       Added help prompt for dealing with duplicate script names (for non wrayth users)
+    2.48 (2023-09-11):
+      add new mapdb-check option to show last mapdb upload date, author, and if mapdb is up-to-date
     2.47 (2023-09-03):
       update show-updatable output to list author & game for scripts
     2.46 (2023-09-01):
@@ -114,7 +116,7 @@
 =end
 
 begin
-  require 'terminal-table'
+  require 'terminal-table' unless defined?(Terminal::Table)
 rescue LoadError
   respond "You need to have the 'terminal-table' gem installed"
   respond "Please install it with the following command: gem install terminal-table"
@@ -679,112 +681,6 @@ format_list = proc { |list, action|
   list.collect { |row| row.join('   ') }.join("\n")
 }
 
-=begin
-# rubocop useless function, no longer used
-download_lich = proc {
-  if RUBY_VERSION !~ /^2/
-    echo "error: This script can't update Lich for you because the new version of Lich requires Ruby 2.0, and you're using Ruby #{RUBY_VERSION}.  See https://lichproject.org/download.html for instructions on updating."
-  else
-    filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
-    if not File.exist?(filename)
-      echo "error: file not found: #{filename}"
-    else
-      begin
-        ssl_socket, socket = connect.call
-        ssl_socket.puth('action' => 'download-lich', 'current-md5sum' => Digest::MD5.file(filename).to_s, 'supported compressions' => 'gzip', 'client' => client_version)
-        response = ssl_socket.geth
-        if response['warning']
-          echo "warning: server says: #{response['warning']}"
-        end
-        if response['error']
-          if response['error'] == 'already up-to-date'
-            echo 'Lich is up-to-date'
-          else
-            echo "error: server says: #{response['error']}"
-          end
-        elsif response['compression'] and response['compression'] != 'gzip'
-          echo "error: unsupported compression method: #{response['compression']}"
-        elsif not response['size'] or not response['version'] or not response['md5sum']
-          echo "error: unrecognized response from server: #{response.inspect}"
-        else
-          response['size'] = response['size'].to_i
-          backupfilename = "#{$temp_dir}lich-#{LICH_VERSION}.rb"
-          backupfilename.concat('w') if $PROGRAM_NAME =~ /w$/
-          tempfilename = "#{$temp_dir}#{rand(100000000)}.repo"
-          echo "downloading Lich #{response['version']}..."
-          File.open(tempfilename, 'wb') { |f|
-            (response['size'] / 1_000_000).times { f.write(ssl_socket.read(1_000_000)) }
-            f.write(ssl_socket.read(response['size'] % 1_000_000)) unless (response['size'] % 1_000_000) == 0
-          }
-          if response['compression'] == 'gzip'
-            ungzipname = "#{$temp_dir}#{rand(100000000)}"
-            File.open(ungzipname, 'wb') { |f|
-              Zlib::GzipReader.open(tempfilename) { |f_gz|
-                while (data = f_gz.read(1_000_000))
-                  f.write(data)
-                end
-                # data = nil # rubocop useless assignment to variable
-              }
-            }
-            begin
-              File.rename(ungzipname, tempfilename)
-            rescue
-              if $!.to_s =~ /Invalid cross-device link/
-                File.open(ungzipname, 'rb') { |r| File.open(tempfilename, 'wb') { |w| w.write(r.read) } }
-                File.delete(ungzipname)
-              else
-                raise $!
-              end
-            end
-          end
-          md5sum_mismatch = (Digest::MD5.file(tempfilename).to_s != response['md5sum'])
-          if md5sum_mismatch and not cmd_force
-            echo "error: md5sum mismatch: file likely corrupted in transit"
-            File.delete(tempfilename)
-          else
-            if md5sum_mismatch
-              echo "warning: md5sum mismatch: file likely corrupted in transit"
-            end
-            if defined?(Win32)
-              begin
-                File.rename(filename, backupfilename)
-              rescue
-                if $!.to_s =~ /Invalid cross-device link/
-                  File.open(filename, 'rb') { |r| File.open(backupfilename, 'wb') { |w| w.write(r.read) } }
-                  File.delete(filename)
-                else
-                  raise $!
-                end
-              end
-              begin
-                File.rename(tempfilename, filename)
-              rescue
-                if $!.to_s =~ /Invalid cross-device link/
-                  File.open(tempfilename, 'rb') { |r| File.open(filename, 'wb') { |w| w.write(r.read) } }
-                  File.delete(tempfilename)
-                else
-                  raise $!
-                end
-              end
-            else
-              # perserves file mode, which might be suid and we can't set that here
-              File.open(filename, 'rb') { |r| File.open(backupfilename, 'wb') { |w| w.write(r.read) } }
-              File.open(tempfilename, 'rb') { |r| File.open(filename, 'wb') { |w| w.write(r.read) } }
-              File.delete(tempfilename)
-            end
-            echo "Lich has been updated to version #{response['version']}."
-            echo "Changes will take effect next time you start Lich."
-          end
-        end
-      ensure
-        ssl_socket.close rescue nil
-        socket.close rescue nil
-      end
-    end
-  end
-}
-=end
-
 download_mapdb = proc {
   unless defined?(Map.save_json)
     echo 'error: Your version of Lich is too old to download the map database.'
@@ -978,6 +874,45 @@ download_mapdb = proc {
       end
       echo 'done'
     end
+  end
+}
+
+mapdb_check = proc {
+  if XMLData.game =~ /^GS/i
+    if XMLData.game =~ /^GSF$|^GSPlat$/i
+      game = XMLData.game.downcase
+    else
+      game = 'gsiv'
+    end
+  elsif XMLData.game =~ /^DR/i
+    if XMLData.game =~ /^DRF$|^DRX$/i
+      game = XMLData.game.downcase
+    else
+      game = 'dr'
+    end
+  else
+    game = XMLData.game.downcase
+  end
+  request = { 'action' => 'download-mapdb', 'game' => game, 'supported compressions' => 'gzip', 'client' => client_version }
+  if (current_map = Dir.entries("#{$data_dir}#{XMLData.game}").find_all { |fn| fn =~ /^map\-[0-9]+\.(?:dat|xml|json)$/i }.sort[-1])
+    request['current-md5sum'] = Digest::MD5.file("#{$data_dir}#{XMLData.game}/#{current_map}").to_s
+  end
+  begin
+    ssl_socket, socket = connect.call
+    ssl_socket.puth(request)
+    response = ssl_socket.geth
+    if response['warning']
+      echo "warning: server says: #{response['warning']}"
+    end
+    if response['error'] == 'already up-to-date'
+      echo "map database is currently up to date."
+    else
+      echo "map database is not currently up to date."
+    end
+    echo "map database last updated by #{response['uploaded by']} at #{Time.at(response['timestamp'].to_i)}"
+  ensure
+    ssl_socket.close rescue nil
+    socket.close rescue nil
   end
 }
 
@@ -2222,6 +2157,16 @@ elsif (cmd[0] =~ /^download-?map(?:db)?$/i)
   download_mapdb.call
 
 #
+# show mapdb last updated by
+#
+elsif (cmd[0] =~ /^mapdb-check$/i)
+  if cmd[1]
+    echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
+    exit
+  end
+  mapdb_check.call
+
+#
 # upload-lich
 #
 elsif (cmd[0] =~ /^upload-?lich$/i)
@@ -2497,6 +2442,8 @@ elsif cmd[0] =~ /^help$/i
   output.concat "   change-password NEWPASS   change your repository password\n"
   #    output.concat "   download-lich             download the latest version of Lich\n"
   output.concat "   download-mapdb            download the latest map database\n"
+  output.concat "   mapdb-check               check whether your current mapdb is current or not.\n"
+  output.concat "                             shows last upload date and user that uploaded.\n"
   output.concat "   checkout-mapdb            must be done before editing the map database\n"
   output.concat "   release-mapdb             if you checkout-mapdb and change your mind\n"
   output.concat "   upload-mapdb              upload your changes to the map database\n"

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -187,6 +187,7 @@ cmd_hide_size      = nil
 cmd_hide_author    = nil
 cmd_hide_downloads = nil
 cmd_hide_rating    = nil
+link_clicked       = false
 
 get_comments_from_data = proc { |data|
   begin
@@ -467,6 +468,21 @@ add_comments_to_list = proc { |list|
   end
 }
 
+add_links_to_list = proc { |list, action| # Make file name clickable t
+  unless (["download", "delete", "rate"].include?(action))
+    # Assume generally we want script info
+    action = "info"
+  end
+  headers = list.shift
+  if (fi = headers.index('file')) and (ai = headers.index('author')) and (gi = headers.index('game'))
+    list.each { |row| row[fi] = "<d cmd=';#{script.name} #{action} #{row[fi]} --link-click --author=#{row[ai]} --game=#{row[gi]}'>#{row[fi]} </d>" }
+  elsif (fi = headers.index('file')) and (ai = headers.index('author')) # Game column can be stripped if not needed (no name clashes)
+    list.each { |row| row[fi] = "<d cmd=';#{script.name} #{action} #{row[fi]} --link-click --author=#{row[ai]}'>#{row[fi]} </d>" }
+  end
+  list.unshift(headers)
+  list
+}
+
 filter_list = proc { |list|
   headers = list.shift
   if cmd_name and (fi = headers.index('file'))
@@ -538,7 +554,7 @@ filter_list = proc { |list|
   list
 }
 
-format_list = proc { |list|
+format_list = proc { |list, action|
   headers = list.shift
   if (rti = headers.index('rating total')) and (rci = headers.index('rating count'))
     list.each_index { |ri|
@@ -588,6 +604,7 @@ format_list = proc { |list|
     f_list = list.collect { |r| r[f] }.uniq
     g_list = list.collect { |r| r[c] }.uniq
     g_list.delete('any')
+    #        duplicate file name         or only one game type (excluding any)
     unless (f_list.length < list.length) or (g_list.length > 1)
       headers.delete_at(c)
       list.each { |r| r.delete_at(c) }
@@ -635,6 +652,7 @@ format_list = proc { |list|
       column_width[list_i] = [column_width[list_i].to_i, r[list_i].to_s.length].max
     }
   }
+  list = add_links_to_list.call(list, action) # Add links after columns have been sized
   headers = list.shift
   if cmd_limit
     if cmd_limit =~ /^([0-9]+),([0-9]+)$/
@@ -1189,6 +1207,9 @@ for var in script.vars[1..-1]
         echo 'error: --version option not complete; e.g. --version=1.2'
         exit
       end
+    elsif var =~ /^--link-click/
+      # Used on all SF links, if a link is clicked and the action is dangerous prompt user for confirmation
+      link_clicked = true
     else
       echo "error: unknown option: #{var}"
       exit
@@ -1206,7 +1227,7 @@ if cmd[0] =~ /^list$/i
     echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
     exit
   end
-  respond "\n#{format_list.call(filter_list.call(get_list.call))}\n\n"
+  puts "\n#{format_list.call(filter_list.call(get_list.call), 'info')}\n\n"
 
 #
 # list-updates
@@ -1230,7 +1251,7 @@ elsif cmd[0] =~ /^list-?update[sd]$/i
     end
   }
   list.unshift(headers)
-  respond "\n#{format_list.call(list)}\n\n"
+  puts "\n#{format_list.call(list, 'list-updates')}\n\n"
 
 #
 # list-new
@@ -1254,7 +1275,7 @@ elsif cmd[0] =~ /^list-?new$/i
     end
   }
   list.unshift(headers)
-  respond "\n#{format_list.call(list)}\n\n"
+  puts "\n#{format_list.call(list, 'list-new')}\n\n"
 
 #
 # list-tags
@@ -1306,7 +1327,7 @@ elsif (cmd[0] =~ /^info$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    respond "\nMultiple files match: be more specific\n\n#{format_list.call(list)}\n\n"
+    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'info')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]
@@ -1330,7 +1351,7 @@ elsif (cmd[0] =~ /^info$/i)
       ssl_socket.close rescue nil
       socket.close rescue nil
     end
-    output = "\n#{format_list.call(list)}\n\n"
+    output = "\n#{format_list.call(list, 'info')}\n\n"
     if response['versions']
       sorted_versions = response['versions'].split(';').collect { |v| v.split('.') }.sort { |a, b|
         i = r = 0
@@ -1352,7 +1373,7 @@ elsif (cmd[0] =~ /^info$/i)
       output.concat "available versions: #{sorted_versions}\n\n"
     end
     output.concat "#{data}\n\n"
-    respond output
+    puts output
   end
 
 #
@@ -1382,10 +1403,46 @@ elsif (cmd[0] =~ /^download$/i)
   if list.empty?
     echo "error: file not found"
   elsif list.length > 1
+    names = list.map { |row| row[0] }
     list.unshift(headers)
-    respond "\nMultiple files match: be more specific\n\n#{format_list.call(list)}\n\n"
+    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'download')}\n\n"
+    if names.length != names.uniq.length
+      respond ""
+      puts Lich::Messaging.msg_format("info", " You can specify a specific author by adding --author=bob to your command or game by adding --game=gs to the command. For example:")
+      puts Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --author=bob")
+      puts Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --game=gs")
+      respond ""
+    end
   else
-    echo "downloading #{list[0][fi]} in 3 seconds... (;k #{script.name} to cancel)"
+    if link_clicked
+      time_out = 10
+      start_time = Time.now
+      confirmed = false
+
+      respond ""
+      respond " You have clicked a link to download #{list[0][fi]} by the author #{list[0][headers.index('author')]}"
+      respond " To confirm this action please ';send yes' in the next #{time_out} seconds to confirm."
+      respond ""
+
+      loop {
+        line = get?
+        if line =~ /^(?:y|ye|yes)$/i
+          redpond " Download starting."
+          confirmed = true
+          break
+        elsif line =~ /^(?:n|no|stop)$/i
+          break
+        end
+        break if (Time.now - start_time) > time_out
+        sleep(0.1)
+      }
+      unless confirmed
+        respond " Download canceled."
+        exit
+      end
+    else
+      echo "downloading #{list[0][fi]} in 3 seconds... (;k #{script.name} to cancel)"
+    end
     sleep 3 unless list[0][fi] =~ /^(infomon|waggle|x?narost)\.lic$/i
     if list[0][fi] =~ /^(infomon|waggle|x?narost)\.lic$/i
       echo "#{list[0][fi]} no longer updatable via ;repository."
@@ -1523,7 +1580,7 @@ elsif (cmd[0] =~ /^set-?updat(?:e|able)$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    respond "\nMultiple files match: be more specific\n\n#{format_list.call(list)}\n\n"
+    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'show-updateable')}\n\n"
   else
     info = { :filename => list[0][fi], :game => list[0][gi], :author => list[0][ai] }
     Settings['updatable'] ||= Hash.new
@@ -1717,7 +1774,7 @@ elsif (cmd[0] =~ /^delete$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    respond "\nMultiple files match: be more specific\n\n#{format_list.call(list)}\n\n"
+    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'delete')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]
@@ -1793,7 +1850,7 @@ elsif (cmd[0] =~ /^rate$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    respond "\nMultiple files match: be more specific\n\n#{format_list.call(list)}\n\n"
+    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'rate')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,7 +10,7 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.48
+       version: 2.49
 
   changelog:
     2.49 (2023-09-012):

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,12 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.47
+       version: 2.48
 
   changelog:
+    2.48 (2023-09-012):
+      Added clickable wrayth links to any command that list script names (works even if duplicate script names)
+      Added help prompt for dealing with duplicate script names (for non wrayth users)
     2.47 (2023-09-03):
       update show-updatable output to list author & game for scripts
     2.46 (2023-09-01):
@@ -1227,7 +1230,7 @@ if cmd[0] =~ /^list$/i
     echo "error: extra words on command line: #{cmd[1..-1].join(' ')}"
     exit
   end
-  puts "\n#{format_list.call(filter_list.call(get_list.call), 'info')}\n\n"
+  _respond "\n#{format_list.call(filter_list.call(get_list.call), 'info')}\n\n"
 
 #
 # list-updates
@@ -1251,7 +1254,7 @@ elsif cmd[0] =~ /^list-?update[sd]$/i
     end
   }
   list.unshift(headers)
-  puts "\n#{format_list.call(list, 'list-updates')}\n\n"
+  _respond "\n#{format_list.call(list, 'list-updates')}\n\n"
 
 #
 # list-new
@@ -1275,7 +1278,7 @@ elsif cmd[0] =~ /^list-?new$/i
     end
   }
   list.unshift(headers)
-  puts "\n#{format_list.call(list, 'list-new')}\n\n"
+  _respond "\n#{format_list.call(list, 'list-new')}\n\n"
 
 #
 # list-tags
@@ -1327,7 +1330,7 @@ elsif (cmd[0] =~ /^info$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'info')}\n\n"
+    _respond "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'info')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]
@@ -1405,12 +1408,12 @@ elsif (cmd[0] =~ /^download$/i)
   elsif list.length > 1
     names = list.map { |row| row[0] }
     list.unshift(headers)
-    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'download')}\n\n"
+    _respond "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'download')}\n\n"
     if names.length != names.uniq.length
       respond ""
-      puts Lich::Messaging.msg_format("info", " You can specify a specific author by adding --author=bob to your command or game by adding --game=gs to the command. For example:")
-      puts Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --author=bob")
-      puts Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --game=gs")
+      _respond Lich::Messaging.msg_format("info", " You can specify a specific author by adding --author=bob to your command or game by adding --game=gs to the command. For example:")
+      _respond Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --author=bob")
+      _respond Lich::Messaging.msg_format("info", "  ;repo download awsomeScript --game=gs")
       respond ""
     end
   else
@@ -1427,7 +1430,7 @@ elsif (cmd[0] =~ /^download$/i)
       loop {
         line = get?
         if line =~ /^(?:y|ye|yes)$/i
-          redpond " Download starting."
+          respond " Download starting."
           confirmed = true
           break
         elsif line =~ /^(?:n|no|stop)$/i
@@ -1580,7 +1583,7 @@ elsif (cmd[0] =~ /^set-?updat(?:e|able)$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'show-updateable')}\n\n"
+    _respond "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'show-updateable')}\n\n"
   else
     info = { :filename => list[0][fi], :game => list[0][gi], :author => list[0][ai] }
     Settings['updatable'] ||= Hash.new
@@ -1774,7 +1777,7 @@ elsif (cmd[0] =~ /^delete$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'delete')}\n\n"
+    _respond "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'delete')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]
@@ -1850,7 +1853,7 @@ elsif (cmd[0] =~ /^rate$/i)
     echo "error: file not found"
   elsif list.length > 1
     list.unshift(headers)
-    puts "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'rate')}\n\n"
+    _respond "\nMultiple files match: be more specific\n\n#{format_list.call(list, 'rate')}\n\n"
   else
     file = list[0][fi]
     game = list[0][gi]


### PR DESCRIPTION
Initial draft to show a possible implementation. Before this change a ;repo download action pauses for 3 seconds before continuing, due to ease of accidentally clicking a link logic is added to prompt for user confirmation via ;send and if not given in time the script will exit without downloading.

This is achieved by adding a '--clicked' link to all links the script generates, this means any manual ;repo download commands will still exhibit old behaviour. This means new feature (links) new behaviour (;send confirmation instead of auto download after timeout). This behavior could become the default for all "dangerous" actions.

In this current from the new behavior is only implemented into download action but will be added to delete and (probably) rate as that will cover the three "dangerous" actions that could be done via the links.

First download  command example of no duplicate names, second download is with duplicates (bonus text appears to explain how to download).
First appearance of ">alias.lic" is a link click, this one no response is given and times out
Second appearance of ">alias.lic" is a link click, followed by a confirmation (and download completing)
![image](https://github.com/elanthia-online/scripts/assets/14922332/78df2d57-5ab2-4428-897c-188af7684cb4)
