### PR TITLE
[bigshot.lic] v5.1.6 cmd_force adjustments

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.1.6 (2023-09-12)
+    - bugfix for cmd_force when target has 115
   v5.1.5 (2023-08-30)
     - bugfix for calling escape_rooms for tail
   v5.1.4 (2023-08-30)
@@ -3050,7 +3052,7 @@ class Bigshot
       buffer = reget(35)
       buffer.each_with_index { |line, i|
         if (line =~ /^You.*(#{checknpcs.join('|')})|^You feint (high|low|(to the (left|right)))/)
-          if (buffer[i + 1] && buffer[i + 1] =~ /== \+(\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /== \+(\d+)/)
+          if (buffer[i + 1] && buffer[i + 1] =~ /== \+(\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /== \+(\d+)/) || (buffer[i + 3] && buffer[i + 3] =~ /== \+(\d+)/)
             return true if $1.to_i >= goal # spell/swing
           elsif (buffer[i - 1] && buffer[i - 1] =~ /^\[(?:Roll|SMR|SSR) result: (\d+)/) || (buffer[i - 2] && buffer[i - 2] =~ /^\[(?:Roll|SMR|SSR) result: (\d+)/) || (buffer[i + 1] && buffer[i + 1] =~ /^\[(?:Roll|SMR|SSR) result: (\d+)/) || (buffer[i + 2] && buffer[i + 2] =~ /^\[(?:Roll|SMR|SSR) result: (\d+)/)
             return true if $1.to_i >= goal # cman
@@ -3060,6 +3062,8 @@ class Bigshot
         elsif (line =~ /^You do not have enough stamina to attempt this maneuver\.|^(?:.*) is lying down -- attempting to (?:.*) would be a rather awkward proposition\./)
           return false
         elsif (line =~ /^Your magic fizzles ineffectually\./)
+          return false
+        elsif (line =~ /^Your magic fails to find a target\./)
           return false
         elsif (line =~ /^You are (?:still )?stunned\./ || muckled?)
           return false

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.1.5
+       version: 5.1.6
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -179,7 +179,7 @@ require 'fileutils'
 FileUtils.mkdir_p(File.join($data_dir, XMLData.game, Char.name, "bigshot_profiles"))
 
 # Alphabetized Global Variables
-BIGSHOT_VERSION = '5.1.5'
+BIGSHOT_VERSION = '5.1.6'
 RALLY_TIME = 1
 REST_INTERVAL = 60
 $bigshot_1614_list = []


### PR DESCRIPTION
Some targets have 115 which can add an additional line between `You gesture` and the resolution line. Added a check for buffer[i + 3] to deal with this.
Added a match to break out of the loop when `Your magic fails to find a target.`