### PR TITLE
[TargetWindow.lic]v1.2 adjusted annotation occurence

### DIFF
--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -11,10 +11,12 @@
   contributors: Dalzashel
           game: Gemstone
           tags: hunting, combat, status tracking, target tracking
-       version: 1.1
+       version: 1.2
       required: Wrayth
 
   Change Log:
+  v1.2 (2023-09-19)
+    - adjusted when flashing box occurs
   v1.1 (2023-09-18)
     - typos
   v1.0 (2023-09-16)
@@ -80,8 +82,9 @@ module TargetWindow
       end
       _respond(output)
       blink = %Q[<annotate dialog="quick" control="#{XMLData.current_target_id}" seconds="5"/>]
-      _respond(blink) if CharSettings['flash_target']
-      wait_while { old_targets == GameObj.targets }
+      _respond(blink) if CharSettings['flash_target'] unless XMLData.current_target_id.nil?
+      curr_target = XMLData.current_target_id
+      wait_while { old_targets == GameObj.targets && curr_target == XMLData.current_target_id }
       old_targets = GameObj.targets
     }
   end


### PR DESCRIPTION
made an adjustment so the flashing box will happen when you change targets and not require the number of targets/status to change to fire it off.