### PR TITLE
[TargetWindow.lic] v1.3 - Arm Count

### DIFF
--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -47,14 +47,21 @@ module TargetWindow
     old_targets = GameObj.targets
     _respond("<closeDialog id='TargetWindow'/><openDialog type='dynamic' id='TargetWindow' title='Targets' target='TargetWindow' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Targets'></dialogData></openDialog>")
     loop {
-      if GameObj.targets.length > 0
+      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || t.name =~ /^animated /) }
+      if targets.length > 0
         output = "<dialogData id='TargetWindow' clear='t'>"
-        output += "<link id='total' value='Total Targets: #{GameObj.targets.delete_if { |t| t.noun =~ @grasp_arms }.length}' cmd='target next' echo='target next' justify='3' top='3' left='0' height='15' width='195'/>"
-        GameObj.targets.each { |t|
-          next if t.noun =~ @grasp_arms
+        output += "<link id='total' value='Total Targets: #{targets.length}' cmd='target next' echo='target next' justify='3' top='3' left='0' height='15' width='195'/>"
+        targets.each { |t|
           target_status = TargetWindow.status_fix(t.status) unless t.status.nil?
           output += "<link id='#{t.id}' value='#{target_status} #{t.name.split.map(&:capitalize).join(' ')}' cmd='target ##{t.id}' echo='target ##{t.id}'  justify='3' left='0' height='15' width='195'/>"
         }
+        echo "setting #{CharSettings['show_arms']}"
+        if CharSettings['show_arms']
+          echo "arms!!"
+          arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
+          output += "<label id= 'armCount' value='Total arms: #{arms.length}' top='#{15 * (targets.length + 2)}' left='0'  width='187'/>" unless arms.empty?
+        end
+
         output += "</dialogData>"
       else
         output = "<dialogData id='TargetWindow' clear='t'><label id= 'none' value='No Targets' justify='3' top='5' left='0' align='center' width='187'/></dialogData>"
@@ -68,14 +75,18 @@ module TargetWindow
   def self.watch_quickbar
     old_targets = GameObj.targets
     loop {
-      if GameObj.targets.length > 0
+      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || t.name =~ /^animated /) }
+      if targets.length > 0
         output = "<dialogData id='quick' clear='t'>"
-        output += "<link id='twtotal' value='Total Targets: #{GameObj.targets.delete_if { |t| t.noun =~ @grasp_arms }.length}' cmd='target next' echo='target next'/>"
-        GameObj.targets.each { |t|
-          next if t.noun =~ @grasp_arms
+        output += "<link id='twtotal' value='Total Targets: #{targets.length}' cmd='target next' echo='target next'/>"
+        targets.each { |t|
           target_status = TargetWindow.status_fix(t.status) unless t.status.nil?
           output += "<link id='#{t.id}' value='#{target_status} #{t.name.split.map(&:capitalize).join(' ')}  ' cmd='target ##{t.id}' echo='target ##{t.id}'/>"
         }
+        if CharSettings['show_arms']
+          arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
+          output += "<link id='armCount' value='Total arms: #{arms.length} ' cmd=''/>"
+        end
         output += "</dialogData>"
       else
         output = "<dialogData id='quick' clear='t'><label id= 'lblnone' value='No targets found.' top='0' left='0' align='center' width='187'/></dialogData>"
@@ -104,9 +115,16 @@ elsif Script.current.vars[0].to_s =~ /^flash/
     _respond("Current target will not flash.")
     exit
   end
+elsif Script.current.vars[0].to_s =~ /^showarms/ # name something better
+  CharSettings['show_arms'] = !CharSettings['show_arms']
+  respond "Total arm count will #{CharSettings['show_arms'] == false ? "NOT " : ""}be shown."
 else
   _respond("Please specify where the targets should be displayed.")
   _respond(";#{script.name} window")
   _respond(";#{script.name} quick")
+  _respond("")
+  _respond("You may also toggle the showing of a count of how many arms are in the room with:")
+  _respond(";#{script.name} showarms")
+  _respond("")
   exit
 end

--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -11,10 +11,12 @@
   contributors: Dalzashel
           game: Gemstone
           tags: hunting, combat, status tracking, target tracking
-       version: 1.2
+       version: 1.3
       required: Wrayth
 
   Change Log:
+  v1.3 (2023-09-21)
+    - Add showarms setting to include a total count of the number of arms in the room (useful for Sorcerer's to see if they still have arms left)
   v1.2 (2023-09-19)
     - adjusted when flashing box occurs
   v1.1 (2023-09-18)
@@ -115,7 +117,7 @@ elsif Script.current.vars[0].to_s =~ /^flash/
     _respond("Current target will not flash.")
     exit
   end
-elsif Script.current.vars[0].to_s =~ /^showarms/ # name something better
+elsif Script.current.vars[0].to_s =~ /^showarms/
   CharSettings['show_arms'] = !CharSettings['show_arms']
   respond "Total arm count will #{CharSettings['show_arms'] == false ? "NOT " : ""}be shown."
 else

--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -49,7 +49,7 @@ module TargetWindow
     old_targets = GameObj.targets
     _respond("<closeDialog id='TargetWindow'/><openDialog type='dynamic' id='TargetWindow' title='Targets' target='TargetWindow' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Targets'></dialogData></openDialog>")
     loop {
-      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || t.name =~ /^animated /) }
+      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || (t.name =~ /^animated / && t.name != "animated slush")) }
       if targets.length > 0
         output = "<dialogData id='TargetWindow' clear='t'>"
         output += "<link id='total' value='Total Targets: #{targets.length}' cmd='target next' echo='target next' justify='3' top='3' left='0' height='15' width='195'/>"
@@ -59,7 +59,7 @@ module TargetWindow
         }
         if CharSettings['show_arms']
           arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
-          output += "<label id= 'armCount' value='Total arms: #{arms.length}' top='#{15 * (targets.length + 2)}' left='0'  width='187'/>" unless arms.empty?
+          output += "<link id='armCount' value='Total arms: #{arms.length}' cmd='incant 709' echo='incant 709' top='#{15 * (targets.length + 2)}' justify='3' left='0' height='15' width='195'/>"
         end
 
         output += "</dialogData>"
@@ -78,15 +78,15 @@ module TargetWindow
       targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || t.name =~ /^animated /) }
       if targets.length > 0
         output = "<dialogData id='quick' clear='t'>"
+        if CharSettings['show_arms']
+          arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
+          output += "<link id='twarms' value='Total Arms: #{arms.length}  ' cmd='incant 709' echo='incant 709'/>"
+        end
         output += "<link id='twtotal' value='Total Targets: #{targets.length}' cmd='target next' echo='target next'/>"
         targets.each { |t|
           target_status = TargetWindow.status_fix(t.status) unless t.status.nil?
           output += "<link id='#{t.id}' value='#{target_status} #{t.name.split.map(&:capitalize).join(' ')}  ' cmd='target ##{t.id}' echo='target ##{t.id}'/>"
         }
-        if CharSettings['show_arms']
-          arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
-          output += "<link id='armCount' value='Total arms: #{arms.length} ' cmd=''/>"
-        end
         output += "</dialogData>"
       else
         output = "<dialogData id='quick' clear='t'><label id= 'lblnone' value='No targets found.' top='0' left='0' align='center' width='187'/></dialogData>"

--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -26,7 +26,7 @@
 =end
 
 module TargetWindow
-  before_dying { _respond("<closeDialog id='TargetWindow'/>") }
+  before_dying { puts("<closeDialog id='TargetWindow'/>") }
   CharSettings['flash_target'] = false if CharSettings['flash_target'].nil?
   @grasp_arms = Regexp.new(/^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i)
 
@@ -47,7 +47,7 @@ module TargetWindow
 
   def self.watch_window
     old_targets = GameObj.targets
-    _respond("<closeDialog id='TargetWindow'/><openDialog type='dynamic' id='TargetWindow' title='Targets' target='TargetWindow' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Targets'></dialogData></openDialog>")
+    puts("<closeDialog id='TargetWindow'/><openDialog type='dynamic' id='TargetWindow' title='Targets' target='TargetWindow' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Targets'></dialogData></openDialog>")
     loop {
       targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || (t.name =~ /^animated / && t.name != "animated slush")) }
       if targets.length > 0
@@ -66,7 +66,7 @@ module TargetWindow
       else
         output = "<dialogData id='TargetWindow' clear='t'><label id= 'none' value='No Targets' justify='3' top='5' left='0' align='center' width='187'/></dialogData>"
       end
-      _respond(output)
+      puts(output)
       wait_while { old_targets == GameObj.targets }
       old_targets = GameObj.targets
     }
@@ -75,7 +75,7 @@ module TargetWindow
   def self.watch_quickbar
     old_targets = GameObj.targets
     loop {
-      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || t.name =~ /^animated /) }
+      targets = GameObj.targets.select { |t| !(t.noun =~ @grasp_arms || (t.name =~ /^animated / && t.name != "animated slush")) }
       if targets.length > 0
         output = "<dialogData id='quick' clear='t'>"
         if CharSettings['show_arms']
@@ -91,9 +91,9 @@ module TargetWindow
       else
         output = "<dialogData id='quick' clear='t'><label id= 'lblnone' value='No targets found.' top='0' left='0' align='center' width='187'/></dialogData>"
       end
-      _respond(output)
+      puts(output)
       blink = %Q[<annotate dialog="quick" control="#{XMLData.current_target_id}" seconds="5"/>]
-      _respond(blink) if CharSettings['flash_target'] unless XMLData.current_target_id.nil?
+      puts(blink) if CharSettings['flash_target'] unless XMLData.current_target_id.nil?
       curr_target = XMLData.current_target_id
       wait_while { old_targets == GameObj.targets && curr_target == XMLData.current_target_id }
       old_targets = GameObj.targets
@@ -108,23 +108,23 @@ elsif Script.current.vars[0].to_s =~ /^window/
 elsif Script.current.vars[0].to_s =~ /^flash/
   if CharSettings['flash_target'] == false
     CharSettings['flash_target'] = true
-    _respond("Current target will flash.")
+    puts("Current target will flash.")
     exit
   elsif CharSettings['flash_target'] == true
     CharSettings['flash_target'] = false
-    _respond("Current target will not flash.")
+    puts("Current target will not flash.")
     exit
   end
 elsif Script.current.vars[0].to_s =~ /^showarms/
   CharSettings['show_arms'] = !CharSettings['show_arms']
   respond "Total arm count will #{CharSettings['show_arms'] == false ? "NOT " : ""}be shown."
 else
-  _respond("Please specify where the targets should be displayed.")
-  _respond(";#{script.name} window")
-  _respond(";#{script.name} quick")
-  _respond("")
-  _respond("You may also toggle the showing of a count of how many arms are in the room with:")
-  _respond(";#{script.name} showarms")
-  _respond("")
+  puts("Please specify where the targets should be displayed.")
+  puts(";#{script.name} window")
+  puts(";#{script.name} quick")
+  puts("")
+  puts("You may also toggle the showing of a count of how many arms are in the room with:")
+  puts(";#{script.name} showarms")
+  puts("")
   exit
 end

--- a/scripts/targetwindow.lic
+++ b/scripts/targetwindow.lic
@@ -57,9 +57,7 @@ module TargetWindow
           target_status = TargetWindow.status_fix(t.status) unless t.status.nil?
           output += "<link id='#{t.id}' value='#{target_status} #{t.name.split.map(&:capitalize).join(' ')}' cmd='target ##{t.id}' echo='target ##{t.id}'  justify='3' left='0' height='15' width='195'/>"
         }
-        echo "setting #{CharSettings['show_arms']}"
         if CharSettings['show_arms']
-          echo "arms!!"
           arms = GameObj.targets.select { |t| t.noun =~ @grasp_arms }
           output += "<label id= 'armCount' value='Total arms: #{arms.length}' top='#{15 * (targets.length + 2)}' left='0'  width='187'/>" unless arms.empty?
         end


### PR DESCRIPTION
Minor addition intended for sorcerers to show the total amount of arms in the room.
Window:
![image](https://github.com/elanthia-online/scripts/assets/14922332/cca60605-a982-4b62-85a0-82079d73602e)

Quick:
![image](https://github.com/elanthia-online/scripts/assets/14922332/26c60122-57e7-42c3-a982-d027fe9c8a58)
Honestly not sure if I like how it looks in the quick bar, but I guess it is also optional.

Also as mentioned if you don't want these changes no pressure to accept them, as the Sorcerer I liked the removal of the spam of arms but still like to know how many I have left.
