### PR TITLE
[Multiple] - Bugfix - Change in Wealth output

### DIFF
--- a/scripts/coins.lic
+++ b/scripts/coins.lic
@@ -27,7 +27,7 @@
 person = variable[1]
 keep_coins = variable[2].to_i
 
-loop { 
+loop {
   sleep(60) if !checkpcs.map!(&:downcase).include? person
   next if !checkpcs.map!(&:downcase).include? person
   results = Lich::Util.quiet_command_xml("wealth quiet", /^You have (no|[,\d]+|but one) silver with you\./)
@@ -42,7 +42,7 @@ loop {
         coins = coins.gsub(",", "").to_i
       end
       if (coins > 0 && keep_coins == 0) || (coins > keep_coins)
-        fput "give #{person} #{coins}" 
+        fput "give #{person} #{coins}"
       end
     end
   }

--- a/scripts/coins.lic
+++ b/scripts/coins.lic
@@ -10,9 +10,11 @@
  contributors: Tysong
          name: coins
          tags: coins, silver
-      version: 1.3.0
+      version: 1.3.1
 
   changelog:
+    1.3.1 (2023-09-21)
+      Bugfix for matching change in wealth output.
     1.3.0 (2022-11-08)
       Updated to use Lich::Util.quiet_command_xml
       Now supports optional keep silvers option

--- a/scripts/coins.lic
+++ b/scripts/coins.lic
@@ -28,9 +28,9 @@ keep_coins = variable[2].to_i
 loop { 
   sleep(60) if !checkpcs.map!(&:downcase).include? person
   next if !checkpcs.map!(&:downcase).include? person
-  results = Lich::Util.quiet_command_xml("wealth quiet", /^You have (.*) (?:coins|coin) with you\./)
+  results = Lich::Util.quiet_command_xml("wealth quiet", /^You have (no|[,\d]+|but one) silver with you\./)
   results.each { |result|
-    if result =~ /^You have (.*) (?:coins|coin) with you\./
+    if result =~ /^You have (no|[,\d]+|but one) silver with you\./
       coins = $1
       if coins =~ /but/
         coins = 1

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -15,7 +15,7 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 4.6.0
-           version: 1.5.17
+           version: 1.5.18
 
   1.5.17 (2023-06-11)
     - change to 650 implementation
@@ -24,6 +24,8 @@
 =begin
   Version Semantics:
     Major_change.feature_addition.bugfix
+  1.5.18 (2023-09-21)
+    - Bugfix for matching change in wealth output.
   1.5.16 (2023-06-01)
     - bugfix added word boundary to regex for finding similarly named containers
   1.5.15 (2023-05-31)

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -17,15 +17,15 @@
           requires: Lich >= 4.6.0
            version: 1.5.18
 
-  1.5.17 (2023-06-11)
-    - change to 650 implementation
+  1.5.18 (2023-09-21)
+    - Bugfix for matching change in wealth output.
 
 =end
 =begin
   Version Semantics:
     Major_change.feature_addition.bugfix
-  1.5.18 (2023-09-21)
-    - Bugfix for matching change in wealth output.
+  1.5.17 (2023-06-11)
+    - change to 650 implementation
   1.5.16 (2023-06-01)
     - bugfix added word boundary to regex for finding similarly named containers
   1.5.15 (2023-05-31)

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -2279,12 +2279,12 @@ module EHerbs
     end
 
     def self.check_silver
-      lines = Utility.get_lines('wealth quiet', /^You have no|^You have ([\d,]+) coins|^You have but one coin with you./)
+      lines = Utility.get_lines('wealth quiet', /^You have (no|[,\d]+|but one) silver with you/)
 
       coins = 0
-      if lines.any? { |l| l =~ /You have ([\d,]+) coins/ }
+      if lines.any? { |l| l =~ /You have ([,\d]+) silver/ }
         coins = Regexp.last_match(1).gsub(',', '').to_i
-      elsif lines.any? { |l| l =~ /You have but one coin/ }
+      elsif lines.any? { |l| l =~ /You have but one silver/ }
         coins = 1
       end
 

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -1286,7 +1286,7 @@ module ELoot
   end
 
   def self.silver_check
-    wealth_pattern = /^You have (no silver|[,\d]+|but one) coins?/
+    wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/
     wealth = ELoot.get_lines("wealth quiet", wealth_pattern).join(" ")
     coins = 0
     if wealth.gsub('but one', '1') =~ wealth_pattern

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -14,12 +14,12 @@
               tags: loot
            version: 1.6.7
   Improvements:
-  v1.6.6 (2023-09-10)
-    - bugfix to deposit silvers for ;eloot pool deposit.
-=end
-=begin
   v1.6.7 (2023-09-21)
     - Bugfix for matching change in wealth output.
+=end
+=begin
+  v1.6.6 (2023-09-10)
+    - bugfix to deposit silvers for ;eloot pool deposit.
   v1.6.5 (2023-09-05)
     - bugfix for the bugfix for calling deposit when nothing to do.
   v1.6.4 (2023-09-05)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -12,12 +12,14 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian
               game: Gemstone
               tags: loot
-           version: 1.6.6
+           version: 1.6.7
   Improvements:
   v1.6.6 (2023-09-10)
     - bugfix to deposit silvers for ;eloot pool deposit.
 =end
 =begin
+  v1.6.7 (2023-09-21)
+    - Bugfix for matching change in wealth output.
   v1.6.5 (2023-09-05)
     - bugfix for the bugfix for calling deposit when nothing to do.
   v1.6.4 (2023-09-05)

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.0.9
+           version: 2.0.10
           required: Lich >= 5.4.1
 
    changelog:
+      2.0.10 (2023-09-21):
+        Bugfix for matching change in wealth output.
       2.0.9 (2023-07-05): Xanlin:
         Fix for permanent urchin guide access. Rubocop cleanup.
       2.0.8 (2023-03-03): Tysong:

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -150,7 +150,7 @@ module Go2
   end
 
   def self.wealth_quiet();
-    wealth_pattern = /^You have (no silver|[,\d]+|but one) coins?/;
+    wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/;
     wealth = dothistimeout 'wealth quiet', 3, wealth_pattern;
     coins = 0;
     if wealth.gsub('but one', '1') =~ wealth_pattern;

--- a/scripts/spa.lic
+++ b/scripts/spa.lic
@@ -160,7 +160,7 @@ end
 module Spa
   module Util
     def self.wealth()
-      wealth_pattern = /^You have (no silver|[,\d]+|but one) coins?/
+      wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/
       wealth = dothistimeout 'wealth quiet',2, wealth_pattern
       coins = 0
       if wealth.gsub('but one','1') =~ wealth_pattern

--- a/scripts/spa.lic
+++ b/scripts/spa.lic
@@ -64,7 +64,7 @@
     ;spa --floor                 picks all boxes on the floor (warning: spa may leave the room with your boxes on the floor, use an alt)
 
   author=Ondreian
-  version=1.2.0
+  version=1.2.1
 
    Changelog:
     1.0.0 : initial release
@@ -72,6 +72,7 @@
             adds 10% difficulty modifier to plinites to account for detect bug
     1.2.0 : all vars now exist in the `spa/` namespace
             adds `spa/max-risk` variable for the maximum risk allowed in simulated lockpicking outcomes*
+    1.2.1 : Bugfix for matching change in wealth output.
 
 =end
 

--- a/scripts/uhaul.lic
+++ b/scripts/uhaul.lic
@@ -7,7 +7,7 @@
   Required: Lich 4.6.4
   Tags: lockers, movers, move
   Author: Ondreian
-  version: 2
+  version: 2.0.1
   
   Xanlin:
     Added Kraken's Fall and Cysaegir.

--- a/scripts/uhaul.lic
+++ b/scripts/uhaul.lic
@@ -72,7 +72,7 @@ class Movers
   end
   
   def self.wealth();
-    wealth_pattern = /^You have (no silver|[,\d]+|but one) coins?/;
+    wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/;
     wealth = dothistimeout 'wealth quiet',2, wealth_pattern;
     coins = 0;
     if wealth.gsub('but one','1') =~ wealth_pattern;


### PR DESCRIPTION
The output of the wealth command changed today:
https://discord.com/channels/226045346399256576/1121832778791665716/1154365026942070835

I have done a quick search for all EO scripts implementing their own wealth check and update the regex, is a chance I missed some but this should be a good start. I have not been able to test all of the script myself but have tried eherb/eloot and they seem ok and the rest implement in basically the same way.