### PR TITLE
[OverWatch.lic] silent strike update

### DIFF
--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -64,7 +64,7 @@ module OverWatch
       end
     end
     echo "Silent Strike not detected or failed." if silent_strike && @debug
-    
+
     unless GameObj.targets.any? { |npc| npc.id == target_id }
       GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))
       echo "#{target_id} added to GameObj.npcs."

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -70,11 +70,11 @@ module OverWatch
 
     unless GameObj.targets.any? { |npc| npc.id == target_id }
       GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))
-      echo "#{target_id} added to GameObj.npcs."
+      echo "#{target_id} added to GameObj.npcs." if @debug
     end
     unless XMLData.current_target_ids.include?(target_id)
       XMLData.current_target_ids.unshift(target_id)
-      echo "#{target_id} added to XMLData.current_target_ids."
+      echo "#{target_id} added to XMLData.current_target_ids." if @debug
     end
   end
 

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -60,10 +60,13 @@ module OverWatch
             echo "Silent Strike Detected. Target #{target_id} #{target_name} is hidden." if @debug
             return
           end
+        when /You notice <pushBold\/>\w+ <a exist="(\d+)" noun=" ?\w+">[^<]+<\/a><popBold\/> botch an attempt at concealing <pushBold\/><a exist="\d+" noun=" ?\w+">\w+<\/a><popBold\/>\./
+          if target_id == $1
+            echo "Silent Strike Botched. Target #{target_id} #{target_name}." if @debug
+          end
         end
       end
     end
-    echo "Silent Strike not detected or failed." if silent_strike && @debug
 
     unless GameObj.targets.any? { |npc| npc.id == target_id }
       GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -52,7 +52,7 @@ module OverWatch
 
     if silent_strike
       echo "Checking for silent strike against #{target_id} #{target_name}." if @debug
-      result = reget(10, /fades into the surroundings\./, /slips into the shadows\., /botch an attempt at concealing\./)
+      result = reget(10, /fades into the surroundings\./, /slips into the shadows\./, /botch an attempt at concealing\./)
       unless result.length == 0
         case result[0]
         when /With a (?:barely audible hiss|sibilant exhalation), <pushBold\/>\w+ <a exist="(\d+)" noun=" ?\w+">[^<]+<\/a><popBold\/> (?:fades into the surroundings|slips into the shadows)\./

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -52,7 +52,7 @@ module OverWatch
 
     if silent_strike
       echo "Checking for silent strike against #{target_id} #{target_name}." if @debug
-      result = reget(10, /fades into the surroundings\./, /slips into the shadows\./)
+      result = reget(10, /fades into the surroundings\./, /slips into the shadows\., /botch an attempt at concealing\./)
       unless result.length == 0
         case result[0]
         when /With a (?:barely audible hiss|sibilant exhalation), <pushBold\/>\w+ <a exist="(\d+)" noun=" ?\w+">[^<]+<\/a><popBold\/> (?:fades into the surroundings|slips into the shadows)\./

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -52,7 +52,7 @@ module OverWatch
 
     if silent_strike
       echo "Checking for silent strike against #{target_id} #{target_name}." if @debug
-      result = reget(25, /fades into the surroundings\./, /slips into the shadows\./)
+      result = reget(10, /fades into the surroundings\./, /slips into the shadows\./)
       unless result.length == 0
         case result[0]
         when /With a (?:barely audible hiss|sibilant exhalation), <pushBold\/>\w+ <a exist="(\d+)" noun=" ?\w+">[^<]+<\/a><popBold\/> (?:fades into the surroundings|slips into the shadows)\./

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -26,7 +26,7 @@
 module OverWatch
   status_tags
   @hidden_targets = nil
-  @debug = true
+  @debug = false
 
   HIDING_REGEX = Regexp.union(
     /<pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> slips into hiding\./,

--- a/scripts/overwatch.lic
+++ b/scripts/overwatch.lic
@@ -6,9 +6,11 @@
   contributers: FarFigNewGut, Nisugi
           game: Gemstone
           tags: hunting, target, hidden, bandits
-       version: 1.1
+       version: 1.2
 
   Improvements:
+  v1.2 (2023-10-08)
+    - added check for silent strikes
   v1.1 (2023-07-03)
     - Added Boreal Forest critters
     - Refactored hiding detection.
@@ -24,14 +26,15 @@
 module OverWatch
   status_tags
   @hidden_targets = nil
-  @debug = false
+  @debug = true
 
   HIDING_REGEX = Regexp.union(
     /<pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/> slips into hiding\./,
     /flies out of the shadows toward you\!/, # You being attacked
     /A faint silvery light flickers from the shadows\./, # Hidden Bandits
     /Suddenly, a tiny shard of jet black crystal flies from the shadows toward you!/, # Hidden Bandits
-    /With a barely audible hiss, <pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> fades into the surroundings\./, # Silent Strike ?
+    /With a barely audible hiss, <pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> fades into the surroundings\./, # Silent Strike
+    /With a sibilant exhalation, <pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> slips into the shadows\./, # Silent Strike
     /flies out of the shadows toward <a exist="\-\d+" noun="\w+">[^<]+<\/a>\!/, # Mob or player attacking player
     /flies out of the shadows toward <pushBold\/>\w+ <a exist="\d+" noun="\w+">[^<]+<\/a><popBold\/>\!/, # Player (maybe mob) attacking mob
     /<pushBold\/>\w+ <a exist="\d+" noun=" ?\w+">[^<]+<\/a><popBold\/> darts into the shadows\./, # Halfling Cannibal
@@ -41,21 +44,34 @@ module OverWatch
 
   def self.track_hidden_targets(room_id)
     @hidden_targets = room_id
-    echo "Target hid." if @debug
   end
 
-  def self.push_revealed_targets(target_id, target_noun, target_name)
+  def self.push_revealed_targets(target_id, target_noun, target_name, silent_strike = false)
     @hidden_targets = nil
-    echo "Target located." if @debug
-    if GameObj.targets.any? { |npc| npc.id == target_id }
-      echo "NPC already included" if @debug
-    else
-      GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))
+    echo "push_revealed_targets(#{target_id}, #{target_noun}, #{target_name}, #{silent_strike})" if @debug
+
+    if silent_strike
+      echo "Checking for silent strike against #{target_id} #{target_name}." if @debug
+      result = reget(25, /fades into the surroundings\./, /slips into the shadows\./)
+      unless result.length == 0
+        case result[0]
+        when /With a (?:barely audible hiss|sibilant exhalation), <pushBold\/>\w+ <a exist="(\d+)" noun=" ?\w+">[^<]+<\/a><popBold\/> (?:fades into the surroundings|slips into the shadows)\./
+          if target_id == $1
+            echo "Silent Strike Detected. Target #{target_id} #{target_name} is hidden." if @debug
+            return
+          end
+        end
+      end
     end
-    if XMLData.current_target_ids.include?(target_id)
-      echo "ID already in current_target_ids" if @debug
-    else
+    echo "Silent Strike not detected or failed." if silent_strike && @debug
+    
+    unless GameObj.targets.any? { |npc| npc.id == target_id }
+      GameObj.new_npc(target_id, target_noun, target_name.gsub(/  /, " "))
+      echo "#{target_id} added to GameObj.npcs."
+    end
+    unless XMLData.current_target_ids.include?(target_id)
       XMLData.current_target_ids.unshift(target_id)
+      echo "#{target_id} added to XMLData.current_target_ids."
     end
   end
 
@@ -69,7 +85,6 @@ module OverWatch
 
   def self.room_with_hiders_reset
     @hidden_targets = nil
-    return @hidden_targets
   end
 
   def self.watch
@@ -82,11 +97,11 @@ module OverWatch
         OverWatch.room_with_hiders_reset
 
       # Revealed
+      when /You discover the hiding place of <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/>\!/
+        OverWatch.push_revealed_targets($1, $2, $3)
       when /^You reveal <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> from hiding\!/ # Sunburst
         OverWatch.push_revealed_targets($1, $2, $3)
       when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> is forced from hiding\!/
-        OverWatch.push_revealed_targets($1, $2, $3)
-      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> leaps from hiding to attack\!/ # Players, Assassins
         OverWatch.push_revealed_targets($1, $2, $3)
       when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> is revealed from hiding\./ # Players, Bandits, Wardens
         OverWatch.push_revealed_targets($1, $2, $3)
@@ -102,12 +117,16 @@ module OverWatch
         OverWatch.push_revealed_targets($1, $2, $3)
       when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> suddenly leaps from <pushBold\/><a exist="\d+" noun="\w+">\w+<\/a><popBold\/> hiding place\!/ # Bandit Spawn
         OverWatch.push_revealed_targets($1, $2, $3)
-      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> springs upon you from behind and aims a blow to your head\!/ # Subdue?
-        OverWatch.push_revealed_targets($1, $2, $3)
+
+      # Silent Strikes? Attacks that could be silent strikes resulting in reveal/rehide in the same action.
       when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> springs upon you from behind and attempts to grasp you by the chin while bringing <pushBold\/><a exist="\d+" noun=" ?\w+">\w+<\/a><popBold\/> <a exist="\d+" noun="[^"]+">[^<]+<\/a> up to slit your throat\!/ # Cutthroat
-        OverWatch.push_revealed_targets($1, $2, $3)
+        OverWatch.push_revealed_targets($1, $2, $3, true)
       when /^With an ululating shriek, <pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> leaps from the shadows and hurtles at you, swinging wildly with a <a exist="\d+" noun="[^"]+">[^<]+<\/a>!/ # Halfling Cannibal
-        OverWatch.push_revealed_targets($1, $2, $3)
+        OverWatch.push_revealed_targets($1, $2, $3, true)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> leaps from hiding to attack\!/ # Players, Assassins
+        OverWatch.push_revealed_targets($1, $2, $3, true)
+      when /^<pushBold\/>\w+ <a exist="(\d+)" noun=" ?(\w+)">([^<]+)<\/a><popBold\/> springs upon you from behind and aims a blow to your head\!/ # Subdue?
+        OverWatch.push_revealed_targets($1, $2, $3, true)
       end
     end
   end


### PR DESCRIPTION
Added a check to see if target re-hid on events that could be a silent strike. Not adding to GameObj if a hide was successfully detected after an attack.