### PR TITLE
[bigshot] v5.2.2 bugfix in bs_wander

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4800,6 +4800,7 @@ class Bigshot
 
   def single_stop()
     Script.self.kill
+    sleep 0.5
   end
 
   def room_id()

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.2.1
+       version: 5.2.2
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.2.2 (2023-11-21)
+    - bugfix causing bs_wander to delay 0.5 seconds longer than needed
+    - added Roa'ter and Ooze escape check in bs_wander 
   v5.2.1 (2023-11-15)
     - add new efury, caststop, and wield cmd
     - redo unravel/barddispel cmd
@@ -591,14 +594,8 @@ class Bigshot
 
     def all_present?
       @members.each_pair { |k, _v|
-        begin
-          return false if !checkpcs.include?(k) && k != @leader.name
-        rescue
-          @leader.message("yellow", "Error polling member(all_present?). Removing #{k}!")
-          @members.delete(k)
-        end
+        return false unless checkpcs.include?(k)
       }
-      sleep 0.5
       return true
     end
 
@@ -5623,10 +5620,10 @@ class Bigshot
       else
         way.call
       end
+      
+      escape_rooms
       set_room_claimed([])
-
       check_for_deaders_prone
-
       cast_signs(true)
     }
 
@@ -5674,7 +5671,8 @@ class Bigshot
         cmd_hide(1) unless hidden
         wait_rt
       end
-
+      
+      escape_rooms
       wait_while { @followers.roundtime? }
 
       if (Char.prof == "Ranger") && !Effects::Cooldowns.active?("Tracking") && !@TRACKING_CREATURE.empty?

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,7 +19,7 @@
     Major_change.feature_addition.bugfix
   v5.2.2 (2023-11-21)
     - bugfix causing bs_wander to delay 0.5 seconds longer than needed
-    - added Roa'ter and Ooze escape check in bs_wander 
+    - added Roa'ter and Ooze escape check in bs_wander
   v5.2.1 (2023-11-15)
     - add new efury, caststop, and wield cmd
     - redo unravel/barddispel cmd
@@ -5620,7 +5620,7 @@ class Bigshot
       else
         way.call
       end
-      
+
       escape_rooms
       set_room_claimed([])
       check_for_deaders_prone
@@ -5671,7 +5671,7 @@ class Bigshot
         cmd_hide(1) unless hidden
         wait_rt
       end
-      
+
       escape_rooms
       wait_while { @followers.roundtime? }
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4529,6 +4529,8 @@ class Bigshot
       go2(@RESTING_ROOM_ID)
     end
 
+    escape_rooms
+
     if (@QUIET_FOLLOWERS) && !any_wounded
       @followers.add_event(:FOLLOW_NOW)
       message("yellow", "Waiting for followers....") if !@followers.all_present?


### PR DESCRIPTION
there was an unintended 0.5 second wait in follower.all_present? causing bs_wander to add that to its wait between rooms 