### PR TITLE
[eloot] v1.6.13 stow box instead of exiting when unknown response at locksmith

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -12,12 +12,14 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian
               game: Gemstone
               tags: loot
-           version: 1.6.12
+           version: 1.6.13
   Improvements:
-  v1.6.12 (2023-11-24)
-    - update get_regex for unique messaging
+  v1.6.13 (2023-11-27)
+    - changed unknown response at locksmith to put item in container and keep going instead of exiting
 =end
 =begin
+  v1.6.12 (2023-11-24)
+    - update get_regex for unique messaging
   v1.6.11 (2023-11-19)
     - check to make sure box is locked when using locksmith
   v1.6.10 (2023-11-03)
@@ -735,6 +737,7 @@ module ELoot
         break
       end
     }
+
     ready_lines.each { |line|
       if line =~ sheath_list_match
         ELoot.data.ready_list.store(Regexp.last_match(1).to_s.downcase, GameObj.inv.find { |i| i.id == Regexp.last_match(2) })
@@ -2420,8 +2423,6 @@ module ELoot
       return if item.nil?
 
       if item.type =~ /box/
-        # item = ELoot.box_phase(item)
-
         if ELoot.data.disk && !ELoot.data.disk_full && ELoot.data.settings[:use_disk]
           # Wait for disk to arrive
           ELoot.wait_for_disk
@@ -3795,12 +3796,13 @@ module ELoot
         end
 
         unless res
-          ELoot.msg "info", 'unknown locksmith response'
-          exit
+          ELoot.msg "info", ' Unknown locksmith response.'
+          Inventory.single_drag(box, false)
+          return
         end
 
-        res = dothistimeout('pay', 2, /accepts|have enough/)
-        if res =~ /have enough/
+        result = dothistimeout('pay', 2, /accepts|have enough/)
+        if result =~ /have enough/
           Inventory.single_drag(box, false)
           ELoot.silver_withdraw(8000)
           ELoot.go2('locksmith')


### PR DESCRIPTION
Occasionally the locksmith will not recognize a box. Maybe this is just in Shattered though.

glance
You glance down to see a gilded carved modwir case decorated with bits of colorful glass in your right hand and nothing in your left hand.
>open my case
It appears to be locked.
>pull keys
You pull on the tree of keys, causing an enormous racket!