### PR TITLE
[vars.lic] v1.2.0 add boolean support

### DIFF
--- a/scripts/vars.lic
+++ b/scripts/vars.lic
@@ -9,9 +9,11 @@
    game: Gemstone
    tags: core
    required: Lich > 5.0.1
-   version: 1.1
+   version: 1.2.0
 
   changelog:
+    1.2.0 (2023-12-04)
+      Allowed setting of vars to boolean values true/false
     1.1 (2023-09-07)
       Remove #quiet to prevent script being ran quietly
       Rubocop cleanup
@@ -39,12 +41,17 @@
 if (script.vars[1] == 'set') and (script.vars[0] =~ /^set\s+([^\s]+)\s*=\s*(.+)/)
   name = $1
   value = $2.strip
-  if Vars[name].nil?
+  old_value = Vars[name]
+  if value.to_s.downcase == 'true'
+    Vars[name] = true
+  elsif value.to_s.downcase == 'false'
+    Vars[name] = false
+  else
     Vars[name] = value
+  end
+  if old_value.nil?
     respond "\n--- variable \"#{name}\" set to: \"#{value}\"\n\n"
   else
-    old_value = Vars[name]
-    Vars[name] = value
     respond "\n--- variable #{name} changed to: #{value} (was #{old_value})\n\n"
   end
 elsif (script.vars[1] =~ /^del(ete)?$|^rem(?:ove)?$/) and script.vars[2]


### PR DESCRIPTION
Adds the ability to set vars to true/false booleans as previously it would store it as a string instead of actual TrueClass and FalseClass. Fixes and resolves #1314 