### PR TITLE
[Ebounty.lic] v1.1.35

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,9 +9,11 @@
   contributors: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-       version: 1.1.34
+       version: 1.1.35
 
   Improvements:
+  v1.1.35 (2024-01-02)
+    - added check for nomagic tag before casting spells.
   v1.1.34 (2023-11-16)
     - bugfix in location check for foraging
 =end

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -2808,16 +2808,18 @@ module EBounty
             end
 
             # Cast any helper spells before kneeling
-            Spell[604].cast if Spell[604].known? && Spell[604].affordable? && !Effects::Spells.active?("Nature's Bounty") && EBounty.data.settings[:forage_options].include?("use_604")
-            Spell[506].cast if Spell[506].known? && Spell[506].affordable? && !Effects::Buffs.active?("Celerity") && !Effects::Cooldowns.active?("Celerity") && EBounty.data.settings[:forage_options].include?("use_506")
-            Spell[919].cast if Spell[919].known? && Spell[919].affordable? && !Effects::Buffs.active?("Wizard's Shield") && !Effects::Cooldowns.active?("Wizard's Shield") && EBounty.data.settings[:forage_options].include?("use_919")
-            Spell[140].cast if Spell[140].known? && Spell[140].affordable? && !Effects::Buffs.active?("Wall of Force") && !Effects::Cooldowns.active?("Wall of Force") && EBounty.data.settings[:forage_options].include?("use_140")
-            Spell[1035].cast if Spell[1035].known? && Spell[1035].affordable? && !Effects::Buffs.active?("Song of Tonis") && EBounty.data.settings[:forage_options].include?("use_1035")
-            Spell[9704].cast if Spell[9704].known? && Spell[9704].affordable? && !Effects::Buffs.active?("Sigil of Resolve") && EBounty.data.settings[:forage_options].include?("use_resolve")
+            unless Map.current.tags.include?("meta:nomagic")
+              Spell[604].cast if Spell[604].known? && Spell[604].affordable? && !Effects::Spells.active?("Nature's Bounty") && EBounty.data.settings[:forage_options].include?("use_604")
+              Spell[506].cast if Spell[506].known? && Spell[506].affordable? && !Effects::Buffs.active?("Celerity") && !Effects::Cooldowns.active?("Celerity") && EBounty.data.settings[:forage_options].include?("use_506")
+              Spell[919].cast if Spell[919].known? && Spell[919].affordable? && !Effects::Buffs.active?("Wizard's Shield") && !Effects::Cooldowns.active?("Wizard's Shield") && EBounty.data.settings[:forage_options].include?("use_919")
+              Spell[140].cast if Spell[140].known? && Spell[140].affordable? && !Effects::Buffs.active?("Wall of Force") && !Effects::Cooldowns.active?("Wall of Force") && EBounty.data.settings[:forage_options].include?("use_140")
+              Spell[1035].cast if Spell[1035].known? && Spell[1035].affordable? && !Effects::Buffs.active?("Song of Tonis") && EBounty.data.settings[:forage_options].include?("use_1035")
+              Spell[9704].cast if Spell[9704].known? && Spell[9704].affordable? && !Effects::Buffs.active?("Sigil of Resolve") && EBounty.data.settings[:forage_options].include?("use_resolve")
+            end
 
             if !GameObj.targets.empty? && EBounty.data.settings[:forage_options].include?("use_619")
               targets = GameObj.targets.reject { |w| creatures.any? { |c| c.id == w.id } }
-              Spell[619].cast if Spell[619].known? && Spell[619].affordable? && targets.length.positive?
+              Spell[619].cast if Spell[619].known? && Spell[619].affordable? && targets.length.positive? && !Map.current.tags.include?("meta:nomagic")
               creatures.concat(targets)
               sleep 0.5
               waitcastrt?
@@ -2830,7 +2832,7 @@ module EBounty
 
             empty_hands if checkleft || checkright
 
-            if EBounty.data.settings[:forage_options].include?("use_650")
+            if EBounty.data.settings[:forage_options].include?("use_650") && !Map.current.tags.include?("meta:nomagic")
               if Spell[650].known? && Spell[650].affordable? && !Spell[650].active? && !Spell[9039].active?
                 multifput("prep 650", "assume yierka")
               elsif Spell[650].active? && !Spell[9039].active?
@@ -2841,8 +2843,10 @@ module EBounty
 
             if (EBounty.data.settings[:forage_options].include?("hiding") && !EBounty.data.settings[:forage_options].include?("use_608")) || EBounty.data.settings[:forage_options].include?("use_gambit")
               fput "hide" unless hidden?
-            elsif EBounty.data.settings[:forage_options].include?("use_608")
-              Spell[608].cast if Spell[608].known? && Spell[608].affordable? && !hidden?
+            elsif EBounty.data.settings[:forage_options].include?("use_608") && !Map.current.tags.include?("meta:nomagic")
+              Spell[608].cast if Spell[608].known? && Spell[608].affordable?
+            else
+              fput "hide" unless hidden?
             end
 
             forage_result = dothistimeout "forage for #{forage_item}", 2, EBounty.data.forage_result
@@ -2868,11 +2872,11 @@ module EBounty
 
             elsif forage_result =~ EBounty.data.forage_injury
               EBounty.wait_rt
-              Spell[114].cast if Spell[114].known? and Spell[114].affordable?
+              Spell[114].cast if Spell[114].known? and Spell[114].affordable? && !Map.current.tags.include?("meta:nomagic")
             elsif forage_result.nil? || (forage_result =~ /^As you carefully forage around you (can find no hint|see no evidence) of what you are looking for(?: right now, though you are fairly certain this is where it can be found)?\./)
               break
             elsif forage_result =~ /^As you forage around, you notice that someone has been foraging here recently and you are unable to find anything useful\./
-              unless Effects::Cooldowns.active?("Nature's Bounty Foraging") || Skills.slblessings < 15 || !Spell[604].affordable? || !Spell[604].known? || !EBounty.data.settings[:forage_options].include?("use_604evoke")
+              unless Effects::Cooldowns.active?("Nature's Bounty Foraging") || Skills.slblessings < 15 || !Spell[604].affordable? || !Spell[604].known? || !EBounty.data.settings[:forage_options].include?("use_604evoke") || Map.current.tags.include?("meta:nomagic")
                 Spell[604].force_evoke
                 next
               end
@@ -2907,7 +2911,7 @@ module EBounty
 
       lines = EBounty.get_lines("spell active", /<dialogData id='Active Spells'/)
 
-      if EBounty.data.settings[:forage_options].include?("use_1011") && lines.any? { |l| l =~ /Song of Peace/ }
+      if EBounty.data.settings[:forage_options].include?("use_1011") && lines.any? { |l| l =~ /Song of Peace/ } && !Map.current.tags.include?("meta:nomagic")
         fput "stop 1011"
       end
 

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3161,24 +3161,24 @@ module EBounty
                 Spell[213].cast if Spell[213].known? && Spell[213].affordable?
               end
             end
-  
+
             lines = EBounty.get_lines("spell active", /<dialogData id='Active Spells'/)
-  
+
             unless EBounty.data.settings[:heirloom_options].include?("use_1011") && lines.grep(/Song of Peace/).any?
               Spell[1011].cast if Spell[1011].known? && Spell[1011].affordable?
             end
-  
+
             if EBounty.data.settings[:heirloom_options].include?("use_709") && !GameObj.targets.any? { |c| c.name =~ /arm/ } && !GameObj.targets.empty?
               Spell[709].cast if Spell[709].known? && Spell[709].affordable?
             end
-  
+
             # Cast any helper spells before kneeling
             Spell[402].cast if Spell[402].known? && Spell[402].affordable? && !Effects::Buffs.active?("Presence") && EBounty.data.settings[:heirloom_options].include?("use_402")
             Spell[506].cast if Spell[506].known? && Spell[506].affordable? && !Effects::Buffs.active?("Celerity") && !Effects::Cooldowns.active?("Celerity") && EBounty.data.settings[:heirloom_options].include?("use_506")
             Spell[919].cast if Spell[919].known? && Spell[919].affordable? && !Effects::Buffs.active?("Wizard's Shield") && !Effects::Cooldowns.active?("Wizard's Shield") && EBounty.data.settings[:heirloom_options].include?("use_919")
             Spell[140].cast if Spell[140].known? && Spell[140].affordable? && !Effects::Buffs.active?("Wall of Force") && !Effects::Cooldowns.active?("Wall of Force") && EBounty.data.settings[:heirloom_options].include?("use_140")
             Spell[1035].cast if Spell[1035].known? && Spell[1035].affordable? && !Effects::Buffs.active?("Song of Tonis") && EBounty.data.settings[:heirloom_options].include?("use_1035")
-  
+
             if !GameObj.targets.empty? && EBounty.data.settings[:heirloom_options].include?("use_619")
               targets = GameObj.targets.reject { |w| creatures.any? { |c| c.id == w.id } }
               Spell[619].cast if Spell[619].known? && Spell[619].affordable? && targets.length.positive?

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3154,37 +3154,38 @@ module EBounty
 
       loop {
         unless (GameObj.targets.count.positive? && EBounty.data.settings[:heirloom_options].include?("run")) || checkpcs || GameObj.loot.each { |i| i.name =~ /black void/ }
-
-          if Char.prof =~ /Cleric|Empath/i && EBounty.data.settings[:heirloom_options].include?("use_213")
-            lines = EBounty.get_lines("sense", /You open your soul to the lesser/)
-            unless lines.any? { |l| l =~ /An obvious presence of peace saturates the area and a feeling of safety overwhelms you/ }
-              Spell[213].cast if Spell[213].known? && Spell[213].affordable?
+          unless Map.current.tags.include?("meta:nomagic")
+            if Char.prof =~ /Cleric|Empath/i && EBounty.data.settings[:heirloom_options].include?("use_213")
+              lines = EBounty.get_lines("sense", /You open your soul to the lesser/)
+              unless lines.any? { |l| l =~ /An obvious presence of peace saturates the area and a feeling of safety overwhelms you/ }
+                Spell[213].cast if Spell[213].known? && Spell[213].affordable?
+              end
             end
-          end
-
-          lines = EBounty.get_lines("spell active", /<dialogData id='Active Spells'/)
-
-          unless EBounty.data.settings[:heirloom_options].include?("use_1011") && lines.grep(/Song of Peace/).any?
-            Spell[1011].cast if Spell[1011].known? && Spell[1011].affordable?
-          end
-
-          if EBounty.data.settings[:heirloom_options].include?("use_709") && !GameObj.targets.any? { |c| c.name =~ /arm/ } && !GameObj.targets.empty?
-            Spell[709].cast if Spell[709].known? && Spell[709].affordable?
-          end
-
-          # Cast any helper spells before kneeling
-          Spell[402].cast if Spell[402].known? && Spell[402].affordable? && !Effects::Buffs.active?("Presence") && EBounty.data.settings[:heirloom_options].include?("use_402")
-          Spell[506].cast if Spell[506].known? && Spell[506].affordable? && !Effects::Buffs.active?("Celerity") && !Effects::Cooldowns.active?("Celerity") && EBounty.data.settings[:heirloom_options].include?("use_506")
-          Spell[919].cast if Spell[919].known? && Spell[919].affordable? && !Effects::Buffs.active?("Wizard's Shield") && !Effects::Cooldowns.active?("Wizard's Shield") && EBounty.data.settings[:heirloom_options].include?("use_919")
-          Spell[140].cast if Spell[140].known? && Spell[140].affordable? && !Effects::Buffs.active?("Wall of Force") && !Effects::Cooldowns.active?("Wall of Force") && EBounty.data.settings[:heirloom_options].include?("use_140")
-          Spell[1035].cast if Spell[1035].known? && Spell[1035].affordable? && !Effects::Buffs.active?("Song of Tonis") && EBounty.data.settings[:heirloom_options].include?("use_1035")
-
-          if !GameObj.targets.empty? && EBounty.data.settings[:heirloom_options].include?("use_619")
-            targets = GameObj.targets.reject { |w| creatures.any? { |c| c.id == w.id } }
-            Spell[619].cast if Spell[619].known? && Spell[619].affordable? && targets.length.positive?
-            creatures.concat(targets)
-            sleep 0.5
-            waitcastrt?
+  
+            lines = EBounty.get_lines("spell active", /<dialogData id='Active Spells'/)
+  
+            unless EBounty.data.settings[:heirloom_options].include?("use_1011") && lines.grep(/Song of Peace/).any?
+              Spell[1011].cast if Spell[1011].known? && Spell[1011].affordable?
+            end
+  
+            if EBounty.data.settings[:heirloom_options].include?("use_709") && !GameObj.targets.any? { |c| c.name =~ /arm/ } && !GameObj.targets.empty?
+              Spell[709].cast if Spell[709].known? && Spell[709].affordable?
+            end
+  
+            # Cast any helper spells before kneeling
+            Spell[402].cast if Spell[402].known? && Spell[402].affordable? && !Effects::Buffs.active?("Presence") && EBounty.data.settings[:heirloom_options].include?("use_402")
+            Spell[506].cast if Spell[506].known? && Spell[506].affordable? && !Effects::Buffs.active?("Celerity") && !Effects::Cooldowns.active?("Celerity") && EBounty.data.settings[:heirloom_options].include?("use_506")
+            Spell[919].cast if Spell[919].known? && Spell[919].affordable? && !Effects::Buffs.active?("Wizard's Shield") && !Effects::Cooldowns.active?("Wizard's Shield") && EBounty.data.settings[:heirloom_options].include?("use_919")
+            Spell[140].cast if Spell[140].known? && Spell[140].affordable? && !Effects::Buffs.active?("Wall of Force") && !Effects::Cooldowns.active?("Wall of Force") && EBounty.data.settings[:heirloom_options].include?("use_140")
+            Spell[1035].cast if Spell[1035].known? && Spell[1035].affordable? && !Effects::Buffs.active?("Song of Tonis") && EBounty.data.settings[:heirloom_options].include?("use_1035")
+  
+            if !GameObj.targets.empty? && EBounty.data.settings[:heirloom_options].include?("use_619")
+              targets = GameObj.targets.reject { |w| creatures.any? { |c| c.id == w.id } }
+              Spell[619].cast if Spell[619].known? && Spell[619].affordable? && targets.length.positive?
+              creatures.concat(targets)
+              sleep 0.5
+              waitcastrt?
+            end
           end
 
           until kneeling?


### PR DESCRIPTION
It's probably far and few between, but at least in the atoll there is a forage bounty for seaweed that has you on the log which is nomagic. If using 506 this causes you to cast and fail, cast and fail, then forage. Decided to see about implementing the nomagic tag that Xanlin added to the mapdb. 

Feel free to change any of this as I'm probably not considering everything here. Not sure I got all the casting either.

Adding a check for `Map.current.tags.include?("meta:nomagic")` when casting spells.