### PR TITLE
[repository.lic] v2.49 effect-list.xml default updatable

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.48
+       version: 2.49
 
   changelog:
+    2.49 (2024-01-04):
+      change effect-list.xml to be updatable on fresh installs by default as required for core functionality
     2.48 (2023-09-11):
       add new mapdb-check option to show last mapdb upload date, author, and if mapdb is up-to-date
     2.47 (2023-09-03):
@@ -41,76 +43,6 @@
     2.37 (2022-03-13):
       changed updatables
 =end
-=begin
-    2.36 (2020-12-19):
-      show the author name and time of the last map database upload when downloading it
-    2.35 (2020-06-27):
-      change mapdb format to json
-    2.34 (2018-08-26):
-      change ownership of gameobj-data.xml to elanthia-online
-    2.33 (2017-03-04):
-      don't ask for a password to upload playershops.xml
-    2.32 (2017-03-04):
-      change checkout-mapdb time limit to 12 hours
-    2.31 (2016-04-04):
-      give DragonRealms Fallen its own map database
-    2.30 (2015-07-27):
-      fix for losing previous map data when using checkout-mapdb under certain conditions
-    2.29 (2015-06-03):
-      don't ask for a password for author "nobody"
-    2.28 (2015-05-21):
-      don't restart infomon and lnet: infomon failed to start on some machines
-    2.27 (2015-05-14):
-      give progress updates while uploading the map database if it's slow
-    2.26 (2015-04-21):
-      auto load/restart spell-list.xml, gameobj-data.xml, lnet, infomon after downloading
-      check for missing map images even if the map database was up-to-date
-      allow the server to display warning messages
-    2.25 (2015-02-21):
-      an update just for people who have managed to ignore hundreds of download errors a day for months
-    2.24 (2015-01-23):
-      added --version option to download command
-      give a warning if the system date is outside the range of the CA cert date
-      disable SSLv2 and SSLv3
-    2.23 (2015-01-16):
-      new host name
-    2.22 (2014-11-23):
-      set map database as updatable by default
-    2.21 (2014-11-23):
-      set default values for download-updates on first run
-    2.20 (2014-11-22):
-      show game in list when there's multiple files with the same name
-    2.19 (2014-11-11):
-      slow down download-updates
-    2.18 (2014-11-06):
-      workaround to deal with the plat_updater script disabling OpenSSL::SSL::VERIFY_PEER
-    2.17 (2014-10-12):
-      started on gui
-    2.16 (2014-10-12):
-      delete old map databases after downloading a new one
-    2.15 (2014-10-07):
-      don't look in data directory for xml files on Lich 4.4
-    2.14 (2014-10-07):
-      fix Invalid cross-device link error (when temp directory is on a different disk)
-    2.13 (2014-10-05):
-      automatically download-mapdb after checkout-mapdb
-    2.12 (2014-10-05):
-      alias --sort=date to --sort=age
-      improve error reporting for bad commands and options
-      add options to show/hide columns in list
-    2.11 (2014-10-02):
-      look in data directory when uploading xml files
-    2.10 (2014-10-01):
-      fix download-updates not checking update times correctly
-    2.9 (2014-10-01):
-      reduce width of list
-    2.8 (2014-10-01):
-      added download-updates command
-      changed download-lich to preserve file mode of lich.rb on non-Windows
-    2.7 (2014-09-29):
-      cache file list and reuse if nothing has changed
-      added download-lich command
-=end
 
 begin
   require 'terminal-table' unless defined?(Terminal::Table)
@@ -136,6 +68,7 @@ if Settings['updatable'].nil?
   if XMLData.game =~ /^GS/
     # GemstoneIV specific updatable scripts here
     Settings['updatable'][:scripts].push(:filename => 'gameobj-data.xml', :game => 'gs', :author => 'elanthia-online')
+    Settings['updatable'][:scripts].push(:filename => 'effect-list.xml', :game => 'gs', :author => 'elanthia-online')
   elsif XMLData.game =~ /^DR/
     # DragonRealms specific updatable scripts here
   end


### PR DESCRIPTION
change effect-list.xml to be updatable on fresh installs by default as required for core functionality