### PR TITLE
[foreach.lic] correct filter regex capture groups

### DIFF
--- a/scripts/foreach.lic
+++ b/scripts/foreach.lic
@@ -25,9 +25,11 @@
           game: Gemstone
           tags: utility, inventory,
       required: Lich > 5.0.1
-       version: 1.0.6
+       version: 1.0.7
 
   changelog:
+    1.0.7 (2024-01-09)
+      Fix regex match for filter causing all queries to default to TYPE
     1.0.6 (2024-01-06)
       Remove experimental feature, no longer used
     1.0.5 (2024-01-05)

--- a/scripts/foreach.lic
+++ b/scripts/foreach.lic
@@ -1616,7 +1616,7 @@ module ForeachScript
     end
 
     filter_matches = Regexp.last_match
-    filter_attr = (filter_matches[1].downcase or 'type')
+    filter_attr = (filter_matches[2].downcase or 'type')
     filter_value = filter_matches[3]
     position = (filter_matches[1] or filter_matches[4])
     targets = filter_matches[5]


### PR DESCRIPTION
During a recent refactor the regex capture group for the main filter (m=blah, n=blah, etc.) was changed from match[2] to match[1]. This breaks the logic and makes all filters default to a TYPE filter.

Link to previous versions of script using the [2] match group (first group is either NIL or the conditional skip/first/etc. extra filters)
https://github.com/elanthia-online/scripts/blob/a836db6f0c295a0934297f02d035c3a21d2998c7/scripts/foreach.lic#L1689