### PR TITLE
[ebestiary.lic] updates for new wiki format

### DIFF
--- a/scripts/ebestiary.lic
+++ b/scripts/ebestiary.lic
@@ -9,9 +9,11 @@
    author: elanthia-online
      game: Gemstone
      tags: info, play.net, wiki, bestiary, monsters, critters, help, bestiary, elanthia-online
-  version: 1.0.1
+  version: 1.1
 
   changelog:
+    1.2 - 2024-01-25
+      - updates to handle new wiki format
     1.0.1 - 2023-02-23
       - adds code to handle creatures with non-standard name capitalization schemes
     1.0
@@ -57,7 +59,7 @@ class EBestiary
 
   def get_level_from_main(tab, level)
     url_root = 'https://gswiki.play.net'
-    lvl_list = XPath.first(tab, "//td/b/a[@title=\"Category:Level #{level} Creatures\"]").parent.parent
+    lvl_list = XPath.first(tab, "//td/b/a[text()=\"Level #{level}\"]").parent.parent
     lvl_list = XPath.match(lvl_list, './/li/a')
     @charsettings['creatures_by_level'][level] = []
     lvl_list.each do |m|
@@ -118,7 +120,7 @@ class EBestiary
 
   def get_types(fakeobj)
     types = fakeobj.type
-    types = 'UNKNOWN' if types.nil? || types.empty?
+    types = 'UNKNOWN' if (types.nil? || types.empty?)
     types = types.split(',')
     types.reject! { |t| t == 'aggressive npc' }
     types.join(',')
@@ -159,7 +161,28 @@ class EBestiary
     _http_code, resp = get_page(@base_url)
     @charsettings['page_cache'] = resp
     @charsettings['updated_at'] = Time.now
-    @page = Document.new(resp)
+    # at one point during the changeover the page was not parsing at all
+    # so we try to parse it, and if it fails then we manually pull out the table
+    # element with some lame text manipulation
+    begin
+      @page = Document.new(resp)
+    rescue
+      resp_lines = resp.split("\n")
+      tab_lines = []
+      in_tab = false
+      resp_lines.each { |l| 
+        if l =~ /<table/
+          tab_lines.push(l.gsub(/^.*<table/, '<table'))
+          in_tab = true
+        elsif l =~ /<\/table>/
+          tab_lines.push(l)
+          break
+        elsif in_tab
+          tab_lines.push(l)
+        end 
+      }
+      @page = Document.new(tab_lines.join())
+    end
     @creature_table = XPath.first(@page, '//table')
     max_level = resp.scan(/Category:Level ([0-9]+) Creatures/).flatten.map(&:to_i).max
     echo 'Building cache by level...'

--- a/scripts/ebestiary.lic
+++ b/scripts/ebestiary.lic
@@ -12,7 +12,7 @@
   version: 1.1
 
   changelog:
-    1.2 - 2024-01-25
+    1.1 - 2024-01-25
       - updates to handle new wiki format
     1.0.1 - 2023-02-23
       - adds code to handle creatures with non-standard name capitalization schemes
@@ -47,6 +47,9 @@ class EBestiary
     http.use_ssl = true
 
     req = Net::HTTP::Get.new(uri.request_uri)
+    # at one point during the changeover the page was not parsing at all
+    # so we try to parse it, and if it fails then we manually pull out the table
+    # element with some lame text manipulation
     begin
       resp = http.request(req)
       http_code = "HTTP: #{resp.code}"
@@ -89,17 +92,17 @@ class EBestiary
   # we manually set these here so they don't show up as UNKNOWN
   def name_override(creature)
     name_overrides = {
-      'Nasty little gremlin' => 'nasty little red gremlin',
-      'Myklian' => 'red myklian',
+      'Nasty little gremlin'       => 'nasty little red gremlin',
+      'Myklian'                    => 'red myklian',
       'Decaying citadel guardsman' => 'decaying Citadel guardsman',
       'Rotting citadel arbalester' => 'rotting Citadel arbalester',
-      'Putrefied citadel herald' => 'putrefied Citadel herald',
-      'Supple ivasian inciter' => 'supple Ivasian inciter',
-      'Magna vereri' => 'voluptuous magna vereri'
+      'Putrefied citadel herald'   => 'putrefied Citadel herald',
+      'Supple ivasian inciter'     => 'supple Ivasian inciter',
+      'Magna vereri'               => 'voluptuous magna vereri'
     }
     return name_overrides.fetch(creature, creature)
   end
-  
+
   # makes a fake creature game obj to check type
   def fake_obj(creature)
     creature = name_override(creature)
@@ -161,16 +164,13 @@ class EBestiary
     _http_code, resp = get_page(@base_url)
     @charsettings['page_cache'] = resp
     @charsettings['updated_at'] = Time.now
-    # at one point during the changeover the page was not parsing at all
-    # so we try to parse it, and if it fails then we manually pull out the table
-    # element with some lame text manipulation
     begin
       @page = Document.new(resp)
     rescue
       resp_lines = resp.split("\n")
       tab_lines = []
       in_tab = false
-      resp_lines.each { |l| 
+      resp_lines.each { |l|
         if l =~ /<table/
           tab_lines.push(l.gsub(/^.*<table/, '<table'))
           in_tab = true
@@ -179,7 +179,7 @@ class EBestiary
           break
         elsif in_tab
           tab_lines.push(l)
-        end 
+        end
       }
       @page = Document.new(tab_lines.join())
     end


### PR DESCRIPTION
```ruby
>;ebest refresh
--- Lich: ebestiary active.
Updating local cache of creature list from wiki (last updated: 2024-01-25 09:59:56 -0600)...
[ebestiary: Building cache by level...]
[ebestiary: level 10]
[ebestiary: level 20]
[ebestiary: level 30]
[ebestiary: level 40]
[ebestiary: level 50]
[ebestiary: level 60]
[ebestiary: level 70]
[ebestiary: level 80]
[ebestiary: level 90]
[ebestiary: level 100]
[ebestiary: level 110]
[ebestiary: level 120]
[ebestiary: Done!]

>;ebest 5
--- Lich: ebestiary active.
Loading local cache of creature list from wiki (last updated: 2024-01-25 10:06:46 -0600)
+-------+----------------------+---------------------+----------------------------------------------+
| Level | Creature             | Types               | Wiki Link                                    |
+-------+----------------------+---------------------+----------------------------------------------+
| 5     | Bobcat               |                     | https://gswiki.play.net/Bobcat               |
| 5     | Coyote               |                     | https://gswiki.play.net/Coyote               |
| 5     | Dark apparition      | undead,noncorporeal | https://gswiki.play.net/Dark_apparition      |
| 5     | Mist wraith          | undead,noncorporeal | https://gswiki.play.net/Mist_wraith          |
| 5     | Mongrel hobgoblin    |                     | https://gswiki.play.net/Mongrel_hobgoblin    |
| 5     | Nasty little gremlin |                     | https://gswiki.play.net/Nasty_little_gremlin |
| 5     | Night golem          |                     | https://gswiki.play.net/Night_golem          |
| 5     | Water witch          |                     | https://gswiki.play.net/Water_witch          |
+-------+----------------------+---------------------+----------------------------------------------+
--- Lich: ebestiary has exited.

>;ebest 114
--- Lich: ebestiary active.
Loading local cache of creature list from wiki (last updated: 2024-01-25 10:06:46 -0600)
+-------+----------------------+--------+----------------------------------------------+
| Level | Creature             | Types  | Wiki Link                                    |
+-------+----------------------+--------+----------------------------------------------+
| 114   | Shining winged disir | undead | https://gswiki.play.net/Shining_winged_disir |
+-------+----------------------+--------+----------------------------------------------+
--- Lich: ebestiary has exited.

>;ebest 110 114
--- Lich: ebestiary active.
Loading local cache of creature list from wiki (last updated: 2024-01-25 10:06:46 -0600)
+-------+----------------------------------+---------------------+----------------------------------------------------------+
| Level | Creature                         | Types               | Wiki Link                                                |
+-------+----------------------------------+---------------------+----------------------------------------------------------+
| 110   | Infernal lich                    | undead              | https://gswiki.play.net/Lich                             |
| 110   | Frostborne lich                  | undead              | https://gswiki.play.net/Lich                             |
| 110   | Roiling crimson angargeist       | undead,noncorporeal | https://gswiki.play.net/Roiling_crimson_angargeist       |
| 110   | Translucent kiramon strandweaver |                     | https://gswiki.play.net/Translucent_kiramon_strandweaver |
+-------+----------------------------------+---------------------+----------------------------------------------------------+
| 111   | Colossal boreal undansormr       |                     | https://gswiki.play.net/Colossal_boreal_undansormr       |
+---------------------------------------------------------------------------------------------------------------------------+
| 112   | Bloated kiramon broodtender      |                     | https://gswiki.play.net/Bloated_kiramon_broodtender      |
| 112   | Eyeless black valravn            | undead              | https://gswiki.play.net/Eyeless_black_valravn            |
+---------------------------------------------------------------------------------------------------------------------------+
| 113   | Flayed gigas disciple            |                     | https://gswiki.play.net/Flayed_gigas_disciple            |
+---------------------------------------------------------------------------------------------------------------------------+
| 114   | Shining winged disir             | undead              | https://gswiki.play.net/Shining_winged_disir             |
+---------------------------------------------------------------------------------------------------------------------------+

>;ebest 110 114  undead
--- Lich: ebestiary active.
Loading local cache of creature list from wiki (last updated: 2024-01-25 10:06:46 -0600)
+-------+----------------------------+---------------------+----------------------------------------------------+
| Level | Creature                   | Types               | Wiki Link                                          |
+-------+----------------------------+---------------------+----------------------------------------------------+
| 110   | Infernal lich              | undead              | https://gswiki.play.net/Lich                       |
| 110   | Frostborne lich            | undead              | https://gswiki.play.net/Lich                       |
| 110   | Roiling crimson angargeist | undead,noncorporeal | https://gswiki.play.net/Roiling_crimson_angargeist |
+-------+----------------------------+---------------------+----------------------------------------------------+
| 112   | Eyeless black valravn      | undead              | https://gswiki.play.net/Eyeless_black_valravn      |
+---------------------------------------------------------------------------------------------------------------+
| 114   | Shining winged disir       | undead              | https://gswiki.play.net/Shining_winged_disir       |
+---------------------------------------------------------------------------------------------------------------+
--- Lich: ebestiary has exited.
```