### PR TITLE
[ebounty.lic] bug fix ebounty may invoke eherbs repeatedly

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -473,7 +473,9 @@ module EBounty
 
   def self.check_health
     return if EBounty.data.settings[:skip_healing]
-    return unless XMLData.injuries.any? { |_a, h| h['wound'] > 0 || h['scar'] > 1 } || percenthealth < 95
+
+    # this condition must not be less restrictive than the eherbs 'Hypochondriasis' condition otherwise ebounty will invoke eherbs repeatedly
+    return unless XMLData.injuries.any? { |_a, h| h['wound'] > 0 || h['scar'] > 1 } || percenthealth < 95 && (checkhealth + 7) < maxhealth
 
     # If playing Shattered and in the Nexus check for Nexushealbot
     if checkpcs.any? { |x| x == 'Nexushealbot' } && XMLData.game == 'GSF' && Room.current.id == 20239
@@ -481,7 +483,7 @@ module EBounty
       sleep 15
     end
 
-    Script.run(EBounty.data.healing_script) if XMLData.injuries.any? { |_a, h| h['wound'] > 0 || h['scar'] > 1 } || percenthealth < 95
+    Script.run(EBounty.data.healing_script) if XMLData.injuries.any? { |_a, h| h['wound'] > 0 || h['scar'] > 1 } || percenthealth < 95 && (checkhealth + 7) < maxhealth
   end
 
   def self.deadmans_switch

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -3242,6 +3242,7 @@ module EHerbs
   Game.puts '_injury 2'
   sleep(0.5)
 
+  # if this condition changes, make sure to update Ebounty.check_health accordingly
   unless [Wounds.head, Wounds.neck, Wounds.torso, Wounds.limbs, Wounds.nerves, Scars.head, Scars.neck, Scars.torso, Scars.limbs, Scars.nerves].max > 0 || ((checkhealth + 7) < maxhealth)
     Utility.distill if EHerbs.data[:distiller]
     respond

--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -3242,7 +3242,7 @@ module EHerbs
   Game.puts '_injury 2'
   sleep(0.5)
 
-  # if this condition changes, make sure to update Ebounty.check_health accordingly
+  # if this condition changes, make sure to update EBounty.check_health accordingly
   unless [Wounds.head, Wounds.neck, Wounds.torso, Wounds.limbs, Wounds.nerves, Scars.head, Scars.neck, Scars.torso, Scars.limbs, Scars.nerves].max > 0 || ((checkhealth + 7) < maxhealth)
     Utility.distill if EHerbs.data[:distiller]
     respond


### PR DESCRIPTION
A young player's health may be less than 95% but still higher than the eherbs 'Hypochondriasis' condition for (checkhealth + 7) < maxhealth. This state results in ebounty repeatedly invoking the eherbs script.