### PR TITLE
[map.lic] v1.1.1 bugfix to unhide circle when doing a 'find room' search

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -15,7 +15,7 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich > 5.0.1
-      version: 1.1.2
+      version: 1.1.1
 
   changelog:
     v1.1.1 (2024-02-27)


### PR DESCRIPTION
If you're inside a building in town, the circle is hidden from the map. If you do a 'find room' from the context menu at that point, the map will change, but the circle does not get unhidden to show the found room.