### PR TITLE
[ebounty.lic] 1.2.2 bugfix for gem hoarding scripts that handle selling gems

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,9 +9,11 @@
   contributors: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-       version: 1.2.1
+       version: 1.2.2
 
   Improvements:
+  v1.2.2 (2024-03-03)
+    - bugfix for gem hoarding scripts that handle selling gems
   v1.2.1 (2024-02-25)
     - bugfix for condition where ebounty may be repeatedly invoke eherbs
   v1.2.0 (2024-02-09)
@@ -3101,11 +3103,16 @@ module EBounty
         EBounty.data.settings[:hording_script].split(/,\s*/).each do |i|
           tokens = i.split(/\s+/)
           if (tokens.size > 1)
-            start_script tokens[0], tokens[1..-1]
+            Script.run(tokens[0], tokens[1..-1])
           else
-            start_script tokens[0]
+            Script.run(tokens[0])
           end
         end
+      end
+
+      # the hoarding script may have handled selling the gems
+      if checkbounty =~ /succeeded in your task/
+        return
       end
 
       # Lets check if we have enough gems to turn in already


### PR DESCRIPTION
When ebounty invokes a gem hoarding script, it needs to wait for the script to finish before proceeding. Also, some gem hoarding scripts will handle selling the gems, so ebounty need to check if the bounty is completed after the hoarding script runs.