### PR TITLE
[eloot.lic] v1.6.20 withdraw a note when the max bank account balance is reached

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -13,8 +13,11 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian
               game: Gemstone
               tags: loot
-           version: 1.6.19
+           version: 1.6.20
   Improvements:
+  v1.6.20 (2024-03-15)
+    - (F2P) withdraw a note when the max bank account balance is reached
+    - fix to not "Share silvers" from the allotment of "Keep Silvers"
   v1.6.19 (2024-03-13)
     - fix to not sell bounty items in FWI when selling disabled for that type
   v1.6.18 (2024-03-08)
@@ -1430,15 +1433,72 @@ module ELoot
       end
     end
 
-    ending_silver = ELoot.silver_check
-    keep_silvers = ELoot.data.settings[:sell_keep_silver].to_i
-    note = ELoot.data.sacks["default"].contents.find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
+    current_silvers = ELoot.silver_check
+    keep_silvers = [ELoot.data.settings[:sell_keep_silver].to_i, 0].max
+    share_silvers = current_silvers - keep_silvers
 
-    unless ending_silver - keep_silvers == 0
+    if ELoot.data.settings[:sell_share_silvers] && share_silvers > 1
+      fput("share #{share_silvers}")
+      current_silvers = ELoot.silver_check
+    end
+
+    deposit_silver_regex = /You deposit ([\d,]+) silvers? into your account./
+    deposit_notes_regex = /You hand over your notes to the teller, who nods, carefully recording each amount./ # this is the response to "deposit all" even for scrip/chit
+    deposit_exceeded_regex = /you can only deposit up to ([\d,]+) silvers? into your bank account./
+    balance_regex = /Your balance is currently at ([\d,]+) silvers?./
+    no_account_regex = /you don't have access to bank accounts in multiple towns./
+
+    if current_silvers != keep_silvers
       ELoot.go2('bank')
-      fput('share all') if ELoot.data.settings[:sell_share_silvers] && ending_silver > 1
-      fput('deposit all') if ending_silver > 0 || note
-      fput("withdraw #{keep_silvers}") if keep_silvers.positive?
+
+      note = ELoot.data.sacks["default"].contents.find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
+      if current_silvers > keep_silvers || note
+        line = dothistimeout 'deposit all', 5, Regexp.union(deposit_silver_regex, deposit_notes_regex, deposit_exceeded_regex)
+        if line =~ deposit_silver_regex
+          current_silvers -= $1.delete(',').to_i
+        elsif line =~ deposit_exceeded_regex
+          # F2P accounts have a maximum balance, deposit up to the maximum then withdraw a note to make room for more silver.
+          # withdraw a note of up to 100k but retain at least 10k silvers for errands such as travelling and locksmith pool.
+          max_balance = $1.delete(',').to_i
+          line = dothistimeout 'check balance', 5, Regexp.union(balance_regex, no_account_regex)
+          if line =~ balance_regex
+            current_balance = $1.delete(',').to_i
+
+            # loop on the off chance that someone is carrying multiple times more silver than the max allowed balance
+            loop do
+              max_deposit = max_balance - current_balance
+              if current_silvers - max_deposit < keep_silvers
+                break
+              end
+
+              if max_deposit > 0
+                fput "deposit #{max_deposit}"
+                current_balance += max_deposit
+                current_silvers -= max_deposit
+              end
+
+              Inventory.free_hand
+              retain_silvers = [10000, keep_silvers].max
+              note_size = [100000, max_balance + current_silvers - retain_silvers].min
+              fput("withdraw #{note_size}")
+              note = [GameObj.right_hand, GameObj.left_hand].find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
+              break if note.nil?
+              fput("stow ##{note.id}")
+              current_balance -= note_size
+            end
+
+            if current_silvers > keep_silvers
+              deposit_size = [current_silvers - keep_silvers, max_balance].min
+              fput("deposit #{deposit_size}")
+              current_silvers -= deposit_size
+            end
+          end
+        end
+      end
+
+      if keep_silvers.positive? && current_silvers < keep_silvers
+        fput("withdraw #{keep_silvers - current_silvers}")
+      end
     end
   end
 


### PR DESCRIPTION
F2P accounts have a max bank account balance. When the cap is reached, eloot will now withdraw a note of up to 100k to make room for more silvers to be deposited into the account. It will retain at least 10k silvers in the account for running errands.