### PR TITLE
[eloot.lic] v1.6.22 frozen bramble fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -13,8 +13,10 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian
               game: Gemstone
               tags: loot
-           version: 1.6.21
+           version: 1.6.22
   Improvements:
+  v1.6.22 (2024-03-29)
+    - fix for Frozen Bramble creatures requiring left hand to be empty in order to loot. 
   v1.6.21 (2024-03-26)
     - add messaging for valence weapons
   v1.6.20 (2024-03-16)
@@ -3210,7 +3212,7 @@ module ELoot
         ELoot.change_stance('defensive') if ELoot.data.settings[:loot_defensive]
 
         if thing.name =~ inhand_critters
-          Inventory.free_hand
+          (thing.name =~ /tumbleweed|plant|shrub|creeper|vine|bush/) ? Inventory.free_hands(left: true) : Inventory.free_hand
           if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
             free_hand = "left"
           else

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -16,7 +16,7 @@
            version: 1.6.22
   Improvements:
   v1.6.22 (2024-03-29)
-    - fix for Frozen Bramble creatures requiring left hand to be empty in order to loot. 
+    - fix for Frozen Bramble creatures requiring left hand to be empty in order to loot
   v1.6.21 (2024-03-26)
     - add messaging for valence weapons
   v1.6.20 (2024-03-16)


### PR DESCRIPTION
fix for Frozen Bramble creatures requiring left hand to be empty in order to loot. Fixes #1456