### PR TITLE
Bigshot reim time

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.3.7
+       version: 5.3.8
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.3.8 (2024-05-18)
+    - account for all reim NPC name collisions with non-aggressive types
   v5.3.7 (2024-05-01)
     - fix for Char.prof/Char.level to Stats.prof/Stats.level
   v5.3.6 (2024-04-28)
@@ -4111,7 +4113,7 @@ class Bigshot
     npcs = GameObj.targets.find_all { |i| i.status !~ /dead|gone/ }
     npcs.delete_if { |npc| (npc.name =~ /animated/ && npc.name !~ /animated slush/) }
     npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
-    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
+    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/ }
     npcs.delete_if { |npc| npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i }
     return npcs.size.to_i
   end
@@ -5046,7 +5048,7 @@ class Bigshot
     npcs = GameObj.targets.find_all { |i| i.status !~ /dead|gone/ }
     npcs.delete_if { |npc| (@INVALID_TARGETS.include?(npc.name) or @INVALID_TARGETS.include?(npc.noun)) }
     npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
-    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
+    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/ }
     npcs.delete_if { |npc| npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i }
     npcs.delete_if { |npc| npc.noun =~ /^(?:grik|grik'trak|grik'mlar|grik'pwal|grik'tval|verlok|verlok'asha|verlok'cina|verlok'ar|imp|abyran|abyran'a|abyran'sa|grantris|igaesha|haze|rouk|brume|haar|murk|nyle|mist|smoke|vapor|fog|aishan|shien|darkling|shadowling|arashan)$/i }
     npcs.delete_if { |npc| ['quickly growing troll king', 'severed troll arm', 'severed troll leg'].include?(npc.name) }
@@ -5073,7 +5075,7 @@ class Bigshot
     return false if $bigshot_room_claimed.length > 0
 
     echo " false if target.noun.... (not last one)" if $bigshot_debug
-    return false if target.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && target.name !~ /ethereal|celestial|unworldly/i
+    return false if target.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/
 
     echo " false if target.name =~ /animated/ #{target.name =~ /animated/}" if $bigshot_debug
     if (target.name =~ /animated/ && target.name !~ /animated slush/)
@@ -5117,9 +5119,9 @@ class Bigshot
       end
       npcs = GameObj.targets.find_all { |i| i.status !~ /dead|gone/ }
       npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
-      npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
+      npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/ }
       if ($bigshot_bandits)
-        npcs.delete_if { |npc| npc.noun !~ /thief|rogue|bandit|mugger|outlaw|highwayman|marauder|brigand|thug|robber/i && npc.name !~ /ethereal|celestial|unworldly/i }
+        npcs.delete_if { |npc| npc.noun !~ /thief|rogue|bandit|mugger|outlaw|highwayman|marauder|brigand|thug|robber/i && npc.type !~ /realm:reim/ }
       end
       npcs.each { |i| tokens.push(i.name) }
 
@@ -5154,7 +5156,7 @@ class Bigshot
     stoppriority = false
     npcs = GameObj.targets.find_all { |i| i.status !~ /dead|gone/ }
     npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
-    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.name !~ /ethereal|celestial|unworldly/i }
+    npcs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/ }
     @TARGETS.keys.each { |t|
       break if stoppriority == true
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -5075,7 +5075,7 @@ class Bigshot
     return false if $bigshot_room_claimed.length > 0
 
     echo " false if target.noun.... (not last one)" if $bigshot_debug
-    return false if target.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/
+    return false if target.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && target.type !~ /realm:reim/
 
     echo " false if target.name =~ /animated/ #{target.name =~ /animated/}" if $bigshot_debug
     if (target.name =~ /animated/ && target.name !~ /animated slush/)


### PR DESCRIPTION
Some reim mobs have a noun collision with passive NPC mobs (escorts). There was already an exception to handle reim mobs by name but it was incomplete. failing at least on the `Foreign Dignitary`

We already have all(?) the reim mobs in a migration that adds them explicitly as aggressive NPCs and adds a special `realm:reim` type to them. We should use that exception instead. I'm not aware of any non-reim mobs that would be affected by the change.

tested the new logic with:
```ruby
test_npc_nouns = ['dignitary', 'merchant', 'Dignitary']
test_npc_names = ['foreign', 'Foreign', 'half-elven']
combos = test_npc_names.product(test_npc_nouns)

objs = []
combos.each_with_index { |c,i| objs.push(GameObj.new(696969 + i, c[1], "#{c.join(' ')}")) }

objs.each { |o|
  echo o.name
}
objs.delete_if { |npc| npc.noun =~ /child|traveller|scribe|merchant|dignitary|official|magistrate/i && npc.type !~ /realm:reim/ }
echo "FILTERED:"
objs.each { |o|
  echo o.name
}
```

```
--- Lich: test active.
[test: foreign dignitary]
[test: foreign merchant]
[test: foreign Dignitary]
[test: Foreign dignitary]
[test: Foreign merchant]
[test: Foreign Dignitary]
[test: half-elven dignitary]
[test: half-elven merchant]
[test: half-elven Dignitary]
[test: FILTERED:]
[test: Foreign Dignitary]
```

We want to leave valid aggressive NPCs as the only remaining things in the list so this is the expected result (and the type check is case sensitive so `foreign dignitary` was dropped)