### PR TITLE
[autostart.lic] v0.61 use Lich5 update module on newer lich

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -8,10 +8,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.60
+       version: 0.61
       required: Lich >= 4.6.58
 
   changelog:
+    0.61 (2024-05-20):
+      Use internal Lich5 update module on Lich > 5.6.2 instead of script
     0.60 (2023-09-07):
       Removal of #quiet to prevent script being ran in quiet mode.
     0.59 (2023-07-29):
@@ -150,6 +152,9 @@ if script.vars.empty?
       # Loop through list
       for script_info in script_list
         if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
+          next
+        elsif script_info[:name] == 'lich5-update' && Gem::Version.new(LICH_VERSION) > Gem::Version.new('5.6.2')
+          Lich::Util::Update.request("#{script_info[:args]}")
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
           respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with '#{$clean_lich_char}autostart remove --global dependency'"


### PR DESCRIPTION
Use internal Lich5 update module on Lich > 5.6.2 instead of script