### PR TITLE
Improved ready_to_rest? logic to reduce misleading messages

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -5475,12 +5475,11 @@ class Bigshot
   def ready_to_rest?
     echo "ready_to_rest? called by #{caller[0]}" if $bigshot_debug
     return false if $bigshot_quick
-    $rest_reason = nil
 
     # Define rest_conditions with lambda functions representing conditions
     rest_conditions = {
       bounty_mode: lambda { @BOUNTY_MODE && $bigshot_should_rest },
-      should_rest: lambda { $bigshot_should_rest },
+      provided_reason: lambda { $rest_reason != nil},
       wounded: lambda { wounded? },
       percentencumbrance: lambda { percentencumbrance >= @ENCUMBERED },
       creaping_dread: lambda { creaping_dread? },
@@ -5488,13 +5487,14 @@ class Bigshot
       wot_poison: lambda { wot_poison? },
       confusion_debuff: lambda { @CONFUSION == true && Effects::Debuffs.active?("Confusion") },
       fried_overkill_and_lte_boost: lambda { fried? && overkill? && lte_boost? },
-      oom: lambda { oom? }
+      oom: lambda { oom? },
+      should_rest: lambda { $bigshot_should_rest }
     }
 
     # Define rest_actions with lambda functions representing actions
     rest_actions = {
       bounty_mode: lambda { $rest_reason = 'bounty complete.' },
-      should_rest: lambda { $rest_reason = '$bigshot_should_rest was set to true.' unless $rest_reason },
+      provided_reason: lambda { true }, #$rest_reason will have been set external to this function so just return true
       wounded: lambda { $rest_reason = 'wounded.' },
       percentencumbrance: lambda { $rest_reason = 'encumbered.' },
       creaping_dread: lambda { $rest_reason = 'creaping dread limit.' },
@@ -5502,7 +5502,8 @@ class Bigshot
       wot_poison: lambda { $rest_reason = 'wall of thorns poison.' },
       confusion_debuff: lambda { $rest_reason = 'confusion debuff.' },
       fried_overkill_and_lte_boost: lambda { $rest_reason = 'fried.' },
-      oom: lambda { wrack() if @USE_WRACKING; return false unless oom?; $rest_reason = 'out of mana.' }
+      oom: lambda { wrack() if @USE_WRACKING; return false unless oom?; $rest_reason = 'out of mana.' },
+      should_rest: lambda { $rest_reason = '$bigshot_should_rest was set to true.' unless $rest_reason },
     }
 
     # Iterate through rest_conditions and execute corresponding actions from rest_actions


### PR DESCRIPTION
Fixes https://github.com/elanthia-online/scripts/issues/1521

There are a few places in the script that set $bigshot_should_rest to true. For example, in the cmd_spell function. If a spell is unaffordable, it sets $bigshot_should_rest to true and provides a reason.

However in the ready_to_rest? function, it immediately sets $rest_reason to nil, erasing any indicator of a pre-existing rest reason. This adds a new rest_condition and rest_action that simply captures this pre-existing reason. 

It also moves should_rest to the end so it acts as a "default" reason, allowing more detailed reasons to be processed first