### PR TITLE
[bigshot.lic] v5.3.9 cmd_assault additional regex

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.3.8
+       version: 5.3.9
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.3.9 (2024-05-29)
+    - add additional missing cmd_assault regex matching
   v5.3.8 (2024-05-18)
     - remove superfluous check for escorts, not needed since they are not valid targets
   v5.3.7 (2024-05-01)
@@ -2636,6 +2638,7 @@ class Bigshot
       /You feel a fair amount more durable./i,
       /With a final snap of your wrist/i,
       /You complete your assault/i,
+      /to the ready, your assault complete\./i,
       /Upon firing your last (?:arrow|bolt)/i,
       /With a final, explosive breath/i,
       /recentering yourself for the fight/i,
@@ -2650,6 +2653,7 @@ class Bigshot
       /Barrage can not be used with attack as the attack type/i,
       /may not be activated within 60 seconds of a Multi-Strike\./i,
       /\.\.\.wait/i,
+      /(?:Barrage|Flurry|Fury|Guardant Thrusts|Pummel|Thrash) is still in cooldown\./,
     )
 
     result_regex = Regexp.union(complete_regex, error_regex)


### PR DESCRIPTION
Adds additional messaging for when in cooldown and messaging not captured, to error out. Add additional regex completion for whips and pummel as was not matching:
```
# matching:
With a final snap of your wrist, you sweep your skull-piercer back to the ready, your assault complete.
# not-matching:
With a susurration of ghezyte, you give your whip a final flick and return to the ready, your assault complete.
```