### PR TITLE
[all] [go2.lic] Move go2_start_room from sqlite UserVars to global variable

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -1262,15 +1262,21 @@ module Go2
   end
 
   if target_search_string =~ /goback/i
-    last_start_room = UserVars.go2_start_room.to_s
-    if last_start_room
-      target_search_string = last_start_room
-      echo "Attempting to return to last start room of: #{last_start_room}"
-    else
+    if $go2_start_room.nil?
       echo "go2 does not have a stored start room from the last time it ran."
       exit
+    else
+      last_start_room = $go2_start_room.to_s
+      if last_start_room
+        target_search_string = last_start_room
+        echo "Attempting to return to last start room of: #{last_start_room}"
+      else
+        echo "go2 does not have a stored start room from the last time it ran."
+        exit
+      end
     end
   end
+
 
   #
   # target was given; use saved settings, override them with command line settings, but don't save them
@@ -1778,7 +1784,7 @@ module Go2
   first_move   = true
 
   # Store start room for future use
-  UserVars.go2_start_room = start_room.id
+  $go2_start_room = start_room.id
 
   loop {
     moves_sent = $room_count

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -1277,7 +1277,6 @@ module Go2
     end
   end
 
-
   #
   # target was given; use saved settings, override them with command line settings, but don't save them
   #


### PR DESCRIPTION
Updating UserVars everytime that go2 gets called can cause some performance issues when multiboxing.

Does this value _really_ need to be persisted across sessions?  It seems to me that storing it in a global variable `$go2_start_room` in place of `UserVars.go2_start_room` would satisfy still satisfy real world use, would not suffer performance impact of UserVars.