### PR TITLE
Revert "[map.lic] v1.3.1 - fixes for operation under WSL"

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -18,9 +18,6 @@ Tracks your current room on visual maps
       version: 1.3.0
 
   changelog:
-    v1.3.1 (2024-06-29)
-      * fix popup menu crash under WSL
-      * fix pointer click offset issues in WSL
     v1.3.0 (2024-06-26)
       * add runtime toggle for opacity (ala orbuculum)
       * add runtime toggle for borderless window and no scrollbar window (also orbuculum)
@@ -288,8 +285,6 @@ opacity = Settings['opacity'] || 1.0
 
 $narost_maps ||= Hash.new
 scale = nil
-window_offset_x = 0
-window_offset_y = 0
 map_offset_x = nil
 map_offset_y = nil
 narost_exit = false
@@ -505,16 +500,8 @@ Gtk.queue {
   window.title = "Map: #{Char.name}"
   window.set_icon(@default_icon)
   window.signal_connect('delete_event') { narost_exit = true }
-  window.signal_connect("size-allocate") do |_widget, allocation|
-    window_resized = true
-    window_width, window_height = window.size
-    # on windows (at least through WSL) an unaccounted for border and titlebar are included in the
-    # pointer position, so we must offset by them
-    window_offset_x = (allocation.width - window_width) / 2 # effectively the resize border width
-    window_offset_y = (allocation.height - window_height) - window_offset_x # titlebar height
-    window_offset_x *= 1 / (scale ? scale : (global_scale ? global_scale : 1.0))
-    window_offset_y *= 1 / (scale ? scale : (global_scale ? global_scale : 1.0))
-  end
+  window.signal_connect('size_allocate') { window_resized = true }
+
   scroller = Gtk::ScrolledWindow.new
   scroller.border_width = 0
   setting_hide_scrollbars ? scroller.set_policy(:never, :never) : scroller.set_policy(:automatic, :always)
@@ -817,8 +804,7 @@ Gtk.queue {
   layout.add_events(:button_press_mask)
   layout.signal_connect('button_press_event') { |_owner, ev|
     if ev.button == 3
-      # fix for Gdk error in WSL - probably GDK version related - just using the newer wrapper for popup
-      menu.popup_at_pointer(ev)
+      menu.popup(nil, nil, ev.button, ev.time)
     elsif ev.button == 4
       respond 'button4'
     elsif ev.button == 5
@@ -866,9 +852,8 @@ Gtk.queue {
         dragging = false
         if (ev.event_type == Gdk::EventType::BUTTON_RELEASE) and (ev.button == 1)
           pointer_x, pointer_y = get_pointer.call(layout.parent.parent)
-          click_x = ((scroller.hadjustment.value.to_i + pointer_x.to_i - map_offset_x.to_i) / scale.to_f) - window_offset_x
-          click_y = ((scroller.vadjustment.value.to_i + pointer_y.to_i - map_offset_y.to_i) / scale.to_f) - window_offset_y
-
+          click_x = (scroller.hadjustment.value.to_i + pointer_x.to_i - map_offset_x.to_i) / scale.to_f
+          click_y = (scroller.vadjustment.value.to_i + pointer_y.to_i - map_offset_y.to_i) / scale.to_f
           # fixme: check state correctly
           if (ev.state.inspect =~ /shift-mask.*control-mask|control-mask.*shift-mask/) and (script.vars[0] =~ /fix/)
             map_name = current_map.slice(/([^\/\\]+)$/)


### PR DESCRIPTION
Reverts elanthia-online/scripts#1556 - complaints of window size / position not saved.  Confirmed prior version 1.3.0 works.  Need to review this a bit more to find out why the size shrinks.  Details in Discord #help and #scripting.