### PR TITLE
[isquelch.lic] v0.2.1 minor tweaks

### DIFF
--- a/scripts/isquelch.lic
+++ b/scripts/isquelch.lic
@@ -1,25 +1,31 @@
 # frozen_string_literal: true
 
-#
-# Script for configurable squelching of incoming lines.
-#
-# author: Ineum
-# game: Gemstone IV
-# tags: squelching, squelch
-# version: 0.2.0
-#
-# changelog:
-#   0.2.0 (2020-12-03)
-#     Introduced export command for exporting squelches compatible with import.
-#   0.1.0 (2020-12-02)
-#     Now has ability to import ignores from a StormFront XML file.
-#     Accept arguments on first run, and improve help documentation with examples.
-#   0.0.3 (2020-11-30)
-#     Defined instance variable for usage, simplified the default configuration creation.
-#   0.0.2 (2020-10-22)
-#     Refactored code to pass rubocop linting.
-#   0.0.1 (2020-10-21)
-#     Initial release.
+=begin
+
+ Script for configurable squelching of incoming lines.
+
+ author: elanthia-online
+ game: gs
+ tags: squelching, squelch
+ version: 0.2.1
+
+ changelog:
+   0.2.1 (2024-07-12)
+     Bugfix in special Regexp characters being escaped in error
+     Change puts usage to respond
+     Rubocop cleanup
+   0.2.0 (2020-12-03)
+     Introduced export command for exporting squelches compatible with import.
+   0.1.0 (2020-12-02)
+     Now has ability to import ignores from a StormFront XML file.
+     Accept arguments on first run, and improve help documentation with examples.
+   0.0.3 (2020-11-30)
+     Defined instance variable for usage, simplified the default configuration creation.
+   0.0.2 (2020-10-22)
+     Refactored code to pass rubocop linting.
+   0.0.1 (2020-10-21)
+     Initial release.
+=end
 
 require 'English'
 require 'rexml/document'
@@ -31,43 +37,43 @@ CMD_STRING = "#{$lich_char}#{@script_name}"
 DOWNSTREAM_HOOK_NAME = "#{@script_name} filter"
 @regex_mutex = Mutex.new
 
-Vars[@script_name] ||= { squelches: [] }
+UserVars[@script_name] ||= { squelches: [] }
 
 def rebuild_regex
   # Function to rebuild regex when necessary, respecting the lock for threading.
   @regex_mutex.synchronize do
-    enabled_squelches = Vars[@script_name][:squelches].select { |entry| entry[:enabled] }
-    @regex = Regexp.union(enabled_squelches.map { |val| val[:text] })
+    enabled_squelches = UserVars[@script_name][:squelches].select { |entry| entry[:enabled] }
+    @regex = Regexp.union(enabled_squelches.map { |val| Regexp.new(val[:text]) })
   end
 end
 
 def remove_squelch(index, verbose: true)
-  if index >= Vars[@script_name][:squelches].length
+  if index >= UserVars[@script_name][:squelches].length
     respond "Invalid index #{index} cannot be removed" if verbose
     return false
   end
-  text = Vars[@script_name][:squelches][index][:text]
-  Vars[@script_name][:squelches].delete_at(index)
+  text = UserVars[@script_name][:squelches][index][:text]
+  UserVars[@script_name][:squelches].delete_at(index)
   respond "Removed \/#{text}\/" if verbose
   true
 end
 
 def toggle_squelch(index, state, state_text = '', verbose: true)
   # Toggle squelch at the specified index.
-  if index >= Vars[@script_name][:squelches].length
+  if index >= UserVars[@script_name][:squelches].length
     respond 'Cannot access invalid entry' if verbose
     return false
   end
-  Vars[@script_name][:squelches][index][:enabled] = state
-  puts "${Vars[@script_name][:squelches][index]} is now #{state_text}d." if verbose
+  UserVars[@script_name][:squelches][index][:enabled] = state
+  respond "${UserVars[@script_name][:squelches][index]} is now #{state_text}d." if verbose
   true
 end
 
 def print_squelches
-  if Vars[@script_name][:squelches].empty?
+  if UserVars[@script_name][:squelches].empty?
     respond 'No squelch entries recorded.'
   else
-    Vars[@script_name][:squelches].each_with_index do |squelch, i|
+    UserVars[@script_name][:squelches].each_with_index do |squelch, i|
       respond "#{i}. \/#{squelch[:text]}\/ (#{squelch[:enabled] ? 'enabled' : 'disabled'})"
     end
   end
@@ -126,7 +132,7 @@ toggle_upstream
 get_next_line = false
 
 loop do
-  line = get_next_line ? upstream_get : "#{CMD_STRING} #{script.vars[1..-1].join(' ')}"
+  line = get_next_line ? upstream_get : "#{CMD_STRING} #{Script.current.vars[1..-1].join(' ')}"
   get_next_line = true
   # Exit early if the command isn't for us
   next unless line =~ /#{CMD_STRING}\s*(?<command>\w+)\s*(?<argument>.*)/
@@ -137,7 +143,7 @@ loop do
   update_regex = false
   case command
   when /add/
-    Vars[@script_name][:squelches].push({ text: argument, enabled: true })
+    UserVars[@script_name][:squelches].push({ text: argument, enabled: true })
     respond "Added \/#{argument}\/"
     update_regex = true
   when /(?<state>en|dis)able/
@@ -152,7 +158,7 @@ loop do
     import = File.open(argument)
     document = REXML::Document.new(import)
     REXML::XPath.each(document, '//settings/ignores/*/@text') do |elem|
-      Vars[@script_name][:squelches].push({ text: Regexp.escape(elem.to_s), enabled: true })
+      UserVars[@script_name][:squelches].push({ text: Regexp.escape(elem.to_s), enabled: true })
     end
     update_regex = true
   when /export/
@@ -165,12 +171,12 @@ loop do
     # Build list of ignore lines from chosen set.
     ignore_lines = []
     if arguments.empty?
-      Vars[@script_name][:squelches].each do |squelch|
+      UserVars[@script_name][:squelches].each do |squelch|
         ignore_lines.push("<h text=\"#{squelch[:text]}\"/>")
       end
     else
-      arguments.each do |index|
-        text = Vars[@script_name][:squelches][index.to_i][:text]
+      arguments.each do |arg_i|
+        text = UserVars[@script_name][:squelches][arg_i.to_i][:text]
         ignore_lines.push("<h text=\"#{text}\"/>")
       end
     end


### PR DESCRIPTION
Bugfix in special Regexp characters being escaped in error Rubocop cleanup
Change `puts` to `respond`
Change `Vars` to `UserVars`
Change `script.vars` references to `Script.current`