### PR TITLE
Update enhancives.lic

### DIFF
--- a/scripts/enhancives.lic
+++ b/scripts/enhancives.lic
@@ -284,6 +284,6 @@ loop do
       _respond Enhancives.msg('Your ' + line + ' is below your threshold!')
     end
   end
-  sleep 1.hour # production check hourly for changes to charges
+  sleep 3600 # pre 5.10 production check hourly for changes to charges
   Enhancives.rescan! # check to see if there are any changes
 end # main


### PR DESCRIPTION
Until 5.10 is deployed and embraced, need to use seconds instead of .minute .hour extensions.