### PR TITLE
[eloot.lic] v1.6.33 get_regex update

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -13,9 +13,11 @@
       contributors: SpiffyJr, Athias, Demandred, Tysong, Deysh, Ondreian, Lieo
               game: Gemstone
               tags: loot
-           version: 1.6.32
+           version: 1.6.33
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.6.33 (2024-07-25)
+    - add additional get_regex for READY WEAPON
   v1.6.32 (2024-07-20)
     - box_in_hand method updated to process both hands.
   v1.6.31 (2024-06-30)
@@ -1732,7 +1734,8 @@ module ELoot
         /^You already have that/,
         /Reaching over your shoulder/,
         /^As you draw/,
-        /^Ribbons of.*?light/
+        /^Ribbons of.*?light/,
+        /^You are already holding/
       )
 
       @put_regex = Regexp.union(


### PR DESCRIPTION
Add additional match for `get_regex` for:
```
[eloot]>ready weapon
You are already holding a glowing runestaff.
```