### PR TITLE
[bigshot.lic] v5.4.2 cmd_spell stance dancing fix

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -18,7 +18,8 @@
   Version Control:
     Major_change.feature_addition.bugfix
   v5.4.2  (2024-08-17)
-    - fix in cmd_spell to set Spell's @@after_stance to prevent forced stance dancing when hunting_stance is offensive
+    - bugfix in cmd_spell to set Spell's @@after_stance to prevent forced stance dancing when hunting_stance is offensive
+    - bugfix in no_players_hunt to return true if $bigshot_room_claimed so that disk checking isn't performed for players passing thru
   v5.4.1  (2024-08-14)
     - room command check logic correction
   v5.4.0  (2024-08-07)
@@ -4524,7 +4525,7 @@ class Bigshot
     return true if $bigshot_quick
     return false if $ambusher_here
     return false if $obvious_hiding_player
-    return false if $bigshot_room_claimed.length > 0
+    return true if $bigshot_room_claimed.length == 0
     return false if room_contains_disks_of_non_group_members()
 
     return true

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.4.1
+       version: 5.4.2
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.4.2  (2024-08-17)
+    - fix in cmd_spell to set Spell's @@after_stance to prevent forced stance dancing when hunting_stance is offensive
   v5.4.1  (2024-08-14)
     - room command check logic correction
   v5.4.0  (2024-08-07)
@@ -3608,9 +3610,12 @@ class Bigshot
         bs_put "target clear"
       end
 
+      after_stance = Spell.class_variable_get(:@@after_stance)
+      Spell.after_stance = stance()
       change_stance('offensive') if Spell[id].stance || (id.to_s =~ /1700/i && extra =~ /evoke/i)
       Spell[id].force_incant(extra) # bs_put "incant #{id} #{extra}"
       change_stance(@HUNTING_STANCE)
+      Spell.after_stance = after_stance
 
       if selfcast
         bs_put "target ##{target.id}"

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,7 +19,6 @@
     Major_change.feature_addition.bugfix
   v5.4.2  (2024-08-17)
     - bugfix in cmd_spell to set Spell's @@after_stance to prevent forced stance dancing when hunting_stance is offensive
-    - bugfix in no_players_hunt to return true if $bigshot_room_claimed so that disk checking isn't performed for players passing thru
   v5.4.1  (2024-08-14)
     - room command check logic correction
   v5.4.0  (2024-08-07)
@@ -4525,7 +4524,7 @@ class Bigshot
     return true if $bigshot_quick
     return false if $ambusher_here
     return false if $obvious_hiding_player
-    return true if $bigshot_room_claimed.length == 0
+    return false if $bigshot_room_claimed.length > 0
     return false if room_contains_disks_of_non_group_members()
 
     return true


### PR DESCRIPTION
`Spell.cast` logic when a spell supports stancing, forces stancing back to defensive/guarded unless an `@@after_stance` is set. This sets that logic so that if you're hunting in an advanced hunting stance, it will put you back in the prior stance. Should prevent having to use `inc 903` to prevent stancing logic by `Spell.cast`