### PR TITLE
[ewaggle.lic] v1.0.5 LNet query use XMLData.game

### DIFF
--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -8,10 +8,12 @@
           game: gs
           tags: magic, utility, spell
       required: Lich >= 5.4.0
-       version: 1.0.4
+       version: 1.0.5
 
   Version Control:
     Major_change.feature_addition.bugfix
+  1.0.5 (2024-08-19):
+    Fix to only inquiry the current XMLData game when using LNet API
   1.0.4 (2024-07-09):
     Fix to Symbol of Mana to not spam if out of favor
   1.0.3 (2024-05-01):
@@ -1061,7 +1063,7 @@ get_target_info = proc { |target|
     target_info
   elsif defined?(LNet.get_data)
     echo "#{target} has spell privacy enabled, attempting to use LNet"
-    LNet.get_data(target, 'spells')
+    LNet.get_data("#{XMLData.game}:#{target}", 'spells')
   else
     nil
   end


### PR DESCRIPTION
Fix to only inquiry the current XMLData game when using LNet API

Prevents querying name in wrong instance if same name is used in any other game instance