### PR TITLE
[FlareLog.lic] Initial creation

### DIFF
--- a/flarelog.lic
+++ b/flarelog.lic
@@ -1,0 +1,868 @@
+=begin
+
+  FlareLog - Expand your data.
+
+ Requires Lich 5.10.0 or higher as it utilizes the new CritRanks lib. I recommend 5.10.3+ to make sure crit tables are up to date.
+
+ Will keep a count of non damaging flares, can track specifics such as resource returned from mana and aganjira flares.
+ Tracks damage flares and records Flare: type_of_crit: location_of_crit: rank_of_crit: [damage, damage].
+
+ If you're on Wrayth, there is a window to display some statistics. The window can be a bit much though.
+  ;flarelog debug                     Toggles debug messages. Shows whats going on behind the scenes.
+  ;flarelog window                    Toggles Wrayth window to display flare statistics.
+  ;flarelog --flares=<flare>,<flare>  Choose which flares to display in the Wrayth window.
+                                      ;flarelog --flares=lightning,briar,necromancy lore,holyfire,air_lore
+
+ A few other commands
+  ;eq FlareLog.save(true)         Force a save to the yaml file. Automatically does this on exit.
+  ;eq FlareLog.damage_flares      Displays a list of damage flares currently implemented
+  ;eq FlareLog.no_damage_flares   Displays a list of non damaging flares currently implemented
+  ;eq FlareLog.update_window      Forces an update to the Wrayth window.
+  ;eq FlareLog.data.keys          Displays a list of the the flares recorded. FlareLog.data returns the database.
+  ;eq FlareLog.reset_data         Start Fresh.
+  ;eq FlareLog.display_data       Displays breakdown of flare data in story window depending on which you set with --flares=
+  ;eq FlareLog.display_data("<flare>")    Displays breakdown for specific flare only.
+  ;eq FlareLog.display_data("all")        Displays breakdown for all flares recorded.
+
+ Please provide me with any ERROR messages you recieve. This is still a work in progress.
+ ***   ERROR no match for damage:
+ ***   ERROR no match for crit:
+
+        author: Nisugi
+  contributors: Nisugi
+          game: Gemstone
+          tags: data, flares, damage, critical
+       version: 1.0.0
+
+  Needs: Crit tables error checked: Cold, Crush, Disintegrate, Fire, Lightning, Plasma, Puncture, Unbalance
+  Improvements:
+  v1.0.0 (09/12/2024)
+    Initial launch
+=end
+
+# start version check.
+lich_gem_requires = '5.10.0'
+requirement_failed = false
+
+# Check version of Lich for compatibility
+if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
+  requirement_failed = true
+  if $frontend == 'stormfront' || $frontend == 'profanity'
+    _respond "\<preset id=\"speech\"\>" + "########################################" + "\<\/preset\>"
+    _respond "\<preset id=\"thought\"\>" + "Script: #{script.name} now requires a newer version of Lich (#{lich_gem_requires}+) to run." + "\<\/preset\>"
+    _respond "\<preset id=\"thought\"\>" + "Please update to a newer version." + "\<\/preset\>"
+    _respond ""
+    _respond "\<preset id=\"thought\"\>" + "Currently Running Lich Version: #{Gem::Version.new(LICH_VERSION)}" + "\<\/preset\>"
+    _respond "\<preset id=\"thought\"\>" + "For help updating visit: https://gswiki.play.net/Lich_(software)/Installation" + "\<\/preset\>"
+    _respond "\<preset id=\"speech\"\>" + "########################################" + "\<\/preset\>"
+  else
+    _respond "##" + "########################################"
+    _respond ">" + "Script: #{script.name} now requires a newer version of Lich (#{lich_gem_requires}+) to run."
+    _respond ">" + "Please update to a newer version."
+    _respond ">" + ""
+    _respond ">" + "Currently running Lich Version: #{Gem::Version.new(LICH_VERSION)}"
+    _respond ">" + "For help updating visit: https://gswiki.play.net/Lich_(software)/Installation"
+    _respond "##" + "########################################"
+  end
+end
+
+exit if requirement_failed
+# end version check
+
+module FlareLog
+  require 'yaml'
+
+  DAMAGE_FLARES = { # Common Flares
+    /Your .*? releases a spray of acid/ => 'Acid',
+    /Your .*? unleashes a blast of air/ => 'Air',
+    /Your .*? glows intensely with a cold blue light/ => 'Cold',
+    /Your .*? releases a shimmering beam of disintegration/ => 'Disintegration',
+    /Your .*? releases a quivering wave of disruption/ => 'Disruption',
+    /Your .*? flares with a burst of flame/ => 'Fire',
+    /Your .*? releases a twisted tendril of force/ => 'Grapple',
+    /Your .*? releases a blast of vibrating energy/ => 'Impact',
+    /Your .*? emits a searing bolt of lightning/ => 'Lightning',
+    /Your .*? pulses with a burst of plasma energy/ => 'Plasma',
+    /Your .*? erupts with a plume of steam/ => 'Steam',
+    /Your .*? unleashes an invisible burst of force/ => 'Unbalance',
+    /As you hit, the edge of your .*? seems to fold inward upon itself drawing everything it touches along with it/ => 'Vacuum',
+    /Your .*? shoots a blast of water/ => 'Water',
+    # GEF Flares
+    /A howling gale of steaming air rushes from .*?/ => 'GEF_Air',
+    /A vortex of razor-sharp ice gusts from .*? and coalesces around a .*?/ => 'GEF_Cold',
+    /A violent explosion of frenetic energy rumbles from .*?/ => 'GEF_Earth',
+    /Burning orbs of pure flame burst from .*?/ => 'GEF_Fire',
+    /A vicious torrent of crackling lightning surges from .*?/ => 'GEF_Lightning',
+    /A howling gale of steaming air rushes from .*?/ => 'GEF_Steam',
+    /A nebulous dome of violet energy discharges from .*?/ => 'GEF_Void',
+    # Material
+    /Your .*? emits a fist-sized ball of lightning-suffused flames/ => 'Firewheel',
+    /As a resonating song emanates from your vethinye bow, it entwines you in night blue wisps of ephemera.  Suddenly, a star-sparked rush of percussive pressure from the bow whips out at .*?/ => 'Starsong',
+    /As you coax a resonating song from your vethinye bow, it entwines you in night blue wisps of ephemera.  Suddenly, a star-sparked rush of percussive pressure from the bow whips out at .*?/ => 'Starsong',
+    /Your .*? unleashes a blast of psychic energy/ => 'Low_Steel',
+    # Other
+    /Your .*? sprays with a burst of plasma energy/ => 'Guiding_Light',
+    /Consumed by the hallowed flames, .*? is ravaged for \d+ points? of damage/ => 'Holy_Fire',
+    /The flaming aura surrounding you lashes out at .*?/ => 'Flaming_Aura',
+    /Your .*? expels a glob of molten magma/ => 'Magma',
+
+    # Script
+    /Vines of vicious briars whip out from your .*?, raking the .*? with its thorns.  The .*? looks slightly ill as the glistening emerald coating from each briar works itself under its skin/ => 'Briar',
+    /A beam of .*? energy emits from the tip of your .*? and collides with .*?/ => 'Energy',
+    /From somewhere nearby, a snowball comes whizzing towards .*?, splattering as it connects/ => 'Greater_Rhimar',
+    /The .*? sprite on your shoulder sends forth a cylindrical, .*? blast of magic at .*?/ => 'Sprite',
+    /A solid strike from your .*? to the temple causes .*? to stumble/ => 'Knockout',
+    /A solid strike from your .*? to the temple causes .*? to stumble as \w+ is swept off \w+ feet from the blow/ => 'Knockout',
+    /With a solid *THUNK*, your .*? bounces off the head of .*?/ => 'Knockout',
+    /You feint left, then right, then crack .*? across the head/ => 'Knockout',
+    /You leap up, bringing your .*? down across the head of .*? with a sickening thud/ => 'Knockout',
+    /You smack the .*? with your .*? on one side of \w+ head, then reverse direction and crack \w+ across the other/ => 'Knockout',
+    /Your .*? bounces off the head of .*?, causing \w+ to reassess the situation for a moment while standing still/ => 'Knockout',
+    /Your .*? plows right into the forehead of .*?/ => 'Knockout',
+    /Your .*? cracks the halfling robber on the back of the head.  He gibbers mindlessly/ => 'Knockout',
+    /Your .*? thumps .*? in the head.  \w+ looks a bit dazed, yet recovers after several quick missteps/ => 'Knockout',
+    /Your .*? thumps .*? in the head.  \w+ stumbles around for a moment desperate to keep \w+ balance but in the end \w+ fails miserably, and collapses to the ground in a heap, looking dazed/ => 'Knockout',
+    /A slender crimson and black tendril lashes out from .*? and slashes .*?/ => 'Parasite',
+    /Tendrils of .*? energy lash out from your .*? hitting .*?/ => 'Twin_Detonation',
+    /A coil of .*? energy bursts out of thin air and strikes .*?/ => 'Valence',
+    # Lore Flares
+    /A fierce whirlwind erupts around .*?, encircling .*? in a suffocating cyclone/ => 'Air_Lore',
+    /Chunks of earth violently orbit .*?, pelting .*? with heavy debris and stone/ => 'Earth_Lore',
+    /A blazing inferno erupts around .*?, engulfing .*? and scorching everything in its wake/ => 'Fire_Lore',
+    /A watery deluge erupts violently around .*?, crushing .*? with relentless force/ => 'Water_Lore',
+    /A radiant mist surrounds a cudgel, unfurling into a whip of plasma that wreathes .*? in its sizzling embrace/ => 'Summoning_Lore',
+    /Rippling and half-seen, strands of psychic power unravel from the dagger to strike at .*?/ => 'Telepathy_Lore',
+    /Divine flames kindle around .*?, leaping forth to engulf .*? in a sacred inferno/ => 'Religion_Lore',
+    /A sickly green aura radiates from a .*? and seeps into .*? wounds/ => 'Necromancy_Lore',
+    # Lore Flare Dots
+    /The cyclone whirls around .*? anew, a suffocating force of nature/ => 'Air_Lore_Dot',
+    /The ground trembles violently, pelting .*? again with heavy debris and stone/ => 'Earth_Lore_Dot',
+    /The inferno blazing around .*? ignites anew, unleashing more waves of scorching heat/ => 'Fire_Lore_Dot',
+    /The water surrounding .*? churns anew, rough waters roiling towards it/ => 'Water_Lore_Dot',
+    /The whip of plasma continues to wreathe .*? in its sizzling embrace/ => 'Summoning_Lore_Dot',
+    /Locked in mental durance, .*? is assailed by some unseen attack/ => 'Telepathy_Lore_Dot',
+    /The sacred inferno surrounding .*? ignites anew, searing \w+ with divine fire/ => 'Religion_Lore_Dot',
+    /Darkened sores form all over .*?, leaking ooze leaks from the fresh wounds/ => 'Necromancy_Lore_Dot',
+    /.*? skin cracks open and oozes an inky black ichor/ => 'Necromancy_Lore_Dot',
+    /Rotting ulcers spread across .*? body/ => 'Necromancy_Lore_Dot',
+    /Abscesses drain a bloody yellow fluid across .*? body/ => 'Necromancy_Lore_Dot',
+    /.*? loses .*? balance/ => 'Necromancy_Lore_Dot',
+    /Skin peels off .*? body, exposing rotting flesh/ => 'Necromancy_Lore_Dot',
+    /A fierce rash spreads across .*? body/ => 'Necromancy_Lore_Dot',
+    /Rotting skin falls from .*? body in large flakes/ => 'Necromancy_Lore_Dot',
+    /.*? breathing appears to be labored/ => 'Necromancy_Lore_Dot',
+    /Blisters form on .*? skin and ooze a putrid dark yellow fluid/ => 'Necromancy_Lore_Dot',
+    /Small pieces of flesh rot off .*? body/ => 'Necromancy_Lore_Dot',
+    # Rangers
+    /.*? charges forward and slashes .*? claws at .*? faster than .*? can react/ => 'Cat_Slash',
+    /.*? pounces on .*/ => 'Cat_Pounce',
+    /The .*? takes the opportunity to slash .*? claws at the .*? chest/ => 'Cat_Double_Slash',
+    /The .*? lashes out violently at .*?, dragging .*? to the ground/ => 'Tangle_Weed',
+    /The .*? lashes out at .*?, wraps itself around \w+ body and entangles \w+ on the ground/ => 'Tangle_Weed',
+    # Fatal Afflares
+    /A thin stream of icy cold liquid shoots forth from your .*?, water droplets freezing instantly into razor sharp slivers as they sail toward .*? and maim .*? on impact/ => 'Cold',  # Fatal Afflares
+  }
+  NO_DAMAGE_FLARES = 
+    { 
+      /Your .*? glows intensely with a verdant light/ => 'Acuity',
+      /You feel \d+ mana surge into you/ => 'Mana',
+      /A wave of wicked power surges forth from your .*? and fills .*? with terror, .*? form trembling with unmitigated fear/ => 'Terror',
+      # Material
+      /Cords of plasma-veined grey mist seep from your .*? and entangle .*?, causing .*? to tremble violently/ => 'Ghezyte',
+      /Exploding in a tumbling current of frothy foam, a wave of sea water suddenly materializes at the call of your .*? and courses through the room/ => 'Rusalkan',
+      /Succumbing to the force of the tidal wave, .*? is thrown to the ground/ => 'Rusalkan_Hit',
+      /For a split second, the striations of your .*? expand into a sinuous pearlescent mist that rushes towards .*?, enveloping it entirely and causing it to collapse, fast asleep/ => 'Somnis',
+      # Script
+      /Your .*? suddenly lights up with hundreds of tiny blue sparks/ => 'Blink',
+      /A burst of blue light flares up around your .*? as a series of blue and green ethereal chains encase your body against .*?/ => 'Ethereal_Armor',
+      /Mana cascades across your .*?, causing the fabric to shiver against your skin as it draws the scattered power into it and transforms it into .*?.  \[You gain \d+ \w+!\]/ => 'Aganjira_Restore',
+      /CS: [-+\d]+ \- TD: [-+\d]+ \+ CvA: [-+\d]+ \+ d(\d+): [-+\d]+(?: \- [-+\d]+)? \=\= [-+\d]+/ => 'Aganjira_TD',
+      /Branching filaments of power snap outward from your .*? in a lambent .*? corona/ => 'Wondrous_Weave',
+      /A .*? distorts the air around you, confounding .*? spell/ => 'Masquerade_Dispel',
+      /Numerous sigils along your .*? abruptly flare to brilliance! .*? surges from each, twining into an echo of your last spell\.\.\./ => 'Sigil_Double_Cast',
+      /A .*? leaps from your .*? and sets the sigils along your .*? ablaze\.  .*? out at .*? and cage .*? within bands of concentric geometry\.\.\./ => 'Sigil_Set',
+      /The coraesine relic on your .*? flares up with a blazing white-grey aura! Vicious winds curl around you in a spiraling vortex, increasing your momentum as you let loose a lightning-quick strike/ => 'Quick_Flares',
+      /Your .*? emits an ominous black-green glow/ => 'Xazkruvrixis',
+      /Immediately following your attack, your body quickly melts into a nebulous ethereal mist and you rapidly reform on the other side of .*?, where you solidify and strike again/ => 'Incision_Igaesha',
+      # Ranger
+      /Soot brown specks of leaf mold trail in the wake of .*? movements, distorted by a murky haze/ => 'Natures_Decay',
+      /An earthy, sweet aroma clings to .*? in a murky haze, accompanied by soot brown specks of leaf mold/ => 'Natures_Decay',
+      /The earthy, sweet aroma clinging to .*? grows more pervasive/ => 'Natures_Decay',
+      /An earthy, sweet aroma wafts from .*? in a murky haze/ => 'Natures_Decay',
+      /.*? is buffeted by a burst of wind and pushed back/ => 'Breeze',
+      /.*? is buffeted by a sudden gust of wind/ => 'Breeze',
+      /A gust of wind shoves .*? back/ => 'Breeze',
+      /Vital energy infuses you, hastening your arcane reflexes/ => 'Arcane_Reflex',
+      /The vitality of nature bestows you with a burst of strength/ => 'Physical_Prowess',
+      /A favorable tailwind springs up behind you/ => 'Tailwind',
+      /You shift position, taking advantage of a favorable tailwind/ => 'Tailwind',
+      /The wind turns in your favor/ => 'Tailwind',
+      /The layer of bark on you hardens and absorbs the attack!  The bark crackles as it crumbles to dust/ => 'Bark_Skin_Crumble',
+      /The layer of bark on you hardens and absorbs the magical energy!  The bark crackles as it crumbles to dust/ => 'Bark_Skin_Crumble',
+      # Ensorcell
+      /You feel healed/ => 'Ensorcell_Heal',
+      /You feel empowered/ => 'Ensorcell_Mana',
+      /You feel rejuvenated/ => 'Ensorcell_Spirit',
+      /You feel reinvigorated/ => 'Ensorcell_Stamina',
+      /You feel energized/ => 'Ensorcell_Acuity',
+      #'EnsorcellUsed'     => /You feel the unnatural surge of necrotic power wane away/,
+      # psm weapon tech applied debuffs
+      /Your attack exposes a vulnerability in .*? defenses/ => 'Vulnerable',
+  }
+  DISPEL_FLARES = {
+    /Tendrils of .*? energy lash out from your .*? toward .*? and cage .*? within bands of concentric geometry that constrict as one, shattering upon impact/ => 'Sigil_Dispel',
+    /Your .*? glows brightly for a moment, consuming the magical energies around .*?/ => 'Dispel',
+  }
+  SPELL_DISPELS = {
+    /The light blue glow leaves .*?/ => 101,
+    /The powerful look leaves .*?/ => 103,
+    /.*? appears to lose some internal strength/ => 104,
+    /.*? becomes unbalanced for a second, then recovers/ => 105,
+    /The deep blue glow leaves .*?/ => 107,
+    /The misty halo fades from .*?/ => 112,
+    /The dull golden nimbus fades from around .*?/ => 115,
+    /The white light leaves .*?/ => 120,
+    /The wall of force disappears from around .*?/ => 140,
+    /The dim aura fades from around .*?/ => 202,
+    /.*? begins to breathe less deeply/ => 207,
+    /.*? appears less confident/ => 211,
+    /The brilliant aura fades away from .*?/ => 215,
+    /The opalescent aura fades from around .*?/ => 219,
+    /A white glow rushes away from .*?/ => 303,
+    /.*? seems hesitant, looking unsure of .*?/ => 307,
+    /.*? seems slightly different/ => 310,
+    /A subtle light fades from .*? eyes./ => 313,
+    /An ethereal golden collection bowl drifts out of .*?, then vanishes/ => 314,
+    /The air about .*? shimmers momentarily before the evanescent shield surrounding .*? collapses/ => 319,
+    /The silvery luminescence fades from around .*?/ => 401,
+    /.*? loses some awareness/ => 402,
+    /The scintillating light fades from .*? hands/ => 403,
+    /The focused look leaves .*?/  => 404,
+    /The bright luminescence fades from around .*?/ => 406,
+    /The brilliant luminescence fades from around .*?/ => 414,
+    /.*? glances around, looking a bit less confident/ => 425,
+    /The tingling sensation and sense of security leaves .*?/ => 430,
+    /The glowing specks of energy surrounding .*? suddenly shoot off in all directions, then quickly fade away/ => 503,
+    /.*? is no longer protected by the shimmering field of energy/ => 507,
+    /.*? appears somehow different/ => 508,
+    /.*? seems a bit less imposing/ => 509,
+    /.*? no longer bristles with energy/ => 513,
+    /The layer of raw elemental energy surrounding .*? dissipates/ => 520,
+    /.*? returns to normal color/ => 601,
+    /The air about .*? stops shimmering/ => 602,
+    /.*? looks less aware of the surroundings/ => 604,
+    /.*? seems to lose some internal strength/ => 606,
+    /The swirling breeze around .*? finally settles/ => 612,
+    /.*? seems to lose an aura of confidence/ => 613,
+    /.*? is no longer moving so silently/ => 617,
+    /.*? seems to lose some dexterity/ => 618,
+    /.*? appears less powerful/ => 625,
+    /.*? loses a thorny barrier/ => 640,
+    /.*? body pulses momentarily into semi transparency and then returns to normal/ => 704,
+    /A shadow seems to detach itself from .*? body, swiftly dissipating into the air/ => 712,
+    /.*? exhales the last of a virulent green mist/ => 716,
+    /The shimmering multicolored sphere fades from around .*?/ => 905,
+    /.*? becomes solid again/ => 911,
+    /A luminescent aura fades from around .*?/ => 913,
+  }
+  SKIP_THIS_LINE = Regexp.union(
+    /\*\* Recorded .* \*\*/,
+    # Damage
+    /\.\.\.wait \d+ seconds?./,
+    /A shimmering sphere momentarily flashes around .*/,
+    /The shimmering sphere partially absorbs the attack/,
+    /The murky haze surrounding .*? seems to intensify the .*/,
+    /The murky haze surrounding .*? seems to draw the attention of the .*/,
+    /.*? manages to block some of the elemental damage with .*/,
+    # Crit Pre
+    /Barely touched./,
+    /Brutal blow to the neck sends head flying!/,
+    /Feint to .*? head!/,
+    /Feint left spins .*? around!/,
+    /Flashy attack passes through the side of the neck\./,
+    /Good hit!/,
+    /Grazing slash to .*? face!/,
+    /Hard blow to .*? ear!/,
+    /Hard slash to .*? side!/,
+    /Hit to eye empties the socket./,
+    /Powerful slash trims .*? fingernails\.\.\./,
+    /Quick flick at .*? weapon hand!/,
+    /Quick, powerful slash!/,
+    /Rapped .*? knuckles hard!/,
+    /Slash to .*? chest!/,
+    /Slash to .*? right arm!/,
+    /Spectacular slash!/,
+    /Strong attack rips through the neck!/,
+    /Strong attack separates head from shoulders\./,
+    /The .*? neck bones snap\./,
+    /Tremendous strike!/,
+    /Upward slash gouges .*? cheek!/,
+    # Crit Post
+    /Loose organs cause .*? to watch its step!/,
+    /Might leave a stain!/,
+    /Now that's fire in the belly!/,
+    /Unfortunately it quickly fills with blood!/,
+    /What is this, a haberdashery./,
+    # Crit Status
+    /It is knocked to the ground!/,
+  )
+
+  # only write to file once every 5+ minutes unless forced
+  def self.save(force = false)
+    if @flarelog[:save_time] < (Time.now - 300)
+      @flarelog[:save_time] = Time.now
+      File.write(@filename, @flarelog.to_yaml)
+    elsif force
+      @flarelog[:save_time] = Time.now
+      File.write(@filename, @flarelog.to_yaml)
+    end
+  end
+  
+  # load or create our yaml file and initialize @flarelog
+  def self.load
+    @filename = "#{$data_dir}#{XMLData.game}/#{Char.name}/flarelog.yaml"
+    game_dir = "#{$data_dir}#{XMLData.game}"
+    char_dir = "#{game_dir}/#{Char.name}"
+    Dir.mkdir(game_dir) unless File.exist?(game_dir)
+    Dir.mkdir(char_dir) unless File.exist?(char_dir)
+  
+    if File.exist?(@filename)
+      @flarelog = YAML.load_file(@filename, permitted_classes: [Symbol, Time])
+      respond "Flare tracking file loaded. #{@filename}"
+    else
+      @flarelog = {}
+      File.write(@filename, @flarelog.to_yaml)
+      respond "Creating flare tracking file. #{@filename}"
+    end
+    
+    @flarelog[:save_time] = Time.now
+    before_dying do 
+      @flarelog[:save_time] = Time.now  
+      File.write(@filename, @flarelog.to_yaml)
+      puts("<closeDialog id='FlareLog'/>")
+    end
+  end
+
+  # access the data from anywhere.
+  def self.data
+    return @flarelog
+  end
+
+  def self.damage_flares
+    return DAMAGE_FLARES.values.uniq
+  end
+
+  def self.no_damage_flares
+    return NO_DAMAGE_FLARES.values.uniq
+  end
+
+  def self.spell_dispels
+    return Regexp.union(SPELL_DISPELS.keys)
+  end
+
+  def self.reset_data
+    @flarelog = {}
+    _respond(Lich::Messaging.msg_format("info","*** Flare tracking data has been reset ***"))
+    _respond(Lich::Messaging.msg_format("bold","*** If this was intentional, back up the flarelog.yaml file before closing flarelog.lic ***"))
+  end
+
+  def self.display_data(flare = nil)
+    # Which flares are we displaying?
+    case flare
+    
+    # Show them all ... can be a lot
+    when 'all'
+      my_flares = @flarelog.keys.map(&:to_s)
+      chosen_flares = DAMAGE_FLARES.values.uniq
+      common_flares = chosen_flares & my_flares
+    
+    # if no selection made will default to chosen flares set, or all if none set
+    when nil
+      if @flarelog[:chosen_flares].empty?
+        chosen_flares = DAMAGE_FLARES.values.uniq
+      else
+        chosen_flares = @flarelog[:chosen_flares]
+      end
+      my_flares = @flarelog.keys.map(&:to_s)
+      common_flares = chosen_flares & my_flares
+    
+    # and what if we want to specify multiple flares?
+    else
+      chosen_flares = flare.split(/,\s*/).map(&:strip).map { |f| f.downcase.gsub(/\s|-/,'_') }
+      available_flares = @flarelog.keys.map(&:to_s).reject { |key| key =~ /save_time|chosen_flares/}
+      common_flares = chosen_flares.map do |input|
+        available_flares.find { |key| key.downcase.include?(input) }
+      end.compact.uniq
+    end
+    
+    msg = ""
+    # gather the data...
+    common_flares.each do |flare|
+      # set up our variables
+      flare_data = @flarelog[flare.to_sym] || {}
+      fatal_flares = flare_data[:fatal] || 0
+      total_flares = flare_data[:count] || 0
+      rank_1_flares = 0;rank_2_flares = 0
+      rank_3_flares = 0;rank_4_flares = 0
+      rank_5_flares = 0;rank_6_flares = 0
+      rank_7_flares = 0;rank_8_flares = 0
+      rank_9_flares = 0;rank_5_9_flares = 0
+      total_damage = 0
+      max_damage = nil
+      all_damage = []
+
+      # prepare our data structure
+      flare_data.each do |type, locations|
+        next if type == :fatal || type == :fatal_concussion
+
+        locations.each do |location, rank_data|
+          next unless rank_data.is_a?(Hash)
+
+          rank_data.each do |rank_key, damage_list|
+            rank_number = rank_key.to_s.split('_').last.to_i
+            next unless damage_list.is_a?(Array)
+
+            # record the data
+            total_damage += damage_list.sum
+            total_flares += damage_list.size
+            max_damage = [damage_list.max, max_damage].compact.max
+            all_damage.concat(damage_list)
+
+            # Count rank 5-9 flares
+            if rank_number >= 5
+              rank_5_9_flares += damage_list.size
+            end
+
+            # Break down percentage across all ranks
+            case rank_number
+            when 1
+              rank_1_flares += damage_list.size
+              rank_1_damage += damage_list.sum
+            when 2
+              rank_2_flares += damage_list.size
+              rank_2_damage += damage_list.sum
+            when 3
+              rank_3_flares += damage_list.size
+              rank_3_damage += damage_list.sum
+            when 4
+              rank_4_flares += damage_list.size
+              rank_4_damage += damage_list.sum
+            when 5
+              rank_5_flares += damage_list.size
+              rank_5_damage += damage_list.sum
+            when 6
+              rank_6_flares += damage_list.size
+              rank_6_damage += damage_list.sum
+            when 7
+              rank_7_flares += damage_list.size
+              rank_7_damage += damage_list.sum
+            when 8
+              rank_8_flares += damage_list.size
+              rank_8_damage += damage_list.sum
+            when 9
+              rank_9_flares += damage_list.size
+              rank_9_damage += damage_list.sum
+            end
+          end
+        end
+      end
+
+      # Calculate averages and percentages
+      avg_damage = all_damage.size > 0 ? (all_damage.sum / all_damage.size.to_f).round(2) : 0
+      fatal_percent = total_flares > 0 ? (fatal_flares.to_f / total_flares * 100).round(2) : 0
+      rank_1_percent = total_flares > 0 ? (rank_1_flares.to_f / total_flares * 100).round(2) : 0
+      rank_2_percent = total_flares > 0 ? (rank_2_flares.to_f / total_flares * 100).round(2) : 0
+      rank_3_percent = total_flares > 0 ? (rank_3_flares.to_f / total_flares * 100).round(2) : 0
+      rank_4_percent = total_flares > 0 ? (rank_4_flares.to_f / total_flares * 100).round(2) : 0
+      rank_5_percent = total_flares > 0 ? (rank_5_flares.to_f / total_flares * 100).round(2) : 0
+      rank_6_percent = total_flares > 0 ? (rank_6_flares.to_f / total_flares * 100).round(2) : 0
+      rank_7_percent = total_flares > 0 ? (rank_7_flares.to_f / total_flares * 100).round(2) : 0
+      rank_8_percent = total_flares > 0 ? (rank_8_flares.to_f / total_flares * 100).round(2) : 0
+      rank_9_percent = total_flares > 0 ? (rank_9_flares.to_f / total_flares * 100).round(2) : 0
+      rank_5_9_percent = total_flares > 0 ? (rank_5_9_flares.to_f / total_flares * 100).round(2) : 0
+
+
+      total_width = 21
+      cleaned_flare = flare.gsub('_',' ')
+      flare_padding_left = (total_width - cleaned_flare.length) / 2
+      flare_padding_right = total_width - (flare_padding_left + cleaned_flare.length)
+      flare_line = " " * flare_padding_left + cleaned_flare + " " * flare_padding_right
+      
+      # Add flare to output
+      msg += " -== " + flare_line + " ==- \n"
+      msg += "     Count: #{total_flares}".ljust(12) + "  Fatal: #{fatal_percent}\%\n".ljust(12)
+      msg += "   Avg Dmg: #{avg_damage}".ljust(12) + "  Max Dmg: #{max_damage}\n"
+      msg += " -== Critical Distribution ==-\n"
+      msg += "        Rank 1: #{rank_1_percent}%\n" unless rank_1_percent == 0
+      msg += "        Rank 2: #{rank_2_percent}%\n" unless rank_2_percent == 0
+      msg += "        Rank 3: #{rank_3_percent}%\n" unless rank_3_percent == 0
+      msg += "        Rank 4: #{rank_4_percent}%\n" unless rank_4_percent == 0
+      msg += "        Rank 5: #{rank_5_percent}%\n" unless rank_5_percent == 0
+      msg += "        Rank 6: #{rank_6_percent}%\n" unless rank_6_percent == 0
+      msg += "        Rank 7: #{rank_7_percent}%\n" unless rank_7_percent == 0
+      msg += "        Rank 8: #{rank_8_percent}%\n" unless rank_8_percent == 0
+      msg += "        Rank 9: #{rank_9_percent}%\n" unless rank_9_percent == 0
+      msg += "       % R5-R9: #{rank_5_9_percent}%\n" unless rank_5_9_percent == 0
+      msg += "\n"
+
+    end
+    Lich::Messaging.mono(msg)
+  end
+
+  def self.update_window
+    # start building our wrayth window
+    puts("<closeDialog id='FlareLog'/><openDialog type='dynamic' id='FlareLog' title='FlareLog' target='FlareLog' location='main' height='300' resident='true'><dialogData id='FlareLog'></dialogData></openDialog>")
+    output = "<dialogData id='FlareLog' clear='t'>"
+    output += "<label id='damage_flare_header' value='Damage Flares'  left='10' height='16' width='150'/>"
+    output += "<label id='line1' value='' left='10' height='8' width='150'/>"
+    
+    # determin which flares we have data for
+    my_flares = @flarelog.keys.map(&:to_s)
+    # show chosen flares if set, otherwise show all recorded flares.
+    chosen_flares = @flarelog[:chosen_flares] || DAMAGE_FLARES.values.uniq
+    common_flares = chosen_flares & my_flares
+
+    # gather data and build output for each damaging flare
+    common_flares.each do |flare|
+      # set up our variables
+      flare_data = @flarelog[flare.to_sym] || {}
+      fatal_flares = flare_data[:fatal] || 0
+      total_flares = flare_data[:count] || 0
+      total_damage = 0
+      rank_5_9_flares = 0
+      rank_5_9_damage = 0
+      max_damage = nil
+      all_damage = []
+      
+      # break down the data structure.
+      flare_data.each do |type, locations|
+        next if type == :fatal || type == :fatal_concussion
+
+        locations.each do |location, rank_data|
+          next unless rank_data.is_a?(Hash)
+
+          rank_data.each do |rank_key, damage_list|
+            rank_number = rank_key.to_s.split('_').last.to_i
+            next unless damage_list.is_a?(Array)
+            
+            # record the data
+            total_damage += damage_list.sum
+            total_flares += damage_list.size
+            max_damage = [damage_list.max, max_damage].compact.max
+            all_damage.concat(damage_list)
+  
+            # Count rank 5-9 flares
+            if rank_number >= 5
+              rank_5_9_flares += damage_list.size
+            end
+          end
+        end
+      end
+      
+      # Calculate averages and percentages
+      avg_damage = all_damage.size > 0 ? (all_damage.sum / all_damage.size.to_f).round(2) : 0
+      fatal_percent = total_flares > 0 ? (fatal_flares.to_f / total_flares * 100).round(2) : 0
+      rank_5_9_percent = total_flares > 0 ? (rank_5_9_flares.to_f / total_flares * 100).round(2) : 0
+
+      # Add the flare stats to the output
+      output += "<label id='#{flare}_1' value='#{flare}' left='10' height='16' width='150'/>"
+      output += "<label id='#{flare}_2' value='Count: #{total_flares} ' left='10' height='16' width='150'/>"
+      output += "<label id='#{flare}_3' value='Avg: #{avg_damage}' left='10' height='16' width='150'/>"
+      output += "<label id='#{flare}_4' value='Fatal: #{fatal_percent} pct' left='10' height='16' width='150'/>"
+      output += "<label id='#{flare}_5' value='5-9: #{rank_5_9_percent} pct' left='10' height='16' width='150'/>"
+      output += "<label id='#{flare}_line' value='' left='10' height='8' width='150'/>"
+    end
+
+    # Process non-damaging flares
+    # output += "<label id='line2' value='' left='10' height='8' width='150'/>"
+    # output += "<label id='non_damage_flare_header' value='Damage Free Flares'  left='10' height='16' width='150'/>"
+    # output += "<label id='line3' value='' left='10' height='8' width='150'/>"
+    # no_damage_flares = []
+    # NO_DAMAGE_FLARES.each_value{ |flare| no_damage_flares << flare }
+    # no_my_flares = @flarelog.keys.map(&:to_s)
+    # no_common_flares = no_damage_flares & no_my_flares
+
+    # no_common_flares.each do |flare|
+      # count = @flarelog[flare.to_sym]&.fetch(:count, 0) || 0
+      # output += "<label id='#{flare}' value='#{flare}: #{count}'  left='10' height='16' width='150'/>"
+    # end
+    output += "</dialogData>"
+    # Output the window content
+    puts(output)
+  end
+
+  def self.record_damage_flare(flare,damage,crit)
+
+    location = crit[:location].downcase
+    rank = "rank_#{crit[:rank]}"
+    type = crit[:type].downcase.gsub('-','_')
+    # record our damage as  flare => { type => { location => { rank => [ damage ] } } }  with location rank and damage type we can look up any other crit values thanks to CritRanks
+    @flarelog[flare.to_sym] ||= {}
+    @flarelog[flare.to_sym][type.to_sym] ||= {}
+    @flarelog[flare.to_sym][type.to_sym][location.to_sym] ||= {}
+    @flarelog[flare.to_sym][type.to_sym][location.to_sym][rank.to_sym] ||= []
+    @flarelog[flare.to_sym][type.to_sym][location.to_sym][rank.to_sym] << damage
+    @flarelog[flare.to_sym][:fatal] ||= 0
+    @flarelog[flare.to_sym][:fatal] += 1 if crit[:fatal]
+    _respond(Lich::Messaging.msg_format("info"," ** Recorded #{flare.gsub('_',' ')} #{type} #{location} #{rank} #{damage} **")) if @flarelog[:debug]
+    FlareLog.update_window if @flarelog[:window]
+  end
+
+  def self.parse_no_damage_flare(line)
+    flare = NO_DAMAGE_FLARES.find { |regex,_| line =~ regex }&.last
+    # add one to the flare's counter
+    @flarelog[flare.to_sym] ||= { count: 0 }
+    @flarelog[flare.to_sym][:count] += 1
+    
+    # additional handling for special cases.
+    case line
+    # Aganjira Restore
+    when /Mana cascades across your .*?, causing the fabric to shiver against your skin as it draws the scattered power into it and transforms it into \w+.  \[You gain (\d+) (\w+)!\]/
+      (@flarelog[flare.to_sym][$2.to_sym] ||= []) << $1.to_i
+    # Aganjira TD
+    when /CS: [-+\d]+ \- TD: [-+\d]+ \+ CvA: [-+\d]+ \+ d(\d+): [-+\d]+(?: \- [-+\d]+)? \=\= [-+\d]+/
+      mod = 100 - $1.to_i
+      (@flarelog[flare.to_sym][:modifier] ||= []) << mod.to_i if mod >= 1
+    # Mana
+    when /You feel (\d+) mana surge into you/
+      (@flarelog[flare.to_sym][:mana] ||= []) << $1.to_i
+    end
+    _respond(Lich::Messaging.msg_format("info"," ** Recorded #{flare.gsub('_',' ')} **")) if @flarelog[:debug] && !mod == 100
+  end
+
+  def self.parse_damage_flare(trigger,buffer)
+    # find our flare and create our variable if needed
+    flare = DAMAGE_FLARES.find { |regex,_| trigger =~ regex }&.last
+    @flarelog[flare.to_sym] ||= {}
+
+    # holy fire concussion damage is in the flare message
+    (@flarelog[flare.to_sym][:concussion] ||= []) << $1.to_i if trigger =~ /Consumed by the hallowed flames, .*? is ravaged for (\d+) points? of damage/
+    _respond(Lich::Messaging.msg_format("info"," ** Recorded #{flare.gsub('_',' ')} concussion damage: #{$1} **")) if @flarelog[:debug] && flare == "Holy_Fire"
+    
+    # parse out the damage and crit info
+    damage = 0;crit = {}
+    buffer.each_with_index do |line,index|
+    
+      # we found our flare in the buffer
+      if line =~ Regexp.new(Regexp.escape(trigger))
+    
+        # find our damage line
+        index += 1;damage_line = buffer[index]
+        # blink?
+        break if damage_line =~ /With an abrupt flash, .*? disappears and reappears a few feet away, avoiding any danger completely!/
+        # sometimes there is a susceptibility line preceeding
+        while damage_line =~ SKIP_THIS_LINE
+          index += 1;damage_line = buffer[index]
+        end
+        
+        # record our damage
+        if damage_line =~ /\.\.\. (\d+) points? of damage!/
+          damage = $1.to_i
+        # if holyfire concussion damage kills the target, there will be no damage line
+        elsif flare == "Holy_Fire"
+          @flarelog[flare.to_sym][:fatal_concussion] ||= 0
+          @flarelog[flare.to_sym][:fatal_concussion] += 1
+        else
+          _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for damage: damage line:#{damage_line} buffer line:#{buffer[index]}   flare: #{flare} ***")) if damage == 0
+        end
+
+        # find our crit line
+        index += 1;crit_line = buffer[index]
+        # crit library sometimes skips first line of multi line crit messages
+        while crit_line =~ SKIP_THIS_LINE
+          index += 1;crit_line = buffer[index]
+        end
+
+        # record our crit data
+        crit = CritRanks.parse(crit_line).values.first || {}
+        if crit.empty?
+          if flare != "Holy_Fire"
+            _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for crit: crit_line:#{crit_line} buffer line:#{buffer[index]}  line:#{line}  dam: #{damage} flare: #{flare}***"))
+          end
+        end
+        # record our findings
+        FlareLog.record_damage_flare(flare,damage,crit) unless damage == 0
+
+        # some flares have two damage cycles.
+        damage = 0;crit = {}
+        case flare
+        # List flares with two damage cycles
+        when /Firewheel|GEF_\w+|Greater_Rhimar|\w+_Lore_Dot/
+          
+          # find our damage line
+          index += 1;damage_line = buffer[index]
+          while damage_line =~ SKIP_THIS_LINE
+            index += 1;damage_line = buffer[index]
+          end
+
+          # record our damage
+          damage = $1.to_i if damage_line =~ /\.\.\. (\d+) points? of damage!/
+          break if damage == 0
+          
+          # find our crit line
+          index += 1;crit_line = buffer[index]
+          # crit library sometimes skips first line of multi line crit messages
+          while crit_line =~ SKIP_THIS_LINE
+            index += 1;crit_line = buffer[index]
+          end
+          
+          # record our crit data
+          crit = CritRanks.parse(crit_line).values.first || {}
+          _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for crit: #{crit_line}   dam: #{damage} flare: #{flare}***")) if crit.empty?
+          
+          # record our findings
+          FlareLog.record_damage_flare(flare,damage,crit) unless damage == 0
+          # let's get out of here.
+          break
+        else
+          # our flare wasn't one with two damage cycles, break out of the buffer.
+          break
+        end
+      end
+    end
+  end
+
+  def self.parse_dispel_flare(trigger,buffer)
+    flare = nil;target = nil
+    case trigger
+    when /Tendrils of .*? energy lash out from your .*? toward (.*?) and cage .*? within bands of concentric geometry that constrict as one, shattering upon impact/
+      target = $1.gsub(' ','_');flare = "Sigil_Dispel"
+    when /Your .*? glows brightly for a moment, consuming the magical energies around (.*?)/
+      target = $1.gsub(' ','_');flare = "Dispel"
+    end
+    @flarelog[flare.to_sym][target.to_sym] ||= []
+
+    damage = 0;crit = {};dispel = false
+    spells_dispelled = @flarelog[flare.to_sym][target.to_sym]
+    buffer.each_with_index do |line,index|
+      case line
+      when Regexp.new(Regexp.escape(trigger))
+        index += 1;damage_line = buffer[index]
+        # sometimes there is a susceptibility line preceeding
+        break if damage_line =~ /With an abrupt flash, .*? disappears and reappears a few feet away, avoiding any danger completely!/
+        if damage_line =~ SKIP_THIS_LINE
+          index += 1;damage_line = buffer[index]
+        end
+        # record our damage
+        if damage_line =~ /\.\.\. (\d+) points? of damage!/
+          damage = $1.to_i
+        else
+          echo "*** ERROR no damage match for dispel"
+          break
+        end
+        # find our crit line
+        index += 1;crit_line = buffer[index]
+        # crit library sometimes skips first line of multi line crit messages
+        if crit_line =~ SKIP_THIS_LINE
+          index += 1;crit_line = buffer[index]
+        end
+        # record our crit data
+        crit = CritRanks.parse(crit_line).values.first || {}
+        _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for crit: #{crit_line}   dam: #{damage} flare: #{flare}***")) if crit.empty?
+        # record our findings
+        FlareLog.record_damage_flare(flare,damage,crit) unless damage == 0
+
+      when Regexp.union(SPELL_DISPELS.keys)
+        # spell = SPELL_DISPELS.find { |regex,_| line =~ regex }&.last
+        # _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for spell: #{line}   regex: #{regex}  spells_dispelled: #{spells_dispelled}***")) if spell.empty?
+        # spells_dispelled << spell
+
+
+      when /The (?:hazy film|elemental aura|murky veil) around .*? fluxes chaotically/ # flux
+        index += 1;damage_line = buffer[index]
+        # sometimes there is a susceptibility line preceeding
+        if damage_line =~ SKIP_THIS_LINE
+          index += 1;damage_line = buffer[index]
+        end
+        # record our damage
+        if damage_line =~ /\.\.\. (\d+) points? of damage!/
+          damage = $1.to_i
+        else
+          echo "*** ERROR no damage match for dispel"
+          break
+        end
+        # find our crit line
+        index += 1;crit_line = buffer[index]
+        # crit library sometimes skips first line of multi line crit messages
+        if crit_line =~ SKIP_THIS_LINE
+          index += 1;crit_line = buffer[index]
+        end
+        # record our crit data
+        crit = CritRanks.parse(crit_line).values.first || {}
+        _respond(Lich::Messaging.msg_format("bold","***   ERROR no match for crit: #{crit_line}   dam: #{damage} flare: #{flare}***")) if crit.empty?
+        # record our findings
+        FlareLog.record_damage_flare(flare,damage,crit) unless damage == 0
+      else
+        next
+      end
+    end
+    #@flarelog[flare.to_sym][target.to_sym] << spells_dispelled.uniq
+  end
+
+  # a little help for my friend
+  if Script.current.vars[0].include?("help")
+    output += " FlareLog - Expand your data.\n\n"
+    output += " Requires Lich 5.10.0 or higher as it utilizes the new CritRanks lib. I recommend 5.10.3+ to make sure crit tables are up to date.\n\n"
+    output += " Will keep a count of non damaging flares, can track specifics such as resource returned from mana and aganjira flares.\n"
+    output += " Tracks damage flares and records Flare: type_of_crit: location_of_crit: rank_of_crit: [damage, damage].\n\n"
+    output += " If you're on Wrayth, there is a window to display some statistics. The window can be a bit much though.\n"
+    output += "  ;flarelog window                Will launch with the window. Window only updates when a damage flare occurs.\n\n"
+    output += "  ;flarelog debug                 Gives message for every flare recorded. If you're wondering if it's working.\n"
+    output += "  ;flarelog window debug          If that's your thing too.\n\n"
+    output += " A few other commands\n"
+    output += "  ;eq FlareLog.save(true)         Force a save to the yaml file. Automatically does this on exit.\n"
+    output += "  ;eq FlareLog.damage_flares      Displays a list of damage flares currently implemented\n"
+    output += "  ;eq FlareLog.no_damage_flares   Displays a list of non damaging flares currently implemented\n"
+    output += "  ;eq FlareLog.update_window      Forces an update to the Wrayth window.\n"
+    output += "  ;eq FlareLog.data.keys          Displays a list of the the flares recorded. FlareLog.data returns the database.\n"
+    output += "  ;eq FlareLog.reset_data         Start Fresh.\n\n\n"
+    output += " Please provide me with any ERROR messages you recieve. This is still a work in progress.\n"
+    output += "  ***   ERROR no match for damage:\n"
+    output += "  ***   ERROR no match for crit:\n"
+    Lich::Messaging.mono(output)
+    exit
+  end
+  # load our data, initialize our variables
+  FlareLog.load
+
+  case Script.current.vars[0]
+  when /\-\-flares?=(.*)/
+    @flarelog[:chosen_flares] ||= []
+    if $1 == "all"
+      DAMAGE_FLARES.each_value { |flare| @flarelog[:chosen_flares] << flare }
+      exit
+    end
+    chosen_flares = $1.split(/,\s*/).map(&:strip).map { |f| f.downcase.gsub(/\s|-/,'_') }
+    available_flares = @flarelog.keys.map(&:to_s).reject { |key| key =~ /save_time|chosen_flares/}
+    
+    matched_flares = chosen_flares.map do |input|
+      available_flares.find { |key| key.downcase.include?(input) }
+    end.compact.uniq
+    @flarelog[:chosen_flares] = matched_flares || []
+    _respond(Lich::Messaging.msg_format("info", "Chosen flares: #{@flarelog[:chosen_flares]}"))
+    exit
+  when "debug"
+    @flarelog[:debug] = !@flarelog[:debug]
+    _respond(Lich::Messaging.msg_format("info", "Debug mode #{@flarelog[:debug]}."))
+    exit
+  when "window"
+    @flarelog[:window] = !@flarelog[:window]
+  end
+  FlareLog.update_window if @flarelog[:window]
+  #def self.parse_game
+  while line = get
+    case line
+    when Regexp.union(NO_DAMAGE_FLARES.keys)
+      FlareLog.parse_no_damage_flare(line)
+    when Regexp.union(DAMAGE_FLARES.keys)
+      sleep(0.15)
+      FlareLog.parse_damage_flare(line,reget(20))
+    when Regexp.union(DISPEL_FLARES.keys)
+      sleep(0.15)
+      FlareLog.parse_dispel_flare(line,reget(20))
+    else
+      next
+    end
+  end
+
+end


### PR DESCRIPTION
Looking for a review for glaring errors before I make public. Probably want to wait until 5.10.03 is released. Then can require it so crit tables aren't throwing a bunch of errors.

FlareLog tracks flares! But it's not just any old tracking script that counts how many times your flare goes off. No way.
FlareLog leverages the CritRank library to record expansive flare data in the moment. 

Data is saved as @flarelog -> flare -> type -> location -> rank -> [damage, damage, damage]

Supports a wrayth window, or simply display the data in the story window upon request.