### PR TITLE
[ebounty.lic] v1.3.11 standalone foraging fix

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,10 +9,12 @@
   contributors: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-       version: 1.3.10
+       version: 1.3.11
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.3.11 (2024-09-24)
+    - fix to allow for CLI foraging without setting Gem/Default profile
   v1.3.10 (2024-08-19)
     - bugfix for ask_guard response
   v1.3.9 (2024-08-14)
@@ -702,10 +704,10 @@ module EBounty
     EBounty.data.close_containers.push(container.id) unless EBounty.data.close_containers.include?(container.id)
   end
 
-  def self.set_variables
+  def self.set_variables(load_profile: true)
     EBounty.data.elapsed_time = Time.now
 
-    unless EBounty.data.settings[:basic]
+    unless EBounty.data.settings[:basic] || !load_profile
       # Check if a default profile was selected
       if EBounty.data.settings[:default_profile].to_s.empty?
         EBounty.msg "error", 'Please select a Gem/Default profile in "Profiles" tab. Ebounty needs this to work right.'
@@ -3520,7 +3522,7 @@ when 'forage'
   end
   return_room = Room.current.id
   EBounty.load(EBounty.load_profile)
-  EBounty.set_variables
+  EBounty.set_variables(load_profile: false)
   EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i)
   EBounty.go2(return_room)
 when 'location'


### PR DESCRIPTION
Allow to use ebounty without any Gem/Default settings if used for standalone CLI foraging