### PR TITLE
[repository.lic] Change DR default settings.

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -105,8 +105,8 @@ if (Settings['updatable'][:mapdb] == Hash.new)
     Settings['updatable'][:mapdb]['GSPlat'] = true
   elsif XMLData.game =~ /^DR/
     Settings['updatable'][:mapdb]['DR'] = true
-    Settings['updatable'][:mapdb]['DRF'] = true
-    Settings['updatable'][:mapdb]['DRX'] = true
+    Settings['updatable'][:mapdb]['DRF'] = false
+    Settings['updatable'][:mapdb]['DRX'] = false
     # DragonRealms specific updatable scripts here
     dr_scripts_to_update = %w(alias autostart jinx map repository vars version log go2 logxml)
     dr_scripts_to_update.each do |script_name|

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.58
+       version: 2.59
 
   changelog:
+    2.59 (2024-11-10):
+      Change DR auto-update settings
     2.58 (2024-11-04):
       Rejig per-game gating to set DR defaults. Add reset-update-settings option.
     2.57 (2024-07-13):

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -84,8 +84,7 @@ if Settings['updatable'].nil?
   Settings['updatable'][:mapdb] = Hash.new
 end
 
-if (Settings['updatable'][:mapdb] == Hash.new) || (XMLData.game =~ /^DR/)
-  Settings['updatable'][:mapdb][XMLData.game] = true
+if (Settings['updatable'][:mapdb] == Hash.new)
   Settings['updatable'][:lich] = false
   if XMLData.game =~ /^GS/
     # GemstoneIV specific updatable scripts here
@@ -105,6 +104,9 @@ if (Settings['updatable'][:mapdb] == Hash.new) || (XMLData.game =~ /^DR/)
     Settings['updatable'][:mapdb]['GSF'] = true
     Settings['updatable'][:mapdb]['GSPlat'] = true
   elsif XMLData.game =~ /^DR/
+    Settings['updatable'][:mapdb]['DR'] = true
+    Settings['updatable'][:mapdb]['DRF'] = true
+    Settings['updatable'][:mapdb]['DRX'] = true
     # DragonRealms specific updatable scripts here
     dr_scripts_to_update = %w(alias autostart jinx map repository vars version log go2 logxml)
     dr_scripts_to_update.each do |script_name|


### PR DESCRIPTION
Turns out our Fallen and Plat instances both use the Prime map, always.