### PR TITLE
[repository.lic] v2.60 generic XMLData.game mapdb update setting

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.59
+       version: 2.60
 
   changelog:
+    2.60 (2024-11-10):
+      Add support for initial XMLData.game mapdb update incase unknown from presets
     2.59 (2024-11-10):
       Change DR auto-update settings
     2.58 (2024-11-04):
@@ -87,6 +89,7 @@ if Settings['updatable'].nil?
 end
 
 if (Settings['updatable'][:mapdb] == Hash.new)
+  Settings['updatable'][:mapdb][XMLData.game] = true
   Settings['updatable'][:lich] = false
   if XMLData.game =~ /^GS/
     # GemstoneIV specific updatable scripts here


### PR DESCRIPTION
Add explicit support for "other" game types than the 6 specifically called out in script. Should support GSTest and DRTest and whatever other options come down the pipeline