### PR TITLE
[ecaster.lic] add option to hide

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -32,9 +32,9 @@ end
 
 module ECaster
   @@options = CharSettings[:options] || {
-    channel: false, conserve: false, safety: false, stance: false
+    channel: false, conserve: false, safety: false, stance: false, hide: false
   }
-
+  @@hide = CharSettings[:hide] || []
   @@mantle = CharSettings[:mantle] || {}
 
   @@stance = CharSettings[:stance] || {}
@@ -118,6 +118,8 @@ module ECaster
         ECaster.verb(first, second)
       elsif action == 'set'
         ECaster.option(first, second)
+      elsif action == 'hide'
+        ECaster.hide(first)
       else
         ECaster.help
       end
@@ -162,6 +164,8 @@ module ECaster
     ECaster.send ""
     ECaster.send " Verbs: #{@@verbs}"
     ECaster.send ""
+    ECaster.send " Hide: #{@@hide}"
+    ECaster.send ""
     ECaster.send "<output class=\"\"/>"
   end
 
@@ -183,6 +187,23 @@ module ECaster
         # @@mantle.
       end
     end
+  end
+
+  def self.hide(spell_number)
+    if spell_number.nil? or spell_number == 0 or Spell[spell_number].nil?
+      ECaster.send "You must specify a valid spell number."
+      return
+    end
+    spell_number = spell_number.to_i
+    if @@hide.include?(spell_number)
+      @@hide.delete(spell_number)
+      ECaster.send "#{spell_number} has been removed from your hide list."
+    else
+      @@hide << spell_number
+      ECaster.send "#{spell_number} has been added to your hide list."
+    end
+    CharSettings[:hide] = @@hide
+    CharSettings.save
   end
 
   def self.verb(*args)
@@ -265,12 +286,12 @@ module ECaster
     option, value = args
     unless option && value
       ECaster.send "You must specify a valid option and value."
-      ECaster.send "Valid options include: #{@@option.keys.join(' ')}"
+      ECaster.send "Valid options include: #{@@options.keys.join(' ')}"
     else
       option = option.to_sym
       unless @@options.keys.include?(option)
         ECaster.send "Specified option '#{option}' is not valid."
-        ECaster.send "Current options are: #{@@option}"
+        ECaster.send "Current options are: #{@@options}"
       else
         value = (value == 'on')
         @@options[option] = value
@@ -357,11 +378,17 @@ module ECaster
       return
     end
 
+    if @@options[:hide] && @@hide.include?(spell_number.to_i)
+      hide_me = true
+    else
+      hide_me = false
+    end
+
     if checkcastrt > 0
       echo "Waiting for cast roundtime..."
       waitcastrt? while checkcastrt > 0
     end
-
+    
     if @@stance[spell_alias] || @@stance[spell_number] || @@options[:stance] && spell.stance
       stance = @@stance[spell_alias] || @@stance[spell_number] || 'offensive'
       unless checkstance == stance || dead?
@@ -390,6 +417,8 @@ module ECaster
         put "incant #{spell_number} #{count}"
       end
     end
+
+    put "hide" if hide_me
 
     if @@stance[spell_alias] || @@stance[spell_number] || @@options[:stance] && spell.stance
       stance = 'guarded'


### PR DESCRIPTION
;ec hide <spell_number>  - will add/remove spell to @@hide list. 
;ec set hide true/false  -  will enter a single hide command after you cast a spell that's in @@hide

The question is where to place the hide? Before or after the stance change? I like it before the stance change because that allows the use of a `put` to provide a .1-.2 second delay between casting and hiding. This would require a short sleep and waitrt before the stance change or you get a wait 1 second message from the stance command. It could go after the stance command. This takes 2x-3x the time to hide as putting it before the stance. We're still talking something like .5-.7s to be hidden.

This actually makes no difference to me personally as the only spell I use that uses a stance is 615 swarm. So I get the instant hide before or after the stance. Who is actually going to use this though? Rangers. Rogues for the occasional ewave?  Nobody other than me since it hasn't been added yet?
