### PR TITLE
[bigshot] v5.6.9 bugfix for weapon reaction and remove group names from room claim 

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.6.8
+       version: 5.6.9
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.6.9  (2024-12-09)
+    - bugfix for group members in room claim
+    - bugfix for weapon reactions to be done in @HUNTING_STANCE
   v5.6.8  (2024-12-06)
     - additional regex for rooted debuff
     - bugfix for leader waiting to regroup during rest cycle
@@ -2096,6 +2099,9 @@ class Bigshot
     debug_settings = %i[@DEBUG_COMBAT @DEBUG_COMMANDS @DEBUG_STATUS @DEBUG_SYSTEM]
     debug_settings.each { |var| instance_variable_set(var, true) }
 
+    # Create a group
+    @followers =  Group.new()
+
     # Run the method
     send(test_method, *args)
   end
@@ -2621,8 +2627,6 @@ class Bigshot
     debug_msg(@DEBUG_COMMANDS, "cmd | command: #{command} | called by #{caller[0]}")
 
     check_for_deaders_prone
-
-
 
     original_command = command
     command = command.dup
@@ -5183,11 +5187,7 @@ class Bigshot
     wait_while { !@followers.all_present? }
     wait_while { @followers.roundtime? }
     wait_while { !@followers.rest_prep_complete? }
-
     sleep 2
-
-    # make sure we get everyone recognized as part of the group
-    groupcheck()
 
     # this doesn't seem to do anything? Custom bit for something?
     if (!solo? && leading?)
@@ -5212,7 +5212,11 @@ class Bigshot
       sleep(REST_INTERVAL)
     end
 
-    hunt() if !$bigshot_bandits
+    # make sure we get everyone recognized as part of the group
+    groupcheck()
+    wait_rt
+
+    hunt()
   end
 
   def mana_pulse(spell_id)
@@ -5544,8 +5548,10 @@ class Bigshot
 
   def perform_reaction()
     debug_msg(@DEBUG_COMBAT, "performing weapon reaction | $bigshot_reaction: #{$bigshot_reaction} | called by #{caller[0]}")
-
+    original_stance = checkstance
+    change_stance(@HUNTING_STANCE)
     fput "weapon #{$bigshot_reaction}"
+    change_stance(original_stance)
     $bigshot_reaction = nil
   end
 
@@ -6236,7 +6242,7 @@ class Bigshot
     end
 
     # Disk variables
-    disk_claimed = []
+    disks_in_room = []
     disk_section = /You also see(.*?)(?=Also here|<compass>|<prompt>|<\/compDef>|Obvious (?:exits|paths))/m
     disk_nouns_reg = Regexp.union(['bassinet', 'cassone', 'chest', 'coffer', 'coffin', 'coffret', 'disk', 'hamper', 'saucer', 'sphere', 'trunk', 'tureen'])
     disk_pattern = /([A-Z][a-z]+) #{disk_nouns_reg}\b/
@@ -6261,18 +6267,19 @@ class Bigshot
     end
 
     # Check for obviously hidden
-    hidden = text.match(/obvious signs of someone hiding/)
-    if hidden
-      $bigshot_room_claimed.push('hidden')
+    if text.downcase.include?('obvious signs of someone hiding')
+      $bigshot_room_claimed << 'hidden'
       set_obvious_hiding_player(true)
     end
 
-    # Find all the disks in the room
-    captured_disk = text.match(disk_section)
-    if captured_disk
-      captured_disk = captured_disk[1].strip
-      captured_disk.scan(disk_pattern) do |matches|
-        disk_claimed << matches.compact.join.strip
+    # Find all the disks in the room unless ignored
+    unless @IGNORE_DISKS
+      captured_disk = text.match(disk_section)
+      if captured_disk
+        captured_disk = captured_disk[1].strip
+        captured_disk.scan(disk_pattern) do |matches|
+          $bigshot_room_claimed << matches.compact.join.strip
+        end
       end
     end
 
@@ -6285,14 +6292,10 @@ class Bigshot
       end
     end
 
-    allowed_disk_names = $grouplist + [Char.name]
-    disk_in_room = disk_claimed - allowed_disk_names
-
-    # Add any names of character disks not in your group
-    $bigshot_room_claimed.push(*disk_in_room) unless @IGNORE_DISKS
-
     # remove any group members that made it on the list.
-    $bigshot_room_claimed = ($bigshot_room_claimed - $grouplist).uniq
+    $bigshot_room_claimed -= $grouplist
+    $bigshot_room_claimed -= @followers.get_names
+    $bigshot_room_claimed.uniq!
 
     debug_msg(@DEBUG_COMBAT, "set_room_claimed | result: #{$bigshot_room_claimed} | called by #{caller[0]}") if finished
 


### PR DESCRIPTION
Instead of chasing the groupcheck process I figure just automatically removing followers from the room claim would make more sense. That way if the groupcheck failed for whatever reason it wouldn't impact the claim process.