### PR TITLE
[isigils.lic] fix: Update for native GTK3

### DIFF
--- a/scripts/isigils.lic
+++ b/scripts/isigils.lic
@@ -99,7 +99,7 @@ elsif script.vars[1] =~ /^setup$|^options$/i												#Pulls up GUI if user en
 		majprot_check.signal_connect('toggled') { Gtk.queue { minprot_check.active = false if majprot_check.active? } }
 		minprot_check.signal_connect('toggled') { Gtk.queue { majprot_check.active = false if minprot_check.active? } }
 
-		tooltips = Gtk::Tooltips.new												#Tool Tips!
+		# tooltips = Gtk::Tooltips.new # removed for GTK3 native												#Tool Tips!
 		contact_check.set_tooltip_text("1 Mana")										#Displays mana cost of sigil when mouse hovers over indicated CheckButton
 		resolve_check.set_tooltip_text("5 Stamina")
 		minbane_check.set_tooltip_text("3 Mana, 2 Stamina")


### PR DESCRIPTION
Removing `Tooltips` as that method is not available in GTK3.  It worked previously due to a monkey patch on the method that has been removed 20241210.