### PR TITLE
[SpellWindows.lic] initial creation

### DIFF
--- a/scripts/SpellWindows.lic
+++ b/scripts/SpellWindows.lic
@@ -1,0 +1,206 @@
+=begin
+  SpellWindow.lic
+  
+  Replaces Wrayths integrated spell active windows for spells, buffs, debuffs, cooldowns.
+  
+  The script blocks the xml feed for active spells, buffs, debuffs, cooldowns, quickbar, and combat.
+  It grabs the data from Effects:: and populates the wrayth windows.
+  This gives the same exact information, without committing a ddos attack on your frontend.
+
+  NOTE ** If you use the combat window in order to click to attack, be sure to toggle that feed with:
+      ;spellwindow combat
+
+  ;spellwindow              - starts the script
+  ;spellwindow window help  - see how to choose which windows are active
+
+        author: Nisugi
+  contributors: Nisugi
+          game: Gemstone
+          tags: hunting, combat, tracking, spells, buffs, debuffs, cooldowns
+       version: 1.0
+      required: Wrayth
+
+  Change Log:
+  v1.0 (2024-12-12)
+    - Initial Release
+=end
+
+module SpellWindow
+
+  @@ACTIVE_SPELLS = Regexp.new(/<dialogData id=\'Active Spells\' clear=\'t\'><\/dialogData>/)
+	@@DEBUFFS = Regexp.new(/<dialogData id=\'Debuffs\' clear=\'t\'><\/dialogData>/)
+	@@BUFFS = Regexp.new(/<dialogData id=\'Buffs\' clear=\'t\'><\/dialogData>/)
+	@@COOLDOWNS = Regexp.new(/<dialogData id=\'Cooldowns\' clear=\'t\'><\/dialogData>/)
+	@@COMBAT = Regexp.new(/<dialogData id=\'combat\'>/)
+	@@QUICK = Regexp.union(/<openDialog id=\"quick\" location=\"quickBar\"/,
+						   /<switchQuickBar id=\"quick\"\/>/)
+
+  def self.initialize_categories
+    categories = ['spells', 'buffs', 'debuffs', 'cooldowns']
+    categories.each do |item|
+      CharSettings[item] ||= true
+    end
+    @show_spells = CharSettings['spells']
+    @show_buffs = CharSettings['buffs']
+    @show_debuffs = CharSettings['debuffs']
+    @show_cooldowns = CharSettings['cooldowns']
+    @block_combat = CharSettings['combat']
+  end
+
+  def self.build_max_check
+    regexes = [@@ACTIVE_SPELLS, @@DEBUFFS, @@BUFFS, @@COOLDOWNS, @@QUICK]
+    regexes << @@COMBAT unless @block_combat
+    Regexp.union(regexes)
+  end
+
+  def self.window_help
+    respond ""
+    respond "#############################################################################"
+    respond ""
+    respond "           #{Script.current.name.capitalize} Help"
+    respond "------------------------------------------------------------"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window all <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window check <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window spells <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window buffs <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window debuffs <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} window cooldowns <true/false>"
+    respond ""
+    respond " Options can be combined:"
+    respond "         #{$lich_char}#{Script.current.name} window buffs debuffs cooldowns <true/false>"
+    respond ""
+    respond " #{$lich_char}#{Script.current.name} combat  - toggle combat window feed"
+    respond ""
+    respond "#############################################################################"
+    respond ""
+  end
+
+  def self.window_update(args)
+    categories = ['spells', 'buffs', 'debuffs', 'cooldowns']
+    window_array = args.split(/[\s,|]+/)
+    window_array.shift
+  
+    case
+    when window_array.include?('help') || window_array.empty?
+      SpellWindow.window_help
+    when window_array.last =~ /check/i
+      echo
+      categories.each do |item|
+        echo "#{item.gsub('_', ' ').ljust(16)} = #{!!CharSettings[item]}"
+      end
+      echo
+    # when !['true', 'false'].include?(window_array.last)
+    when !%w[true false].include?(window_array.last.strip.downcase)
+      echo
+      echo "The window parameters need to end with true or false"
+      echo "#{$lich_char}#{Script.current.name} window help for examples"
+      echo
+    else
+      update_setting = window_array.last.strip.downcase == "true"
+  
+      if window_array.first =~ /all/i
+        echo
+        categories.each do |item|
+          CharSettings[item] = !!update_setting
+          echo "#{item.gsub('_', ' ').ljust(16)} = #{!!CharSettings[item]}"
+        end
+        echo
+      else
+        echo
+        window_array[0...-1].each do |item|
+          item = "debug_#{item}"
+          CharSettings[item] = update_setting
+          echo "#{item.gsub('_', ' ').ljust(16)} = #{!!CharSettings[item]}"
+        end
+        echo
+      end
+    end
+  end
+
+  def self.format_time(timeleft)
+    seconds = timeleft * 60
+    hours = (seconds / 3600).to_i
+    minutes = (seconds % 3600 / 60).to_i
+    seconds = (seconds % 60).to_i
+    format("%02d:%02d:%02d", hours, minutes, seconds)
+  end
+
+  def self.display_time(timeleft)
+    seconds = timeleft * 60
+    if seconds < 120
+      "#{seconds.to_i}s"
+    else
+      hours = (seconds / 3600).to_i
+      minutes = (seconds % 3600 / 60).to_i
+      format("%d:%02d", hours, minutes)
+    end
+  end
+
+  def self.build_output(effect_type, title)
+    output = "<dialogData id='#{title}' clear='t'></dialogData><dialogData id='#{title}'>"
+    top_value = 0
+
+    effects = effect_type.to_h
+    id_effects = effects.select { |k, _v| k.is_a?(Integer) }
+    text_effects = effects.reject { |k, _v| k.is_a?(Integer) }
+
+    if id_effects.empty?
+      output += "<label id='lblNone' value='No #{title.downcase} found.' top='0' left='0' align='center'/>"
+    else
+      id_effects.each do |sn, end_time|
+        stext = text_effects.shift[0]
+        duration = ((end_time - Time.now) / 60.to_f)
+        next if duration < 0
+
+        max_duration = Spell[sn].max_duration || 5
+        bar_value = ((duration / max_duration) * 100).to_i
+        output += "<progressBar id='#{sn}' value='#{bar_value}' text=\"#{stext}\" left='22%' top='#{top_value}' width='76%' height='15' time='#{format_time(duration)}'/><label id='l#{sn}' value='#{display_time(duration)} ' top='#{top_value}' left='0' justify='2' anchor_right='spel'/>"
+        top_value += 16
+      end
+    end
+    output += "</dialogData>"
+    output
+  end
+
+  def self.update_window
+    loop do
+      output = ''
+      output += build_output(Effects::Spells, 'Active Spells') if @show_spells
+      output += build_output(Effects::Buffs, 'Buffs') if @show_buffs
+      output += build_output(Effects::Debuffs, 'Debuffs') if @show_debuffs
+      output += build_output(Effects::Cooldowns, 'Cooldowns') if @show_cooldowns
+      puts(output)
+      sleep(1)
+    end
+  end
+  
+  def self.check_line(xml_line)
+    return nil if @@MAX_CHECK.match?(xml_line)
+    return xml_line
+  end
+
+  initialize_categories
+  if Script.current.vars[0].to_s =~ /help/i
+    SpellWindow.window_help
+  elsif Script.current.vars[1].to_s =~ /window/i
+    SpellWindow.window_update(Script.current.vars[0])
+    exit
+  elsif Script.current.vars[0].to_s =~ /combat/i
+    @block_combat = !@block_combat
+    CharSettings['combat'] = @block_combat
+    Lich::Messaging.msg("info", "Combat window xml feed enabled: #{@block_combat}")
+    exit
+  else
+    @@MAX_CHECK = SpellWindow.build_max_check
+    spellWindowHook = proc { |server_string| SpellWindow.check_line(server_string) }
+    DownstreamHook.add('spellWindowHook', spellWindowHook)
+    before_dying { DownstreamHook.remove('spellWindowHook')}
+    update_window
+  end
+end


### PR DESCRIPTION
Combines flextape with wrayth's spell active windows. Best of both worlds! A snappy Wrayth and up to date information.

Blocks active spells, buffs, debuffs, cooldowns, quickbar, and combat window feeds Uses Effects:: data to populate the spells, buffs, debuffs, and cooldowns data and sends it to the windows.

Choose which windows gets updated.
Can turn on combat window feed if you use that sucker.

I know Tysong prefers _respond, but _respond spams log.lic, and this only works with wrayth.