### PR TITLE
[SpellWindows.lic] updates

### DIFF
--- a/scripts/SpellWindows.lic
+++ b/scripts/SpellWindows.lic
@@ -7,7 +7,7 @@
   It grabs the data from Effects:: and populates the wrayth windows.
   This gives the same exact information, without committing a ddos attack on your frontend.
 
-  Now it also incorporates buff_tracker.
+  Now it also incorporates buff_tracker and targetwindow!
 
   NOTE ** If you use the combat window in order to click to attack, be sure to toggle that feed with:
       ;spellwindow combat
@@ -20,10 +20,13 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, spells, buffs, debuffs, cooldowns
-       version: 1.2
+       version: 1.3
       required: Wrayth
 
   Change Log:
+  v1.3 (2024-12-14)
+    - target_window back in
+    - dynamic window updating
   v1.2 (2024-12-13)
     - removed target_window
   v1.1 (2024-12-13)
@@ -34,79 +37,126 @@
 =end
 
 module SpellWindow
-  UPSTREAM_HOOK_ID = "#{Script.current.name.downcase}::upstream"
-  DOWNSTREAM_HOOK_ID = "#{Script.current.name.downcase}::downstream"
-  HOOK_CMD_RX = /^(?:<c>)?;(?:#{Script.current.name}|buff)(?:\s(.*))?$/i
+  class Pattern
+    UPSTREAM_HOOK_ID = "#{Script.current.name.downcase}::upstream"
+    DOWNSTREAM_HOOK_ID = "#{Script.current.name.downcase}::downstream"
+    HOOK_CMD_RX = %r{^(?:<c>)?;(?:#{Script.current.name}?|buff)(?: (.*))?$}i
+    ACTIVE_SPELLS = %r{^<dialogData id='Active Spells' clear='t'></dialogData>}
+    BUFFS = %r{<dialogData id='Buffs' clear='t'></dialogData>}
+    DEBUFFS = %r{<dialogData id='Debuffs' clear='t'></dialogData>}
+    COOLDOWNS = %r{<dialogData id='Cooldowns' clear='t'></dialogData>}
+    COMBAT = %r{<dialogData id='combat'>/}
+    QUICKBAR = %r{<openDialog id="quick" location="quickBar"}
+    QUICKBAR_SWITCH = %r{<switchQuickBar id="quick"/>}
+    GRASP_ARMS = %r{(?:arm|appendage|claw|limb|pincer|tentacle|palpus|palpi)s?}
+
+    attr_reader :regex
+    
+    def initialize(regex)
+      @regex = regex
+    end
+
+    def match(input)
+      regex.match(input)
+    end
+
+    def match?(input)
+      !!regex.match(input)
+    end
+
+    def extract(input)
+      match_data = regex.match(input)
+      match_data ? match_data.captures : []
+    end
+  end
+  
   CMD_QUEUE = Queue.new
 
   def self.save_settings
-    CharSettings['spells'] = @show_spells
-    CharSettings['buffs'] = @show_buffs
-    CharSettings['debuffs'] = @show_debuffs
-    CharSettings['cooldowns'] = @show_cooldowns
-    CharSettings['combat'] = @block_combat
+    CharSettings['show_spells'] = @show_spells
+    CharSettings['show_buffs'] = @show_buffs
+    CharSettings['show_debuffs'] = @show_debuffs
+    CharSettings['show_cooldowns'] = @show_cooldowns
+    CharSettings['block_combat'] = @block_combat
+    CharSettings['show_missing'] = @show_missing
+    CharSettings['show_targets'] = @show_targets
+    CharSettings['show_arms'] = @show_arms
     CharSettings['my_buffs'] = @my_buffs
-    CharSettings['missing'] = @show_missing
   end
-
-  # settings!
+    
   def self.initialize_script
+    # set up default settings
+    @debug = false
     defaults = {
-      'spells'    => true,
-      'buffs'     => true,
-      'debuffs'   => true,
-      'cooldowns' => true,
-      'combat'    => true,
-      'my_buffs'  => [],
-      'missing'   => false
+      'show_spells'    => true,
+      'show_buffs'     => true,
+      'show_debuffs'   => true,
+      'show_cooldowns' => true,
+      'block_combat'   => true,
+      'show_missing'   => false,
+      'show_targets'   => false,
+      'show_arms'      => false,
+      'my_buffs'  => []
     }
-
     defaults.each do |key, value|
       CharSettings[key] ||= value
     end
-
-    @show_spells = CharSettings['spells']
-    @show_buffs = CharSettings['buffs']
-    @show_debuffs = CharSettings['debuffs']
-    @show_cooldowns = CharSettings['cooldowns']
-    @block_combat = CharSettings['combat']
-    @show_missing = CharSettings['missing']
+    
+    # retrieve settings
+    @show_spells = CharSettings['show_spells']
+    @show_buffs = CharSettings['show_buffs']
+    @show_debuffs = CharSettings['show_debuffs']
+    @show_cooldowns = CharSettings['show_cooldowns']
+    @block_combat = CharSettings['block_combat']
+    @show_missing = CharSettings['show_missing']
+    @show_targets = CharSettings['show_targets']
+    @show_arms = CharSettings['show_arms']
     @my_buffs = CharSettings['my_buffs']
+    
+    @@thread = nil
+    
+    # create our pattern for Flextape
+    patterns = [
+      Pattern::ACTIVE_SPELLS,
+      Pattern::BUFFS,
+      Pattern::DEBUFFS,
+      Pattern::COOLDOWNS,
+      Pattern::QUICKBAR,
+      Pattern::QUICKBAR_SWITCH
+    ]
+    patterns << Pattern::COMBAT if @block_combat
+    @@MAX_CHECK = Regexp.union(patterns)
 
-    @@ACTIVE_SPELLS = Regexp.new(/<dialogData id=\'Active Spells\' clear=\'t\'><\/dialogData>/)
-    @@DEBUFFS = Regexp.new(/<dialogData id=\'Debuffs\' clear=\'t\'><\/dialogData>/)
-    @@BUFFS = Regexp.new(/<dialogData id=\'Buffs\' clear=\'t\'><\/dialogData>/)
-    @@COOLDOWNS = Regexp.new(/<dialogData id=\'Cooldowns\' clear=\'t\'><\/dialogData>/)
-    @@COMBAT = Regexp.new(/<dialogData id=\'combat\'>/)
-    @@QUICK = Regexp.union(/<openDialog id=\"quick\" location=\"quickBar\"/,
-                           /<switchQuickBar id=\"quick\"\/>/)
-    regexes = [@@ACTIVE_SPELLS, @@DEBUFFS, @@BUFFS, @@COOLDOWNS, @@QUICK]
-    regexes << @@COMBAT if @block_combat
-    @@MAX_CHECK = Regexp.union(regexes)
-
-    # Get to hookin'
-    DownstreamHook.add(DOWNSTREAM_HOOK_ID, proc do |server_string| SpellWindow.check_line(server_string) end)
-    UpstreamHook.add(UPSTREAM_HOOK_ID, proc do |command|
-      if command =~ HOOK_CMD_RX
+    # set up our hooks.
+    DownstreamHook.add(Pattern::DOWNSTREAM_HOOK_ID, proc do |server_string| SpellWindow.flextape(server_string) end)
+    UpstreamHook.add(Pattern::UPSTREAM_HOOK_ID, proc do |command|
+      if command =~ Pattern::HOOK_CMD_RX
         CMD_QUEUE.push($1)
         nil
       else
         command
       end
     end)
-
-    # Clean up
+    
+    # clean up 
     before_dying {
-      UpstreamHook.remove(UPSTREAM_HOOK_ID)
-      DownstreamHook.remove(DOWNSTREAM_HOOK_ID)
+      UpstreamHook.remove(Pattern::UPSTREAM_HOOK_ID)
+      DownstreamHook.remove(Pattern::DOWNSTREAM_HOOK_ID)
       @@thread.kill if @@thread.alive?
       SpellWindow.save_settings
     }
-    if @show_missing
-      puts("<closeDialog id='Missing Spells'/><openDialog type='dynamic' id='Missing Spells' title='Missing Spells' target='Missing Spells' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Missing Spells'></dialogData></openDialog>")
-    end
+
+    # create our missing spells and target windows. The other 4 windows are auto opened by wrayth if you use them.
+    puts("<closeDialog id='Missing Spells'/><openDialog type='dynamic' id='Missing Spells' title='Missing Spells' target='Missing Spells' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Missing Spells'></dialogData></openDialog>") if @show_missing
+    puts("<closeDialog id='Target Window'/><openDialog type='dynamic' id='Target Window' title='Targets' target='Target Window' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Targets'></dialogData></openDialog>") if @show_targets
   end
 
+  def self.flextape(xml_line)
+    return nil if @@MAX_CHECK.match?(xml_line)
+    return xml_line
+  end
+
+  # missing spells stuff .. formerly buff_tracker
   def self.add_buff(var)
     @my_buffs << var unless @my_buffs.include?(var)
     puts("#{Spell[var].name} added.")
@@ -143,6 +193,72 @@ module SpellWindow
     output
   end
 
+  def self.status_fix(status)
+    status_mapping = {
+      /rather calm/ => 'calmed',
+      /to be frozen in place/ => 'frozen',
+      /held in place/ => 'held',
+      /lying down/ => 'prone',
+      /entangled by a lashing \w+ \w+/ => 'entangled'
+    }
+
+    fix_status = status_mapping.find { |pattern, _| pattern.match?(status) }&.last || status
+    return "(#{fix_status})"
+  end
+  
+  def self.build_target_links(entities, include_titles: true)
+    entities.map do |entity|
+      if include_titles
+        name = entity.name.split.map(&:capitalize).join(' ')
+      else
+        # Strip the title for players, assuming titles are part of the name
+        name = entity.name.split.last.capitalize
+      end
+      status = SpellWindow.status_fix(entity.status) unless entity.status.nil?
+      "<link id='#{entity.id}' value='#{status} #{name}' cmd='target ##{entity.id}' echo='target ##{entity.id}' justify='3' left='0' height='15' width='195'/>"
+    end.join
+  end
+
+  def self.target_window
+    targets = GameObj.targets.reject { |t| t.noun =~ Pattern::GRASP_ARMS || (t.name =~ /^animated / && t.name != "animated slush") }
+    group_members = Group.members
+    non_group_members = GameObj.pcs.reject { |player| group_members.any? { |member| member.id == player.id } }
+  
+    output = "<dialogData id='Target Window' clear='t'></dialogData><dialogData id='Target Window'>"
+  
+    # Targets Section
+    if targets.any?
+      output += "<link id='total' value='Total Targets: #{targets.size}' cmd='target next' echo='target next' justify='3' top='3' left='0' height='15' width='195'/>"
+      output += build_target_links(targets, include_titles: true)
+    else
+      output += "<label id='noTargets' value='-= No Targets =-' justify='3' left='0' width='187'/>"
+    end
+  
+    output += "<label id='space1' value=' ' justify='3' left='0' width='187'/>"
+  
+    # Players Section
+    if non_group_members.any?
+      output += "<label id='pcs' value='Total Players: #{non_group_members.size}' justify='3' left='0' height='15' width='195'/>"
+      output += build_target_links(non_group_members, include_titles: false)
+    else
+      output += "<label id='noPcs' value='-= No Players =-' justify='3' left='0' width='187'/>"
+    end
+  
+    output += "<label id='space2' value=' ' justify='3' left='0' width='187'/>"
+  
+    # Group Members Section
+    if group_members.any?
+      output += "<label id='group' value='Group Size: #{group_members.size}' justify='3' left='0' height='15' width='195'/>"
+      output += build_target_links(group_members, include_titles: false)
+    else
+      output += "<label id='noGroup' value='-= No Group =-' justify='3' left='0' width='187'/>"
+    end
+  
+    output += "</dialogData>"
+    output
+  end
+
+  # spell windows .. active spells, buffs, debuffs, cooldowns
   # format simu uses for the progress bar time value
   def self.format_time(timeleft)
     seconds = timeleft * 60
@@ -164,63 +280,203 @@ module SpellWindow
     end
   end
 
-  # build outputs for our Effects windows
-  def self.build_output(effect_type, title)
-    output = "<dialogData id='#{title}' clear='t'></dialogData><dialogData id='#{title}'>"
-    top_value = 0
+  def self.get_spell_max_duration(sn, stext)
+    custom_durations = {
+      'Celerity'                   => 1,
+      'Barkskin'                   => 1,
+      'Assume Aspect'              => 10,
+      'Nature\'s Touch Arcane Ref' => 0.5,
+      'Nature\'s Touch Physical P' => 0.5,
+      'Tangleweed Vigor'           => 2,
+      'Slashing Strikes'           => 2,
+      'Evasiveness'                => 0.05,
+      'Wall of Force'              => 1.5
+    }
+    custom_durations[stext] || Spell[sn].max_duration || 5
+  end
 
+  # build outputs for our Effects windows
+  def self.build_output(effect_type, title, current_status)
     effects = effect_type.to_h
     id_effects = effects.select { |k, _v| k.is_a?(Integer) }
     text_effects = effects.reject { |k, _v| k.is_a?(Integer) }
 
     if id_effects.empty?
-      output += "<label id='lblNone' value='No #{title.downcase} found.' top='0' left='0' align='center'/>"
-    else
-      id_effects.each do |sn, end_time|
-        stext = text_effects.shift[0]
-        duration = ((end_time - Time.now) / 60.to_f)
-        next if duration < 0
-
-        max_duration = Spell[sn].max_duration || 5
-        bar_value = ((duration / max_duration) * 100).to_i
-        output += "<progressBar id='#{sn}' value='#{bar_value}' text=\"#{stext}\" left='22%' top='#{top_value}' width='76%' height='15' time='#{format_time(duration)}'/><label id='l#{sn}' value='#{display_time(duration)} ' top='#{top_value}' left='0' justify='2' anchor_right='spell'/>"
-        top_value += 16
-      end
+      return "<dialogData id='#{title}' clear='t'></dialogData><dialogData id='#{title}'><label id='lblNone' value='No #{title.downcase} found.' top='0' left='0' align='center'/></dialogData>"
     end
+
+    output = "<dialogData id='#{title}' clear='t'></dialogData><dialogData id='#{title}'>"
+    top_value = 0
+
+    id_effects.each do |sn, end_time|
+      stext = text_effects.shift[0]
+      duration = ((end_time - Time.now) / 60.to_f)
+      next if duration < 0
+
+      max_duration = get_spell_max_duration(sn, stext)
+      bar_value = ((duration / max_duration) * 100).to_i
+      output += "<progressBar id='#{sn}' value='#{bar_value}' text=\"#{stext}\" left='22%' top='#{top_value}' width='76%' height='15' time='#{format_time(duration)}'/><label id='l#{sn}' value='#{display_time(duration)} ' top='#{top_value}' left='0' justify='2' anchor_right='spell'/>"
+      top_value += 16
+    end
+
     output += "</dialogData>"
     output
   end
 
-  def self.update_window
+  def self.update_windows
+    @@thread.kill if @@thread&.alive?  # Terminate the old thread
     @@thread = Thread.new do
       begin
+        window_to_effects = {
+          'active_spells' => Effects::Spells,
+          'buffs' => Effects::Buffs,
+          'debuffs' => Effects::Debuffs,
+          'cooldowns' => Effects::Cooldowns,
+          'missing_spells' => @my_buffs
+        }
+        update_intervals = {
+          'active_spells' => 60,
+          'buffs' => 5,
+          'debuffs' => 5,
+          'cooldowns' => 5
+        }
+        next_update_time = update_intervals.transform_values { |interval| Time.now + interval }
+        old_target_output = ''
+        last_sent_output = ''
+        window_outputs = {}
+        old_outputs = {
+          'active_spells' => '',
+          'buffs' => '',
+          'debuffs' => '',
+          'cooldowns' => '',
+          'missing_spells' => ''
+        }
+        
+        last_state = {
+          'active_spells' => {},
+          'buffs' => {},
+          'debuffs' => {},
+          'cooldowns' => {},
+          'missing_spells' => [],
+          'targets' => [],
+          'status' => {
+            'active_spells' => 'no spells',
+            'buffs' => 'no spells',
+            'debuffs' => 'no spells',
+            'cooldowns' => 'no spells',
+            'missing_spells' => 'no spells'
+          }
+        }
+
         loop do
+          now = Time.now
           output = ''
-          output += SpellWindow.build_output(Effects::Spells, 'Active Spells') if @show_spells
-          output += SpellWindow.build_output(Effects::Buffs, 'Buffs') if @show_buffs
-          output += SpellWindow.build_output(Effects::Debuffs, 'Debuffs') if @show_debuffs
-          output += SpellWindow.build_output(Effects::Cooldowns, 'Cooldowns') if @show_cooldowns
-          output += SpellWindow.missing_spells if @show_missing
-          puts(output)
-          sleep(1)
-        rescue StandardError => e
-          _respond("[ERROR] Exception in update_window: #{e.message}")
-          _respond(e.backtrace)
+
+          # target window, update asap on any change.
+          new_target_output = SpellWindow.target_window if @show_targets
+          if new_target_output == old_target_output
+            output += ''
+          else
+            output += new_target_output if new_target_output
+            old_target_output = new_target_output
+          end
+
+          # determine our current state
+          current_state = {}
+          window_to_effects.each do |window, effect_type|
+            if window == 'missing_spells'
+              current_state[window] = @my_buffs - Spell.active.map { |s| s.name }
+            else
+              # Use durations for other windows
+              current_state[window] = effect_type.to_h.transform_values { |end_time| (end_time - Time.now).to_i }
+            end
+          end
+
+          # state based updates
+          window_to_effects.keys.each do |window|
+            if window == 'missing_spells'
+              # Handle "missing_spells" specifically as an array comparison
+              missing_changed = current_state[window].sort != last_state[window]&.sort
+              if missing_changed
+                output += SpellWindow.missing_spells if @show_missing
+                last_state[window] = current_state[window].dup
+              end
+            else
+              status = current_state[window].empty? ? 'no spells' : 'active spells'
+              duration_increased = current_state[window].any? do |spell, duration|
+                duration > (last_state[window][spell] || 0)
+              end
+
+              if current_state[window].keys.map(&:to_s).sort != last_state[window].keys.map(&:to_s).sort ||
+                status != last_state['status'][window] || duration_increased
+                case window
+                when 'active_spells'
+                  output += SpellWindow.build_output(Effects::Spells, 'Active Spells', last_state['status']['active_spells']) if @show_spells
+                when 'buffs'
+                  output += SpellWindow.build_output(Effects::Buffs, 'Buffs', last_state['status']['buffs']) if @show_buffs
+                when 'debuffs'
+                  output += SpellWindow.build_output(Effects::Debuffs, 'Debuffs', last_state['status']['debuffs']) if @show_debuffs
+                when 'cooldowns'
+                  output += SpellWindow.build_output(Effects::Cooldowns, 'Cooldowns', last_state['status']['cooldowns']) if @show_cooldowns
+                when 'missing_spells'
+                  output += SpellWindow.missing_spells
+                end
+
+                # update the state
+                last_state[window] = current_state[window].dup
+                last_state['status'][window] = status
+              end
+            end
+          end
+
+          # timer based updates
+          update_intervals.each do |window, interval|
+            # idea for urgent was when spells get below a certain duration, we speed up the updates to make them real time.
+            # but it may cause memory to build up to fast since wrayth doesn't take out the trash.
+            # urgent = %w[buffs debuffs cooldowns].include?(window) && window_to_effects[window].to_h.values.any? { |end_time| (end_time - Time.now) <= 8 }
+            next if now < next_update_time[window]
+            # next_update_time[window] = now + (urgent ? 1 : interval) if now >= next_update_time[window]
+            next_update_time[window] = now + interval if now >= next_update_time[window]
+
+            case window
+            when 'active_spells'
+              window_outputs[window] = SpellWindow.build_output(Effects::Spells, 'Active Spells', last_state['status']['active_spells']) if @show_spells
+            when 'buffs'
+              window_outputs[window] = SpellWindow.build_output(Effects::Buffs, 'Buffs', last_state['status']['buffs']) if @show_buffs
+            when 'debuffs'
+              window_outputs[window] = SpellWindow.build_output(Effects::Debuffs, 'Debuffs', last_state['status']['debuffs']) if @show_debuffs
+            when 'cooldowns'
+              window_outputs[window] = SpellWindow.build_output(Effects::Cooldowns, 'Cooldowns', last_state['status']['cooldowns']) if @show_cooldowns
+            end
+
+            if window_outputs[window] != old_outputs[window]
+              output += window_outputs[window]
+              old_outputs[window] = window_outputs[window]
+            end
+          end
+
+          if output != last_sent_output
+            wait_while { Script.running?("go2")}
+            puts(output) unless output.empty?
+            echo(output) unless output.empty? if @debug
+            last_sent_output = output
+          else
+          end
+          sleep(0.1)
         end
+      rescue StandardError => e
+        _respond("[ERROR] Exception in update_window: #{e.message}")
+        _respond(e.backtrace)
       end
     end
   end
 
-  def self.check_line(xml_line)
-    return nil if @@MAX_CHECK.match?(xml_line)
-    return xml_line
-  end
-
+  # processing commands from upstream
   def self.command(args)
     action, arg = args.split(' ')
     action = action.downcase
     unless action
-      SpellWindow.update_window
+      SpellWindow.update_windows
     else
       if action == 'help'
         puts('<output class="mono"/>')
@@ -236,6 +492,8 @@ module SpellWindow
           ['list',           'List spells you are currently tracking.'],
           ['quickload',      'Adds all of your currently worn (+ known) spells to the list.'],
           ['combat',         'Toggle combat window feed. Enable if you use the combat window to click.'],
+          ['targets',        'Toggle targets window.'],
+          ['arms',           'Show Grasp of the Grave arm count in the target window.'],
           ['settings',       'Lists current settings.'],
         ].each { |cmd_pair|
           puts(
@@ -255,6 +513,8 @@ module SpellWindow
         puts("      Cooldowns   #{@show_cooldowns}")
         puts(" Missing Spells   #{@show_missing}")
         puts("         Combat   #{!@block_combat}")
+        puts("        Targets   #{@show_targets}")
+        puts("      Arm Count   #{@show_arms}")
         puts("")
         puts('<output class=""/>')
         SpellWindow.my_buffs
@@ -294,8 +554,19 @@ module SpellWindow
         puts(@show_missing ? 'Missing spells window enabled' : 'Missing spells window disabled')
         puts("<closeDialog id='Missing Spells'/><openDialog type='dynamic' id='Missing Spells' title='Missing Spells' target='Missing Spells' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Missing Spells'></dialogData></openDialog>") if @show_missing
         puts("<closeDialog id='Missing Spells'/>") if !@show_missing
+      elsif action == 'targets'
+        @show_targets = !@show_targets
+        puts(@show_targets ? 'Targets window enabled' : 'Targets window disabled')
+        puts("<closeDialog id='Target Window'/><openDialog type='dynamic' id='Target Window' title='Target Window' target='Target Window' scroll='manual' location='main' justify='3' height='68' resident='true'><dialogData id='Target Window'></dialogData></openDialog>") if @show_targets
+        puts("<closeDialog id='Target Window'/>") if !@show_targets
+      elsif action == 'arms'
+        @show_arms = !@show_arms
+        puts(@show_arms ? 'Grasp of the Grave arms will display in target window' : 'Grasp of the Grave arms will not display in target window')
+      elsif action == 'debug'
+        @debug = !@debug
+        puts(@show_targets ? 'Debug enabled' : 'Debug disabled')
       else
-        SpellWindow.update_window
+        SpellWindow.update_windows
       end
     end
   end
@@ -307,9 +578,10 @@ module SpellWindow
       SpellWindow.command(command)
     end
   end
-
+  
   SpellWindow.initialize_script
-  CMD_QUEUE.push(Script.current.vars[0] || 'update_window')
+  update_windows
+  CMD_QUEUE.push(Script.current.vars[0])
 
   loop {
     SpellWindow.processQueue

--- a/scripts/SpellWindows.lic
+++ b/scripts/SpellWindows.lic
@@ -49,25 +49,6 @@ module SpellWindow
     QUICKBAR = %r{<openDialog id="quick" location="quickBar"}
     QUICKBAR_SWITCH = %r{<switchQuickBar id="quick"/>}
     GRASP_ARMS = %r{(?:arm|appendage|claw|limb|pincer|tentacle|palpus|palpi)s?}
-
-    attr_reader :regex
-    
-    def initialize(regex)
-      @regex = regex
-    end
-
-    def match(input)
-      regex.match(input)
-    end
-
-    def match?(input)
-      !!regex.match(input)
-    end
-
-    def extract(input)
-      match_data = regex.match(input)
-      match_data ? match_data.captures : []
-    end
   end
   
   CMD_QUEUE = Queue.new


### PR DESCRIPTION
Pretty big refactor to resolve some hidden issues.

Target window is back in as an option, was able to get it to update instantly. Missing spells updates instantly as well.

Windows now update dynamically. Updates when a spell is added/removed and every 5s for buff/debuff/cooldown, every 60 for active spells window.

Was testing buff/debuff/cooldown windows updating every second when a duration gets below say 10s, but if you're someone that has 10+ buffs while hunting, it hits the FE pretty hard. Wish Wrayth was able to do some garbage colelction ...