### PR TITLE
[ecaster.lic] v1.1.1 bugfix ecaster hide option

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -6,10 +6,11 @@
           tags: magic, spell, casting
           game: gs
       required: Lich > 5.7.0
-       version: 1.1.0
+       version: 1.1.1
 
   Version Control:
     Major_change.feature_addition.bugfix
+      1.1.1: bugfix in hide option setting for existing ecaster users not working
       1.1.0: hide after casting spell from hide list
       1.0.2: bugfix for rapid fire channel 0sec RT casting
       1.0.1: change checkmana to Char.mana calls
@@ -35,6 +36,7 @@ module ECaster
   @@options = CharSettings[:options] || {
     channel: false, conserve: false, safety: false, stance: false, hide: false
   }
+  @@options[:hide] ||= false
   @@hide = CharSettings[:hide] || []
   @@mantle = CharSettings[:mantle] || {}
 


### PR DESCRIPTION
Existing characters that have ran ecaster would not get the hash key `:hide` in `CharSettings[:options]` set due to hash already existing. This stuffs it in if it's missing due to that