### PR TITLE
[ecaster.lic] v1.1.2 bugfix change hide_me variable to hide_after_cast

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -6,10 +6,11 @@
           tags: magic, spell, casting
           game: gs
       required: Lich > 5.7.0
-       version: 1.1.1
+       version: 1.1.2
 
   Version Control:
     Major_change.feature_addition.bugfix
+      1.1.2: bugfix change hide_me variable to hide_after_cast to not conflict with Lich5 method hide_me
       1.1.1: bugfix in hide option setting for existing ecaster users not working
       1.1.0: hide after casting spell from hide list
       1.0.2: bugfix for rapid fire channel 0sec RT casting
@@ -387,9 +388,9 @@ module ECaster
     end
 
     if @@options[:hide] && @@hide.include?(spell_number.to_i)
-      hide_me = true
+      hide_after_cast = true
     else
-      hide_me = false
+      hide_after_cast = false
     end
 
     if checkcastrt > 0
@@ -438,7 +439,7 @@ module ECaster
       result = dothistimeout "stance #{stance}", 2, STANCE_RX until result =~ STANCE_RX
     end
 
-    put "hide" if hide_me
+    put "hide" if hide_after_cast
   end
 
   ECaster.prompt


### PR DESCRIPTION
Avoid usage of top-level Lich5 method `hide_me` and instead use new variable `hide_after_cast` instead.