### PR TITLE
[effect-list.xml] self-cast duration and cost update

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -1177,8 +1177,8 @@
       <cost type='mana'>5</cost>
    </spell>
    <spell availability='self-cast' name='Empathic Focus' number='1109' type='offense/defense'>
-      <duration span='stackable' multicastable='yes'>20 + Spells.empath</duration>
-      <cost type='mana'>9 + [(([Spells.empath,Stats.level].min - 9) / 6.0).round,0].max</cost>
+      <duration span='stackable' multicastable='yes'>(Spell[1109].known? ? 120 : 20) + Spells.empath</duration>
+      <cost type='mana'>9</cost>
       <bonus type='physical-as'>15</bonus>
       <bonus type='bolt-ds'>[25+(([Stats.level,Spells.empath].min-9)/2),25].max</bonus>
       <bonus type='physical-ds'>[25+(([Stats.level,Spells.empath].min-9)/2),25].max</bonus>


### PR DESCRIPTION
Buff Spells Update

The following changes have been made to self-cast buff spells which previously had a minimum duration of 20 minutes:

* Minimum duration has been increased to 2 hours. Spell ranks will continue to increase this duration at 60 seconds per rank.
* Dynamic mana costs have been removed. As an example, 307 might previously cost 50 or more mana, depending on spell training, and will now always cost 7 mana.
* All characters will receive one free use of MANA SPELLUP per day, regardless of Mana Control training.