### PR TITLE
[go2.lic] v.2.2.4 bugfix gs4 vaalor shortcut

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,13 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.2.3
+           version: 2.2.4
           required: Lich >= 5.4.1
 
    changelog:
+      2.2.4 (2025-01-04)
+        Bugfix GS4 Vaalor shortcut prevent usage unless checked
+        Add tooltip for GUI on vaalor shortcut checkbox that climbing/swimming is recommended to be trained
       2.2.3 (2024-12-28)
         Additional stand messaging and fix for pedal boarding
       2.2.2 (2024-11-18)
@@ -480,6 +483,7 @@ module Go2
           load_settings
           self['main'].keep_above = true
           self['main'].set_title "Go2 Setup v#{Go2.get_script_version}"
+          self['use_vaalor_shortcut'].tooltip_text = 'Sets if the shortcut to Ta\'Vaalor should be used. (climbing and/or simming needed)'
           # connect signals after settings are loaded to a bunch of handlers don't trigger
           connect_signals { |handler| method(handler) }
         end
@@ -901,8 +905,8 @@ module Go2
         Room[16745].timeto['16746'] = 15
         Room[16746].timeto['16745'] = 15
       else
-        Room[16745].timeto['16746'] = 15000
-        Room[16746].timeto['16745'] = 15000
+        Room[16745].timeto['16746'] = nil
+        Room[16746].timeto['16745'] = nil
       end
     end
   }


### PR DESCRIPTION
Force pathing for vaalor shortcut to be NIL so that it can not be used unless shortcut setting is enabled.