### PR TITLE
[eherbs.lic] v2.0.18 min_stock_doses bugfix

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -14,9 +14,11 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 4.6.0
-           version: 2.0.17
+           version: 2.0.18
+  2.0.18 (2025-01-06)
+    - fix for min_stock_doses to persist thru current session running
   2.0.17 (2025-01-06)
-    - fix for survival kit to persist thru current session running
+    - fix for survival_kit to persist thru current session running
     - fix for not being able to analyze kit during distill function
   2.0.16 (2024-12-06)
     - add additional debug messaging
@@ -71,6 +73,27 @@
 module EHerbs
   @@data ||= nil
   @@survival_kit ||= nil
+  @@min_stock_doses ||= {
+    'major head scar'   => 6,
+    'minor head wound'  => 4,
+    'major nerve wound' => 4,
+    'minor organ scar'  => 4,
+    'major organ scar'  => 6,
+    'missing eye'       => 7,
+    'blood'             => 50,
+    'major head wound'  => 25,
+    'minor head scar'   => 25,
+    'major organ wound' => 25,
+    'minor organ wound' => 25,
+    'major limb wound'  => 25,
+    'minor limb wound'  => 25,
+    'major limb scar'   => 25,
+    'minor limb scar'   => 25,
+    'severed limb'      => 25,
+    'minor nerve wound' => 25,
+    'major nerve scar'  => 25,
+    'minor nerve scar'  => 25
+  }
 
   def self.survival_kit
     @@survival_kit
@@ -78,6 +101,14 @@ module EHerbs
 
   def self.survival_kit=(value)
     @@survival_kit = value
+  end
+
+  def self.min_stock_doses
+    @@min_stock_doses
+  end
+
+  def self.min_stock_doses=(value)
+    @@min_stock_doses = value
   end
 
   def self.data
@@ -307,27 +338,7 @@ module EHerbs
 
     settings_hash[:cant_bundle] = /tart|feather|special|blubber|pie|porridge|soup|fruit/i
 
-    settings_hash[:min_stock_doses] = {
-      'major head scar'   => 6,
-      'minor head wound'  => 4,
-      'major nerve wound' => 4,
-      'minor organ scar'  => 4,
-      'major organ scar'  => 6,
-      'missing eye'       => 7,
-      'blood'             => 50,
-      'major head wound'  => 25,
-      'minor head scar'   => 25,
-      'major organ wound' => 25,
-      'minor organ wound' => 25,
-      'major limb wound'  => 25,
-      'minor limb wound'  => 25,
-      'major limb scar'   => 25,
-      'minor limb scar'   => 25,
-      'severed limb'      => 25,
-      'minor nerve wound' => 25,
-      'major nerve scar'  => 25,
-      'minor nerve scar'  => 25
-    }
+    settings_hash[:min_stock_doses] = EHerbs.min_stock_doses
 
     # 5 main areas: 'head', 'neck', 'torso', 'limbs', 'nerves'
     # Wound method => herb area
@@ -2621,11 +2632,13 @@ module EHerbs
         amount = (t_amount * (EHerbs.data[:stock] / 100)).to_i
         EHerbs.data[:min_stock_doses].each do |k, _v|
           EHerbs.data[:min_stock_doses][k] = amount
+          EHerbs.min_stock_doses[k] = amount
         end
       else
         EHerbs.data[:min_stock_doses].each do |k, v|
           amount = (v.to_f * (EHerbs.data[:stock] / 100)).to_i
           EHerbs.data[:min_stock_doses][k] = amount
+          EHerbs.min_stock_doses[k] = amount
         end
       end
     end


### PR DESCRIPTION
Due to change of having survival_kit persist in current play session, min_stock_doses was getting set back to default low values, changed to make persist thru play sessions.