### PR TITLE
[go2.lic] v2.2.6 bugfix for checksleeping & checkbound in DR

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.2.5
+           version: 2.2.6
           required: Lich >= 5.4.1
 
    changelog:
+      2.2.6 (2025-01-18)
+        Bugfix for checksleeping & checkbound not available in DR
       2.2.5 (2025-01-14)
         Ungate hide_room_descriptions and hide_room_titles for DR again
       2.2.4 (2025-01-04)
@@ -2084,8 +2086,8 @@ module Go2
 
       exit if dead?
       if muckled?
-        echo("You're currently sleeping! Waiting until you're no longer sleeping!") if checksleeping
-        echo("You're currently bound! Waiting until you're no longer bound!") if checkbound
+        echo("You're currently sleeping! Waiting until you're no longer sleeping!") if XMLData.game =~ /^GS/ && checksleeping
+        echo("You're currently bound! Waiting until you're no longer bound!") if XMLData.game =~ /^GS/ && checkbound
         echo("You're currently stunned! Waiting until you're no longer stunned!") if checkstunned
         echo("You're currently webbed! Waiting until you're no longer webbed!") if checkwebbed
         wait_while { muckled? }


### PR DESCRIPTION
`checksleeping` & `checkbound` are unavailable in DR, gate behind GS `XMLData.game`