### PR TITLE
[gameobj-data.xml] fix wind witch nose bundles

### DIFF
--- a/type_data/migrations/9_skin_fixes.rb
+++ b/type_data/migrations/9_skin_fixes.rb
@@ -7,7 +7,8 @@ migrate :skin, :furrier do
   insert(:name, %{brown boar hide})
   insert(:name, %{moor eagle talon})
   insert(:name, %{mountain snowcat pelt})
-  insert(:name, %{(?:crooked )?witch nose})     # from wind witch
+  delete(:name, %{crooked witch nose})      # fix for crooked witch nose bundles
+  insert(:name, %{(?:crooked )?witch nose}) # fix for crooked witch nose bundles
 end
 
 migrate :skin, :furrier do


### PR DESCRIPTION
Wind witch skins are a "crooked witch nose" and are recognized as skins.  When bundled, they become "a bundle of witch noses" and are no longer recognized as skins.