### PR TITLE
[showexits.lic] v1.0.0 initial creation on EO

### DIFF
--- a/scripts/showexits.lic
+++ b/scripts/showexits.lic
@@ -1,9 +1,9 @@
 =begin
 
   showexits.lic: show current mapdb exits for room, with clickable links for FEs that support it.
-  
+
   Can be passed a LichID or RealID(uid) to get that room's exits.
-  
+
   Examples:
     ;showexits 228
     ;showexits u3003
@@ -11,7 +11,7 @@
 
         author: elanthia-online
           game: any
-          tags: mapdb, exits, paths, 
+          tags: mapdb, exits, paths, stringprocs
        version: 1.0.0
       required: Lich >= 5.6.2
 


### PR DESCRIPTION
show all exits in room, properly sorted by cardinal directions, pathing, then StringProcs. Clickable links supported for FEs that work with it.