### PR TITLE
fix(eloot.lic): v2.1.5 bugfix for hoarding inventory

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -14,9 +14,11 @@
               wiki: https://gswiki.play.net/Lich:Script_Eloot
               game: Gemstone
               tags: loot
-           version: 2.1.4
+           version: 2.1.5
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.1.5  (2025-02-07)
+    - bugfix for hoarding inventory when using a family vault
   v2.1.4  (2025-01-25
     - rework coin bag logic to reduce excessive inspect calls
   v2.1.3  (2025-01-24)
@@ -3755,6 +3757,7 @@ module ELoot
       case ELoot.data.cache
       when /trunk/i
         start_from = "bound in wrought iron"
+        is_family_vault = true
       when /chest/i
         start_from = "deep chest"
       when /rack/i
@@ -3773,6 +3776,7 @@ module ELoot
       start_index = lines.index { |line| line.include?(start_from) }
       end_index = lines[start_index + 1..-1].index('') + start_index + 1
       extracted_elements = lines[(start_index + 1)...end_index]
+      extracted_elements = lines if is_family_vault
 
       empty_jars = lines.count { |line| line.match?(/(?:jar|bottle|beaker)/) && !line.include?("containing") }
       if empty_jars.positive?


### PR DESCRIPTION
Fixes a bug with building the hoarding inventory when using a family vault as the container