### PR TITLE
[bigshot.lic] v5.8.2 bugfix run_script exact name match

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.8.1
+       version: 5.8.2
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.8.2  (2025-02-26)
+    - bugfix in run_script needing EXACT match for Script.running? check. Script.start is not exact. Causing issues
   v5.8.1  (2025-02-26)
     - add garrote command to buffXX command check validity for Enh. Agility buff
     - add garrote command check for active buff check
@@ -4998,7 +5000,7 @@ class Bigshot
       if name == @LOOT_SCRIPT && @BOX_IN_HAND
         looting_watch
       else
-        wait_until { !Script.running?(name) }
+        wait_until { !Script.running?("--------$|#{name}|^--------") }
       end
     end
   end

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,6 +19,7 @@
     Major_change.feature_addition.bugfix
   v5.8.2  (2025-02-26)
     - bugfix in run_script needing EXACT match for Script.running? check. Script.start is not exact. Causing issues
+    - bugfix in command_check split_check
   v5.8.1  (2025-02-26)
     - add garrote command to buffXX command check validity for Enh. Agility buff
     - add garrote command check for active buff check

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3036,7 +3036,7 @@ class Bigshot
       command = $1.strip
 
       $2.split(" ").each { |s|
-        if s =~ /((?:!?e|!?h|!?k|!?m|!?mob!?s|!?tier|!?v))(\d+)/i
+        if s =~ /((?:!?e|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v))(\d+)/i
           amount = $2.to_i
           split_item = $1.strip
 


### PR DESCRIPTION
Issue with resting scripts when using partial name. IE eherb instead of eherbs. `Script.running?` is exact regex match. To get around this, we fool the regex search of the name. This should prevent any issue as long as no script named "--------.lic" is running.