### PR TITLE
[eloot.lic] v2.2.2 bugfix in Region.in_region for HW

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.8.0
-           version: 2.2.1
+           version: 2.2.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.2.2  (2025-02-28)
+    - bugfix in Region.in_region for HW/Cold River
   v2.2.1  (2025-02-26)
     - bugfix in check_bounty_gems using furrier instead of gemshop
     - bugfix for neck sheath containers not populating contents
@@ -2199,6 +2201,7 @@ module ELoot # Regional bounty Selling
       boundaries = [10119, 1014, 991, 6274]
 
       bounty_town = Bounty.town
+      bounty_town = "Hinterwilds" if bounty_town == "Cold River"
 
       place = self.tag_for_town(bounty_town, place).id
       path = Room.current.path_to(Room[place])


### PR DESCRIPTION
Hinterwilds furrier (possibly gemshop) bounties have `Bounty.town` as showing for "Cold River" which is not a tagged entry for mapdb town lookup. Substitute to Hinterwilds so can be found properly