### PR TITLE
Add support for saving go2 targets using a uid

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.2.6
+           version: 2.2.7
           required: Lich >= 5.4.1
 
    changelog:
+      2.2.7 (2025-03-02)
+        Added support for using go2 save with uids
       2.2.6 (2025-01-18)
         Bugfix for checksleeping & checkbound not available in DR
       2.2.5 (2025-01-14)
@@ -1073,6 +1075,25 @@ module Go2
     if target_name =~ /^\d+$/
       echo "error: target name can't be just a number."
       exit
+    end
+    #if any of the targets is a real room id (u number), find the lich ID to use instead
+    if target.any?(/^u\d+$/i)
+      #target could be multiples, so for each target
+      target.each do |roomtarget|
+         if roomtarget =~ /^u\d+$/i  #if this room matches a real id pattern
+            # find the lich id from the real id, could match multiples, so use first
+            newtarget = Map.ids_from_uid(roomtarget[1..-1].to_i).first.to_s
+
+            #see if the lich id target is already present
+            if target.any?(newtarget)
+               #delete the u value, the lich id is already present
+               target.delete_if {|x| x == roomtarget}
+            else
+               #replace the u value with the lich id
+               target = target.map { |x| x == roomtarget ? newtarget : x}
+            end
+         end
+      end
     end
     # User included current room as a custom target. Verify exists.
     if target.include?(/current/i)


### PR DESCRIPTION
Added support for including uids when saving targets.  The code will convert input uids to lich ids and save them.