### PR TITLE
fix(bigshot): v5.8.3 detect run_script name better

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.8.2
+       version: 5.8.3
       required: Lich >= 5.5.0, infomon >= 1.18.11
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.8.3  (2025-03-10)
+    - bugfix in run_script to use exact naming of script that was started
   v5.8.2  (2025-02-26)
     - bugfix in run_script needing EXACT match for Script.running? check. Script.start is not exact. Causing issues
     - bugfix in command_check split_check
@@ -4995,13 +4997,15 @@ class Bigshot
       Script.kill(name)
       wait_while { Script.running?(name) }
     end
-
-    Script.start(name, args)
+    
+    script_ran = Script.start(name, args)
+    return if script_ran.nil?
+    return unless script_ran.name.is_a?(String) && !script_ran.name.empty?
     if pause_bigshot
       if name == @LOOT_SCRIPT && @BOX_IN_HAND
-        looting_watch
+        looting_watch(script_ran)
       else
-        wait_until { !Script.running?("--------$|#{name}|^--------") }
+        wait_until { !Script.running?(script_ran) }
       end
     end
   end
@@ -5761,17 +5765,17 @@ class Bigshot
     end
   end
 
-  def looting_watch
+  def looting_watch(script_ran)
     loop do
-      break if Script.paused?(@LOOT_SCRIPT)
-      break if !Script.running?(@LOOT_SCRIPT)
+      break if Script.paused?(script_ran.name)
+      break if !Script.running?(script_ran.name)
       sleep 0.1
     end
 
     box_in_hand = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type =~ /box/ }
-    if Script.paused?(@LOOT_SCRIPT) && box_in_hand
+    if Script.paused?(script_ran.name) && box_in_hand
       $bigshot_should_rest = true
-      Script.kill(@LOOT_SCRIPT)
+      Script.kill(script_ran.name)
     end
   end
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -4997,7 +4997,7 @@ class Bigshot
       Script.kill(name)
       wait_while { Script.running?(name) }
     end
-    
+
     script_ran = Script.start(name, args)
     return if script_ran.nil?
     return unless script_ran.name.is_a?(String) && !script_ran.name.empty?

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -5005,7 +5005,7 @@ class Bigshot
       if name == @LOOT_SCRIPT && @BOX_IN_HAND
         looting_watch(script_ran)
       else
-        wait_until { !Script.running?(script_ran) }
+        wait_until { !Script.running?(script_ran.name) }
       end
     end
   end


### PR DESCRIPTION
Restores original functionality of ensuring that the exact name of the script started is what is used in the Script.paused/running checks, which should prevent accidental matching against other similar named running scripts.