### PR TITLE
fix(version.lic): v1.1.4 Account for dependency running or not in DR

### DIFF
--- a/scripts/version.lic
+++ b/scripts/version.lic
@@ -5,10 +5,12 @@
   contributors: LostRanger, Doug, Tysong
           game: gs
           tags: utility, version
-       version: 1.1.3
+       version: 1.1.4
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.4 (2025-03-27)
+    - fix for autostart list  when dependency isn't running in DR
   v1.1.3 (2024-08-25)
     - fix for autostart list to not be hardcoded to GSIV
   v1.1.2 (2024-07-10)
@@ -250,7 +252,7 @@ module VersionScript
       unless Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), "#{XMLData.game}:#{XMLData.name}".encode('UTF-8')).nil?
         report["Autostart #{Char.name}"] = Marshal.load(Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), "#{XMLData.game}:#{XMLData.name}".encode('UTF-8')))['scripts'].map { |hash| hash[:name] }.join(', ')
       end
-      report["DR autostarts"]          = list_autostarts.join(', ') if XMLData.game =~ /^DR/
+      report["DR autostarts"]          = (XMLData.game =~ /^DR/ && Script.running?('dependency')) ? list_autostarts.join(', ') : "Dependency not running"
       report["Running scripts"]        = Script.list.map { |x| x.name }.join(', ')
       report["Downstream hooks"]       = (defined?(DownstreamHook.hook_sources) ? DownstreamHook.hook_sources.map { |k, v| "#{v}(#{k})" }.join(', ') : DownstreamHook.list.join(', '))
       report["Upstream hooks"]         = (defined?(UpstreamHook.hook_sources) ? UpstreamHook.hook_sources.map { |k, v| "#{v}(#{k})" }.join(', ') : UpstreamHook.list.join(', '))


### PR DESCRIPTION
As per title.

Dependency running and well is well
```
DR autostarts.............: esp, smartlisten, tarantula, afk, sorter, exp-monitor, textsubs, slacker, tdps, buff-watcher, trigger-watcher, moonwatch, play, almanac, sanowret-crystal
```
Dependency not running:
```
DR autostarts.............: Dependency not running
```