### PR TITLE
[log_search.lic] bug fix

### DIFF
--- a/scripts/log_search.lic
+++ b/scripts/log_search.lic
@@ -8,7 +8,7 @@
     searcharraylog.yaml      - log of every line it matched that can be used to verify results
     SearchDataFromLogs.yaml  - contains the count data
 
-  ;log_search <folder> <options>
+  ;log_search "<folder>" <options>     quotes are not required
   ;log_search C:/Gemstone/Lich5/logs/GSIV-Nisugi/2024/08/ <options>
 
   options being:
@@ -24,6 +24,9 @@
        version: 1.1
 
   Change Log:
+  v1.2 (2025-03-27)
+    - disables timestamps if no timestamps detected instead of erroring
+    - fixed error caused by old error messages in logs
   v1.1 (2025-03-24)
     - added mug for searches
     - removed ascension check on finds
@@ -54,7 +57,7 @@ module LogSearch
     echo "Please install the above gem(s) to run ;#{Script.current.name}"
     exit
   end
-
+  respond("Input: #{Script.current.vars[0]}")
   game_dir = File.join(DATA_DIR, XMLData.game)
   char_dir = File.join(game_dir, Char.name)
   @filename  = File.join(char_dir, "SearchDataFromLogs.yaml")
@@ -79,7 +82,7 @@ module LogSearch
   @scrape_data = {} if Script.current.vars[0] =~ /--reset/
 
   @scrape_data                              ||= {}
-  @scrape_data[:silent]                     ||= true
+  @scrape_data[:silent]                       = true unless @scrape_data[:silent] == false
   @scrape_data[:last_week_reset]            ||= nil
   @scrape_data[:creature]                   ||= "none"
   @scrape_data[:room]                       ||= nil
@@ -100,12 +103,12 @@ module LogSearch
   @scrape_data[:lock_key_found]             ||= {}
   @scrape_data[:feeder_found]               ||= {}
   @scrape_data[:legendary_found]            ||= {}
-  @scrape_data[:quest_complete]             ||= false
-  @debug                                    = false
-  @has_timestamps                           = true
-  @base_date                                = nil
-  @next_reset                               = nil
-  @default_tz                               = Time.now.zone
+  @scrape_data[:quest_complete]               = false unless @scrape_data[:quest_complete]
+  @debug                                      = false
+  @has_timestamps                             = true
+  @base_date                                  = nil
+  @next_reset                                 = nil
+  @default_tz                                 = Time.now.zone
 
   @has_timestamps = false if Script.current.vars[0] =~ /--no-timestamps?/
   @scrape_data[:quest_complete] = true if Script.current.vars[0] =~ /--quest-complete/
@@ -193,7 +196,10 @@ module LogSearch
         time_obj = Time.strptime("#{file_date} #{time_str}", "%Y-%m-%d %H:%M:%S")
       end
     else
-      raise ArgumentError, "Unrecognized timestamp format: #{log_time}"
+      #raise ArgumentError, "Unrecognized timestamp format: #{log_time}"
+      respond("Unrecognized timestamp format or missing formats. Enabling to --no-timestamps")
+      @has_timestamps = false
+      return 1
     end
     time_obj = time_obj.utc
     time_obj.to_i
@@ -218,6 +224,7 @@ module LogSearch
   end
 
   def self.maybe_reset_weekly_counter(current_log_timestamp)
+    return unless @has_timestamps
     eastern = TZInfo::Timezone.get("America/New_York")
     @scrape_data[:weekly_counts] ||= {}
 
@@ -240,10 +247,15 @@ module LogSearch
 
   $search_array_log = []
   respond("Parsing files.")
+  respond("File Location: #{file_location}") if @debug
+  exit if file_location.nil? 
 
   Dir.glob(file_location).each do |file|
     file_date = File.basename(file).gsub(/_.+\.log/, "") if @has_timestamps
-    buffer = File.readlines(file).map(&:chomp)
+
+    #buffer = File.readlines(file).map(&:chomp)
+    buffer = File.binread(file).lines.map { |line| line.force_encoding("UTF-8").scrub.chomp }
+
     $search_array_log.append(file)
     respond("Parsing #{file}") if @debug
 


### PR DESCRIPTION
Force utf8 encoding on the lines because error messages from the logs cause parsing errors from wrong encoding.

When invalid timestamp format is detected it flips the no-timestamp flag and continues.