### PR TITLE
[Killtracker.lic] change output to weekly searches

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -17,9 +17,16 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 1.2
+       version: 1.5
 
 Change Log:
+  v1.5
+    - corrected displays to only show weekly searches for gem.
+  v1.4
+    - fix summary report output when no finds yet.
+  v1.3 
+    - fix announce toggle to not reset
+    - insert command to queue on launch
   v1.2 (2025-03-24)
     - mug support
   v1.1 (2025-03-24)
@@ -78,9 +85,9 @@ module Killtracker
   $killtracker[:lock_key_found]             ||= {}
   $killtracker[:feeder_found]               ||= {}
   $killtracker[:legendary_found]            ||= {}
-  $killtracker[:silent]                     ||= true
-  $killtracker[:last_week_reset]            ||= nil
-  $killtracker[:cached_reset_time]          ||= nil
+  $killtracker[:silent]                       = true if $killtracker[:silent].nil?
+  $killtracker[:last_week_reset]            ||= 0
+  $killtracker[:cached_reset_time]          ||= 0
   File.write(@filename, $killtracker.to_yaml)
 
   def self.help
@@ -107,7 +114,7 @@ module Killtracker
   def self.maybe_reset_weekly_counter
     eastern = TZInfo::Timezone.get("America/New_York")
     $killtracker[:weekly_counts] ||= {}
-    while Time.now.to_i >= $killtracker[:cached_reset_time] && ($killtracker[:last_week_reset].nil? || $killtracker[:last_week_reset] < $cached_reset_time)
+    while Time.now.to_i >= $killtracker[:cached_reset_time] && ($killtracker[:last_week_reset] == 0 || $killtracker[:last_week_reset] < $killtracker[:cached_reset_time])
       finished_week = eastern.to_local(Time.at($killtracker[:cached_reset_time] - 7 * 86400)).strftime("%U").to_i
       $killtracker[:weekly_counts][:"week_#{finished_week}_ascension_searches"] = $killtracker[:weekly_ascension_searches]
       $killtracker[:weekly_ascension_searches] = 0
@@ -135,7 +142,7 @@ module Killtracker
 
     # Set up headings based on event type
     if event_type =~ /jewel/
-      headings = ["Time", "Since", "Week", "Creature", "Name"]
+      headings = ["Time", "Week", "Creature", "Name"]
     else
       headings = ["Time", "Searches", "Creature", "Name"]
     end
@@ -148,7 +155,6 @@ module Killtracker
       if event_type =~ /jewel/
         [
           formatted_time,
-          event[:searches_since] || 0,
           event[:searches_week]  || 0,
           event[:creature]       || "",
           event[:name]           || ""
@@ -170,7 +176,7 @@ module Killtracker
   def self.summary_report
     groups = {
       "Gemstones & Dust" => [
-        { key: :jewel_found,     label: "Gemstone",  since: :searches_since_jewel },
+        { key: :jewel_found,     label: "Gemstone",  since: :weekly_ascension_searches },
         { key: :dust_found,      label: "Dust",      since: :searches_since_dust },
         { key: :idol_found,      label: "Idol",      since: :searches_since_idol }
       ],
@@ -186,9 +192,14 @@ module Killtracker
     }
 
     groups.each do |group_name, events|
-      group_total = events.sum { |evt| ($killtracker[evt[:key]] || {}).size }
+      if group_name == "Gemstones & Dust"
+        group_total = $killtracker[:ascension_searches] || 0
+      else
+        group_total = events.sum { |evt| ($killtracker[evt[:key]] || {}).size }
+      end
+    
       next if group_total == 0
-
+    
       respond "   === #{group_name} ==="
       if group_name == "Gemstones & Dust"
         asc_searches  = $killtracker[:ascension_searches] || 0
@@ -196,22 +207,22 @@ module Killtracker
         respond " #{format('%6d', asc_searches)}: Total Ascension Searches"
         respond " #{format('%6d', weekly_asc)}: Weekly Ascension Searches"
       end
-
+    
       events.each do |evt|
         event_hash = $killtracker[evt[:key]] || {}
         count = event_hash.size
         next if count == 0
-
+    
         if group_name == "Gemstones & Dust"
           avg = count > 0 ? ($killtracker[:ascension_searches].to_f / count) : 0
         else
           search_counts = event_hash.values.map { |data| data[:searches].to_i }
           avg = count > 0 ? search_counts.sum.to_f / count : 0
         end
-
+    
         since = $killtracker[evt[:since]] || 0
         found_label = pluralize(evt[:label], count)
-
+    
         respond " #{format('%6d', count)}: #{found_label} Found"
         respond " #{format('%6d', since)}: Since last #{evt[:label]}"
         respond " #{format('%6d', avg.to_i)}: Avg per #{evt[:label]}"
@@ -219,6 +230,7 @@ module Killtracker
       end
       respond ""
     end
+    
   end
 
   def self.gemstones_report
@@ -245,7 +257,7 @@ module Killtracker
       rows = sorted_events.map do |event|
         event_time = eastern.to_local(Time.at(event[:timestamp]))
         formatted_time = event_time.strftime("%m/%d %H:%M:%S")
-        searches = (event[:type] == "Jewel") ? (event[:searches_since] || 0) : (event[:searches] || 0)
+        searches = (event[:type] == "Jewel") ? (event[:searches_week] || 0) : (event[:searches] || 0)
         [
           formatted_time,
           event[:type],
@@ -327,7 +339,7 @@ module Killtracker
       name = Regexp.last_match[:name]
       room = Room.current.id
       $killtracker[:jewel_found][key] = { searches_since: $killtracker[:searches_since_jewel], searches_week: $killtracker[:weekly_ascension_searches], name: name, room: room, creature: $killtracker[:creature] }
-      report = "jewel_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_jewel]}:#{$killtracker[:weekly_ascension_searches]}"
+      report = "jewel_found_#{$killtracker[:creature]}:#{$killtracker[:weekly_ascension_searches]}"
       $killtracker[:searches_since_jewel] = 0
       REPORT_QUEUE.push(report)
 
@@ -376,7 +388,7 @@ module Killtracker
       maybe_reset_weekly_counter
       name = Regexp.last_match[:creature]
       $killtracker[:creature] = name
-      report = nil
+      report = ""
       if ASCENSION_CREATURES.match?(name)
         $killtracker[:ascension_searches] += 1
         $killtracker[:weekly_ascension_searches] += 1
@@ -411,6 +423,8 @@ module Killtracker
   UpstreamHook.add(UPSTREAM_HOOK_ID, proc do |command| parse_upstream(command) end)
   before_dying { DownstreamHook.remove(DOWNSTREAM_HOOK_ID); UpstreamHook.remove(UPSTREAM_HOOK_ID); File.write(@filename, $killtracker.to_yaml) }
 
+  CMD_QUEUE.push(Script.current.vars[0]) unless Script.current.vars[0].nil?
+
   loop do
     unless REPORT_QUEUE.empty?
       report = REPORT_QUEUE.pop
@@ -419,11 +433,11 @@ module Killtracker
       when /^search_report/
         creature, count, jewel, dust = report.gsub("search_report_", "").split(":")
         Lich::Messaging.stream_window("Kills: (#{count}) - (#{creature})", "speech") if $killtracker[:announce_msg]
-        Lich::Messaging.stream_window("Kills since last Jewel: (#{jewel}) Dust: (#{dust}) - (#{creature})", "speech") if !$killtracker[:announce_msg]
+        Lich::Messaging.stream_window("Searches this week: (#{count}) Since last Dust: (#{dust}) - (#{creature})", "speech") if !$killtracker[:announce_msg]
       when /dust_found/
-        Lich::Messaging.stream_window("Found dust after #{report.gsub("dust_found_", "")} kills.", "speech")
+        Lich::Messaging.stream_window("Found dust after #{report.gsub("dust_found_", "")} searches.", "speech")
       when /jewel_found/
-        Lich::Messaging.stream_window("Found a gemstone in #{report.gsub("jewel_found_", "")} kills.", "speech")
+        Lich::Messaging.stream_window("Found a gemstone in #{report.gsub("jewel_found_", "")} searches.", "speech")
       end
     end
 


### PR DESCRIPTION
changed reports to only show weekly searches and omit searches since last jewel since Nyxus alluded to searches the same week as finding the first do not count for subsequent finds.