### PR TITLE
fix(effect-list.xml): update for 1135 Bloodstone Jewelry

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -1951,13 +1951,13 @@
       <cast-proc>dothistimeout &quot;symbol of recognition&quot;, 5, /^There are no undead creatures present\.|^You recognize no fellow members|is and undead creature\.|is a member of the Order of Voln\./</cast-proc>
    </spell>
    <spell availability='self-cast' name='Symbol of Blessing' number='9802' type='utility'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of blessing#{target}&quot;, 5, /^You must specify something\.|^A wave of power flows outward from you|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of blessing#{target}&quot;, 5, /^You must specify something\.|^A wave of power flows outward from you|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='self-cast' name='Symbol of Thought' number='9803' type='utility'>
       <cast-proc>fput &quot;&quot;</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Diminishment' number='9804' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of diminishment#{target}&quot;, 5, /^What were you referring to\?|^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of diminishment#{target}&quot;, 5, /^What were you referring to\?|^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='self-cast' name='Symbol of Courage' number='9805' type='offense'>
       <duration span='stackable'>Society.rank / 6.0</duration>
@@ -1980,19 +1980,19 @@
       <message type='end'>The layer of protection fades away\.</message>
    </spell>
    <spell availability='all' name='Symbol of Submission' number='9807' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of submission#{target}&quot;, 5, /^What were you referring to\?|^You feel the power of the symbol project|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of submission#{target}&quot;, 5, /^What were you referring to\?|^You feel the power of the symbol project|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Kai&apos;s Strike' number='9808'>
       <cast-proc>fput &quot;&quot;</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Holiness' number='9809' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of holiness#{target}&quot;, 5, /^What were you referring to\?|^A wave of power flows out of you|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of holiness#{target}&quot;, 5, /^What were you referring to\?|^A wave of power flows out of you|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Recall' number='9810' type='utility'>
       <cast-proc>fput &quot;symbol of recall&quot;</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Sleep' number='9811' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sleep#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sleep#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Transcendence' number='9812' type='defense'>
       <duration>0.5</duration>
@@ -2003,7 +2003,7 @@
       <cast-proc>dothistimeout &apos;symbol of mana&apos;, 5, /^You call upon a special blessing from Koar.|^You are already at your maximum mana level\.|^You must CONFIRM that you wish to use this symbol during its recovery period\.|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Sight' number='9814' type='utility'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sight#{target}&quot;, 5, /^You concentrate|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of sight#{target}&quot;, 5, /^You concentrate|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Retribution' number='9815' type='attack/utility'>
       <duration span='stackable'>Society.rank / 6.0</duration>
@@ -2033,10 +2033,10 @@
       <message type='end'>The churning spectral aura suddenly vanishes from around you\.</message>
    </spell>
    <spell availability='all' name='Kai&apos;s Smite' number='9821' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;smite#{target}&quot;, 5, /^You currently have no valid target\.  You will need to specify one\.|doesn&apos;t appear to be suffering from the curse of undeath\.|^You .*?smite/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;smite#{target}&quot;, 5, /^You currently have no valid target\.  You will need to specify one\.|doesn&apos;t appear to be suffering from the curse of undeath\.|^You .*?smite/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Turning' number='9822' type='attack'>
-      <cast-proc>if defined?(target); if target.class == GameObj; target = &quot; ##{target.id}&quot;; elsif target.class == Numeric; target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of turning#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
+      <cast-proc>if defined?(target); if target.is_a?(GameObj); target = &quot; ##{target.id}&quot;; elsif target.is_a?(Numeric); target = &quot; ##{target}&quot;; else; target = &quot; #{target}&quot;; end; else; target = &quot;&quot;; end; dothistimeout &quot;symbol of turning#{target}&quot;, 5, /^You draw a glowing pattern in the air|^You strain to perform the symbol/</cast-proc>
    </spell>
    <spell availability='all' name='Symbol of Preservation' number='9823' type='utility'>
       <cast-proc>fput &quot;symbol of preservation&quot;</cast-proc>


### PR DESCRIPTION
Adds 1135 Bloodstone Jewelry and fixes 330 Sanctify

HOLD until 1135 goes live.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `Bloodstone Jewelry` spell and renames `Prayer of Communion` to `Sanctify` in `effect-list.xml`.
> 
>   - **New Spell Addition**:
>     - Adds `Bloodstone Jewelry` spell with number `1135` to `effect-list.xml`.
>     - Spell type is `utility` with a mana cost of `35`.
>   - **Spell Renaming**:
>     - Renames `Prayer of Communion` to `Sanctify` for spell number `330` in `effect-list.xml`.
>   - **Misc**:
>     - Updates `cast-proc` logic for `Symbol of Blessing`, `Symbol of Diminishment`, `Symbol of Submission`, `Symbol of Holiness`, `Symbol of Sleep`, `Kai's Smite`, `Symbol of Turning`, and `Symbol of Sight` to use `is_a?` instead of `class` for type checking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 1c9deea8272a912ab4e1adb24e34a1240888c30c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->