### PR TITLE
Update bigshot.lic

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3429,6 +3429,8 @@ class Bigshot
       /You feel your song echo around the .* as if it had entered a vast empty chamber\./,
       /The serpentine thread stretching between you and the (.*) fades, then disappears\./,
       /Your concentration on unravelling the threads of mana is broken\./,
+      /A little bit late for that don't you think\?/,
+      /What were you referring to\?/,
     )
 
     loop do
@@ -3441,13 +3443,14 @@ class Bigshot
       when /You feel your song resonate around the .*, pulling at the threads of mana within\.|You gain \d+ mana!/
         waitrt?
         waitcastrt?
-        fput("renew 1013 ##{npc.id}") if cmd.empty? && Char.percent_mana < 100
-        waitrt?
         fput('stop 1013')
         break
       when /The silvery tendril continues to wend its way away from the .*\./
         fput('stop 1013')
       when /Your concentration on unravelling the threads of mana is broken\.|You feel your song echo around the .* as if it had entered a vast empty chamber\./
+        break
+      when /What were you referring to\?|A little bit late for that don't you think\?/
+        fput 'release'
         break
       end
     end


### PR DESCRIPTION
Fixing cmd_unravel for errors found when MAing.
Removing the double 1013 cast for efficiency.