### PR TITLE
fix(spellwindows.lic) default room feed to on

### DIFF
--- a/scripts/SpellWindows.lic
+++ b/scripts/SpellWindows.lic
@@ -1,3 +1,4 @@
+#QUIET
 =begin
   SpellWindow.lic
 
@@ -22,11 +23,15 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, spells, buffs, debuffs, cooldowns
-       version: 1.7
+       version: 1.8
       required: Wrayth
 
   Change Log:
+  v1.8 (2025-04-08)
+    - set room and inventory feed to enabled as default instead of disabled.
+    - use Spellsong module for song max duration calculation.
   v1.7 (2025-04-06)
+    - adjusted Group.check usage
     - fixed progress bar on bard songs and armor adjustments.
   v1.6 (2025-03-18)
     - added room window and inventory feeds to optional blocking
@@ -90,8 +95,8 @@ module SpellWindow
     @settings[:show_debuffs]    = true
     @settings[:show_cooldowns]  = true
     @settings[:block_combat]    = true
-    @settings[:block_room]      = true
-    @settings[:block_inventory] = true
+    @settings[:block_room]      = false
+    @settings[:block_inventory] = false
     @settings[:show_missing]    = false
     @settings[:show_targets]    = false
     @settings[:show_arms]       = false
@@ -100,6 +105,7 @@ module SpellWindow
     File.write(@filename, @settings.to_yaml)
     respond("Default settings initialized.")
   end
+  @spellsong_duration = Spellsong.duration / 60
 
   def self.flextape(server_string)
     if server_string =~ INVENTORY_WINDOW && @settings[:block_inventory]
@@ -135,7 +141,7 @@ module SpellWindow
 
   def self.my_buffs
     _respond('<output class="mono"/>')
-    respond(@settings[:my_buffs].empty? ? 'No spells monitored.' : ' Monitoring:')
+    respond(@settings[:my_buffs].empty? ?  'No spells monitored.' : ' Monitoring:')
     @settings[:my_buffs].sort_by { |b| Spell[b].num }.each { |b|
       respond("%5s %s" % [Spell[b].num, Spell[b].name])
     }
@@ -239,21 +245,6 @@ module SpellWindow
       minutes = (seconds % 3600 / 60).to_i
       format("%d:%02d", hours, minutes)
     end
-  end
-
-  def self.calc_bard_song_duration()
-    duration = 120 + Stats.logic[:bonus] + (Stats.influence[:bonus] * 3) + (Char.mental_lore_telepathy * 2)
-    case Stats.level
-    when 76..100
-      duration += 225 + (Stats.level - 75)
-    when 51..75
-      duration += 175 + ((Stats.level - 50) * 2)
-    when 26..50
-      duration += 100 + ((Stats.level - 25) * 3)
-    else
-      duration += (Stats.level * 4)
-    end
-    return duration
   end
 
   def self.get_spell_max_duration(sn, stext)
@@ -526,7 +517,7 @@ module SpellWindow
         @settings[:block_room] = !@settings[:block_room]
         respond(@settings[:block_room] ? 'Room window disabled.' : 'Room window enabled.')
       elsif action == 'inventory'
-        @settings[:block_inventory] = !@settings[:block_inventory]
+        @settings[:block_inventory] = !@settings[:block_inventory]        
         respond(@settings[:block_inventory] ? 'Inventory window disabled.' : 'Inventory window enabled.')
       elsif action == 'spells'
         @settings[:show_spells] = !@settings[:show_spells]
@@ -572,12 +563,6 @@ module SpellWindow
       return if command.nil?
       SpellWindow.command(command)
     end
-  end
-
-  if Stats.prof == "Bard"
-    @spellsong_duration = calc_bard_song_duration()
-  else
-    @spellsonog_duration = 10
   end
 
   Group.maybe_check


### PR DESCRIPTION
implement Spellsong.duration from new Spellsong module

Default blocking of room and inventory feeds to false.