### PR TITLE
chore(all): autostart - update .class type check to .is_a? type check

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -5,7 +5,7 @@
   ;autostart help
 
         author: Tillmen (tillmen@lichproject.org)
- maintained by: Elanthia-Online 
+ maintained by: Elanthia-Online
   contributors: Athias
           game: any
           tags: core
@@ -14,7 +14,7 @@
 
   changelog:
     0.65 (2025-04-15):
-      updated .class type check to .is_a? type check 
+      updated .class type check to .is_a? type check
     0.64 (2024-11-14):
       Ensure repository always runs before dependency for DR. Rejig first run detection.
     0.63 (2024-08-03):


### PR DESCRIPTION
In support of new Sequel settings module.