### PR TITLE
fix(gs): Killtracker and log_search

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -11,37 +11,29 @@
   ;killtracker jewel report
   ;killtracker dust report
 
-  It will announce when a gemstone is found to the Wrayth speech window.
+  Killtracker is now able to submit your finds to an external tracker located at:
+  https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0
+  ;killtracker submit finds - toggles submitting finds to googlesheets.
 
         author: Alastir
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 1.4
+       version: 2.0
 
 Change Log:
-  v1.4
-    - removed permitted_classes from yaml.load_file
-    - fixed weekly reset counter
-  v1.3
-    - fix summary report output when no finds yet.
-    - corrected displays to only show weekly searches for gem.
-    - fix announce toggle to not reset
-    - insert command to queue on launch
-  v1.2 (2025-03-24)
-    - mug support
-  v1.1 (2025-03-24)
-    - typo fixes .. repsond doesn't work for some reason
-    - attempts to install tzinfo, tzinfo-data gems if not present
-  v1.0 (2025-03-23)
-    - release
+  v2.0
+    - added monthly/weekly gemstone tracking
+    - added weekly dust tracking
+    - corrected report outputs
+    - option to submit finds to external spreadsheet
 =end
 
 no_kill_all
 no_pause_all
 
 module Killtracker
-  ['yaml', 'terminal-table', 'time', 'rubygems', 'rubygems/dependency_installer'].each(&method(:require))
+  ['yaml', 'terminal-table', 'time', 'rubygems', 'rubygems/dependency_installer', 'net/http', 'json', 'digest'].each(&method(:require))
 
   installer = Gem::DependencyInstaller.new({ :user_install => true, :document => nil })
   installed_gems = Gem::Specification.map { |gem| gem.name }.sort.uniq
@@ -70,23 +62,18 @@ module Killtracker
   end
   $killtracker                              ||= {}
   $killtracker[:creature]                   ||= "none"
-  $killtracker[:total_searches]             ||= 0
   $killtracker[:ascension_searches]         ||= 0
-  $killtracker[:weekly_ascension_searches]  ||= 0
-  $killtracker[:mutant_searches]            ||= 0
+  $killtracker[:weekly_searches]            ||= 0
   $killtracker[:searches_since_jewel]       ||= 0
   $killtracker[:searches_since_dust]        ||= 0
-  $killtracker[:searches_since_idol]        ||= 0
-  $killtracker[:searches_since_lock_key]    ||= 0
-  $killtracker[:searches_since_feeder]      ||= 0
-  $killtracker[:searches_since_legendary]   ||= 0
   $killtracker[:jewel_found]                ||= {}
   $killtracker[:dust_found]                 ||= {}
-  $killtracker[:idol_found]                 ||= {}
-  $killtracker[:lock_key_found]             ||= {}
-  $killtracker[:feeder_found]               ||= {}
-  $killtracker[:legendary_found]            ||= {}
+  $killtracker[:none_found]                 ||= {}
   $killtracker[:silent]                       = true if $killtracker[:silent].nil?
+  $killtracker[:monthly_gemstones]          ||= 0
+  $killtracker[:weekly_gemstone]            ||= 0
+  $killtracker[:weekly_dust]                ||= 0
+  $killtracker[:last_month_reset]           ||= TZInfo::Timezone.get("America/New_York").now.month
   $killtracker[:last_week_reset]            ||= 0
   $killtracker[:cached_reset_time]          ||= 0
   File.write(@filename, $killtracker.to_yaml)
@@ -100,191 +87,181 @@ module Killtracker
     respond(";killtracker jewel report")
     respond(";killtracker dust report")
     respond("")
+    respond(";killtracker submit finds - Pushes jewel and dust find to google sheets.")
+    respond("   https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0")
   end
 
-  def self.get_next_reset_local_time
-    eastern = TZInfo::Timezone.get('America/New_York')
-    now_est = eastern.now
-    last_sunday_midnight_est = eastern.local_time(now_est.year, now_est.month, now_est.day, 0, 0, 0) - (now_est.wday * 86400)
-    next_reset_est = last_sunday_midnight_est + (7 * 86400)
-    next_reset_est.to_i
-  end
+  def self.dust_report
+    tz     = TZInfo::Timezone.get("America/New_York")
+    events = $killtracker[:dust_found]
+      .sort_by { |key, _| key.to_i }
 
-  $killtracker[:cached_reset_time] = get_next_reset_local_time
-
-  def self.maybe_reset_weekly_counter
-    eastern = TZInfo::Timezone.get("America/New_York")
-    $killtracker[:weekly_counts] ||= {}
-    while Time.now.to_i >= $killtracker[:cached_reset_time] && ($killtracker[:last_week_reset] == 0 || $killtracker[:last_week_reset] < $killtracker[:cached_reset_time])
-      finished_week = eastern.to_local(Time.at($killtracker[:cached_reset_time] - 7 * 86400)).strftime("%U").to_i
-      $killtracker[:weekly_counts][:"week_#{finished_week}_ascension_searches"] = $killtracker[:weekly_ascension_searches]
-      $killtracker[:weekly_ascension_searches] = 0
-      $killtracker[:last_week_reset] = $killtracker[:cached_reset_time]
-      $killtracker[:cached_reset_time] += 7 * 86400
+    rows = events.map do |key, ev|
+      time_str    = tz.to_local(Time.at(key.to_i)).strftime("%m/%d %H:%M:%S")
+      searches    = ev[:searches_week] || 0
+      creature    = ev[:creature] || ""
+      room        = ev[:room] || ""
+      name        = ev[:name] || ""
+      [time_str, searches, creature, room, name]
     end
-  end
-
-  def self.pluralize(word, count)
-    count == 1 ? word : word + "s"
-  end
-
-  def self.detailed_report(event_type)
-    events = $killtracker[event_type] || {}
-    sorted_keys = events.keys.sort_by(&:to_i)
-
-    if event_type =~ /jewel|dust/
-      title = "Detailed #{event_type.to_s.split('_').first.capitalize} Event Log Over #{$killtracker[:ascension_searches]} Searches"
-    else
-      title = "Detailed #{event_type.to_s.split('_').first.capitalize} Event Log Over #{$killtracker[:total_searches]} Searches"
-    end
-    if event_type =~ /idol/
-      title = "Detailed #{event_type.to_s.split('_').first.capitalize} Event Log Over #{$killtracker[:mutant_searches]} Mutant Searches"
-    end
-
-    # Set up headings based on event type
-    if event_type =~ /jewel/
-      headings = ["Time", "Week", "Creature", "Name"]
-    else
-      headings = ["Time", "Searches", "Creature", "Name"]
-    end
-
-    rows = sorted_keys.map do |key|
-      event = events[key]
-      time = Time.at(key.to_i)
-      formatted_time = time.strftime("%m/%d %H:%M:%S")
-
-      if event_type =~ /jewel/
-        [
-          formatted_time,
-          event[:searches_week]  || 0,
-          event[:creature]       || "",
-          event[:name]           || ""
-        ]
-      else
-        [
-          formatted_time,
-          event[:searches]       || 0,
-          event[:creature]       || "",
-          event[:name]           || ""
-        ]
-      end
-    end
-
-    table = Terminal::Table.new :title => title, :headings => headings, :rows => rows
+  
+    title = "Detailed Dust Report: #{$killtracker[:dust_found].size} Dust over #{$killtracker[:ascension_searches]} Searches"
+    table = Terminal::Table.new(
+      title:    title,
+      headings: ["Time", "Searches", "Creature", "Room", "Name"],
+      rows:     rows
+    )
+  
     respond table.to_s
   end
 
-  def self.summary_report
-    groups = {
-      "Gemstones & Dust" => [
-        { key: :jewel_found,     label: "Gemstone",  since: :weekly_ascension_searches },
-        { key: :dust_found,      label: "Dust",      since: :searches_since_dust },
-        { key: :idol_found,      label: "Idol",      since: :searches_since_idol }
-      ],
-      "Lockbox & Key"    => [
-        { key: :lock_key_found,  label: "Lock&Key",  since: :searches_since_lock_key }
-      ],
-      "Legendary"        => [
-        { key: :legendary_found, label: "Legendary", since: :searches_since_legendary }
-      ],
-      "Feeder"           => [
-        { key: :feeder_found,    label: "Feeder",    since: :searches_since_feeder }
-      ]
-    }
+  def self.jewel_report
+    tz     = TZInfo::Timezone.get("America/New_York")
+    events = $killtracker[:jewel_found]
+      .sort_by { |key, _| key.to_i }
 
-    groups.each do |group_name, events|
-      if group_name == "Gemstones & Dust"
-        group_total = $killtracker[:ascension_searches] || 0
-      else
-        group_total = events.sum { |evt| ($killtracker[evt[:key]] || {}).size }
-      end
-
-      next if group_total == 0
-
-      respond "   === #{group_name} ==="
-      if group_name == "Gemstones & Dust"
-        asc_searches  = $killtracker[:ascension_searches] || 0
-        weekly_asc    = $killtracker[:weekly_ascension_searches] || 0
-        respond " #{format('%6d', asc_searches)}: Total Ascension Searches"
-        respond " #{format('%6d', weekly_asc)}: Weekly Ascension Searches"
-        respond ""
-
-      end
-
-      events.each do |evt|
-        event_hash = $killtracker[evt[:key]] || {}
-        count = event_hash.size
-        next if count == 0
-
-        if group_name == "Gemstones & Dust"
-          if evt[:key] == :jewel_found
-            # Extract each jewel's weekly search count and calculate the true average
-            jewel_searches = event_hash.values.map { |data| data[:searches_week].to_i }
-            avg = count > 0 ? jewel_searches.sum.to_f / count : 0
-          else
-            # For other events (like dust), keep the existing calculation
-            avg = count > 0 ? ($killtracker[:ascension_searches].to_f / count) : 0
-          end
-        end
-
-        since = $killtracker[evt[:since]] || 0
-        found_label = pluralize(evt[:label], count)
-
-        respond " #{format('%6d', count)}: #{found_label} Found"
-        respond " #{format('%6d', since)}: Since last #{evt[:label]}" unless evt[:label] == "Gemstone"
-        respond " #{format('%6d', avg.to_i)}: Avg per #{evt[:label]}"
-        respond ""
-      end
-      respond ""
+    total_searches_for_gems = events
+      .map { |_, ev| ev[:searches_week].to_i }
+      .sum
+  
+    rows = events.map do |key, ev|
+      time_str    = tz.to_local(Time.at(key.to_i)).strftime("%m/%d %H:%M:%S")
+      searches    = ev[:searches_week] || 0
+      creature    = ev[:creature] || ""
+      room        = ev[:room] || ""
+      name        = ev[:name] || ""
+      [time_str, searches, creature, room, name]
     end
+  
+    title = "Detailed Jewel Report: #{$killtracker[:jewel_found].size} Jewels over #{total_searches_for_gems} Searches"
+    table = Terminal::Table.new(
+      title:    title,
+      headings: ["Time", "Searches", "Creature", "Room", "Name"],
+      rows:     rows
+    )
+  
+    respond table.to_s
+  end  
+
+  def self.summary_report
+    # overall counts
+    gems_total      = $killtracker[:jewel_found].size
+    dust_total      = $killtracker[:dust_found].size
+  
+    # weekly/monthly buckets
+    weekly_searches = $killtracker[:weekly_searches]
+    gems_this_week  = $killtracker[:weekly_gemstone] || 0
+    dust_this_week  = $killtracker[:weekly_dust]     || 0
+    gems_this_month = $killtracker[:monthly_gemstones] || 0
+  
+    # since‐last counters
+    since_last_gem  = $killtracker[:searches_since_jewel]
+    since_last_dust = $killtracker[:searches_since_dust]
+  
+    # compute sum of searches_week across all gem events
+    total_searches_for_gems = $killtracker[:jewel_found].values
+                               .map { |ev| ev[:searches_week].to_i }
+                               .sum
+  
+    # compute sum of searches_week across all dust events
+    total_searches_for_dust = $killtracker[:dust_found].values
+                               .map { |ev| ev[:searches_week].to_i }
+                               .sum
+  
+    # averages
+    avg_per_gem  = gems_total > 0 ? (total_searches_for_gems.to_f  / gems_total).round : 0
+    avg_per_dust = dust_total > 0 ? (total_searches_for_dust.to_f  / dust_total).round : 0
+  
+    # remaining gems this month (max 3)
+    remaining_gems = [0, 3 - gems_this_month].max
+  
+    rows = [
+      ["Searches This Week",     weekly_searches],
+      [],
+      ["Gemstones Found (all)",  gems_total],
+      [" This Week",           gems_this_week],
+      [" This Month",          gems_this_month],
+      [" Avg Searches/Gem",    avg_per_gem],
+      [" Remaining Gems",      remaining_gems],
+      [],
+      ["Dust Found (all)",       dust_total],
+      [" This Week",           dust_this_week],
+      [" Avg Searches/Dust",   avg_per_dust],
+      [],
+      ["Since Last Gem",         since_last_gem],
+      ["Since Last Dust",        since_last_dust],
+    ]
+  
+    table = Terminal::Table.new(
+      title:    "Killtracker Summary",
+      headings: ["Metric", "Count"],
+      rows:     rows
+    )
+  
+    respond table.to_s
   end
 
   def self.gemstones_report
-    combined_events = []
-
-    $killtracker[:jewel_found].each do |key, event|
-      combined_events << event.merge({ timestamp: key.to_i, type: "Jewel" })
+    tz = TZInfo::Timezone.get("America/New_York")
+  
+    combined = []
+    $killtracker[:jewel_found].each do |key, ev|
+      combined << ev.merge(
+        timestamp:    key.to_i,
+        type:         "Gemstone",
+        since:        ev[:searches_since]
+      )
     end
-
-    $killtracker[:dust_found].each do |key, event|
-      combined_events << event.merge({ timestamp: key.to_i, type: "Dust" })
+    $killtracker[:dust_found].each do |key, ev|
+      combined << ev.merge(
+        timestamp:    key.to_i,
+        type:         "Dust",
+        since:        ev[:searches_since]
+      )
     end
-
-    eastern = TZInfo::Timezone.get("America/New_York")
-
-    events_by_week = combined_events.group_by do |event|
-      eastern.to_local(Time.at(event[:timestamp])).strftime("%U").to_i
+    $killtracker[:none_found].each do |key, ev|
+      combined << ev.merge(
+        timestamp: key.to_i,
+        type:      "None",
+        since:     ev[:searches_since]
+      )
     end
-
-    current_week = eastern.to_local(Time.now).strftime("%U").to_i
+  
+    events_by_week = combined.group_by do |ev|
+      local = tz.to_local(Time.at(ev[:timestamp]))
+      local.strftime("%U").to_i
+    end
+  
+    current_week = tz.to_local(Time.now).strftime("%U").to_i
 
     events_by_week.sort.each do |week_number, events|
-      sorted_events = events.sort_by { |event| event[:timestamp] }
-      rows = sorted_events.map do |event|
-        event_time = eastern.to_local(Time.at(event[:timestamp]))
-        formatted_time = event_time.strftime("%m/%d %H:%M:%S")
-        searches = (event[:type] == "Jewel") ? (event[:searches_week] || 0) : (event[:searches] || 0)
+      weekly_count =
+        if week_number == current_week
+          $killtracker[:weekly_searches]
+        else
+          ($killtracker[:weekly_counts] &&
+           $killtracker[:weekly_counts][:"week_#{week_number}_searches"]) || 0
+        end
+      
+      next if weekly_count == 0
+      title = "Week #{week_number} Gemstone Search Report: #{weekly_count} Searches"
+      rows = events.sort_by { |ev| ev[:timestamp] }.map do |ev|
+        time_str = tz.to_local(Time.at(ev[:timestamp])).strftime("%m/%d %H:%M:%S")
         [
-          formatted_time,
-          event[:type],
-          searches,
-          event[:creature] || "N/A",
-          event[:room] || "N/A",
-          event[:name] || ""
+          time_str,        # Time
+          ev[:type],       # Type
+          ev[:searches_week] || 0,  # Searches so far that week at event
+          ev[:since] || 0, # Searches since last find
+          ev[:creature],   # Creature
+          ev[:name]        # Name
         ]
       end
-
-      if week_number == current_week
-        weekly_count = $killtracker[:weekly_ascension_searches]
-      else
-        weekly_count = ($killtracker[:weekly_counts] && $killtracker[:weekly_counts][:"week_#{week_number}_ascension_searches"]) || 0
-      end
-
-      title = "Week #{week_number} Gemstone Search Report: #{weekly_count} Searches"
-      table = Terminal::Table.new title: title,
-                                  headings: ["Time", "Type", "Searches", "Creature", "Room", "Name"],
-                                  rows: rows
-
+  
+      table = Terminal::Table.new(
+        title:    title,
+        headings: ["Time", "Type", "Week", "Since", "Creature", "Name"],
+        rows:     rows
+      )
       respond table.to_s
     end
   end
@@ -298,12 +275,9 @@ module Killtracker
   SEARCH_CREATURE = %r{You search the <pushBold/><a exist="\d+" noun="[^"]+">(?<creature>[^<]+)</a><popBold/>.}
   SEARCH_MUG      = %r{Taking advantage of the scuffle, you roughly pat (?:<.+?>)?the (?:<.+?>)?(?<creature>[-A-Za-z ]+)(?:<.+?>)? down for hidden valuables!}
   EVIL_EYE_FLEE = %r{The <pushBold/><a exist="\d+" noun="[^"]+">(?<creature>[^<]+)</a><popBold/> turns and runs screaming into the distance, never to be seen again.}
-  FEEDER_ITEM = %r{\*\*\* A glint of light draws your attention to your latest find! \*\*\*}
-  LEGENDARY_ITEM = %r{A prismatic display of color tints the air around you and arcs away, heralding your discovery of a legendary treasure!}
-  LOCK_KEY = %r{A <a exist="\d+" noun="[^"]+">(?<name>[^<]+)</a> appears on the ground!}
-  GEMSTONE_DUST = %r{<pushBold/>You notice a scintillating mote of gemstone dust on the ground and gather it quickly.}
-  GEMSTONE_JEWEL = %r{<pushBold/> \*\* A glint of light catches your eye, and you notice an? <a exist="\d+" noun="\w+">(?<name>[^<]+)</a> at your feet! \*\*}
-  DRACONIC_IDOL = %r{While rifling through <pushBold/>the <a exist="\d+" noun="mutant">mutant's</a><popBold/> belongings, you find a <a exist="\d+" noun="idol">(?<name>silver-veined black draconic idol)</a> wrapped carefully in rags as if it were a precious trinket.}
+
+  FOUND_DUST = %r{<pushBold/>You notice a scintillating mote of gemstone dust on the ground and gather it quickly.}
+  FOUND_GEMSTONE = %r{<pushBold/> \*\* A glint of light catches your eye, and you notice an? <a exist="\d+" noun="\w+">(?<name>[^<]+)</a> at your feet! \*\*}
   ASCENSION_CREATURES = Regexp.union(
     %r{armored battle mastodon},
     %r{black valravn},
@@ -338,79 +312,148 @@ module Killtracker
     %r{kresh ravager}
   )
 
+  def self.send_to_sheet(ev_type, key)
+    case ev_type
+    when "dust"
+      ev = $killtracker[:dust_found][key]
+    when "jewel" 
+      ev = $killtracker[:jewel_found][key]
+    end
+    return unless ev
+  
+    uri = URI("https://script.google.com/macros/s/AKfycbyltG_Eax1-CY4n1isy9U_ZRlKxD93Ai5XQqbF78Wq-4tIqtFirLjbVcgrd13T59e6z/exec")
+
+    user_id = Digest::SHA256.hexdigest([Char.name, Stats.race, Stats.prof].join('|'))
+
+    req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json')
+    req.body = {
+      timestamp:      key.to_i,
+      type:           ev_type,
+      searches_week:  ev[:searches_week],
+      searches_since: ev[:searches_since],
+      creature:       ev[:creature],
+      room:           ev[:room],
+      name:           ev[:name],
+      user:           user_id
+    }.to_json
+    
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
+    # echo "→ GoogleSheets responded #{res.code}: #{res.body}"
+    res.code.to_i
+  rescue => e
+    # catch network / JSON errors
+    echo "!! send_to_sheet error: #{e.class}: #{e.message}"
+  end
+
+  def self.send_all_finds
+    respond("Sending found jewels...")
+    $killtracker[:jewel_found].each { |j| send_to_sheet("jewel", j.first) }
+    respond("Sending found dust...")
+    $killtracker[:dust_found].each { |d| send_to_sheet("dust", d.first) }
+    respond("Sending complete.")
+    respond("View the data at: https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0")
+    respond("")
+    respond("Please note, this is a special command and should only be ran once.")
+    respond("To continue submitting finds going forward please enable the feature: ;kt submit finds")
+  end
+
+  def self.get_next_reset_local_time
+    eastern = TZInfo::Timezone.get('America/New_York')
+    now_est = eastern.now
+    last_sunday_midnight_est = eastern.local_time(now_est.year, now_est.month, now_est.day, 0, 0, 0) - (now_est.wday * 86400)
+    next_reset_est = last_sunday_midnight_est + (7 * 86400)
+    $killtracker[:cached_reset_time] = next_reset_est.to_i
+  end
+
+  def self.maybe_reset_weekly_counter
+    eastern = TZInfo::Timezone.get("America/New_York")
+    $killtracker[:weekly_counts] ||= {}
+    while Time.now.to_i >= $killtracker[:cached_reset_time] && ($killtracker[:last_week_reset] == 0 || $killtracker[:last_week_reset] < $killtracker[:cached_reset_time])
+      finished_week = eastern.to_local(Time.at($killtracker[:cached_reset_time] - 7 * 86400)).strftime("%U").to_i
+      # determine remaing searches on week since last find
+      total_this_week = $killtracker[:weekly_searches]
+      gap = total_this_week - ($killtracker[:last_weekly_event_searches] || 0)
+      key = $killtracker[:cached_reset_time].to_s
+      $killtracker[:found_none][key] = {
+        searches_since: gap,
+        searches_week: total_this_week,
+        creature: "none",
+        room: "none",
+        name: "Final searches of the week with no find"
+      }
+      $killtracker[:weekly_counts][:"week_#{finished_week}_searches"] = $killtracker[:weekly_searches]
+      $killtracker[:weekly_counts][:"week_#{finished_week}_dust"] = $killtracker[:weekly_dust]
+      $killtracker[:weekly_counts][:"week_#{finished_week}_gemstone"] = $killtracker[:weekly_gemstone]
+      $killtracker[:weekly_searches] = 0
+      $killtracker[:weekly_gemstone] = 0
+      $killtracker[:weekly_dust] = 0
+      $killtracker[:last_week_reset] = $killtracker[:cached_reset_time]
+      get_next_reset_local_time
+    end
+  end
+
+  def self.maybe_reset_monthly_counter
+    est = TZInfo::Timezone.get("America/New_York")
+    current_month = est.now.month
+    if current_month != $killtracker[:last_month_reset]
+      $killtracker[:monthly_gemstones] = 0
+      $killtracker[:last_month_reset] = current_month
+    end
+  end
+
   def self.parse_downstream(line)
     case line
-    when GEMSTONE_JEWEL
+    when FOUND_GEMSTONE
       key = Time.now.to_i.to_s
       name = Regexp.last_match[:name]
       room = Room.current.id
-      $killtracker[:jewel_found][key] = { searches_since: $killtracker[:searches_since_jewel], searches_week: $killtracker[:weekly_ascension_searches], name: name, room: room, creature: $killtracker[:creature] }
-      report = "jewel_found_#{$killtracker[:creature]}:#{$killtracker[:weekly_ascension_searches]}"
+      $killtracker[:monthly_gemstones] += 1
+      $killtracker[:weekly_gemstone] += 1
+      $killtracker[:jewel_found][key] = {
+        searches_since: $killtracker[:searches_since_jewel],
+        searches_week: $killtracker[:weekly_searches],
+        name: name,
+        room: room,
+        creature: $killtracker[:creature],
+        on_the_month: $killtracker[:monthly_gemstones]
+      }
+      report = ['found gemstone', $killtracker[:creature], $killtracker[:weekly_searches], $killtracker[:searches_since_jewel]]
       $killtracker[:searches_since_jewel] = 0
+      $killtracker[:last_weekly_event_searches] = $killtracker[:weekly_searches]
       REPORT_QUEUE.push(report)
+      REPORT_QUEUE.push(["send jewel report", key]) if $killtracker[:submit_finds]
 
-    when GEMSTONE_DUST
+    when FOUND_DUST
       key = Time.now.to_i.to_s
       room = Room.current.id
-      $killtracker[:dust_found][key] = { searches: $killtracker[:searches_since_dust], name: "gemstone dust", room: room, creature: $killtracker[:creature] }
-      report = "dust_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_dust]}"
+      $killtracker[:weekly_dust] += 1
+      $killtracker[:dust_found][key] = {
+        searches_since: $killtracker[:searches_since_dust],
+        searches_week: $killtracker[:weekly_searches],
+        name: "gemstone dust",
+        room: room,
+        creature: $killtracker[:creature]
+      }
+      report = ['found dust', $killtracker[:creature], $killtracker[:weekly_searches], $killtracker[:searches_since_dust]]
       $killtracker[:searches_since_dust] = 0
+      $killtracker[:last_weekly_event_searches] = $killtracker[:weekly_searches]
       REPORT_QUEUE.push(report)
-
-    when DRACONIC_IDOL
-      key = Time.now.to_i.to_s
-      room = Room.current.id
-      $killtracker[:idol_found][key] = { searches: $killtracker[:searches_since_idol], name: "silver-veined black draconic idol", room: room, creature: $killtracker[:creature] }
-      report = "idol_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_idol]}"
-      $killtracker[:searches_since_idol] = 0
-      REPORT_QUEUE.push(report)
-
-    when LOCK_KEY
-      key = Time.now.to_i.to_s
-      name = Regexp.last_match[:name]
-      room = Room.current.id
-      $killtracker[:lock_key_found][key] = { searches: $killtracker[:searches_since_lock_key], name: name, room: room, creature: $killtracker[:creature] }
-      report = "lock_key_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_lock_key]}"
-      $killtracker[:searches_since_lock_key] = 0
-      REPORT_QUEUE.push(report)
-
-    when FEEDER_ITEM
-      key = Time.now.to_i.to_s
-      room = Room.current.id
-      $killtracker[:feeder_found][key] = { searches: $killtracker[:searches_since_feeder], room: room, creature: $killtracker[:creature] }
-      report = "feeder_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_feeder]}"
-      $killtracker[:searches_since_feeder] = 0
-      REPORT_QUEUE.push(report)
-
-    when LEGENDARY_ITEM
-      key = Time.now.to_i.to_s
-      room = Room.current.id
-      $killtracker[:feeder_found][key] = { searches: $killtracker[:searches_since_legendary], room: room, creature: $killtracker[:creature] }
-      report = "legendary_found_#{$killtracker[:creature]}:#{$killtracker[:searches_since_legendary]}"
-      $killtracker[:searches_since_legendary] = 0
-      REPORT_QUEUE.push(report)
+      REPORT_QUEUE.push(["send dust report", key]) if $killtracker[:submit_finds]
 
     when SEARCH_CREATURE, SEARCH_MUG, EVIL_EYE_FLEE
       maybe_reset_weekly_counter
+      maybe_reset_monthly_counter
       name = Regexp.last_match[:creature]
       $killtracker[:creature] = name
-      report = ""
       if ASCENSION_CREATURES.match?(name)
-        $killtracker[:ascension_searches] += 1
-        $killtracker[:weekly_ascension_searches] += 1
+        $killtracker[:weekly_searches] += 1
         $killtracker[:searches_since_jewel] += 1
         $killtracker[:searches_since_dust] += 1
-        if name =~ /mutant/
-          $killtracker[:searches_since_idol] += 1
-          $killtracker[:mutant_searches] += 1
-        end
-        report = "search_report_#{name}:#{$killtracker[:weekly_ascension_searches]}:#{$killtracker[:searches_since_jewel]}:#{$killtracker[:searches_since_dust]}" unless $killtracker[:silent]
+        report = ["search report", name, $killtracker[:weekly_searches], $killtracker[:searches_since_dust], $killtracker[:searches_since_jewel]]
+        REPORT_QUEUE.push(report) unless $killtracker[:silent]
       end
-      $killtracker[:total_searches] += 1
-      $killtracker[:searches_since_lock_key] += 1
-      $killtracker[:searches_since_feeder] += 1
-      $killtracker[:searches_since_legendary] += 1
-      REPORT_QUEUE.push(report) unless $killtracker[:silent]
     end
     line
   end
@@ -429,23 +472,31 @@ module Killtracker
   UpstreamHook.add(UPSTREAM_HOOK_ID, proc do |command| parse_upstream(command) end)
   before_dying { DownstreamHook.remove(DOWNSTREAM_HOOK_ID); UpstreamHook.remove(UPSTREAM_HOOK_ID); File.write(@filename, $killtracker.to_yaml) }
 
+  get_next_reset_local_time
+  maybe_reset_weekly_counter
+  maybe_reset_monthly_counter
+
   CMD_QUEUE.push(Script.current.vars[0]) unless Script.current.vars[0].nil?
 
   loop do
     unless REPORT_QUEUE.empty?
       report = REPORT_QUEUE.pop
       next if report.nil?
-      case report
-      when /^search_report/
-        creature, count, _jewel, dust = report.gsub("search_report_", "").split(":")
-        Lich::Messaging.stream_window("Kills: (#{count}) - (#{creature})", "speech") if $killtracker[:announce_msg]
-        Lich::Messaging.stream_window("Searches this week: (#{count}) Since last Dust: (#{dust}) - (#{creature})", "speech") if !$killtracker[:announce_msg]
-      when /dust_found/
-        creature, count = report.gsub("dust_found_", "").split(":")
-        Lich::Messaging.stream_window("Found dust after #{count} searches. (#{creature})", "speech")
-      when /jewel_found/
-        creature, count = report.gsub("dust_found_", "").split(":")
-        Lich::Messaging.stream_window("Found a gemstone in #{count} searches. (#{creature})", "speech")
+      case report[0]
+      when "search report"
+        _, creature, week, dust, jewel = report
+        Lich::Messaging.stream_window("Searches: (#{week}) - (#{creature})", "speech") if $killtracker[:announce_msg]
+        Lich::Messaging.stream_window("Searches: (#{week}) - (#{creature}) - Since last Dust: (#{dust})  Since last Jewel: (#{jewel})", "speech") if !$killtracker[:announce_msg]
+      when "found dust"
+        _, creature, week, dust = report
+        Lich::Messaging.stream_window("Found dust after #{week} searches. (#{creature}) - Since last Dust: (#{dust})", "speech")
+      when "found gemstone"
+        _, creature, week, jewel = report
+        Lich::Messaging.stream_window("Found a gemstone in #{week} searches. (#{creature}) - Since last Jewel: (#{jewel})", "speech")
+      when /send dust report/
+        send_to_sheet("dust", report[1])
+      when /send jewel report/
+        send_to_sheet("jewel", report[1])
       end
     end
 
@@ -456,21 +507,15 @@ module Killtracker
       when /help/
         Killtracker.help
       when /jewel report/
-        Killtracker.detailed_report(:jewel_found)
+        Killtracker.jewel_report
       when /dust report/
-        Killtracker.detailed_report(:dust_found)
+        Killtracker.dust_report
       when /gemstones? report/
         Killtracker.gemstones_report
-      when /idol report/
-        Killtracker.detailed_report(:idol_found)
-      when /klock report/
-        Killtracker.detailed_report(:lock_key_found)
-      when /feeder report/
-        Killtracker.detailed_report(:feeder_found)
-      when /legendary report/
-        Killtracker.detailed_report(:legendary_found)
       when /summary/
         Killtracker.summary_report
+      when /send all finds/
+        Killtracker.send_all_finds
       when /announce$/
         $killtracker[:silent] = !$killtracker[:silent] # toggle setting
         msg = $killtracker[:silent] ? 'Reporting only upon a find.' : 'Reporting after each kill.'
@@ -479,6 +524,11 @@ module Killtracker
         $killtracker[:announce_msg] ||= false
         $killtracker[:announce_msg] = !$killtracker[:announce_msg]
         msg = $killtracker[:announce_msg] ? 'Announce shows total search count.' : 'Announce shows searches since last find'
+        Lich::Messaging.stream_window(msg, "speech")
+      when /submit finds/
+        $killtracker[:submit_finds] ||= false
+        $killtracker[:submit_finds] = !$killtracker[:submit_finds]
+        msg = $killtracker[:submit_finds] ? 'NOT sending finds to external spreadsheet' : 'Sending finds to external spreadsheet'
         Lich::Messaging.stream_window(msg, "speech")
       end
     end

--- a/scripts/log_search.lic
+++ b/scripts/log_search.lic
@@ -3,7 +3,7 @@
 
   *** use log.lic to log. ;autostart add --global log --timestamp=\"%T\" --rnum ***
 
-  Parse your logs to get search statistics for Gemstones, Dust, Idols, Klocks, Legendary and Feeder items.
+  Parse your logs to get search statistics for Gemstones and Dust.
   Creates two files in your Lich5/data/GSIV/CharName/ folder:
     searcharraylog.yaml      - log of every line it matched that can be used to verify results
     SearchDataFromLogs.yaml  - contains the count data
@@ -20,10 +20,15 @@
 
         author: Nisugi
           game: Gemstone
-          tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 1.2
+          tags: hunting, combat, tracking, gemstones, jewels, dust, data
+       version: 1.4
 
   Change Log:
+  v1.4
+    - added monthly/weekly gemstone tracking
+    - added weekly dust tracking
+  v1.3 (2025-04-08)
+    - reset dust search count on weekly reset
   v1.2 (2025-03-27)
     - disables timestamps if no timestamps detected instead of erroring
     - fixed error caused by old error messages in logs
@@ -80,35 +85,31 @@ module LogSearch
     @scrape_data = YAML.load_file(@filename)
   end
   @scrape_data = {} if Script.current.vars[0] =~ /--reset/
-
   @scrape_data                              ||= {}
-  @scrape_data[:silent]                       = true unless @scrape_data[:silent] == false
-  @scrape_data[:last_week_reset]            ||= nil
   @scrape_data[:creature]                   ||= "none"
-  @scrape_data[:room]                       ||= nil
-  @scrape_data[:uid]                        ||= nil
-  @scrape_data[:total_searches]             ||= 0
-  @scrape_data[:ascension_searches]         ||= 0
-  @scrape_data[:weekly_ascension_searches]  ||= 0
-  @scrape_data[:mutant_searches]            ||= 0
+  @scrape_data[:weekly_ascension_searches]            ||= 0
+  @scrape_data[:last_weekly_event_searches] ||= 0
   @scrape_data[:searches_since_jewel]       ||= 0
   @scrape_data[:searches_since_dust]        ||= 0
-  @scrape_data[:searches_since_idol]        ||= 0
-  @scrape_data[:searches_since_lock_key]    ||= 0
-  @scrape_data[:searches_since_feeder]      ||= 0
-  @scrape_data[:searches_since_legendary]   ||= 0
+  @scrape_data[:last_week_reset]            ||= 0
   @scrape_data[:jewel_found]                ||= {}
   @scrape_data[:dust_found]                 ||= {}
-  @scrape_data[:idol_found]                 ||= {}
-  @scrape_data[:lock_key_found]             ||= {}
-  @scrape_data[:feeder_found]               ||= {}
-  @scrape_data[:legendary_found]            ||= {}
+  @scrape_data[:none_found]                 ||= {}
+  @scrape_data[:monthly_gemstones]          ||= 0
+  @scrape_data[:weekly_gemstone]            ||= 0
+  @scrape_data[:weekly_dust]                ||= 0
+  @scrape_data[:last_month_reset]           ||= TZInfo::Timezone.get("America/New_York").now.month
+  @scrape_data[:last_week_reset]            ||= 0
+  @scrape_data[:room]                       ||= 0
+  @scrape_data[:uid]                        ||= 0
+  @scrape_data[:ascension_searches]         ||= 0
   @scrape_data[:quest_complete]               = false unless @scrape_data[:quest_complete]
   @debug                                      = false
   @has_timestamps                             = true
   @base_date                                  = nil
   @next_reset                                 = nil
   @default_tz                                 = Time.now.zone
+  @scrape_data[:silent]                       = true unless @scrape_data[:silent] == false
 
   @has_timestamps = false if Script.current.vars[0] =~ /--no-timestamps?/
   @scrape_data[:quest_complete] = true if Script.current.vars[0] =~ /--quest-complete/
@@ -118,12 +119,8 @@ module LogSearch
   SEARCH_MUG      = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*Taking advantage of the scuffle, you roughly pat (?:<.+?>)?the (?:<.+?>)?(?<creature>[-A-Za-z ]+)(?:<.+?>)? down for hidden valuables\!$}
   EVIL_EYE_FLEE   = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*The (?:<.+?>)?(?<creature>[-A-Za-z ]+)(?:<.+?>)? turns and runs screaming into the distance, never to be seen again\.$}
   ROOM_REGEX      = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*\[[^\]]*-\s*(?<room>\d+)\](?:\s+\((?<uid>u\d+)\))?$}
-  FEEDER_ITEM     = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*\*\*\* A glint of light draws your attention to your latest find! \*\*\*$}
-  LEGENDARY_ITEM  = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*A prismatic display of color tints the air around you and arcs away, heralding your discovery of a legendary treasure\!$}
-  LOCK_KEY        = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*A (?<name>.+?) appears on the ground!$}
-  GEMSTONE_DUST   = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*You notice a scintillating mote of gemstone dust on the ground and gather it quickly\.$}
-  GEMSTONE_JEWEL  = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*\*\* A glint of light catches your eye, and you notice an? (?<name>.+?) at your feet! \*\*$}
-  DRACONIC_IDOL   = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*While rifling through the mutant's belongings, you find a silver-veined black draconic idol wrapped carefully in rags as if it were a precious trinket\.$}
+  FOUND_DUST      = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*You notice a scintillating mote of gemstone dust on the ground and gather it quickly\.$}
+  FOUND_GEMSTONE  = %r{^(?<timestamp>(?:\d{4}-\d{2}-\d{2}\s+)?\d{2}:\d{2}:\d{2}(?:\s+[A-Za-z ]+)?)?:?\s*\*\* A glint of light catches your eye, and you notice an? (?<name>.+?) at your feet! \*\*$}
   ASCENSION_CREATURES = Regexp.union(
     %r{armored battle mastodon},
     %r{black valravn},
@@ -186,7 +183,12 @@ module LogSearch
 
     # Regex for timestamp with only time (no date)
     elsif log_time =~ /^(\d{2}:\d{2}:\d{2})(?:\s+(.+))?$/
-      raise ArgumentError, "A base date is required if the timestamp doesn't include a date" if file_date.nil?
+      # raise ArgumentError, "A base date is required if the timestamp doesn't include a date" if file_date.nil?
+      if file_date.nil?
+        respond("Filename missing date information. Enabling --no-timestamps flag.")
+        @has_timestamps = false
+        return 1
+      end
       time_str = $1
       tz_str   = $2
       tz_str = @default_tz if tz_str.nil? || tz_str.empty?
@@ -197,7 +199,7 @@ module LogSearch
       end
     else
       # raise ArgumentError, "Unrecognized timestamp format: #{log_time}"
-      respond("Unrecognized timestamp format or missing formats. Enabling to --no-timestamps")
+      respond("Unrecognized timestamp format or missing formats. Enabling --no-timestamps flag.")
       @has_timestamps = false
       return 1
     end
@@ -236,12 +238,38 @@ module LogSearch
     while current_log_timestamp >= @next_reset
       finished_week = eastern.to_local(Time.at(@next_reset + 3600)).strftime("%U").to_i - 1
       respond("DEBUG: Resetting weekly counter at boundary #{Time.at(@next_reset)} for finished week #{finished_week}.")
+      
+      total_this_week = @scrape_data[:weekly_ascension_searches]
+      gap = total_this_week - (@scrape_data[:last_weekly_event_searches] || 0)
+      key = (@next_reset - 1).to_s
+      @scrape_data[:none_found][key] = {
+        searches_since: gap,
+        searches_week: total_this_week,
+        creature: "none",
+        room: "none",
+        name: "final searches of the week with no find"
+      }
 
       @scrape_data[:weekly_counts][:"week_#{finished_week}_ascension_searches"] = @scrape_data[:weekly_ascension_searches]
+      @scrape_data[:weekly_counts][:"week_#{finished_week}_dust"] = @scrape_data[:weekly_dust]
+      @scrape_data[:weekly_counts][:"week_#{finished_week}_gemstone"] = @scrape_data[:weekly_gemstone]
       @scrape_data[:weekly_ascension_searches] = 0
+      @scrape_data[:weekly_gemstone] = 0
+      @scrape_data[:weekly_dust] = 0
       @scrape_data[:last_week_reset] = @next_reset
       @next_reset += 7 * 86400
       respond("DEBUG: New reset boundary set to #{Time.at(@next_reset)}")
+    end
+  end
+
+  def self.maybe_reset_monthly_counter(current_log_timestamp)
+    return unless @has_timestamps
+    est = TZInfo::Timezone.get("America/New_York")
+    ts_est = Time.at(current_log_timestamp).getlocal(est.current_period.offset.utc_total_offset)
+    current_month = ts_est.month
+    if current_month != @scrape_data[:last_month_reset]
+      @scrape_data[:monthly_gemstones] = 0
+      @scrape_data[:last_month_reset] = current_month
     end
   end
 
@@ -259,7 +287,6 @@ module LogSearch
     $search_array_log.append(file)
     respond("Parsing #{file}") if @debug
 
-
     buffer.each do |line|
       case line
       when %r{The fallen sybil's power lingers in the area, ready for the claiming.  Quickly, take your gemstone and INFUSE it while you still can!}
@@ -269,84 +296,62 @@ module LogSearch
         @scrape_data[:room] = Regexp.last_match[:room] if Regexp.last_match[:room]
         @scrape_data[:uid] = Regexp.last_match[:uid] if Regexp.last_match[:uid]
 
-      when GEMSTONE_JEWEL
+      when FOUND_GEMSTONE
         name = Regexp.last_match[:name]
         key = @scrape_data[:timestamp].to_s if @has_timestamps
         key = @scrape_data[:ascension_searches].to_s if !@has_timestamps
-        week = @scrape_data[:weekly_ascension_searches].to_s
-        @scrape_data[:jewel_found][key] = { searches_since: @scrape_data[:searches_since_jewel], searches_week: week, name: name, room: @scrape_data[:room], creature: @scrape_data[:creature] }
+        @scrape_data[:monthly_gemstones] += 1
+        @scrape_data[:weekly_gemstone] += 1
+        @scrape_data[:jewel_found][key] = {
+          searches_since: @scrape_data[:searches_since_jewel],
+          searches_week: @scrape_data[:weekly_ascension_searches],
+          name: name,
+          room: @scrape_data[:room],
+          creature: @scrape_data[:creature],
+          on_the_month: @scrape_data[:monthly_gemstones]
+        }
         respond("jewel added: #{name} -searches_last: #{@scrape_data[:searches_since_jewel]} -searches_week: #{@scrape_data[:weekly_ascension_searches]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
         @scrape_data[:searches_since_jewel] = 0
+        @scrape_data[:last_weekly_event_searches] = @scrape_data[:weekly_ascension_searches]
         $search_array_log.append(line)
 
-      when GEMSTONE_DUST
+      when FOUND_DUST
         key = @scrape_data[:timestamp].to_s if @has_timestamps
         key = @scrape_data[:ascension_searches].to_s if !@has_timestamps
-        @scrape_data[:dust_found][key] = { searches: @scrape_data[:searches_since_dust], name: "gemstone dust", room: @scrape_data[:room], creature: @scrape_data[:creature] }
+        @scrape_data[:weekly_dust] += 1
+        @scrape_data[:dust_found][key] = {
+          searches_since: @scrape_data[:searches_since_dust],
+          searches_week: @scrape_data[:weekly_ascension_searches],
+          name: "gemstone dust",
+          room: @scrape_data[:room],
+          creature: @scrape_data[:creature]
+        }
         respond("dust added: -searches: #{@scrape_data[:searches_since_dust]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
         @scrape_data[:searches_since_dust] = 0
-        $search_array_log.append(line)
-
-      when DRACONIC_IDOL
-        key = @scrape_data[:timestamp].to_s if @has_timestamps
-        key = @scrape_data[:ascension_searches].to_s if !@has_timestamps
-        @scrape_data[:idol_found][key] = { searches: @scrape_data[:searches_since_idol], name: "silver-veined black draconic idol", room: @scrape_data[:room], creature: @scrape_data[:creature] }
-        respond("idol added: -searches: #{@scrape_data[:searches_since_idol]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
-        @scrape_data[:searches_since_idol] = 0
-        $search_array_log.append(line)
-
-      when LOCK_KEY
-        name = Regexp.last_match[:name]
-        key = @scrape_data[:timestamp].to_s if @has_timestamps
-        key = @scrape_data[:total_searches].to_s if !@has_timestamps
-        @scrape_data[:key_found][key] = { searches: @scrape_data[:searches_since_lock_key], name: name, room: @scrap_data[:room], creature: @scrape_data[:creature] }
-        respond("lockandkey added: #{name} -searches: #{@scrape_data[:searches_since_lock_key]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
-        @scrape_data[:searches_since_key] = 0
-        $search_array_log.append(line)
-
-      when LEGENDARY_ITEM
-        key = @scrape_data[:timestamp].to_s if @has_timestamps
-        key = @scrape_data[:total_searches].to_s if !@has_timestamps
-        @scrape_data[:legendary_found][key] = { searches: @scrape_data[:searches_since_legendary], name: "n/a", room: @scrap_data[:room], creature: @scrape_data[:creature] }
-        respond("legendary added: -searches: #{@scrape_data[:searches_since_legendary]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
-        @scrape_data[:searches_since_legendary] = 0
-        $search_array_log.append(line)
-
-      when FEEDER_ITEM
-        key = @scrape_data[:timestamp].to_s if @has_timestamps
-        key = @scrape_data[:total_searches].to_s if !@has_timestamps
-        @scrape_data[:feeder_found][key] = { searches: @scrape_data[:searches_since_feeder], name: "n/a", room: @scrap_data[:room], creature: @scrape_data[:creature] }
-        respond("feeder added: -searches: #{@scrape_data[:searches_since_feeder]} -room: #{@scrape_data[:room]} -creature: #{@scrape_data[:creature]}")
-        @scrape_data[:searches_since_feeder] = 0
+        @scrape_data[:last_weekly_event_searches] = @scrape_data[:weekly_ascension_searches]
         $search_array_log.append(line)
 
       when SEARCH_CREATURE, SEARCH_MUG, EVIL_EYE_FLEE
-        name = Regexp.last_match[:creature]
-        @scrape_data[:creature] = name
         if @has_timestamps
           log_time = Regexp.last_match[:timestamp]
           @scrape_data[:timestamp] = convert_to_timestamp(log_time, file_date)
           maybe_reset_weekly_counter(@scrape_data[:timestamp])
+          maybe_reset_monthly_counter(@scrape_data[:timestamp])
         end
+        name = Regexp.last_match[:creature]
+        @scrape_data[:creature] = name
         if ASCENSION_CREATURES.match?(name) && @scrape_data[:quest_complete]
           @scrape_data[:ascension_searches] += 1
           @scrape_data[:weekly_ascension_searches] += 1
           @scrape_data[:searches_since_jewel] += 1
           @scrape_data[:searches_since_dust] += 1
-          if name =~ /mutant/
-            @scrape_data[:searches_since_idol] += 1
-            @scrape_data[:mutant_searches] += 1
-          end
         end
-        @scrape_data[:total_searches] += 1
-        @scrape_data[:searches_since_lock_key] += 1
-        @scrape_data[:searches_since_feeder] += 1
-        @scrape_data[:searches_since_legendary] += 1
         $search_array_log.append(line)
       end
     end
   end
   File.write(@filename2, $search_array_log.to_yaml)
+
   # save data to file
   File.write(@filename, @scrape_data.to_yaml)
   respond("Parsing complete. Search data saved to file. #{@filename}")


### PR DESCRIPTION
# Killtracker
- weekly/monthly gemstone count
- weekly dust count
- tracks searches since week start and searches since last find
- gemstone report adds a row at the end of each week showing remaining searches with no finds
- option to push finds to google spreadsheet to aggregate data  ;kt submit finds https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0 uses hash key for user to provide anonimity  (Char.name + Stats.race + Stats.prof)
- send_all_finds  method that parses $killtracker data and sends all jewel/dust finds to the spreadsheet. duplicates are determined by comparing comparing time + user (surely you can't drop a gemstone and dust on the same search) this method isn't documented in hopes it will deter people from running it every time they log in. spreadsheet runs a removeDuplicateAndSort script nightly to clean up entries.

# log_search
- weekly/monthly gemstone count
- weekly dust count
- tracks searches since week start and searches since last find