### PR TITLE
fix(invoker.lic): v2.4.1 couple bug fixes

### DIFF
--- a/scripts/invoker.lic
+++ b/scripts/invoker.lic
@@ -8,9 +8,12 @@
   Contributors: Nesmeor, Athias, Tysong
           name: invoker
           tags: utility, spellup
-       version: 2.4.0
+       version: 2.4.1
 
   Changelog:
+  2.4.1 (2025-04-12)
+    - Change @variables to @@variables
+    - Logic to wait for invoker if got there too early
   2.4.0 (2024-08-06)
     - Change tzinfo/tzinfo-data gem loading to allow for install
   2.3.1 (2024-08-06)
@@ -74,18 +77,18 @@ Settings[:debug]            ||= false
 class Invoker
   def initialize(auto = false)
     if auto == true
-      @auto = true
+      @@auto = true
     else
-      @auto = Settings[:auto]
+      @@auto = Settings[:auto]
     end
-    Invoker.msg("Invoker auto mode: #{@auto}", "info")
+    Invoker.msg("Invoker auto mode: #{@@auto}", "info")
 
     @@current_hour = nil
-    @decision = false
-    @scripts_to_pause = Settings[:scripts_to_pause]
-    @scripts_to_kill = Settings[:scripts_to_kill]
-    @scripts_to_resume = []
-    @dubug = Settings[:debug]
+    @@decision = false
+    @@scripts_to_pause = Settings[:scripts_to_pause]
+    @@scripts_to_kill = Settings[:scripts_to_kill]
+    @@scripts_to_resume = []
+    @@debug = Settings[:debug]
 
     # This defaults the Town Square, Small Park
     invoker_location = 3677
@@ -98,18 +101,18 @@ class Invoker
         new_hour = Time.now.hour
         # Make sure we haven't seen the invoker already
         unless Invoker.current == new_hour
-          @decision = false
-          until @decision
+          @@decision = false
+          until @@decision
             if !Invoker.check_time
               break
             end
             # Automatically ask for spells if in the same room. 284 is duplicate ID
-            if Room.current.id == invoker_location and @auto == true
+            if Room.current.id == invoker_location and @@auto == true
               Invoker.visit_invoker
               Invoker.update_time(new_hour)
               break
             # Otherwise prompt the player to respond
-            elsif @auto == true
+            elsif @@auto == true
               Invoker.msg("Invoker is now available, automatically visiting in 15 seconds. ;stop invoker to prevent this.", "info")
               pause 15
               Invoker.halt_scripts
@@ -144,14 +147,14 @@ class Invoker
 
   def self.msg(text, type = "info")
     # send debug messages if debugging
-    if (type == "debug" && @debug) || type != "debug"
+    if (type == "debug" && @@debug) || type != "debug"
       _respond Lich::Messaging.msg_format(type, text)
     end
   end
 
   def self.update_time(new_hour)
     @@current_hour = new_hour
-    @decision = true
+    @@decision = true
   end
 
   def self.check_time
@@ -192,6 +195,14 @@ class Invoker
       /^The invoker states, "The cost for my services is 10,000 silver and I will provide a full spellup\.  If you'd like me to continue, please have payment in hand and ASK me again with 30 seconds\."$/,
       /^You hand over your payment to a half-elven invoker garbed in colorful layered robes\.  Shaking back the layered sleeves of her multicolored robes, the invoker releases upon you a flurry of abjurations\.\.\.$/
     )
+    if !GameObj.npcs.any? { |npc| npc.noun == 'invoker' } && Time.now.min < 10
+      echo("Invoker not here! Likely he's running a tad late, so waiting for him to arrive or for it to be #{Time.now.hour}:11")
+      loop do
+        break if GameObj.npcs.any? { |npc| npc.noun == 'invoker' }
+        break if Time.now.min > 10
+        sleep(5)
+      end
+    end
     results = dothistimeout("ask invoker about spells", 3, regex_results)
     if results =~ /^The invoker states, "I've already granted you some spells\.  Please wait a few minutes before asking again\."$/
       Invoker.msg("You have already asked for spells, please try again later!", "info")
@@ -228,19 +239,19 @@ class Invoker
   end
 
   def self.halt_scripts
-    @scripts_to_pause.each { |script|
+    @@scripts_to_pause.each { |script|
       Invoker.msg("Invoker.halt_scripts each: #{script}", "debug")
       Invoker.msg("Script.running? #{Script.running?(script)}", "debug")
       if Script.running?(script)
         Script.pause(script)
-        @scripts_to_resume.push(script)
+        @@scripts_to_resume.push(script)
         # in case this terminates early, kill scripts to avoid chaos
         before_dying { kill_script script }
       end
     }
-    Invoker.msg("Invoker.halt_scripts scripts_to_resume:#{@scripts_to_resume}", "debug")
+    Invoker.msg("Invoker.halt_scripts scripts_to_resume:#{@@scripts_to_resume}", "debug")
 
-    @scripts_to_kill.each { |script|
+    @@scripts_to_kill.each { |script|
       if Script.running?(script)
         kill_script script
       end
@@ -248,8 +259,8 @@ class Invoker
   end
 
   def self.resume_scripts
-    Invoker.msg("Invoker.resume_scripts scripts_to_resume: #{@scripts_to_resume}", "debug")
-    @scripts_to_resume.each { |script|
+    Invoker.msg("Invoker.resume_scripts scripts_to_resume: #{@@scripts_to_resume}", "debug")
+    @@scripts_to_resume.each { |script|
       if Script.paused?(script)
         Script.unpause(script)
       end


### PR DESCRIPTION
* change `@variables` to `@@variables` due to being a class.
* add logic to wait for invoker after arrival if got there too early for invoker to be there yet.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes variable scoping and adds logic to wait for late invoker in `invoker.lic` script.
> 
>   - **Behavior**:
>     - Change `@variables` to `@@variables` in `Invoker` class to correct scoping issues.
>     - Add logic in `get_spells` to wait for invoker if it arrives late, checking every 5 seconds until 10 minutes past the hour.
>   - **Misc**:
>     - Update version to 2.4.1 in `invoker.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 566ddee181d85ce80c7d43db61f84e05f276344a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->