### PR TITLE
fix(ejoustsmart): fixed typo in help file

### DIFF
--- a/scripts/ejoustsmart.lic
+++ b/scripts/ejoustsmart.lic
@@ -276,7 +276,7 @@ module EJoustSmart
     respond "   #{$lich_char}vars set ignore_jousting_xp=no"
     respond "   or #{$lich_char}#{Script.current.name} absorb_xp_first"
     respond "You can set it to ignore your mind state by:"
-    respond "   #{$lich_char}vars set ignore_jousting_xp"
+    respond "   #{$lich_char}vars set ignore_jousting_xp=yes"
     respond "   or #{$lich_char}#{Script.current.name} ignore_jousting_xp"
     respond ""
     respond "You may set where you want to store your marker by setting:"


### PR DESCRIPTION
was missing =yes for vars set.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `ejoustsmart.lic` help message by adding missing `=yes` in command example.
> 
>   - **Help Message Fix**:
>     - Corrected typo in `ejoustsmart.lic` help message: added missing `=yes` in `vars set ignore_jousting_xp=yes` command example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7c4eb74be3e1f45d1d99a500b587824d213f1a0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->