### PR TITLE
fix(gs): Killtracker.lic fixes

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -19,9 +19,14 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 2.0
+       version: 2.1
 
 Change Log:
+  v2.1
+    - added way to correct weekly/montly found count
+    - added commas to large numbers
+    - migrate old dust search count to new format
+    - indicate how many weeks to show with gemstone report ;kt gemstone report 4
   v2.0
     - added monthly/weekly gemstone tracking
     - added weekly dust tracking
@@ -76,6 +81,15 @@ module Killtracker
   $killtracker[:last_month_reset]           ||= TZInfo::Timezone.get("America/New_York").now.month
   $killtracker[:last_week_reset]            ||= 0
   $killtracker[:cached_reset_time]          ||= 0
+  
+  # migrate legacy dust count to newer format
+  if $killtracker[:dust_found]
+    $killtracker[:dust_found].each do |ts, ev|
+      if ev.key?(:searches)
+        ev[:searches_since] = ev.delete(:searches)
+      end
+    end
+  end
   File.write(@filename, $killtracker.to_yaml)
 
   def self.help
@@ -86,6 +100,7 @@ module Killtracker
     respond(";killtracker gemstones report")
     respond(";killtracker jewel report")
     respond(";killtracker dust report")
+    respond(";killtracker fix find count - fixes monthly/weekly gemstone finds")
     respond("")
     respond(";killtracker submit finds - Pushes jewel and dust find to google sheets.")
     respond("   https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0")
@@ -97,7 +112,7 @@ module Killtracker
 
     rows = events.map do |key, ev|
       time_str = tz.to_local(Time.at(key.to_i)).strftime("%m/%d %H:%M:%S")
-      searches = ev[:searches_week] || 0
+      searches = ev[:searches_week].with_commas || 0
       creature = ev[:creature] || ""
       room     = ev[:room] || ""
       name     = ev[:name] || ""
@@ -123,7 +138,7 @@ module Killtracker
 
     rows = events.map do |key, ev|
       time_str = tz.to_local(Time.at(key.to_i)).strftime("%m/%d %H:%M:%S")
-      searches = ev[:searches_week] || 0
+      searches = ev[:searches_week].with_commas || 0
       creature = ev[:creature] || ""
       room     = ev[:room] || ""
       name     = ev[:name] || ""
@@ -173,20 +188,20 @@ module Killtracker
     remaining_gems = [0, 3 - gems_this_month].max
 
     rows = [
-      ["Searches This Week", weekly_searches],
+      ["Searches This Week", weekly_searches.with_commas],
       [],
-      ["Gemstones Found (all)", gems_total],
+      ["Gemstones Found (all)", gems_total.with_commas],
       [" This Week", gems_this_week],
       [" This Month", gems_this_month],
-      [" Avg Searches/Gem", avg_per_gem],
+      [" Avg Searches/Gem", avg_per_gem.with_commas],
       [" Remaining Gems", remaining_gems],
       [],
-      ["Dust Found (all)", dust_total],
+      ["Dust Found (all)", dust_total.with_commas],
       [" This Week", dust_this_week],
-      [" Avg Searches/Dust", avg_per_dust],
+      [" Avg Searches/Dust", avg_per_dust.with_commas],
       [],
-      ["Since Last Gem", since_last_gem],
-      ["Since Last Dust", since_last_dust],
+      ["Since Last Gem", since_last_gem.with_commas],
+      ["Since Last Dust", since_last_dust.with_commas],
     ]
 
     table = Terminal::Table.new(
@@ -198,7 +213,7 @@ module Killtracker
     respond table.to_s
   end
 
-  def self.gemstones_report
+  def self.gemstones_report(weeks_back = nil)
     tz = TZInfo::Timezone.get("America/New_York")
 
     combined = []
@@ -225,33 +240,41 @@ module Killtracker
     end
 
     events_by_week = combined.group_by do |ev|
-      local = tz.to_local(Time.at(ev[:timestamp]))
-      local.strftime("%U").to_i
+      tz.to_local(Time.at(ev[:timestamp])).strftime("%U").to_i
     end
-
     current_week = tz.to_local(Time.now).strftime("%U").to_i
 
-    events_by_week.sort.each do |week_number, events|
-      weekly_count =
-        if week_number == current_week
-          $killtracker[:weekly_ascension_searches]
-        else
-          ($killtracker[:weekly_counts] &&
-           $killtracker[:weekly_counts][:"week_#{week_number}_searches"]) || 0
-        end
+    if weeks_back
+      start_week = [0, current_week - (weeks_back - 1)].max
+      allowed_weeks = (start_week..current_week).to_a
+    else
+      allowed_weeks = events_by_week.keys
+    end
 
-      next if weekly_count == 0
-      title = "Week #{week_number} Gemstone Search Report: #{weekly_count} Searches"
-      rows = events.sort_by { |ev| ev[:timestamp] }.map do |ev|
-        time_str = tz.to_local(Time.at(ev[:timestamp])).strftime("%m/%d %H:%M:%S")
-        [
-          time_str,        # Time
-          ev[:type],       # Type
-          ev[:searches_week] || 0, # Searches so far that week at event
-          ev[:since] || 0, # Searches since last find
-          ev[:creature],   # Creature
-          ev[:name]        # Name
-        ]
+    events_by_week
+      .select{ |wk, _| allowed_weeks.include?(wk) }
+      .sort
+      .each do |week_number, events|
+        weekly_count =
+          if week_number == current_week
+            $killtracker[:weekly_ascension_searches]
+          else
+            ($killtracker[:weekly_counts] &&
+            $killtracker[:weekly_counts][:"week_#{week_number}_ascension_searches"]) || 0
+          end
+        next if weekly_count == 0
+
+        title = "Week #{week_number} Gemstone Search Report: #{weekly_count.with_commas} Searches"
+        rows = events.sort_by { |ev| ev[:timestamp] }.map do |ev|
+          time_str = tz.to_local(Time.at(ev[:timestamp])).strftime("%m/%d %H:%M:%S")
+          [
+            time_str,        # Time
+            ev[:type],       # Type
+            ev[:searches_week].with_commas || 0, # Searches so far that week at event
+            ev[:since].with_commas || 0, # Searches since last find
+            ev[:creature],   # Creature
+            ev[:name]        # Name
+          ]
       end
 
       table = Terminal::Table.new(
@@ -308,6 +331,31 @@ module Killtracker
     %r{kiramon strandweaver},
     %r{kresh ravager}
   )
+
+  def self.backfill_counters
+    tz = TZInfo::Timezone.get("America/New_York")
+    now = tz.now
+    current_week  = now.strftime("%U").to_i
+    current_month = now.month
+  
+    $killtracker[:weekly_gemstone]   = 0
+    $killtracker[:monthly_gemstones] = 0
+    $killtracker[:weekly_dust]       = 0
+  
+    $killtracker[:jewel_found].each_key do |key|
+      ts    = key.to_i
+      local = tz.to_local(Time.at(ts))
+  
+      $killtracker[:weekly_gemstone]   += 1 if local.strftime("%U").to_i == current_week
+      $killtracker[:monthly_gemstones] += 1 if local.month == current_month
+    end
+
+    $killtracker[:dust_found].each_key do |key|
+      ts    = key.to_i
+      local = tz.to_local(Time.at(ts))
+      $killtracker[:weekly_dust] += 1 if local.strftime("%U").to_i == current_week
+    end
+  end
 
   def self.send_to_sheet(ev_type, key)
     case ev_type
@@ -380,7 +428,7 @@ module Killtracker
         room: "none",
         name: "Final searches of the week with no find"
       }
-      $killtracker[:weekly_counts][:"week_#{finished_week}_searches"] = $killtracker[:weekly_ascension_searches]
+      $killtracker[:weekly_counts][:"week_#{finished_week}_ascension_searches"] = $killtracker[:weekly_ascension_searches]
       $killtracker[:weekly_counts][:"week_#{finished_week}_dust"] = $killtracker[:weekly_dust]
       $killtracker[:weekly_counts][:"week_#{finished_week}_gemstone"] = $killtracker[:weekly_gemstone]
       $killtracker[:weekly_ascension_searches] = 0
@@ -467,7 +515,7 @@ module Killtracker
 
   DownstreamHook.add(DOWNSTREAM_HOOK_ID, proc do |server_string| parse_downstream(server_string) end)
   UpstreamHook.add(UPSTREAM_HOOK_ID, proc do |command| parse_upstream(command) end)
-  before_dying { DownstreamHook.remove(DOWNSTREAM_HOOK_ID); UpstreamHook.remove(UPSTREAM_HOOK_ID); File.write(@filename, $killtracker.to_yaml) }
+  before_dying { File.write(@filename, $killtracker.to_yaml); DownstreamHook.remove(DOWNSTREAM_HOOK_ID); UpstreamHook.remove(UPSTREAM_HOOK_ID) }
 
   get_next_reset_local_time
   maybe_reset_weekly_counter
@@ -487,9 +535,11 @@ module Killtracker
       when "found dust"
         _, creature, week, dust = report
         Lich::Messaging.stream_window("Found dust after #{week} searches. (#{creature}) - Since last Dust: (#{dust})", "speech")
+        File.write(@filename, $killtracker.to_yaml)
       when "found gemstone"
         _, creature, week, jewel = report
         Lich::Messaging.stream_window("Found a gemstone in #{week} searches. (#{creature}) - Since last Jewel: (#{jewel})", "speech")
+        File.write(@filename, $killtracker.to_yaml)
       when /send dust report/
         send_to_sheet("dust", report[1])
       when /send jewel report/
@@ -507,26 +557,29 @@ module Killtracker
         Killtracker.jewel_report
       when /dust report/
         Killtracker.dust_report
-      when /gemstones? report/
-        Killtracker.gemstones_report
+      when /gemstones? report(?:\s+(\d+))?$/
+        weeks = $1 ? $1.to_i : nil
+        Killtracker.gemstones_report(weeks)
       when /summary/
         Killtracker.summary_report
       when /send all finds/
         Killtracker.send_all_finds
+      when /fix find count/
+        Killtracker.backfill_counters
       when /announce$/
         $killtracker[:silent] = !$killtracker[:silent] # toggle setting
         msg = $killtracker[:silent] ? 'Reporting only upon a find.' : 'Reporting after each kill.'
-        Lich::Messaging.stream_window(msg, "speech")
+        respond(msg)
       when /announce msg/
         $killtracker[:announce_msg] ||= false
         $killtracker[:announce_msg] = !$killtracker[:announce_msg]
         msg = $killtracker[:announce_msg] ? 'Announce shows total search count.' : 'Announce shows searches since last find'
-        Lich::Messaging.stream_window(msg, "speech")
+        respond(msg)
       when /submit finds/
         $killtracker[:submit_finds] ||= false
         $killtracker[:submit_finds] = !$killtracker[:submit_finds]
         msg = $killtracker[:submit_finds] ? 'NOT sending finds to external spreadsheet' : 'Sending finds to external spreadsheet'
-        Lich::Messaging.stream_window(msg, "speech")
+        respond(msg)
       end
     end
     sleep(0.25)


### PR DESCRIPTION
- ;kt fix find count   will look back at previous finds to get week/month count
- commas for large numbers
- automatically migrates old dust :searches count to new :searches_since count
- specify how many weeks to show with ;kt gemstone report #
  leave number off to show all weeks