### PR TITLE
feat(gs): Killtracker.lic cross-char tracking

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -19,9 +19,11 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 2.1
+       version: 2.2
 
 Change Log:
+  v2.2
+    - cross character eligibilty tracking ;kt eligible
   v2.1
     - added way to correct weekly/montly found count
     - added commas to large numbers
@@ -82,6 +84,15 @@ module Killtracker
   $killtracker[:last_week_reset]            ||= 0
   $killtracker[:cached_reset_time]          ||= 0
 
+  # cross-char tracking
+  @eligibility_file = File.join(DATA_DIR, XMLData.game, "jewel_eligibility.yaml")
+  if File.exist?(@eligibility_file)
+    @jewel_eligibility = YAML.load_file(@eligibility_file) || {}
+  else
+    @jewel_eligibility = {}
+    File.write(@eligibility_file, @jewel_eligibility.to_yaml)
+  end
+
   # migrate legacy dust count to newer format
   if $killtracker[:dust_found]
     $killtracker[:dust_found].each do |_, ev|
@@ -97,6 +108,7 @@ module Killtracker
     respond(";killtracker announce     - To watch kills increment in the speech window.")
     respond(";killtracker announce msg - Alternate between two announce messages.")
     respond(";killtracker summary")
+    respond(";killtracker eligibile - show cross character eligibility")
     respond(";killtracker gemstones report")
     respond(";killtracker jewel report")
     respond(";killtracker dust report")
@@ -283,6 +295,38 @@ module Killtracker
     end
   end
 
+  def self.eligibility_report(sort_key = nil)
+    prof_mode = sort_key&.match?(/^(?:prof|profession)$/i)
+    if prof_mode
+      groups = @jewel_eligibility.values.group_by { |stats| stats[:profession] }
+      rows = groups.map do |prof, stats_list|
+        wk = stats_list.sum { |s| s[:weekly_gemstone].to_i }
+        mo = stats_list.sum { |s| s[:monthly_gemstones].to_i }
+        eligible = !(mo == 3 || wk == 1) ? "Yes" : "No"
+        [ prof, eligible, wk, mo ]
+      end
+      title    = "Jewel Eligibility Across Characters (by profession)"
+      headings = ["Prof", "Eligible", "Week", "Month"]
+    else
+      rows = @jewel_eligibility.map do |char, stats|
+        wk = stats[:weekly_gemstone].to_i
+        mo = stats[:monthly_gemstones].to_i
+        eligible = !(mo == 3 || wk == 1) ? "Yes" : "No"
+        [ char, stats[:profession], eligible, wk, mo ]
+      end
+      title    = "Jewel Eligibility Across Characters"
+      headings = ["Name", "Prof", "Eligible", "Week", "Month"]
+    end
+    rows.sort_by! { |r| r[0].downcase }
+
+    table = Terminal::Table.new(
+      title:    title,
+      headings: headings,
+      rows:     rows
+    )
+    respond table.to_s
+  end
+
   CMD_QUEUE = Queue.new
   REPORT_QUEUE = Queue.new
   DOWNSTREAM_HOOK_ID = "#{Script.current.name.downcase}::downstream"
@@ -329,6 +373,16 @@ module Killtracker
     %r{kresh ravager}
   )
 
+  def self.update_eligibility
+    @jewel_eligibility = YAML.load_file(@eligibility_file) || {}
+    @jewel_eligibility[Char.name] = {
+      profession: Stats.prof,
+      weekly_gemstone: $killtracker[:weekly_gemstone],
+      monthly_gemstones: $killtracker[:monthly_gemstones],
+    }
+    File.write(@eligibility_file, @jewel_eligibility.to_yaml)
+  end
+
   def self.backfill_counters
     tz = TZInfo::Timezone.get("America/New_York")
     now = tz.now
@@ -352,6 +406,7 @@ module Killtracker
       local = tz.to_local(Time.at(ts))
       $killtracker[:weekly_dust] += 1 if local.strftime("%U").to_i == current_week
     end
+    update_eligibility
   end
 
   def self.send_to_sheet(ev_type, key)
@@ -517,6 +572,7 @@ module Killtracker
   get_next_reset_local_time
   maybe_reset_weekly_counter
   maybe_reset_monthly_counter
+  update_eligibility
 
   CMD_QUEUE.push(Script.current.vars[0]) unless Script.current.vars[0].nil?
 
@@ -537,6 +593,7 @@ module Killtracker
         _, creature, week, jewel = report
         Lich::Messaging.stream_window("Found a gemstone in #{week} searches. (#{creature}) - Since last Jewel: (#{jewel})", "speech")
         File.write(@filename, $killtracker.to_yaml)
+        update_eligibility
       when /send dust report/
         send_to_sheet("dust", report[1])
       when /send jewel report/
@@ -563,6 +620,9 @@ module Killtracker
         Killtracker.send_all_finds
       when /fix find count/
         Killtracker.backfill_counters
+      when /(?:eligible|eligibility)(?:\s+(\w+))?/
+        sort_key = $1&.downcase
+        Killtracker.eligibility_report(sort_key)
       when /announce$/
         $killtracker[:silent] = !$killtracker[:silent] # toggle setting
         msg = $killtracker[:silent] ? 'Reporting only upon a find.' : 'Reporting after each kill.'


### PR DESCRIPTION
- saves name, profession, weekly_gemstone, and monthly_gemstones counts to jewel_eligibilty.yaml
- ;kt eligible or ;kt eligible prof  to display a break down for the people with many accounts:

```
+-----------------------------------------------------+ 
| Jewel Eligibility Across Characters (by profession) |
+-------------+-------------+------------+------------+
| Prof        | Eligible    | Week       | Month      |
+-------------+-------------+------------+------------+
| Cleric      | No          | 1          | 3          |
| Ranger      | No          | 1          | 2          |
| Rogue       | No          | 1          | 1          |
| Sorcerer    | No          | 1          | 2          |
| Wizard      | Yes         | 0          | 0          |
+-------------+-------------+------------+------------+
```