### PR TITLE
fix(map.lic): v1.3.8 fix window positioning for tiling window managers

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -15,9 +15,11 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich > 5.0.1
-      version: 1.3.7
+      version: 1.3.8
 
   changelog:
+    v1.3.8 (2025-04-20)
+      * Fix for initial default window position for tiling window managers that do not set monitor geometry
     v1.3.7 (2025-04-15)
       * Fix reset and initial default value/position of window to primary monitor location
     v1.3.6 (2025-03-06)
@@ -272,10 +274,10 @@ if Script.current.vars[1] =~ /reset/i
   monitor = display.primary_monitor
   # Get geometry of the primary monitor
   geometry = monitor.geometry
-  monitor_x = geometry.x
-  monitor_y = geometry.y
-  monitor_width = geometry.width
-  monitor_height = geometry.height
+  monitor_x = geometry.x || 0
+  monitor_y = geometry.y || 0
+  monitor_width = geometry.width || 0
+  monitor_height = geometry.height || 0
   # Assume window_position is an array [x, y]
   window_position = [0, 0]
   # Adjust the window position within bounds of the primary monitor
@@ -984,10 +986,10 @@ Gtk.queue {
 
   # Get geometry of the primary monitor
   geometry = monitor.geometry
-  monitor_x = geometry.x
-  monitor_y = geometry.y
-  monitor_width = geometry.width
-  monitor_height = geometry.height
+  monitor_x = geometry.x || 0
+  monitor_y = geometry.y || 0
+  monitor_width = geometry.width || 0
+  monitor_height = geometry.height || 0
 
   # Set window size
   window_width = [window_width, 100].max


### PR DESCRIPTION
Using Hyprland and no monitor geometry is set so the script was throwing an error. Added logic to default to 0 if the WM doesn't set a geometry.