### PR TITLE
fix(eherbs.lic): v2.1.4 put regex update for full survival kit dosage

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -14,7 +14,9 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 5.9.0
-           version: 2.1.3
+           version: 2.1.4
+  2.1.4  (2025-04-22)
+    - add additional put regex for survival kit when fully stocked
   2.1.3  (2025-03-25)
     - remove waitcastrt? from wait_rt method
     - add waitcastrt? to cast_spells method
@@ -363,7 +365,8 @@ module EHerbs
       /wear three functional items/,
       /^Your .*? won't fit in .*?\.$/,
       /You add/,
-      /You find a suitable/
+      /You find a suitable/,
+      /^Your .+ is already fully stocked with (?:solid|liquid) \w+\.  You put .+ in your .+\.$/
     )
 
     settings_hash[:get_regex] = Regexp.union(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `eherbs.lic` to version 2.1.4, adding a regex pattern to handle fully stocked survival kits.
> 
>   - **Behavior**:
>     - Update `put_regex` in `eherbs.lic` to include a new pattern for handling fully stocked survival kits.
>     - Version updated from 2.1.3 to 2.1.4 to reflect this change.
>   - **Documentation**:
>     - Update version history in `eherbs.lic` to document the new regex addition for survival kits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 41e711ab4d035afd794e843ed2d92730161f6e34. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->