### PR TITLE
fix(eloot.lic): v2.3.8 older Ruby 2.6 and Bounty API fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.3.7
+           version: 2.3.8
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.3.8 (2025-04-22)
+    - bugfix for older Ruby 2.6 users and Bounty.task.assigned?
   v2.3.7 (2025-03-27)
     - add ;eloot pool return to options
     - bugfix for Rift talons gem hoarding
@@ -4018,7 +4020,8 @@ module ELoot # Gem and Reagent hoarding
     end
 
     def self.check_gem_bounty # Returns gem bounty name and count
-      return unless ELoot.data.settings[:gem_horde_turnin] && Bounty.task.gem? && !Bounty.task.assigned?
+      # return unless ELoot.data.settings[:gem_horde_turnin] && Bounty.task.gem? && !Bounty.task.assigned? # update to this post 5.11.2+
+      return unless ELoot.data.settings[:gem_horde_turnin] && Bounty.task.gem? && !Bounty.task.type.to_s.end_with?("assignment")
 
       gem_name = Hoard.normalize_name(Bounty.task.gem)
       gem_number = Bounty.task.number
@@ -5051,7 +5054,8 @@ module ELoot # Sells the loot
 
     def self.check_bounty_furrier
       return unless ELoot.data.settings[:sell_loot_types].include?("skin")
-      return unless Bounty.task.skin? && !Bounty.task.assigned?
+      # return unless Bounty.task.skin? && !Bounty.task.assigned? # update to this post 5.11.2+ release
+      return unless Bounty.task.skin? && !Bounty.task.type.to_s.end_with?("assignment")
       need_furrier = false
 
       skin = Bounty.task.skin
@@ -5157,7 +5161,8 @@ module ELoot # Sells the loot
 
     def self.check_bounty_gems
       return unless ELoot.data.settings[:sell_loot_types].include?("gem")
-      return unless Bounty.task.gem? && !Bounty.task.assigned?
+      # return unless Bounty.task.gem? && !Bounty.task.assigned? # update to this post 5.11.2+ release
+      return unless Bounty.task.gem? && !Bounty.task.type.to_s.end_with?("assignment")
       need_gemshop = false
 
       gem = Bounty.requirements[:gem]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes compatibility issue for older Ruby 2.6 users and updates Bounty task logic in `eloot.lic`.
> 
>   - **Bug Fix**:
>     - Fixes compatibility issue for older Ruby 2.6 users in `eloot.lic`.
>     - Updates logic in `check_gem_bounty`, `check_bounty_furrier`, and `check_bounty_gems` to replace `Bounty.task.assigned?` with `!Bounty.task.type.to_s.end_with?("assignment")`.
>   - **Version Update**:
>     - Bumps version to 2.3.8 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for d0a1c0375008b2d6e731090710aebd625f354a30. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->