### PR TITLE
feat(ecleanse.lic): v2.2.0

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -16,6 +16,7 @@
     - remove spell cleave/thieve from bound/web removal, added to cloud/web/globe avoidance
     - bugfix for hive trap/apparatus to not search unless actual room detected for them
     - bugfix add Red Forest fog to invalid cloud check
+    - bugfix in telekinetic disarm xml matching
   v2.1.1  (2025-04-18)
     - fix for Moonsedge bind not triggering properly in XML
     - add Paladin 1635 beseech support in remove_stun and remove_web_bound
@@ -1364,7 +1365,7 @@ module Ecleanse
           Ecleanse.data.recover_item = Regexp.last_match(1)
           Ecleanse.data.recover_room = Room.current
           Ecleanse.data.event_stack << :recover && !Ecleanse.data.event_stack.include?(:recover)
-        elsif server =~ /Your <a exist=".*?" noun="(.*?)">.*?<\/a>tears free from your hands and floats/
+        elsif server =~ /Your <a exist=".*?" noun="(.*?)">.*?<\/a> tears free from your hands and floats/
           Ecleanse.data.recover_item = Regexp.last_match(1)
           Ecleanse.data.event_stack << :telekinetic_recover && !Ecleanse.data.event_stack.include?(:telekinetic_recover)
         elsif server =~ /Striking with a serpent's unsettling quickness, (?:.*)\.  Vile (?:.*), kindling it into an unholy semblance of life.  The (?:.*) form twists and mutates, sprouting scales and cold eyes as it transforms into a <a exist="\d+" noun="([^"]+)">[^<]+<\/a>\!/


### PR DESCRIPTION
- determine whether web/globe/cloud is targetable to avoid dispelling player versions
- track web/globe/cloud ids to not retry casting again via CappedCollection
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `ecleanse.lic` with targetable checks, ID tracking via `CappedCollection`, and various bug fixes.
> 
>   - **Behavior**:
>     - Determine if `web`, `globe`, `cloud` are targetable to avoid dispelling player versions in `ecleanse.lic`.
>     - Track `web`, `globe`, `cloud` IDs using `CappedCollection` to prevent redundant casting.
>     - Remove `spell cleave/thieve` from bound/web removal, add to cloud/web/globe avoidance.
>   - **Classes**:
>     - Add `CappedCollection` class in `ecleanse.lic` to manage a capped list of IDs.
>   - **Bug Fixes**:
>     - Fix hive trap/apparatus search logic to only trigger in correct rooms.
>     - Add Red Forest fog to invalid cloud check.
>     - Correct telekinetic disarm XML matching.
>   - **Misc**:
>     - Update Lich version requirement to `>= 5.11.1` in `ecleanse.lic`.
>     - Add support for Covert Arts: Escape Artist in `ecleanse.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7fc4e7db6ddab22d065dc3743bdc89f37839b10c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->