### PR TITLE
fix(go2.lic): v2.2.11 bugfix in CLI gigas min number

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.2.10
+           version: 2.2.11
           required: Lich >= 5.4.1
 
    changelog:
+      2.2.11 (2025-04-24)
+        Bugfix in CLI gigas_min_number setting not working
       2.2.10 (2025-04-22)
         Allow any characters in save targets
       2.2.9 (2025-04-08)
@@ -1242,8 +1244,8 @@ module Go2
       setting_echo_input = setting_value[$1.downcase]
     elsif (var =~ /^(?:\-\-)?use[_\-]?(?:gigas[_\-]?)?hwtravel?=(on|true|yes|off|false|no)$/i)
       settings_use_gigas_hwtravel = setting_value[$1.downcase]
-    elsif (var =~ /^(?:\-\-)?gigas[_\-]?(?:min[_\-]?)?number?=(on|true|yes|off|false|no)$/i)
-      settings_gigas_min_number = setting_value[$1.downcase]
+    elsif (var =~ /^(?:\-\-)?gigas[_\-]?(?:min[_\-]?)?number?=(\d+)$/i)
+      settings_gigas_min_number = $1.to_i
     else
       target_search_array.push(var)
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `gigas_min_number` setting in `go2.lic` to correctly parse numeric values, updating version to 2.2.11.
> 
>   - **Bugfix**:
>     - Fixes `gigas_min_number` setting in `go2.lic` to correctly parse numeric values instead of boolean values.
>     - Updates regex pattern in `Go2` module to capture numeric input for `gigas_min_number` and convert it to an integer.
>   - **Version Update**:
>     - Bumps version from 2.2.10 to 2.2.11 in `go2.lic`.
>     - Adds changelog entry for version 2.2.11 noting the bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2d076ba38a21dc7457d8fb0c98c3b14d48a612fa. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->