### PR TITLE
fix(rofl-run.lic) - v1.0.4 xml_encoding fix for help display

### DIFF
--- a/scripts/rofl-run.lic
+++ b/scripts/rofl-run.lic
@@ -11,9 +11,12 @@
   contributors: Tysong, Dissonance
           game: Gemstone
           tags: rings of lumnis, RoL
-       version: 1.0.3
+       version: 1.0.4
 
   Changelog:
+  v1.0.4 - 2025-04-25
+    - added xml_encode to help, since .mono isn't currently doing that
+    - corrected style for calling Messaging.mono
   v1.0.3 - 2025-04-23
     - improved hand handling
     - allowed alternate versions of commands (planes/planar, spirits/spiritual, elements/elemental)
@@ -245,39 +248,40 @@ module RofLRun
     end
   end
 
+  # the extra xml_encode will not be necessary in the future, but for now mono does not encode.
   def self.show_help
-    Lich::Messaging::mono("** ** **  Ringing  ** ** **")
-    Lich::Messaging::mono("** ** Version: #{(Script.list.find { |x| x.name == Script.current.name }.inspect)[/version: (\d+\.\d+\.\d+)/i, 1]}  ** **")
-    Lich::Messaging::mono("**")
-    Lich::Messaging::mono("** USAGE: '#{$lich_char}#{Script.current.name} <planes/spirit/elements/chaos/order>'")
-    Lich::Messaging::mono("** ")
-    Lich::Messaging::mono("** This script requires both rofl-puzzles and rofl-questions to be downloaded to work.")
-    Lich::Messaging::mono("**     rofl-puzzles is #{Script.exists?("rofl-puzzles") ? "present" : "missing"} and rofl-questions is #{Script.exists?("rofl-questions") ? "present" : "missing"}")
-    Lich::Messaging::mono("** ")
-    Lich::Messaging::mono("** To stop the script from doing another run after this one:  ")
-    Lich::Messaging::mono("**   #{$lich_char}vars set stop_ringing=yes")
-    Lich::Messaging::mono("**   #{$lich_char}#{Script.current.name} stop")
-    Lich::Messaging::mono("** this gets auto-reset to no after the run finishes as the script exits.")
-    Lich::Messaging::mono("** ")
-    Lich::Messaging::mono("** The script will run endlessly until you are over #{UserVars.ringing_start_resting}% then rest")
-    Lich::Messaging::mono("** until you are under #{UserVars.ringing_stop_resting}%.")
-    Lich::Messaging::mono("** > You can set the preferred resting threshold % by:")
-    Lich::Messaging::mono("**     #{$lich_char}#{Script.current.name} mind_stop=<number> (no percent sign)")
-    Lich::Messaging::mono("** > You can set the preferred re-starting threshold % by:")
-    Lich::Messaging::mono("**     #{$lich_char}#{Script.current.name} mind_start=<number> (no percent sign)")
-    Lich::Messaging::mono("** > You can enable experience management by:")
-    Lich::Messaging::mono("**     #{$lich_char}#{Script.current.name} absorb_xp")
-    Lich::Messaging::mono("** > You can disable experience management by:")
-    Lich::Messaging::mono("**     #{$lich_char}#{Script.current.name} ignore_xp")
-    Lich::Messaging::mono("**")
-    Lich::Messaging::mono("** Prizes will be placed in #{UserVars.lootsack.nil? ? "stowed" : "your " + UserVars.lootsack}.")
-    Lich::Messaging::mono("** If you want to change that, then: ")
-    Lich::Messaging::mono("**    #{$lich_char}vars set lootsack=<container>")
-    Lich::Messaging::mono("**")
-    Lich::Messaging::mono("** Debugging can be toggled (currently: #{@rofl_debug}) by:")
-    Lich::Messaging::mono("**    #{$lich_char}#{Script.current.name} debug")
-    Lich::Messaging::mono("**")
-    Lich::Messaging::mono("** **  Happy Ringing  ** **")
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** ** **  Ringing  ** ** **"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** ** Version: #{(Script.list.find { |x| x.name == Script.current.name }.inspect)[/version: (\d+\.\d+\.\d+)/i, 1]}  ** **"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** USAGE: '#{$lich_char}#{Script.current.name} <planes/spirit/elements/chaos/order>'"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** "))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** This script requires both rofl-puzzles and rofl-questions to be downloaded to work."))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**     rofl-puzzles is #{Script.exists?("rofl-puzzles") ? "present" : "missing"} and rofl-questions is #{Script.exists?("rofl-questions") ? "present" : "missing"}"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** "))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** To stop the script from doing another run after this one:  "))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**   #{$lich_char}vars set stop_ringing=yes"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**   #{$lich_char}#{Script.current.name} stop"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** this gets auto-reset to no after the run finishes as the script exits."))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** "))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** The script will run endlessly until you are over #{UserVars.ringing_start_resting}% then rest"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** until you are under #{UserVars.ringing_stop_resting}%."))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** > You can set the preferred resting threshold % by:"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**     #{$lich_char}#{Script.current.name} mind_stop=<number> (no percent sign)"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** > You can set the preferred re-starting threshold % by:"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**     #{$lich_char}#{Script.current.name} mind_start=<number> (no percent sign)"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** > You can enable experience management by:"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**     #{$lich_char}#{Script.current.name} absorb_xp"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** > You can disable experience management by:"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**     #{$lich_char}#{Script.current.name} ignore_xp"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** Prizes will be placed in #{UserVars.lootsack.nil? ? "stowed" : "your " + UserVars.lootsack}."))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** If you want to change that, then: "))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**    #{$lich_char}vars set lootsack=<container>"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** Debugging can be toggled (currently: #{@rofl_debug}) by:"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**    #{$lich_char}#{Script.current.name} debug"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("**"))
+    Lich::Messaging.mono(Lich::Messaging.xml_encode("** **  Happy Ringing  ** **"))
   end
 
   echo(Script.current.vars[1].downcase) if @rofl_debug


### PR DESCRIPTION
  v1.0.4 - 2025-04-25
    - added xml_encode to help, since .mono isn't currently doing that
    - corrected style for calling Messaging.mono