### PR TITLE
fix(uberbar.lic): v1.2.0 - Fix Display for Rogues and Empaths

### DIFF
--- a/scripts/uberbar_eo.lic
+++ b/scripts/uberbar_eo.lic
@@ -9,7 +9,7 @@
     contributors: Dantax, Tysong, Gibreficul, Bait, Xanlin, Khazaann, Dissonance
             game: gemstone
             tags: bar, uber, vitals
-         version: 1.1.1
+         version: 1.2.0
         required: Lich >= 5.9.2
             todo: Add ;ledger integration
 
@@ -18,6 +18,9 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.2.0 (2025-04-28)
+    - Added rogue to conditional display of resources
+    - Tweaked % capped to display correctly for empaths
   v1.1.1 (2025-04-27)
     - Missed some depreciated calls, fixed them.
   v1.1.0 (2025-04-27)
@@ -229,12 +232,18 @@ openLines = [
 ]
 tosend = openLines.join
 tosend += ubWoundsFullDis()
-openLines = [eval(ublineloggl), eval(ublinehourl), eval(ublinelastl), eval(ublinerooml), eval(ublinesilvl), eval(ublinebountyl), eval(ublineloggv), eval(ublinehourv), eval(ublinelastv), eval(ublineroomv), eval(ublinesilvv), eval(ublinebountyv), eval(ublinebars), eval(ublineheal), eval(ublinemana), eval(ublinestam), eval(ublinespir), eval(ublineascnext), eval(ublinenext), eval(ublinemind), eval(ublinestan), eval(ublineencm), eval(ublinepcapped)]
+openLines = [eval(ublineloggl), eval(ublinehourl), eval(ublinelastl), eval(ublinerooml), eval(ublinesilvl), eval(ublinebountyl), eval(ublineloggv), eval(ublinehourv), eval(ublinelastv), eval(ublineroomv), eval(ublinesilvv), eval(ublinebountyv), eval(ublinebars), eval(ublineheal), eval(ublinemana), eval(ublinestam), eval(ublinespir), eval(ublineascnext), eval(ublinenext), eval(ublinemind), eval(ublinestan), eval(ublineencm)]
 if Society.status =~ /Voln/
   openLines += [eval(ublinefavorl), eval(ublinefavorv)]
 end
-if Stats.prof =~ /Sorcerer|Wizard|Monk|Bard|Warrior|Cleric|Ranger|Paladin/
+if Stats.prof =~ /Sorcerer|Wizard|Monk|Bard|Warrior|Cleric|Ranger|Paladin|Rogue/
   openLines.push(eval(ublineresource))
+  openLines.push(eval(ublinepcapped))
+else
+  # have to change the binding point because resources isn't present
+  # once Empath resources are a thing, this entire if/else can be removed and the contents of the if portion can be moved up with the others
+  ublinepcapped = "\"<progressBar id='ubpcapped'	value='\#{((Lich::Gemstone::Stats.exp).fdiv(7572500)*100).round(2)}'	text='\#{((Lich::Gemstone::Stats.exp).fdiv(7572500)*100).round(2)} % Capped'		anchor_top='ubencm'	top='#{buffy}' left='#{buffx}' width='#{sizebx}' height='#{sizey}'/>\""
+  openLines.push(eval(ublinepcapped))
 end
 tosend += openLines.join
 tosend += "</dialogData></openDialog>"


### PR DESCRIPTION
added rogues to check for displaying resources.  fixed percentcapped display for empaths, who don't have resources yet.