### PR TITLE
fix(repository.lic): v2.64 stop saving cached repo list to disk

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.63
+       version: 2.64
 
   changelog:
+    2.64 (2025-02-28):
+      Change from using Settings for cached list. Doesn't need saving to lich.db3
     2.63 (2025-02-14):
       Bugfix in unneccessary regex comparison
     2.62 (2025-02-13):
@@ -168,6 +170,9 @@ cmd_sort           = nil
 cmd_tags           = nil
 cmd_version        = nil
 hostname           = 'repo.lichproject.org'
+@repository_cached_list ||= nil
+@repository_cached_list_offset ||= nil
+@repository_cached_list_comments ||= nil
 mapdb_reloaded     = false
 no_more_options    = nil
 port               = 7157
@@ -324,7 +329,7 @@ connect = proc {
 
 get_list = proc {
   request = { 'action' => 'list', 'supported compressions' => 'gzip', 'client' => client_version }
-  request['current-md5sum'] = Digest::MD5.new.update(Settings['cached-list']).to_s if Settings['cached-list']
+  request['current-md5sum'] = Digest::MD5.new.update(@repository_cached_list).to_s if @repository_cached_list
   begin
     ssl_socket, socket = connect.call
     ssl_socket.puth(request)
@@ -362,15 +367,15 @@ get_list = proc {
         }
         # data_gz = nil # rubocop useless assignment to variable
       end
-      Settings['cached-list'] = data
-      Settings['cached-list-offset'] = Time.now.to_i - response['server time'].to_i
+      @repository_cached_list = data
+      @repository_cached_list_offset = Time.now.to_i - response['server time'].to_i
     end
-    echo "list data: #{Settings['cached-list'].length}" if $repository_debug
+    echo "list data: #{@repository_cached_list.length}" if $repository_debug
     list = Array.new
-    Settings['cached-list'].split("\n").each { |d| list.push(d.split("\t", -1)) }
+    @repository_cached_list.split("\n").each { |d| list.push(d.split("\t", -1)) }
     headers = list.shift
     if (lui = headers.index('last update'))
-      list.each { |row| row[lui] = row[lui].to_i + Settings['cached-list-offset'] }
+      list.each { |row| row[lui] = row[lui].to_i + @repository_cached_list_offset }
     end
     list.unshift(headers)
     list
@@ -382,7 +387,7 @@ get_list = proc {
 
 add_comments_to_list = proc { |list|
   request = { 'action' => 'list-comments', 'supported compressions' => 'gzip', 'client' => client_version }
-  request['current-md5sum'] = Digest::MD5.new.update(Settings['cached-list-comments']).to_s if Settings['cached-list-comments']
+  request['current-md5sum'] = Digest::MD5.new.update(@repository_cached_list_comments).to_s if @repository_cached_list_comments
   begin
     ssl_socket, socket = connect.call
     ssl_socket.puth(request)
@@ -420,9 +425,9 @@ add_comments_to_list = proc { |list|
         }
         # data_gz = nil # rubocop useless assignment to variable
       end
-      Settings['cached-list-comments'] = data
+      @repository_cached_list_comments = data
     end
-    echo "comments data: #{Settings['cached-list-comments'].length}" if $repository_debug
+    echo "comments data: #{@repository_cached_list_comments.length}" if $repository_debug
     headers = list.shift
     fi = headers.index('file')
     gi = headers.index('game')
@@ -430,7 +435,7 @@ add_comments_to_list = proc { |list|
     headers[ci] = 'comments'
     foist = true
     headers2 = fi2 = gi2 = ci2 = nil
-    Settings['cached-list-comments'].split("\n").each { |d|
+    @repository_cached_list_comments.split("\n").each { |d|
       if foist
         foist = false
         headers2 = d.split("\t", -1)


### PR DESCRIPTION
No need to save repository full list to disk as it's unneeded and bloats the DB with unnecessary data. Instead, save to instance variable usable by script.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Stop saving cached repository list to disk in `repository.lic` by using instance variables instead of `Settings`.
> 
>   - **Behavior**:
>     - Stop saving cached repository list to disk in `repository.lic`.
>     - Use instance variables `@repository_cached_list`, `@repository_cached_list_offset`, and `@repository_cached_list_comments` instead of `Settings`.
>   - **Functions**:
>     - Update `get_list` and `add_comments_to_list` to use instance variables for caching.
>   - **Misc**:
>     - Update version to 2.64 in `repository.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 138b6d7b2518eea06034c6b4cfc44c282ddaa4e8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->