### PR TITLE
fix(eloot.lic): v2.3.10 bugfix in locksmith_tip to ensure numerics in…

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.3.9
+           version: 2.3.10
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.3.10 (2025-04-28)
+    - bugfix in locksmith_tip to ensure numerics incase of string values saved in yaml
   v2.3.9 (2025-04-27)
     - bugfix add coin bag full msg'ing to regex
   v2.3.8 (2025-04-22)
@@ -6250,7 +6252,7 @@ module ELoot # Sells the loot
 
     def self.locksmith_tip(box_no, base_tip, max_tip, alpha)
       factor = (box_no).to_f / 100
-      adjusted_tip = base_tip + (factor**alpha) * (max_tip - base_tip)
+      adjusted_tip = base_tip.to_i + (factor**alpha.to_f) * (max_tip.to_i - base_tip.to_i)
       adjusted_tip.round # return an integer
     end
 


### PR DESCRIPTION
…case of string values
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `locksmith_tip` in `eloot.lic` to ensure numeric calculations with string values, updating version to 2.3.10.
> 
>   - **Bugfix**:
>     - Fixes `locksmith_tip` in `eloot.lic` to ensure numeric calculations when string values are present by converting `base_tip` and `max_tip` to integers.
>   - **Version Update**:
>     - Updates version to 2.3.10 in `eloot.lic` to reflect the bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 853d01be54054e00420e039bfc015bc5cf5fd485. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->