### PR TITLE
fix(Killtracker.lic): reset week counts on month

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -13,9 +13,12 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 2.4
+       version: 2.5
 
 Change Log:
+  v2.5
+    - reset weekly count on month reset if jewel hasn't been found for the week
+    - reset weekly searches  command added to manually reset
   v2.4
     - comment out server response from google sheets on send
   v2.3
@@ -126,6 +129,7 @@ module Killtracker
     respond(";kt dust report        - find report of all dust")
     respond(";kt fix find count     - fixes monthly/weekly gemstone count in summary")
     respond(";kt save               - force search data to be saved to file")
+    respond(";ket reset weekly searches  - sets weekly searches to 0")
     respond("")
     respond(";kt submit finds       - Pushes jewel and dust find to google sheets.")
     respond("   https://docs.google.com/spreadsheets/d/1IOLs8AGRR45Kr6Y9nz6CXlMVBKYR7cHLaz0jjAbjMv0")
@@ -518,6 +522,9 @@ module Killtracker
     if current_month != $killtracker[:last_month_reset]
       $killtracker[:monthly_gemstones] = 0
       $killtracker[:last_month_reset] = current_month
+      if $killtracker[:weekly_gemstone] == 0
+        $killtracker[:weekly_ascension_searches] = 0
+      end
     end
   end
 
@@ -653,6 +660,9 @@ module Killtracker
         Killtracker.backfill_counters
       when /back date reset/
         Killtracker.back_date_reset
+      when /reset weekly searches/
+        $killtracker[:weekly_ascension_searches] = 0
+        respond("Weekly ascension searches reset")
       when /(?:eligible|eligibility)(?:\s+(\w+))?/
         sort_key = $1&.downcase
         Killtracker.eligibility_report(sort_key)


### PR DESCRIPTION
reset weekly search counts on month reset IF you have not found a gem for the week.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Resets weekly search counts on month reset if no jewel found and adds a command to manually reset weekly searches in `Killtracker.lic`.
> 
>   - **Behavior**:
>     - Resets weekly search counts on month reset if no jewel found for the week in `maybe_reset_monthly_counter`.
>     - Adds `reset weekly searches` command in `parse_upstream` to manually reset weekly searches.
>   - **Version**:
>     - Updates version to 2.5 in `Killtracker.lic`.
>   - **Help Command**:
>     - Updates help text to include `reset weekly searches` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ea31216b60a9a2ade4e9fee98260196fd95f3f03. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->