### PR TITLE
fix(uberbar_eo.lic): v2.0.1 set correct anchor for spirit bar

### DIFF
--- a/scripts/uberbar_eo.lic
+++ b/scripts/uberbar_eo.lic
@@ -8,13 +8,15 @@
     contributors: Dantax, Tysong, Gibreficul, Bait, Xanlin, Khazaann, Dissonance
             game: gemstone
             tags: uberbar, bar, uber, vitals, paperdoll
-         version: 2.0.0
+         version: 2.0.1
         required: Lich >= 5.11.0
 
   Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v2.0.1 (2025-05-01)
+    - set correct anchor for spirit bar
   v2.0.0 (2025-04-28)
     - converted to module
     - made various bars/txt togglable display
@@ -345,7 +347,7 @@ module UberBarEO
     ublineheal  = lambda { "<skin id='ubheal' name='healthBar' controls='health'    anchor_left='ubinjury'  anchor_top='ubbars'      top='#{buffy}' left='#{buffx + 1}' width='0' height='#{sizey}'/><progressBar id='health'    value='#{Char.percent_health}'  text='#{Char.health}/#{Char.max_health}'  customText='t' anchor_left='ubinjury' anchor_top='ubbars'  top='#{buffy}' left='#{buffx + 1}' width='#{sizerx}' height='#{sizey}'/>" }
     ublinemana  = lambda { "<skin id='ubmana' name='manaBar' controls='mana'    anchor_left='ubinjury'  anchor_top='ubheal'      top='#{buffy}' left='#{buffx}' width='0' height='#{sizey}'/><progressBar id='mana'    value='#{Char.percent_mana}'    text='#{Char.mana}/#{Char.max_mana}'  customText='t' anchor_left='ubinjury' anchor_top='health'  top='#{buffy}' left='#{buffx + 1}' width='#{sizerx}' height='#{sizey}'/>" }
     ublinestam  = lambda { "<skin id='ubstam' name='staminaBar' controls='stamina'    anchor_left='ubinjury'  anchor_top='ubmana'      top='#{buffy}' left='#{buffx + 1}' width='0' height='#{sizey}'/><progressBar id='stamina'  value='#{Char.percent_stamina}'  text='#{Char.stamina}/#{Char.max_stamina}'  customText='t' anchor_left='ubinjury' anchor_top='mana'    top='#{buffy}' left='#{buffx + 1}' width='#{sizerx}' height='#{sizey}'/>" }
-    ublinespir  = lambda { ub_bottom_anchor = 'ubspir'; "<skin id='ubspir' name='spiritBar' controls='spirit'    anchor_left='ubinjury'  anchor_top='ubstam'      top='#{buffy}' left='#{buffx + 1}' width='0' height='#{sizey}'/><progressBar id='spirit'    value='#{Char.percent_spirit}'  text='#{Char.spirit}/#{Char.max_spirit}'  customText='t' anchor_left='ubinjury' anchor_top='stamina'  top='#{buffy}' left='#{buffx + 1}' width='#{sizerx}' height='#{sizey}'/>" }
+    ublinespir  = lambda { ub_bottom_anchor = 'spirit'; "<skin id='ubspir' name='spiritBar' controls='spirit'    anchor_left='ubinjury'  anchor_top='ubstam'      top='#{buffy}' left='#{buffx + 1}' width='0' height='#{sizey}'/><progressBar id='spirit'    value='#{Char.percent_spirit}'  text='#{Char.spirit}/#{Char.max_spirit}'  customText='t' anchor_left='ubinjury' anchor_top='stamina'  top='#{buffy}' left='#{buffx + 1}' width='#{sizerx}' height='#{sizey}'/>" }
 
     ublinefavorl = lambda { return "" unless @settings['display-favor']; "<label id='ubfavor'    value='Favor'  anchor_top='ubinjury'  top='#{buffy + 2}' left='0' height='#{sizey}' width='#{sizerx}'/>" }
     ublinefavorv = lambda { return "" unless @settings['display-favor']; "<label id='ubfavorv'    value='#{add_commas(Resources.voln_favor)}'  anchor_top='ubfavor'  top='#{buffy}' left='0' height='#{sizey}' width='#{sizerx}'/>" }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes spirit bar anchor in `uberbar_eo.lic` by changing `ub_bottom_anchor` from 'ubspir' to 'spirit'.
> 
>   - **Behavior**:
>     - Fixes spirit bar anchor in `ublinespir` lambda in `uberbar_eo.lic` by changing `ub_bottom_anchor` from 'ubspir' to 'spirit'.
>   - **Versioning**:
>     - Updates version from 2.0.0 to 2.0.1 in `uberbar_eo.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 295df57ecb6fd697727dcc914d9ccd645ba201d9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->