### PR TITLE
fix(uberbar_eo.lic): v2.0.1 update XML dialog name to UberBarEO

### DIFF
--- a/scripts/uberbar_eo.lic
+++ b/scripts/uberbar_eo.lic
@@ -8,13 +8,15 @@
     contributors: Dantax, Tysong, Gibreficul, Bait, Xanlin, Khazaann, Dissonance
             game: gemstone
             tags: uberbar, bar, uber, vitals, paperdoll
-         version: 2.0.0
+         version: 2.0.1
         required: Lich >= 5.11.0
 
   Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v2.0.1 (2025-05-01)
+    - update XML dialog name to UberBarEO to not conflict with older uberbar variants
   v2.0.0 (2025-04-28)
     - converted to module
     - made various bars/txt togglable display
@@ -42,11 +44,6 @@
     - initial release and forking from uberbarv_d version 2.1
 
 =end
-
-no_kill_all
-no_pause_all
-hide_me
-silence_me
 
 unless ['stormfront', 'wrayth'].include?($frontend)
   respond ""
@@ -84,6 +81,11 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
   end
   exit
 end
+
+no_kill_all
+no_pause_all
+hide_me
+silence_me
 
 wait_while { XMLData.next_level_text !~ /(experience|until next level)/ or !XMLData.next_level_value.integer? }
 
@@ -145,7 +147,7 @@ module UberBarEO
   @settings["silent-check-interval"] = 120   if @settings["silent-check-interval"].nil?
 
   before_dying {
-    puts("<closeDialog id='UberBar'/>")
+    puts("<closeDialog id='UberBarEO'/>")
     CharSettings[:settings] = @settings
   }
 
@@ -373,9 +375,9 @@ module UberBarEO
     ublinepcapped = lambda { return "" unless @settings['display-percentcap']; anchor_ublinepcapped = ub_bottom_anchor unless anchor_ublinepcapped; ub_bottom_anchor = 'ubpcapped'; "<progressBar id='ubpcapped'  value='#{((Stats.exp).fdiv(7_572_500) * 100).round(2)}'  text='#{((Stats.exp).fdiv(7_572_500) * 100).round(2)} % Capped'    anchor_top='#{anchor_ublinepcapped}'  top='#{buffy}' left='#{buffx}' width='#{sizebx}' height='#{sizey}'/>" }
 
     openLines = [
-      "<closeDialog id='UberBar'/>",
-      "<openDialog type='dynamic' id='UberBar' title='#{Char.name}'s Uberbar' target='UberBar' location='main' height='282' width='190' resident='true'>",
-      "<dialogData id='UberBar' clear='t'>",
+      "<closeDialog id='UberBarEO'/>",
+      "<openDialog type='dynamic' id='UberBarEO' title='#{Char.name}'s UberBarEO' target='UberBarEO' location='main' height='282' width='190' resident='true'>",
+      "<dialogData id='UberBarEO' clear='t'>",
       "<skin id='ubinjury' name='InjuriesPanel' controls='nsys,leftArm,rightArm,rightLeg,leftLeg,head,rightFoot,leftFoot,rightHand,leftHand,rightEye,leftEye,back,neck,chest,abdomen' top='5' left='5' width='100' height='150' align='nw'/>"
     ]
     tosend = openLines.join
@@ -396,7 +398,7 @@ module UberBarEO
       wait_while { (oldHP == Char.health and oldMP == Char.mana and oldST == Char.stamina and oldSP == Char.spirit and oldXP == XMLData.next_level_text and oldMD == XMLData.mind_text and oldSN == XMLData.stance_text and oldEN == XMLData.encumbrance_text and oldIN == XMLData.injuries.to_s and ((oldRM == Room.current.id and !checkgrouped) or checkgrouped) and Time.now - nowTime < 5) or Script.running?('go2') }
       # echo "Time diff: #{Time.now - nowTime}"
       nowTime = Time.now
-      doLines = "<dialogData id='UberBar'>"
+      doLines = "<dialogData id='UberBarEO'>"
 
       if oldHP != Char.health then echo "updated health" if @settings["debug"]; oldHP = Char.health; doLines += ublineheal.call end
       if oldMP != Char.mana then echo "updated mana" if @settings["debug"]; ascTime = 0 if oldMP < Char.mana; oldMP = Char.mana; doLines += ublinemana.call end
@@ -482,7 +484,7 @@ module UberBarEO
         oldWO = ubWoundsMash()
       end
       doLines += "</dialogData>"
-      puts(doLines) if doLines != "<dialogData id='UberBar'></dialogData>"
+      puts(doLines) if doLines != "<dialogData id='UberBarEO'></dialogData>"
     }
   end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update XML dialog name to `UberBarEO` in `uberbar_eo.lic` to avoid conflicts with older variants and update version to 2.0.1.
> 
>   - **Behavior**:
>     - Update XML dialog name from `UberBar` to `UberBarEO` in `uberbar_eo.lic` to avoid conflicts with older variants.
>     - Version updated to 2.0.1 in `uberbar_eo.lic`.
>   - **Code Structure**:
>     - Moved `no_kill_all`, `no_pause_all`, `hide_me`, `silence_me` to a different location in `uberbar_eo.lic` (no functional change).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 840cffe31517a8c0a9336d7b8257d628bab3c0e2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->