### PR TITLE
fix(BlackArts.lic): v1.3.2 return to place if buying multiple ingredi…

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -7118,7 +7118,7 @@ module BlackArts
       end
 
       BlackArts.data.gld_skills.each do |type|
-        BlackArts.data.settings[:skill_types].reject! { |skill| skill == type } if guild_status[type][:rank] == 63
+        BlackArts.data.settings[:skill_types].reject! { |skill_to_check| skill_to_check == type } if guild_status[type][:rank] == 63
       end
 
       if guild_status['guild'][:vouchers] == 0 && BlackArts.data.settings[:use_vouchers]
@@ -7422,7 +7422,7 @@ module BlackArts
         fput "illusion shadow #{drop_item}"
         Util.wait_rt
 
-        if GameObj.loot.find { |item| item.name =~ /errant shadow/ }
+        if GameObj.loot.find { |object| object.name =~ /errant shadow/ }
           Util.wait_rt
           fput 'illusion shadow shadow'
           Util.wait_rt
@@ -7469,12 +7469,12 @@ module BlackArts
       }
 
       before_dying {
-        if GameObj.loot.find { |item| item.name =~ /errant shadow/ }
+        if GameObj.loot.find { |object| object.name =~ /errant shadow/ }
           Util.wait_rt
           fput 'illusion shadow shadow'
           Util.wait_rt
         end
-        Inventory.store_item(BlackArts.data.shadow_container, BlackArts.data.shadow_item) if GameObj.loot.find { |item| item.id == BlackArts.data.shadow_item.id }
+        Inventory.store_item(BlackArts.data.shadow_container, BlackArts.data.shadow_item) if GameObj.loot.find { |object| object.id == BlackArts.data.shadow_item.id }
       }
     end
 


### PR DESCRIPTION
…ents
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `BlackArts.lic` to return to place after retrieving a new note when buying multiple ingredients.
> 
>   - **Bugfix**:
>     - In `BlackArts.lic`, `Util.travel(place)` added after `Inventory.drag(BlackArts.data.note)` to ensure return to place when buying multiple ingredients.
>   - **Version Update**:
>     - Incremented version from 1.3.1 to 1.3.2 in `BlackArts.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 8eaede8bf7e9e7240e30f826ce7d00cf73880d81. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->