### PR TITLE
fix(escortgo2.lic): v1.0.4 silver check update

### DIFF
--- a/scripts/escortgo2.lic
+++ b/scripts/escortgo2.lic
@@ -25,9 +25,11 @@
    author: elanthia-online
      game: Gemstone
      tags: bounty
-  version: 1.0.3
+  version: 1.0.4
 
   changelog:
+    1.0.4 (2025-05-06):
+      * update silver_check to use Lich::Util.silver_count
     1.0.3 (2025-04-03):
       * correct Icemule dropoff from 2486 to 2412
       * add additional debug info for not able to find next path location for drop-off
@@ -244,25 +246,6 @@ $ego2_travel_cost ||= {
     "Solhaven"           => 4020,
     "Ta'Vaalor"          => 0,
   },
-}
-
-check_silvers = proc {
-  silvers = nil
-  action = proc { |server_string|
-    if server_string =~ /^\s*Name\:|^\s*Gender\:|^\s*Normal \(Bonus\)|^\s*Strength \(STR\)\:|^\s*Constitution \(CON\)\:|^\s*Dexterity \(DEX\)\:|^\s*Agility \(AGI\)\:|^\s*Discipline \(DIS\)\:|^\s*Aura \(AUR\)\:|^\s*Logic \(LOG\)\:|^\s*Intuition \(INT\)\:|^\s*Wisdom \(WIS\)\:|^\s*Influence \(INF\)\:/
-      nil
-    elsif server_string =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9,]+)/
-      silvers = $1.gsub(',', '').to_i
-      DownstreamHook.remove("#{script.name}_check_silvers")
-      nil
-    else
-      server_string
-    end
-  }
-  DownstreamHook.add("#{script.name}_check_silvers", action)
-  $_SERVER_.puts "#{$cmd_prefix}info\n"
-  wait_until { silvers }
-  silvers
 }
 
 hide_me = proc {
@@ -1515,7 +1498,7 @@ unless escort_id
   # get monies for ferry and carts
   #
   travel_cost ||= $ego2_travel_cost[start_town][destination_town].to_i
-  silvers = check_silvers.call
+  silvers = Lich::Util.silver_count
   if silvers < travel_cost
     bank_id = Room[pickup_room].find_nearest_by_tag('bank')
     start_script 'go2', [bank_id.to_s]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `escortgo2.lic` to use `Lich::Util.silver_count` for silver checks, removing custom `check_silvers` proc.
> 
>   - **Behavior**:
>     - Update silver check in `escortgo2.lic` to use `Lich::Util.silver_count` instead of custom `check_silvers` proc.
>     - Remove `check_silvers` proc from `escortgo2.lic`.
>   - **Version**:
>     - Bump version from 1.0.3 to 1.0.4 in `escortgo2.lic`.
>   - **Changelog**:
>     - Add entry for version 1.0.4 noting the update to silver check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 75cf8c96a74c577abc8c7f44296db1d71f0a735c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->