### PR TITLE
fix(ecaster.lic): v1.1.3 CharSettings.save removal

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -6,10 +6,11 @@
           tags: magic, spell, casting
           game: gs
       required: Lich > 5.7.0
-       version: 1.1.2
+       version: 1.1.3
 
   Version Control:
     Major_change.feature_addition.bugfix
+      1.1.3: change CharSettings.save to Settings.save calls
       1.1.2: bugfix change hide_me variable to hide_after_cast to not conflict with Lich5 method hide_me
       1.1.1: bugfix in hide option setting for existing ecaster users not working
       1.1.0: hide after casting spell from hide list
@@ -212,7 +213,7 @@ module ECaster
       ECaster.send "#{spell_number} has been added to your hide list."
     end
     CharSettings[:hide] = @@hide
-    CharSettings.save
+    Settings.save
   end
 
   def self.verb(*args)
@@ -236,7 +237,7 @@ module ECaster
           end
           @@verbs[spell] = verb
           CharSettings[:verbs] = @@verbs
-          CharSettings.save
+          Settings.save
         end
       end
     end
@@ -260,7 +261,7 @@ module ECaster
         @@alias[command] = spell
       end
       CharSettings[:alias] = @@alias
-      CharSettings.save
+      Settings.save
     end
   end
 
@@ -287,7 +288,7 @@ module ECaster
         end
       end
       CharSettings[:stance] = @@stance
-      CharSettings.save
+      Settings.save
     end
   end
 
@@ -305,7 +306,7 @@ module ECaster
         value = (value == 'on')
         @@options[option] = value
         CharSettings[:options] = @@options
-        CharSettings.save
+        Settings.save
         ECaster.send "Set option '#{option}' to #{value}."
       end
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `CharSettings.save` with `Settings.save` in `ecaster.lic` and increment version to 1.1.3.
> 
>   - **Behavior**:
>     - Replace `CharSettings.save` with `Settings.save` in `hide`, `verb`, `alias`, `stance`, and `option` methods in `ecaster.lic`.
>   - **Version**:
>     - Increment version to 1.1.3 in `ecaster.lic` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 27001e84c7dbbd0fc571f83b23bb73c72eea9664. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->