### PR TITLE
fix(signore.lic): v0.8 removal of CharSettings.save

### DIFF
--- a/scripts/signore.lic
+++ b/scripts/signore.lic
@@ -11,7 +11,7 @@
           game: Gemstone
           tags: col, Signore
       required: Lich > 5.0x
-       version: 0.7
+       version: 0.8
         Source: https://github.com/elanthia-online/jinx
     Alt Source: https://github.com/elanthia-online/lich-5
 
@@ -19,10 +19,11 @@
   changelog:
     2-18-2017           Settings now only exist per character
     8-15-2017           Signore now waits to cast while go2 is running
-    2-23-2019  v0.0.4   Fix using Gtk.queue for Windows
-    2-24-2019  v0.0.5   add Sigil of Concentration
-    8-21-2021  v0.0.6 	Updated to support GTK3
-    6-05-2023  v0.0.7 	fix for new Infomon library Lich 5.7.0, rubocop cleanup
+    2-23-2019  v0.4   Fix using Gtk.queue for Windows
+    2-24-2019  v0.5   add Sigil of Concentration
+    8-21-2021  v0.6 	Updated to support GTK3
+    6-05-2023  v0.7 	fix for new Infomon library Lich 5.7.0, rubocop cleanup
+    5-07-2025  v0.8 	change CharSettings.save to Settings.save
 
 =end
 
@@ -155,7 +156,7 @@ module Signore
   def self.save(key, state)
     in_main_thread {
       CharSettings[key.to_s] = state
-      CharSettings.save
+      Settings.save
     }
   end
 
@@ -316,7 +317,7 @@ if script.vars.include?("room:rm")
   Settings[:antimagic_rooms] = Settings[:antimagic_rooms].reject { |id|
     id == to_delete.to_i
   }
-  CharSettings.save
+  Settings.save
   respond "antimagic rooms: #{Settings[:antimagic_rooms].join(", ")}"
   exit
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `CharSettings.save` with `Settings.save` in `signore.lic` and update version to 0.8.
> 
>   - **Behavior**:
>     - Replace `CharSettings.save` with `Settings.save` in `Signore.save` and when managing anti-magic rooms.
>     - Update version to 0.8 in `signore.lic`.
>   - **Changelog**:
>     - Add entry for 5-07-2025 noting the change from `CharSettings.save` to `Settings.save`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 54a30ecaf8fc1c53568a0537bb7bc4c7a0c04519. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->