### PR TITLE
Update kswole.lic shield mind -> shield mind forcert

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -19,13 +19,16 @@
   contributors: Nidal, Tysong, FFNG, H2U, Phocosoen
           name: kswole
           game: Gemstone
-          tags: kroderine soul, feat absorb, feat dispel
+          tags: kroderine soul, feat absorb, feat dispel, shield mind
        version: 1.1.0
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.0 (2025-05-08)
+    - Updated code to execute shield mind during roundtime with forcert command.
+    - Removed waitrt? and script pause during shield mind execution as it is not needed with forcert command.
   v1.1.0 (2025-05-08)
     - Feature Added support for Shield Mind Shield Specialization when Feat Absorb is unavailable or unknown.
   v1.0.11 (2024-12-05)
@@ -250,11 +253,7 @@ class KSwole
             fput("feat absorb")
           end
         elsif !Feat.available?('Absorb Magic') && (!checkstunned && !Effects::Debuffs.active?('Sympathy')) && Shield.available?('Shield Mind')
-          waitcastrt?
-          waitrt?
-          @scripts_to_pause.each { |script| Script.pause(script) if Script.running?(script) }
-          shieldmind = dothistimeout('shield mind', 2, /thereby forcing any incoming attacks against your mind or soul to penetrate your|You must be wielding a shield|^You cannot muster the necessary focus to shield your mind and soul quite so soon\./)
-          @scripts_to_pause.each { |script| Script.unpause(script) if Script.running?(script) }
+          shieldmind = dothistimeout('shield mind forcert', 2, /thereby forcing any incoming attacks against your mind or soul to penetrate your|You must be wielding a shield|^You cannot muster the necessary focus to shield your mind and soul quite so soon\./)
           next if shieldmind.is_a?(String) && shieldmind =~ /^You cannot muster the necessary focus to shield your mind and soul quite so soon\./
         end
       elsif @dispelable_debuffs.any? { |debuff| Effects::Debuffs.active?(debuff) }


### PR DESCRIPTION
Whirlin suggested that shield mind could be executed during rt and he was correct after testing.  Given the nature of the ability, we would always want to execute the command during round time to avoid taking a big hit from a spell.

Removed pausing a script as it is no longer needed. Removed waitrt? and waitcastrt? as it is no longer needed.