### PR TITLE
fix(blackarts.lic): v1.3.3 Guild.check_locations issue if in current …

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -6,10 +6,12 @@
   contributors: Deysh, Tysong, Gob
           game: Gemstone
           tags: alchemy
-       version: 1.3.2
+       version: 1.3.3
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.3 (2025-05-09)
+    - bugfix in Guild.check_locations if you started in a room that offers ingredient as part of recipe
   v1.3.2 (2025-05-03)
     - bugfix in Actions.buy to return to place if a new note is retrieved
   v1.3.1 (2025-02-15)
@@ -6662,7 +6664,7 @@ module BlackArts
       extra_time = place == "hunting" ? 30 : (place == "foraging" ? 10 : 0)
       travel_time = 0
 
-      unless room_list.zero?
+      unless room_list.zero? || room_list == BlackArts.data.current_room.id
         path = BlackArts.data.current_room.path_to(Room[room_list])
 
         if BlackArts.data.boundaries.any? { |fence| path.include?(fence) } || path.nil?


### PR DESCRIPTION
…room
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `Guild.check_locations` in `BlackArts.lic` for starting rooms offering ingredients, updating version to 1.3.3.
> 
>   - **Bug Fix**:
>     - Fixes bug in `Guild.check_locations` in `BlackArts.lic` where starting in a room offering an ingredient caused issues.
>     - Modifies condition to check if `room_list` is zero or matches `BlackArts.data.current_room.id`.
>   - **Version Update**:
>     - Updates version to 1.3.3 in `BlackArts.lic` to reflect the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ec5f744d60558e5697739b566ffdcff3adae7feb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->