### PR TITLE
fix(eloot.lic): v2.3.12 additional fixes

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.3.11
+           version: 2.3.12
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.3.12 (2025-05-10)
+    - fix for Pinefar banker withdraw/deposit
+    - fix for disk/container contents being nil prior to storing an item
   v2.3.11 (2025-05-05)
     - fix find_boxes to now clear sacks found with boxes from sacks_full
     - bugfix in regex for pool parameters to match help text
@@ -413,7 +416,8 @@ module ELoot # Data
         /That's (?<silver>[\d,]+) silver|silvers? to your account/,
         /You deposit your note worth (?<silver>[\d,]+) into your account/,
         /You hand your notes to the teller, who glances over each one and scribbles the amounts in a book.  She says, "They add up to (?<silver>[\d,]+) (?:silver|silvers)/,
-        /You have no coins to deposit/
+        /You have no coins to deposit/,
+        /Smiling greedily, Hurshal takes your silvers and says, "Heh, I'll put dese in ye 'Mule bank account right quick\."/,
       )
 
       @withdraw_regex = Regexp.union(
@@ -421,6 +425,7 @@ module ELoot # Data
         /Very well, a withdrawal of (?<silver>[\d,]+) silver/,
         /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
         /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
+        /The banker nods and says, "Alright, here ye go\.  Ye understand I be takin' a little more than that from ye account in the 'Mule\.  I don't works for free!"/,
       )
 
       @get_regex = Regexp.union(
@@ -433,7 +438,7 @@ module ELoot # Data
         /Reaching over your shoulder/,
         /^As you draw/,
         /^Ribbons of.*?light/,
-        /^You are already holding/
+        /^You are already holding/,
       )
 
       @put_regex = Regexp.union(
@@ -450,7 +455,7 @@ module ELoot # Data
         /Get what/,
         /Reaching over your shoulder/,
         /An ethereal.*?light swirls/,
-        /As you move to put away your (?:<a exist="\d+" noun="\w+">[^<]+<\/a>|[\w-]+), it reverts to its normal state\./
+        /As you move to put away your (?:<a exist="\d+" noun="\w+">[^<]+<\/a>|[\w-]+), it reverts to its normal state\./,
       )
 
       @look_regex = Regexp.union(
@@ -470,7 +475,7 @@ module ELoot # Data
         /stuffed with a variety of shredded up paper and cloth/,
         /As much as you'd like to open it, its not closed\./,
         /^Looking at the .*?, you notice:/i, # neck sheath, no proper gameobjs viewable
-        /^The .+? has .+? in its left-hand scabbard and .+? in its right-hand scabbard\.$/i # swordbelt scabbards, no proper gameobjs viewable
+        /^The .+? has .+? in its left-hand scabbard and .+? in its right-hand scabbard\.$/i, # swordbelt scabbards, no proper gameobjs viewable
       )
 
       @silent_open = Regexp.union(
@@ -495,7 +500,7 @@ module ELoot # Data
         /Myriad spectral moths pull a cloakwing/,
         /<exposeContainer|<container/i,
         /You undo each of the/,
-        /stuffed with a variety of shredded up paper and cloth/
+        /stuffed with a variety of shredded up paper and cloth/,
       )
 
       @close_regex = Regexp.union(
@@ -504,7 +509,7 @@ module ELoot # Data
         /What were you referring to/,
         /seem to be any way to do that/,
         /You tie/,
-        /You fasten the/
+        /You fasten the/,
       )
 
       @urchin_msg = Regexp.union(
@@ -3029,12 +3034,17 @@ module ELoot # Game utility type methods
     note = ELoot.data.sacks["default"].contents.find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
 
     # Head over to the bank if something to do.
-    return unless (ELoot.silver_check != keep_silvers) || (note && !ELoot.f2p?)
+    current_silvers = ELoot.silver_check
+    return unless (current_silvers != keep_silvers) || (note && !ELoot.f2p?)
 
     ELoot.go2('bank')
 
     unless ELoot.f2p?
-      dothistimeout "deposit all", 2, ELoot.data.deposit_regex
+      if XMLData.room_title == '[Pinefar, Depository]'
+        dothistimeout "give banker #{current_silvers} silver", 2, ELoot.data.deposit_regex
+      else
+        dothistimeout "deposit all", 2, ELoot.data.deposit_regex
+      end
     else
       # F2P accounts have to be handled a little different due to bank capacity
       loop do
@@ -3075,7 +3085,11 @@ module ELoot # Game utility type methods
     end
 
     # Finally withdraw any keeper silvers and stow note if given
-    dothistimeout("withdraw #{keep_silvers}", 2, ELoot.data.withdraw_regex) if keep_silvers.positive?
+    if XMLData.room_title == '[Pinefar, Depository]'
+      dothistimeout("ask banker for #{keep_silvers} silvers", 2, ELoot.data.withdraw_regex) if keep_silvers.positive?
+    else
+      dothistimeout("withdraw #{keep_silvers}", 2, ELoot.data.withdraw_regex) if keep_silvers.positive?
+    end
     note = [GameObj.right_hand, GameObj.left_hand].find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
     Inventory.single_drag(note) if note
     ELoot.wait_rt
@@ -3090,7 +3104,11 @@ module ELoot # Game utility type methods
 
     ELoot.silver_deposit
 
-    fput("withdraw #{amount} silvers")
+    if XMLData.room_title == '[Pinefar, Depository]'
+      fput("ask banker for #{amount} silvers")
+    else
+      fput("withdraw #{amount} silvers")
+    end
 
     if ELoot.silver_check < amount
       ELoot.msg(type: "info", text: " Not enough silver in current area's bank.")
@@ -3572,6 +3590,8 @@ module ELoot # Inventory methods
           ELoot.save_profile()
           return true
         end
+
+        Inventory.open_single_container(bag) unless bag.contents.is_a?(Array) || is_skinner
 
         20.times do
           return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && bag.contents.to_a.map(&:id).include?(item.id))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Pinefar Depository banking operations and container content handling in `eloot.lic`.
> 
>   - **Banking Operations**:
>     - Adds specific handling for Pinefar Depository in `ELoot` module, using `give banker` and `ask banker` commands for deposit and withdrawal.
>     - Updates `deposit_regex` and `withdraw_regex` to include Pinefar-specific banker messages.
>   - **Bug Fixes**:
>     - Fixes issue with container contents being `nil` before storing an item in `Inventory` methods.
>   - **Misc**:
>     - Version bump to 2.3.12 in `eloot.lic`.
>     - Minor regex comma additions for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 198d9c162530a7fceefbe5f862d79cca049626c4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->