### PR TITLE
fix(map.lic): v1.3.9 Fix for default geometry

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -20,6 +20,7 @@ Tracks your current room on visual maps
   changelog:
     v1.3.9 (2025-05-10)
       * Fix for default geometry and primary display saved settings forcing window back to primary monitor
+      * Correct MapData variable return to be class variable instead of instance variable
     v1.3.8 (2025-04-20)
       * Fix for initial default window position for tiling window managers that do not set monitor geometry
     v1.3.7 (2025-04-15)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes default geometry handling in `map.lic` to prevent window from defaulting back to primary monitor by updating monitor geometry retrieval.
> 
>   - **Behavior**:
>     - Fixes default geometry handling in `map.lic` to prevent window from defaulting back to primary monitor.
>     - Updates monitor geometry retrieval using `display.default_screen.get_monitor_geometry()`.
>   - **Misc**:
>     - Corrects `@data` to `@@data` in `MapData.data` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ad4a98d5a877b5283a0e5d92c93082558efde6e4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->