### PR TITLE
fix(eherbs.lic): v2.1.5 Cysaegir location check update

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -357,7 +357,7 @@ module EHerbs
     settings_hash[:put_regex] = Regexp.union(
       /^You (?:put|(?:discreetly )?tuck|attach|toss|attempt to shield your|place|.* place|slip|wipe off the blade and sheathe|absent-mindedly drop|carefully add|find an incomplete bundle|untie your drawstring pouch)/,
       /^The .+ is already a bundle/,
-      /^Your bundle would be too large if you if you tried to add that/,
+      /^Your bundle would be too large if you tried to add that/,
       /^The .+ is too large to be bundled\./,
       /^As you place your .+ inside your .+, you notice another .+ inside the .+ and carefully arrange the two .+ into a neat bundle\./,
       /If you wish to continue, throw the item away again within fifteen seconds/,
@@ -1928,7 +1928,7 @@ module EHerbs
       if result =~ EHerbs.data[:drinkable]
         return true
       elsif result =~ /Why don't you leave some for others?/
-        _respond Msg.monsterbold(" You have eaten enought from the #{EHerbs.data[:herb_sack]}.")
+        _respond Msg.monsterbold(" You have eaten enough from the #{EHerbs.data[:herb_sack]}.")
         exit
       end
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes location matching issue for Cysaegir in `eherbs.lic` and updates version to 2.1.5.
> 
>   - **Behavior**:
>     - Fixes location matching issue for Cysaegir in `eherbs.lic` for herb stocking.
>     - Updates version to 2.1.5 in `eherbs.lic`.
>   - **Misc**:
>     - Adds changelog entry for version 2.1.5 in `eherbs.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 98b05808eba9c39b9526ae699b2376adf9630dbc. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->