### PR TITLE
FIX(tourniquet.lic) - Refine Voln Symbol Handling

### DIFF
--- a/scripts/tourniquet.lic
+++ b/scripts/tourniquet.lic
@@ -165,15 +165,23 @@ module Tourniquet
     end
   end
 
+  def self.still_bleeding
+    (checkreallybleeding || checkpoison || checkdisease) && !checkdead
+  end
+
   def self.use_restoration
     Lich::Messaging.msg("info", "Testing Symbol of Restoration...") if Tourniquet.data[:debug]
 
-    return unless Spell["Symbol of Restoration"].known?
+    exit unless Spell["Symbol of Restoration"].known? # there is nothing Tourniquet can do if you don't know this
     unless voln_favor_cost_affordable? # favor doesn't regen quickly, so we're just going to exit if we don't have enough
       Lich::Messaging.msg("error", "Not enough favor to use Symbol of Restoration.")
       exit
     end
 
+    # if we aren't at the start healing point, wait until we are or until we're not bleeding
+    sleep 0.5 until ((Char.percent_health < Tourniquet.data[:start_healing]) || !still_bleeding)
+
+    # are we healing? or did we just stop bleeding? or are we dead now?
     if Char.percent_health < Tourniquet.data[:start_healing]
       Lich::Messaging.msg("info", "Using Symbol of Restoration...") if Tourniquet.data[:debug]
       until (self.stop_healing || !voln_favor_cost_affordable?)


### PR DESCRIPTION
Adjusted logic for voln so that it would not loop every second if bleeding but not enough blood loss to use restoration has occurred.