### PR TITLE
fix(echild.lic) - v1.20.3 fix detecting familiars

### DIFF
--- a/scripts/echild.lic
+++ b/scripts/echild.lic
@@ -450,7 +450,7 @@ module EChild
         wait_while { running?(step_script) }
         wait_until { thatroom != Map.current.id }
         waitrt?
-        if GameObj.targets.size != nil and !checkpcs and GameObj.targets.any? { |npc| !Settings['untargetable'].include?(npc.name) } and !(GameObj.npcs.any? { |npc| npc.name =~ /#{reportee}/i } or GameObj.room_desc.any? { |i| i.name =~ /purser/ })
+        if GameObj.targets.any? and !checkpcs and GameObj.targets.any? { |npc| !Settings['untargetable'].include?(npc.name) } and !(GameObj.npcs.any? { |npc| npc.name =~ /#{reportee}/i } or GameObj.room_desc.any? { |i| i.name =~ /purser/ })
           unless GameObj.npcs.size == 1 and GameObj.npcs.find { |npc| npc.id == child }
             if can_cast_disabler
               found = false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue with detecting familiars incorrectly in `echild.lic` by changing conditional check from `GameObj.npcs` to `GameObj.targets`.
> 
>   - **Behavior**:
>     - Fixes issue with detecting familiars incorrectly in `echild.lic` by changing conditional check from `GameObj.npcs` to `GameObj.targets`.
>   - **Version**:
>     - Updates version to 1.20.3 in `echild.lic` to reflect the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ba1979ef35818f1f36f99314f9e1a96789da851d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->