### PR TITLE
fix(mybounty.lic): v3.6 HW alchemist removal bugfix

### DIFF
--- a/scripts/mybounty.lic
+++ b/scripts/mybounty.lic
@@ -11,7 +11,7 @@ Please report any difficulties or bugs to Luxelle, this was a huge update or thr
     author: Luxelle
     game: Gemstone
     tags: bounty, gems, herbs, specific, lumnis, contest, boost bounty, bounty boost, exclude bounties, bounties, skins, limit
-    version: 3.5
+    version: 3.6
     Tested in: Ta'Illistim, Wehnimer's, Solhaven, Icemule
 
     Notes: to set the bounties you want, you need to first use:  ;mybounty setup
@@ -25,6 +25,7 @@ Please report any difficulties or bugs to Luxelle, this was a huge update or thr
            ;mybounty setup
 
     Changelog:
+      v3.6 - 2025 May 28 - Add support for HW's herbalist/healer task removal as well
       v3.5 - 2025 Apr 24 - Add support for HW's herbalist/healer tasks
       v3.4 - 2024 Jan 04 - Add support for HW's taskmaster name Halfwhistle
       v3.3 - 2021 Sep 13 - Intergrated Mister Doug's GTK 3 support
@@ -476,7 +477,7 @@ if setup == true
       }
 
       break
-    elsif line =~ /local herbalist|local healer|local alchemist/ and forage == false
+    elsif line =~ /local herbalist|local healer|local(?: halfling)? alchemist/ and forage == false
       echo "Refusing this bounty ..."
       sleep 0.2
       fput "ask #{task_npc} for remov"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `mybounty.lic` to support removal of 'halfling alchemist' tasks and updates version to 3.6.
> 
>   - **Behavior**:
>     - Fixes bug in `mybounty.lic` to support removal of 'halfling alchemist' tasks.
>     - Updates version to 3.6 in `mybounty.lic`.
>   - **Changelog**:
>     - Adds entry for v3.6 on 2025 May 28 for the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 298c2b8b13e929303ad8312bf05410d11cd52325. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->