### PR TITLE
fix(map.lic): v1.3.10 dark maps missing or DR with maps-dark folder

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -380,7 +380,7 @@ map_dir = get_map_dir(dark_mode)
 used_maps = Set.new
 Map.list.each { |room| used_maps.add(room.map_name) unless room.map_name.nil? }
 missing_maps = used_maps.find_all { |map_name| not File.exist?(File.join(map_dir, map_name)) }
-echo "These map images were not found: #{missing_maps.sort.join(', ')}" unless missing_maps.empty? || XMLData.game =~ /^DR/
+echo "These map images were not found: #{missing_maps.sort.join(', ')}" unless missing_maps.empty? || (XMLData.game =~ /^DR/ && dark_mode)
 # missing_maps = nil
 
 unless File.exist?(File.join(map_dir, "circle.png"))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix missing dark maps in `map.lic` v1.3.10, ensuring no GTK errors and DR compatibility.
> 
>   - **Behavior**:
>     - Fix missing dark maps causing GTK errors and ensure DR has dark maps in `map.lic`.
>     - Update `change_map` to check for dark mode and adjust map path if necessary.
>     - Modify `change_room` to handle window resizing and map centering correctly.
>   - **Misc**:
>     - Update version to 1.3.10 in `map.lic`.
>     - Add changelog entry for v1.3.10 in `map.lic`.
>     - Fix typo in user instructions ("go there7" to "go there").
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e3f04f30a3de95bd215b09b0e07f0c927c6bb0bd. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->