### PR TITLE
fix(sk.lic): v1.2.3 only use integer values for add/rm

### DIFF
--- a/scripts/sk.lic
+++ b/scripts/sk.lic
@@ -9,8 +9,10 @@
               game: Gemstone
               tags: sk, self knowledge
           requires: Lich >= 4.6.0
-           version: 1.2.2
+           version: 1.2.3
 
+  v1.2.3 (2025-05-30)
+    - Fix to only allow integer string values to be stored
   v1.2.2 (2025-02-01)
     - Add exception to not run if on Lich5 with built-in support for SKs
   v1.2.1 (2024-08-24)
@@ -91,7 +93,7 @@ module SK
 
   def self.main()
     action = Script.current.vars[1].to_sym
-    spells = Script.current.vars[2..-1]
+    spells = Script.current.vars[2..-1].select { |var| var.match?(/^\d+$/) }
     case action
     when :add
       self.add(*spells)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix in `scripts/sk.lic` to ensure only integer strings are processed for spell numbers in `main()` function.
> 
>   - **Behavior**:
>     - In `scripts/sk.lic`, `main()` function now filters `spells` to only include integer strings using `select { |var| var.match?(/\^\d+$/) }`.
>     - Ensures only valid integer spell numbers are processed for `add` and `rm` actions.
>   - **Version**:
>     - Updated version to 1.2.3 to reflect the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 12badb116be8b915084a5fceed26fe5ca93fa8a5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->