### PR TITLE
fix(lnet.lic): v1.13 class check change to is_a?

### DIFF
--- a/scripts/lnet.lic
+++ b/scripts/lnet.lic
@@ -741,14 +741,14 @@ class LNet
               output.concat "   moderators: #{channel_data['moderators'].join(', ')}\n"
             end
             if channel_data['invited'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['invited'].empty?
               output.concat "   invited: none\n"
             else
               output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
             end
             if channel_data['banned'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['banned'].empty?
               output.concat "   banned: none\n"
             else
@@ -780,14 +780,14 @@ class LNet
           for channel_name, channel_data in data['mod_channels']
             output.concat "#{channel_name} (moderator)\n"
             if channel_data['invited'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['invited'].empty?
               output.concat "   invited: none\n"
             else
               output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
             end
             if channel_data['banned'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['banned'].empty?
               output.concat "   banned: none\n"
             else
@@ -1332,8 +1332,8 @@ while (msg = unique_get.strip)
   elsif msg =~ /^allow$/i
     fix_type = { 'all' => 'everyone', 'friends' => 'only your friends', 'enemies' => 'everyone except your enemies', 'none' => 'no one', nil => 'no one' }
     fix_action = { 'locate' => 'locate you', 'spells' => 'view your active spells', 'skills' => "view your #{if rand(100) == 0; 'mad '; end}skills", 'info' => 'view your stats', 'health' => 'view your health', 'bounty' => 'view your bounties' }
-    ['locate', 'spells', 'skills', 'info', 'health', 'bounty'].each { |action|
-      respond "You are allowing #{fix_type[LNet.options['permission'][action]]} to #{fix_action[action]}."
+    ['locate', 'spells', 'skills', 'info', 'health', 'bounty'].each { |lnet_action|
+      respond "You are allowing #{fix_type[LNet.options['permission'][lnet_action]]} to #{fix_action[action]}."
     }
   elsif msg =~ /^allow\s+(locate|spells|skills|info|health|bounty|all)\s+(all|friend|friends|non\-enemies|nonenemies|enemies|enemy|none)$/i
     action, group = $1, $2


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change class checks to `is_a?` checks in `scripts/lnet.lic` and update version to 1.13.
> 
>   - **Behavior**:
>     - Change class checks to `is_a?` checks in `LNet.get_data` and option initializations.
>     - Update version to 1.13 in `scripts/lnet.lic`.
>   - **Changelog**:
>     - Add entry for version 1.13: "change class checks to is_a? checks".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 477740fdae0f47f3fb7ff3360e7d3abb295111a3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->