### PR TITLE
fix(0net.lic): v0.0.9 change class checks to is_a? checks

### DIFF
--- a/scripts/0net.lic
+++ b/scripts/0net.lic
@@ -647,14 +647,14 @@ class LNet
               output.concat "   moderators: #{channel_data['moderators'].join(', ')}\n"
             end
             if channel_data['invited'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['invited'].empty?
               output.concat "   invited: none\n"
             else
               output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
             end
             if channel_data['banned'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['banned'].empty?
               output.concat "   banned: none\n"
             else
@@ -686,14 +686,14 @@ class LNet
           for channel_name, channel_data in data['mod_channels']
             output.concat "#{channel_name} (moderator)\n"
             if channel_data['invited'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['invited'].empty?
               output.concat "   invited: none\n"
             else
               output.concat "   invited: #{channel_data['invited'].join(', ')}\n"
             end
             if channel_data['banned'].nil?
-              nil
+              nil # rubocop:disable Lint/Void
             elsif channel_data['banned'].empty?
               output.concat "   banned: none\n"
             else
@@ -1350,8 +1350,8 @@ while (msg = unique_get.strip)
   elsif msg =~ /^allow$/i
     fix_type = { 'all' => 'everyone', 'friends' => 'only your friends', 'enemies' => 'everyone except your enemies', 'none' => 'no one', nil => 'no one' }
     fix_action = { 'locate' => 'locate you', 'spells' => 'view your active spells', 'skills' => "view your #{if rand(100) == 0; 'mad '; end}skills", 'info' => 'view your stats', 'health' => 'view your health', 'bounty' => 'view your bounties' }
-    ['locate', 'spells', 'skills', 'info', 'health', 'bounty'].each { |action|
-      respond "You are allowing #{fix_type[LNet.options['permission'][action]]} to #{fix_action[action]}."
+    ['locate', 'spells', 'skills', 'info', 'health', 'bounty'].each { |lnet_action|
+      respond "You are allowing #{fix_type[LNet.options['permission'][lnet_action]]} to #{fix_action[action]}."
     }
   elsif msg =~ /^allow\s+(locate|spells|skills|info|health|bounty|all)\s+(all|friend|friends|non\-enemies|nonenemies|enemies|enemy|none)$/i
     action, group = $1, $2


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change class checks to `is_a?` checks in `scripts/0net.lic` for improved type checking, affecting `LNet.get_data` and option initializations.
> 
>   - **Behavior**:
>     - Change class checks to `is_a?` checks in `LNet.get_data` and option initializations in `scripts/0net.lic`.
>     - Specifically affects `LNet.get_data` for `name` and `type` parameters, ensuring they are `String`.
>     - Updates option initializations for `friends`, `enemies`, `permission`, and `ignore` to use `is_a?` checks.
>   - **Version**:
>     - Update version to 0.0.9 in `scripts/0net.lic`.
>   - **Changelog**:
>     - Add entry for version 0.0.9 noting the change to `is_a?` checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 5b028ab72524b646b687259ce9e0216daefe6608. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->