### PR TITLE
fix(eloot.lic): v2.4.1 bugfixes

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -21,6 +21,7 @@
   v2.4.1 (2025-06-05)
     - bugfix for unable to lighten load during pool return and no silvers to deposit to allow more boxes to be returned
     - bugfix for box loot to deposit coins if too many coins on yourself to be able to loot coins from box
+    - change class checks to is_a? checks
   v2.4.0 (2025-05-21)
     - add CLI option to skin only
     - fix regex for sellable/type/sell CLI to make = optional to match help text
@@ -1712,7 +1713,7 @@ module ELoot # UI Setup
           _respond("#{monsterbold_start}= #{opt.capitalize} =#{monsterbold_end}\n")
           @@categories[opt.to_sym].each do |id, _|
             value = @settings[id]
-            value.class == Array ? print_array.call(id, value, 1) : print_value.call(id, value, 1)
+            value.is_a?(Array) ? print_array.call(id, value, 1) : print_value.call(id, value, 1)
           end
         end
         _respond("#{monsterbold_start}= GameObj Types =#{monsterbold_end}\n")
@@ -1737,7 +1738,7 @@ module ELoot # UI Setup
         if value.to_s == 'reset'
           @settings.delete(key)
           ELoot.msg(type: "info", text: " Reset #{key}")
-        elsif @settings[key].class == Array
+        elsif @settings[key].is_a?(Array)
           if value =~ /\d/ && @settings[key][value.to_i]
             @settings[key].delete_at(value.to_i)
           else
@@ -1753,9 +1754,9 @@ module ELoot # UI Setup
 
           ELoot.msg(type: "info", text: " \"#{key}\" is now \"#{@settings[key].join(', ')}\"")
         else
-          if @settings[key].class == FalseClass || @settings[key].class == TrueClass
+          if @settings[key].is_a?(FalseClass) || @settings[key].is_a?(TrueClass)
             value = value =~ /^true|1|yes|on/ ? true : false
-          elsif @settings[key].class == Integer
+          elsif @settings[key].is_a?(Integer)
             value = value.to_i
           end
 
@@ -2464,11 +2465,11 @@ module ELoot # Script utility type methods
 
     return if type == "debug" && (!ELoot.data.settings[:debug] && !ELoot.data.settings[:debug_file])
 
-    if text.class == Hash
+    if text.is_a?(Hash)
       text = text.inspect.gsub("#<", "#")
-    elsif text.class == Array
+    elsif text.is_a?(Array)
       text = text.to_s
-    elsif text.class == String
+    elsif text.is_a?(String)
       text = text.gsub("#<", "#")
     end
 
@@ -2895,7 +2896,7 @@ module ELoot # Game utility type methods
     fput('unhide') if (hidden? || invisible?)
 
     # If we're going to a place we do it based on the sell_fwi settings
-    if place.class == String && ELoot.data.settings[:sell_fwi]
+    if place.is_a?(String) && ELoot.data.settings[:sell_fwi]
       fwi_place = Room.list.find { |room| room.tags.include?(place) && ELoot.fwi?(room) }
 
       place = fwi_place.id if fwi_place
@@ -2907,7 +2908,7 @@ module ELoot # Game utility type methods
       ELoot.msg(type: "error", text: ' unknown room location')
     end
 
-    if place.class == String && UserVars.mapdb_use_urchins && UserVars.mapdb_urchins_expire.positive? && XMLData.game != 'GSIV' && Room.current.location !~ /the Hinterwilds/
+    if place.is_a?(String) && UserVars.mapdb_use_urchins && UserVars.mapdb_urchins_expire.positive? && XMLData.game != 'GSIV' && Room.current.location !~ /the Hinterwilds/
 
       case place
       when 'locksmith pool'
@@ -3394,7 +3395,7 @@ module ELoot # Inventory methods
 
       return if sack.nil? || sack.empty?
 
-      container = sack.class == GameObj ? sack : ELoot.data.sacks[sack]
+      container = sack.is_a?(GameObj) ? sack : ELoot.data.sacks[sack]
       ELoot.msg(type: "debug", text: " open_single_container(sack): before open sack - #{sack} container: #{container}")
 
       # If its in the game obj and contents.is_a?(Array) return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes in `eloot.lic` for handling excess coins during looting and pool return, updating version to 2.4.1.
> 
>   - **Bug Fixes**:
>     - Fix in `eloot.lic` to handle cases where the player cannot hold more silvers during box looting by depositing coins first.
>     - Fix in `eloot.lic` to handle cases where the player needs to lighten load during pool return by depositing coins and retrying.
>   - **Version Update**:
>     - Update version to 2.4.1 in `eloot.lic` to reflect bug fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 51b7eb9dd9b7afa5ad3d71d7e2348de095767e02. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->