### PR TITLE
fix(repository.lic): v2.65 force DR installs to always update depende…

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -155,7 +155,6 @@ if XMLData.game =~ /^DR/ && !(Settings['updatable'][:scripts].any? { |script_upd
   Settings['updatable'][:scripts].push(:filename => 'dependency.lic', :game => 'dr', :author => 'elanthia-online')
 end
 
-
 require 'openssl'
 require 'digest/md5'
 


### PR DESCRIPTION
…ncy.lic
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `dependency.lic` is always updatable for DR installs in `repository.lic`, updating version to 2.65.
> 
>   - **Behavior**:
>     - Force `dependency.lic` to always be updatable for DragonRealms (DR) installs in `repository.lic`.
>     - Update ownership of `dependency.lic` to `elanthia-online` if not already set.
>     - Add `dependency.lic` to updatable list if not present for DR installs.
>   - **Version**:
>     - Increment version to 2.65 in `repository.lic`.
>     - Update changelog to reflect the new behavior for version 2.65.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 8f3a8d03cd431d814bdb11c25c3745c76819fa90. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->