### PR TITLE
fix(version.lic): v1.1.5 show DR dependency version in list

### DIFF
--- a/scripts/version.lic
+++ b/scripts/version.lic
@@ -5,10 +5,12 @@
   contributors: LostRanger, Doug, Tysong
           game: gs
           tags: utility, version
-       version: 1.1.4
+       version: 1.1.5
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.5 (2025-06-17)
+    - show DR dependency version in list
   v1.1.4 (2025-03-27)
     - fix for autostart list  when dependency isn't running in DR
   v1.1.3 (2024-08-25)
@@ -166,6 +168,7 @@ module VersionScript
       report["Ruby platform"]        = const_get(:RUBY_PLATFORM, missing: 'unknown')
       report["Ruby engine"]          = const_get(:RUBY_ENGINE, missing: 'unknown')
       report["Lich version"]         = const_get(:LICH_VERSION, missing: 'unknown')
+      report["Dependency"]           = $DEPENDENCY_VERSION if XMLData.game =~ /^DR/
       report["SQLite3 version"]      = module_version(:SQLite3)
       report["Gtk version"]          = gtk_version
       report["Cairo version"]        = module_version(:Cairo)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds display of DR dependency version in the version report in `version.lic`, bumping version to 1.1.5.
> 
>   - **Behavior**:
>     - Adds display of DR dependency version in the version report if the game is DR, in `VersionScript.main()`.
>   - **Versioning**:
>     - Bumps version from 1.1.4 to 1.1.5 in `version.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 52cb183f04456fa153a51400ed009e7574bd5dca. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->