### PR TITLE
fix(BlackArts.lic): v1.3.4 add KF chit notes

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -6,10 +6,12 @@
   contributors: Deysh, Tysong, Gob
           game: Gemstone
           tags: alchemy
-       version: 1.3.3
+       version: 1.3.4
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.4 (2025-06-19)
+    - fix bank_notes to include KF salt-stained kraken chit
   v1.3.3 (2025-05-09)
     - bugfix in Guild.check_locations if you started in a room that offers ingredient as part of recipe
   v1.3.2 (2025-05-03)
@@ -5130,7 +5132,7 @@ module BlackArts
       @current_admin = nil
 
       @note = nil
-      @note_names = ['Northwatch bond note', 'Icemule promissory note', 'Borthuum Mining Company scrip', "Wehnimer's promissory note", 'Torren promissory note', 'mining chit', 'City-States promissory note', 'Vornavis promissory note', 'Mist Harbor promissory note']
+      @note_names = ['Northwatch bond note', 'Icemule promissory note', 'Borthuum Mining Company scrip', "Wehnimer's promissory note", 'Torren promissory note', 'mining chit', 'City-States promissory note', 'Vornavis promissory note', 'Mist Harbor promissory note', 'salt-stained kraken chit']
 
       @herb = nil
       @remaining_herbs = 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'salt-stained kraken chit' to `@note_names` in `BlackArts.lic` for KF bank notes, updating version to 1.3.4.
> 
>   - **Behavior**:
>     - Adds 'salt-stained kraken chit' to `@note_names` array in `BlackArts` module to handle KF bank notes.
>   - **Version Update**:
>     - Updates version from 1.3.3 to 1.3.4 in `BlackArts.lic`.
>     - Adds version note for v1.3.4 detailing the inclusion of KF salt-stained kraken chit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 16af2a1b9d75137eb43d7b226fd1fc34226d34d9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->