### PR TITLE
fix(ecleanse.lic): v2.2.1 fix GTK for spell cleave/thieve

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.11.1
-       version: 2.2.0
+       version: 2.2.1
 
   Improvements:
+  v2.2.1  (2025-06-21)
+    - allow dispel magic and dispel webs to be toggled if Spell Cleave or Spell Thieve known.
   v2.2.0  (2025-04-23)
     - add support for Covert Arts: Escape Artist
     - determine whether web/globe/cloud is targetable to avoid dispelling player versions
@@ -452,8 +454,8 @@ module Ecleanse
           "cleanse_grounded"     => !(CMan.known?("Retreat") || Feat.known?("escapeartist")),
           "cleanse_magical"      => [417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil?,
           "dispel_clouds"        => [417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil?,
-          "dispel_magic"         => [417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil?,
-          "avoid_webs"           => [209, 417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil? && !Feat.known?("escapeartist"),
+          "dispel_magic"         => [417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil? && !CMan.known?("Spell Cleave") && !CMan.known?("Spell Thieve"),
+          "avoid_webs"           => [209, 417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }.nil? && !Feat.known?("escapeartist") && !CMan.known?("Spell Cleave") && !CMan.known?("Spell Thieve"),
           "use_stunned_barkskin" => !Spell[605].known?,
           "use_berserk_stunned"  => !CMan.known?("Berserk"),
           "use_stunned1040"      => !Spell[1040].known?,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ecleanse.lic` to toggle dispel actions based on `Spell Cleave` and `Spell Thieve` knowledge, version 2.2.1.
> 
>   - **Behavior**:
>     - Update `ecleanse.lic` to allow toggling of `dispel_magic` and `avoid_webs` if `Spell Cleave` or `Spell Thieve` are known.
>   - **Version**:
>     - Increment version to 2.2.1 in `ecleanse.lic`.
>   - **Conditions**:
>     - Modify conditions in `load_settings` and `Action` methods to include checks for `Spell Cleave` and `Spell Thieve`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for eccb5725b42620373674a92714547f87a55f2f7e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->