### PR TITLE
fix(ebounty.lic): v1.6.2 bugfix for large groups in NPC area

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -2313,7 +2313,7 @@ module EBounty
           guards.push("purser")
         else
           timeout = Time.now + 5
-          until (guards = GameObj.npcs.find_all { |npc| npc.name =~ /(?:guard|sergeant|guardsman|sentry|tavernkeeper|alchemist)/i })
+          until (guards = (GameObj.room_desc.to_a + GameObj.npcs.to_a).find_all { |npc| npc.name =~ /(?:guard|sergeant|guardsman|sentry|tavernkeeper|alchemist)/i })
             EBounty.msg "yellow", "Waiting 1 second (max 5 seconds) while trying to detect NPC to use. (guard|sergeant|guardsman|sentry|tavernkeeper|alchemist)"
             sleep(1)
             break if Time.now > timeout
@@ -2982,7 +2982,7 @@ module EBounty
       room = town.find_nearest_by_tag('gemshop')
       EBounty.go2(room)
 
-      until (npc = GameObj.npcs.find { |t| t.name =~ /areacne|dwarven clerk|gem dealer|jeweler|Zirconia|Brindlestoat/i })
+      until (npc = (GameObj.room_desc.to_a + GameObj.npcs.to_a).find { |t| t.name =~ /areacne|dwarven clerk|gem dealer|jeweler|Zirconia|Brindlestoat/i })
         EBounty.msg "yellow", "Waiting 1 second while trying to detect NPC to use. (areacne|dwarven clerk|gem dealer|jeweler|Zirconia|Brindlestoat)"
         sleep(1)
       end
@@ -3194,7 +3194,7 @@ module EBounty
       room = town.find_nearest_by_tag('furrier')
       EBounty.go2(room)
 
-      until (npc = GameObj.npcs.find { |t| t.name =~ /dwarven clerk|furrier|Delosa|Bramblefist/i })
+      until (npc = (GameObj.room_desc.to_a + GameObj.npcs.to_a).find { |t| t.name =~ /dwarven clerk|furrier|Delosa|Bramblefist/i })
         EBounty.msg "yellow", "Waiting 1 second while trying to detect NPC to use. (dwarven clerk|furrier|Delosa|Bramblefist)"
         sleep(1)
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes NPC detection delay in crowded rooms in `ebounty.lic` by adding a timeout and simplifying NPC selection logic.
> 
>   - **Behavior**:
>     - Fixes bug in `ebounty.lic` where NPCs were not detected quickly in rooms with many characters by adding a 5-second timeout and retry mechanism.
>     - Simplifies NPC selection by using room UID to directly determine NPC name (e.g., "Halfwhistle" or "Taskmaster").
>   - **Misc**:
>     - Updates version to 1.6.2 in `ebounty.lic`.
>     - Adds a log message for waiting during NPC detection.
>     - Comments out unused code related to tavernkeeper detection in `ask_guard` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7304ca73858637594e8ead3c968c7aad0d269094. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->