### PR TITLE
fix(uhaul.lic): v2.0.2 various fixes

### DIFF
--- a/scripts/uhaul.lic
+++ b/scripts/uhaul.lic
@@ -1,14 +1,14 @@
 =begin
-  Automated locker moving. 
-  If you aren't premie you must give it a speed, as the default is immediate
-  
+  Automated locker moving.
+  If you aren't premie you must give it a speed. Options include immediate(default), express, or standard
+
   example: ;uhaul landing teras immediate
-  
+
   Required: Lich 4.6.4
   Tags: lockers, movers, move
   Author: Ondreian
-  version: 2.0.1
-  
+  version: 2.0.2
+
   Xanlin:
     Added Kraken's Fall and Cysaegir.
     No longer requires trust.
@@ -19,34 +19,33 @@
   Standard Adventurers:
 
     Standard Shipping  -  1,000 silvers for delivery in 2 hours.
-    Express Shipping   -  10,000 silvers for delivery in 30 minutes.
+    Express Shipping   - 10,000 silvers for delivery in 30 minutes.
 
   Premium Adventurers:
 
-    Standard Shipping  -  1,000 silvers for delivery in 2 hours.
-    Express Shipping   -  2,500 silvers for delivery in 30 minutes.
-    Immediate Shipping -  5,000 silvers for delivery in 1 minute.
+    Standard Shipping  - 1,000 silvers for delivery in 2 hours.
+    Express Shipping   - 2,500 silvers for delivery in 30 minutes.
+    Immediate Shipping - 5,000 silvers for delivery in 1 minute.
 =end
 
 class Movers
-
   SPEEDS = {
     "immediate" => 5000,
-    "express"   => 10000, #if you aren't using immediate, then you're probably not premium, using standard prices
-    "standard"  => 1000, 
+    "express"   => 10000, # if you aren't using immediate, then you're probably not premium, using standard prices
+    "standard"  => 1000,
   }
 
   ROOMS = {
-    "landing"     => 8896,
-    "icemule"     => 3373,
-    "fwi"         => 16146,
-    "teras"       => 12539,
-    "vaalor"      => 10439,
-    "illistim"    => 13250,
-    "solhaven"    => 5601,
-    "riversrest"  => 10954,
-    "krakensfall" => 28977,
-    #cysaegir: #don't know the room for this mover yet
+    "landing"     => Map.ids_from_uid(72032).first,
+    "icemule"     => Map.ids_from_uid(4043357).first,
+    "fwi"         => Map.ids_from_uid(3204302).first,
+    "teras"       => Map.ids_from_uid(3001048).first,
+    "vaalor"      => Map.ids_from_uid(14103425).first,
+    "illistim"    => Map.ids_from_uid(13103100).first,
+    "solhaven"    => Map.ids_from_uid(2120207).first,
+    "riversrest"  => Map.ids_from_uid(5001202).first,
+    "krakensfall" => Map.ids_from_uid(7121028).first,
+    # cysaegir: #don't know the room for this mover yet
   }
 
   LOOKUP = {
@@ -60,29 +59,29 @@ class Movers
     "icemule"            => /mule|imt/,
     "zul logoth"         => /zul|logoth/,
     "cysaegir"           => /cysaegir|cys?/,
-    "kraken's fall"      => /kraken|fall|kf/
+    "kraken's fall"      => /kraken|fall|kf/,
   }
-  
+
   def self.lookup(arg)
-    LOOKUP.each_pair.find { |town, pattern| arg =~ pattern }.shift || arg
+    LOOKUP.each_pair.find { |_town, pattern| arg =~ pattern }.shift || arg
   end
 
   def self.closest_mover
     return Room.current.find_nearest(ROOMS.values)
   end
-  
-  def self.wealth();
-    wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/;
-    wealth = dothistimeout 'wealth quiet',2, wealth_pattern;
-    coins = 0;
-    if wealth.gsub('but one','1') =~ wealth_pattern;
-      coins = $1.gsub(',','').to_i;
-    end;
-    return coins;
-  end;
-    
-  def self.swap(from, to, speed="immediate")
-    starting_room = Room.current.id;
+
+  def self.wealth
+    wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/
+    wealth = dothistimeout 'wealth quiet', 2, wealth_pattern
+    coins = 0
+    if wealth.gsub('but one', '1') =~ wealth_pattern
+      coins = $1.gsub(',', '').to_i
+    end
+    return coins
+  end
+
+  def self.swap(from, to, speed = "immediate")
+    starting_room = Room.current.id
     cost = SPEEDS[speed.downcase]
     if !cost
       error "unrecognized speed: #{speed}\n  valid speeds: #{SPEEDS.to_h.keys.join(', ')}"
@@ -90,29 +89,33 @@ class Movers
     end
 
     fput "unhide" if hidden
-    #skip bank if we already have the coins
+    # skip bank if we already have the coins
     coins = self.wealth
     if coins < cost
-      #TODO: check bank account first
-      #TODO: jump to fwi if we don't have cash local and are premium, use movers there
-      Script.run('go2','bank')
-      fput "withdraw #{cost-coins}"
+      # TODO: check bank account first
+      # TODO: jump to fwi if we don't have cash local and are premium, use movers there
+      Script.run('go2', 'bank')
+      fput "withdraw #{cost - coins}"
     end
-    Script.run('go2',"#{closest_mover}")
+    Script.run('go2', "#{closest_mover}")
     sleep 0.2
-    #TODO: verify npc exists
+
     if Room.current.id == closest_mover
-      fput "ask ##{GameObj.npcs.first.id} for move"
+      if (clerk = (GameObj.room_desc.to_a + GameObj.npcs.to_a).find { |npc| npc.name =~ /\bclerk\b/i })
+        fput "ask ##{clerk.id} for move"
+      else
+        fput "ask clerk for move"
+      end
       fput "say yes"
       fput "say #{from}"
       fput "say #{to}"
       fput "say #{speed}"
     end
-    #TODO: verify locker move messaging
-    #The young clerk nods and jots something down.  "Okay, it's done!  Immediate rate locker shipping from Kharag 'doth Dzulthu to Kraken's Fall."
-    #You hand the young clerk 5000 silvers.
-    
-    Script.run('go2',"#{starting_room}") if starting_room != Room.current.id
+    # TODO: verify locker move messaging
+    # The young clerk nods and jots something down.  "Okay, it's done!  Immediate rate locker shipping from Kharag 'doth Dzulthu to Kraken's Fall."
+    # You hand the young clerk 5000 silvers.
+
+    Script.run('go2', "#{starting_room}") if starting_room != Room.current.id
   end
 
   def self.help
@@ -134,5 +137,4 @@ args = script.vars[1..-1].map { |str| str.downcase } || []
 Movers.help                                         if args.include?("help")
 Movers.error "at most 3 arguments are allowed"      if args.size > 3
 Movers.error "<from> and <to> are required options" if args.size < 1
-Movers.swap *args.map {|arg| Movers.lookup arg }
-
+Movers.swap(*args.map { |arg| Movers.lookup arg })


### PR DESCRIPTION
Convert to UID instead of Lich ID. Validated CLERK npc.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert to UID for room IDs and validate CLERK NPC in `uhaul.lic`.
> 
>   - **Behavior**:
>     - Convert room IDs to use `Map.ids_from_uid` in `ROOMS` hash in `uhaul.lic`.
>     - Validate presence of CLERK NPC in `swap()` method in `uhaul.lic`.
>   - **Code Style**:
>     - Update version to 2.0.2 in `uhaul.lic`.
>     - Minor formatting and whitespace adjustments in `uhaul.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9b14c527020d33d2a60c9937182674c6165a6d13. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->