### PR TITLE
fix(bigshot.lic): v5.9.1 bs_wander groupcheck sequence correction

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.9.0
+       version: 5.9.1
       required: Lich >= 5.12.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.9.1  (2025-06-27)
+    - Fix for head/tails bs_wander groupcheck logic
   v5.9.0  (2025-04-03)
     - Convert over to use Group and Claim modules from core Lich5
     - bugfix in cmd_assaults for confusion
@@ -6725,10 +6727,10 @@ class Bigshot
       new_room = true
 
       if !@followers.all_present? || Lich::Gemstone::Group.broken?
-        groupcheck
         @followers.add_event(:FOLLOW_NOW) # trigger rubber band
         message("yellow", "Waiting for followers....")
         sleep(0.5) while (!@followers.all_present?)
+        groupcheck
       end
 
       # Wait for follower to finish looting if needed


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes group check sequence in `bs_wander` logic in `bigshot.lic` by moving `groupcheck` call after followers are confirmed present.
> 
>   - **Behavior**:
>     - Fixes group check sequence in `bs_wander` logic in `bigshot.lic` by moving `groupcheck` call after followers are confirmed present.
>   - **Versioning**:
>     - Updates version to 5.9.1 in `bigshot.lic` to reflect bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 578aaaec914388fbd0202ebcf0f41369a141aa0d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->