### PR TITLE
fix(bigshot.lic): v5.9.3 various fixes

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -20,6 +20,7 @@
   v5.9.3  (2025-07-02)
     - bugfix for shield bash if using CMan instead of shield
     - bugfix for FORCE cmd to stop checking older lines if it found a proper attack messaging but failed the match
+    - bugfix for cmd_tether to end if link is broken
   v5.9.2  (2025-06-30)
     - bugfix in cmd_tether potential npc logic
   v5.9.1  (2025-06-27)
@@ -4792,6 +4793,7 @@ class Bigshot
     return unless Spell[706].known? and Spell[706].affordable?
 
     complete_line = /dissolve into black mist/
+    broken_line = /^You struggle to maintain control of the dark force, but you feel it break away\!|^You feel your connection to the dark presence fade away\./
     tether_transferred = /^As the signs of life fade from an? [\w\s\-]+, the tenebrous chains binding [\w\s\-]+ begin to vibrate and emit a sinister thrum that emanates through the surrounding area\.$/
 
     waitrt?
@@ -4804,7 +4806,7 @@ class Bigshot
 
     Thread.new do
       while (line = get)
-        if line =~ complete_line || Time.now > time_out
+        if line =~ complete_line || line =~ broken_line || Time.now > time_out
           spell_complete = true
           break
         elsif line =~ tether_transferred


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `bigshot.lic` to v5.9.3 with bug fixes for shield bash, force command logic, and tether termination.
> 
>   - **Version Update**:
>     - Update version to 5.9.3 in `bigshot.lic`.
>   - **Bug Fixes**:
>     - Fix shield bash handling in `Bigshot` class to use `CMan.affordable?` for `cman sbash`.
>     - Fix `FORCE` command logic to stop checking older lines after a failed match in `Bigshot` class.
>     - Fix `cmd_tether` to terminate if the link is broken in `Bigshot` class.
>   - **Misc**:
>     - Add `broken_line` regex to handle broken tether scenarios in `Bigshot` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 3a7916e6c57f351f81f162ef0d4db5983e22d95f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->