### PR TITLE
fix(ecleanse.lic): v2.2.2 berserk web fix

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.11.1
-       version: 2.2.1
+       version: 2.2.2
 
   Improvements:
+  v2.2.2  (2025-07-04)
+    - bugfix in allowing berserk when webbed to actually work
   v2.2.1  (2025-06-21)
     - allow dispel magic and dispel webs to be toggled if Spell Cleave or Spell Thieve known.
   v2.2.0  (2025-04-23)
@@ -1188,7 +1190,7 @@ module Ecleanse
     end
 
     def self.remove_web_bound
-      return unless Ecleanse.data.settings[:avoid_webs]
+      return unless Ecleanse.data.settings[:avoid_webs] || Ecleanse.data.settings[:use_berserk_webbed]
       Action.mana_pulse(1040) if Spell[1040].known?
 
       spell_1040_ready = Spell[1040].known? && Spell[1040].affordable?


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `remove_web_bound` method in `ecleanse.lic` to allow berserk action when webbed if `use_berserk_webbed` setting is enabled.
> 
>   - **Behavior**:
>     - Fixes bug in `remove_web_bound` method in `ecleanse.lic` to allow berserk action when webbed if `use_berserk_webbed` setting is enabled.
>   - **Misc**:
>     - Update version to 2.2.2 in `ecleanse.lic`.
>     - Add changelog entry for version 2.2.2 in `ecleanse.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 6e7ab806460741d6795e639a9cdb3f3381784b53. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->