### PR TITLE
fix(effect-list.xml): 1135 name to Bloodsmith

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -1247,7 +1247,7 @@
       <message type='start'>You feel an intense resolve fill your mind, and concentrate on improving your efforts to guard yourself\.</message>
       <message type='end'>Your intensity subsides\.</message>
    </spell>
-   <spell availability='all' name='Bloodstone Jewelry' number='1135' type='utility'>
+   <spell availability='all' name='Bloodsmith' number='1135' type='utility'>
       <cost type='mana'>35</cost>
    </spell>
    <spell availability='all' name='Regeneration' number='1150' type='utility'>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed spell 'Bloodstone Jewelry' to 'Bloodsmith' for spell number '1135' in `effect-list.xml`.
> 
>   - **Rename**:
>     - Renamed spell `name` from 'Bloodstone Jewelry' to 'Bloodsmith' for spell number '1135' in `effect-list.xml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ac16e488d29ab9519a79c301e55f45870dea4e2e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->