### PR TITLE
feat(map.lic): add Locations dropdown similar to tags

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -15,9 +15,11 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich > 5.0.1
-      version: 1.3.10
+      version: 1.4.0
 
   changelog:
+    v1.4.0 (2025-07-04)
+      * Add Locations drop down (similar to tags)
     v1.3.10 (2025-05-29)
       * Fix for missing dark maps causing GTK errors and DR not having any dark maps
     v1.3.9 (2025-05-10)
@@ -364,10 +366,17 @@ tag_img_pixbuf = nil
 tag_img_width = nil
 tag_img_height = nil
 tag_img_list = Array.new
+
+location_img_pixbuf = nil
+location_img_width = nil
+location_img_height = nil
+location_img_list = Array.new
 menu = nil
 menu_scale_list = nil
 menu_tags_list = nil
 current_tag = nil
+menu_locations_list = nil
+current_location = nil
 scale_list = [10, 25, 33, 50, 66, 75, 90, 100, 110, 125, 133, 150, 166, 175, 190, 200]
 opacity_list = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
 begin
@@ -391,11 +400,20 @@ unless File.exist?(File.join(map_dir, "tag_img.png"))
   File.open(File.join(map_dir, "tag_img.png"), 'wb') { |f| f.puts('iVBORw0KGgoAAAANSUhEUgAAAB0AAAAdCAYAAABWk2cPAAAAAXNSR0IArs4c6QAABspJREFUSMetlntwFeUZxn/f7p491yQnJxcwEAghNBGCgYJQ0sRCIsNQqmDRilPUKkRSKiItHTt1aKcycVRmHDu2hcqAFIZbA0WnpVqBglKRS+QiSLiD3ElCDrmcnMue3bd/eDrDIIyx8M7sPzuz32+f531330cRerqTzu1uEscbge8BYe54+apw919P6CEdUU0GngIbJE6XtwSzYBvSdzQdb95BcPB+AmXvkH5/EiPLJnq4h0b0gImR6ZD9ZAR/WSFGy1YwMu8MMH0svpJ3CFTaKBNiRwzaNusa7TvfRSwDs7eDu8gicbEEkjuB2wNnPVNFRvV6AsMFiSs6P3HR/LafxJGZGvaFx7Cjf8fucCFxhXeghXtgIWj7Af//BQw9WYWnTz1pFTZiCF37Ddo2+pCOGmCZAsC9TJG2ezUSm4iekUQSED/ionNHB040X0QUkAd4gEtKqVYAEXEDhUAOcFopdY6c2VW4QuvwDXewwxqtf/XQ9p4XrOnAEgADgPhPhDg/RqWvJXDvRPyDYvgGJzFyfHTtPbvrUHLkyFLjO0AP4JSIbAI0oAwYBbQACv+DA3CF1uG9W3BlC7rbRguA5pmGYy39nxH6daYIKr6e+LkyEs2luHok0dKF7Kfkgx3hh595NP+06VKDgX6AAxSlgD7Amf3CUt+uhgPL0Tw6klQIAujowZ/RtuEv17uv39ANAWctdmsl8S+KyZkeJTDUSjgez5nGjZU/GFt6XNf1XkB1CugGLs2t+7hp4eorC2x3qYBAx3aTyC4PWvZMLjy/4saWazfeEBFNRL5v9nj4X5o7RwdbRTvO6pu3HjJ/+av5ExOJhAakAUHAXPRWfez3Cze+HrcMDeUFI1vwliZRvhlcnLv8ZnOmbgINpYbDLB7/8W9ONf57TDJyMomeJjlBW3tiSlXk1XmTP9F1xe7de05M+OFzc1piA7rQPAJKPG6PuntQ6fy979csB64ppaLdgfYDhgD9LctOTJ4y58FtWzdXd0hJFFeu488amuyTn9c6pvT0iytXvL2qjaERlA6x43pQ/8z905mzFr5c97tG4DLQoJQ6012l5cAIINdxHFX3yh9GLFm8uOyLcFGM4IQYZrbD1bXpRBsFT38bq1kLmY3uurr5i2prawFsoBH4QCl1/Gt7ClwDdgKfA15N08rm/fq5pprpU455re1enKs6dqeG3W6TuKTTdVQndsI9bdr0utraWgO4CzCBY8CVbvX0OsUVwBygBGgFNt3Vb/ToyzL525i9HNq2uoif01BuHeF5ubb2IvBoCroHeAs4p5RKdEcpIpILTABCQBtwas27B5rb7OIxmH1s9DRBeQUjALoriUr+fN++z1uAZiACFAM/Agpudr5xC6G9gUDqgJMvv75h87y6Vaud2MkEOffo6AGhc4eL+FEDJ6YhiaKKii2rDx7c+4vCwkIfkJG6eqZs/voSkWIReVxE5ixYsOBxI6NCCFTG0Hw2OTM6jfzfije9dLthGPLlDwUBTTJy7z3ceLTpARGZlXq+oNtLQkS8IpJV8t35o8idLhT8OUzeC+2Yfa284sfkj8t2LBaRmePGjftQ0zQB08Y1IEFWTUTLm/9pxdiFOSLiEhHtGw0SBW8MBfde3H2voryQvKKC9qbQm68+vXLqI+XBlP1nqqur+27b1jDa8Y2IEhyXAKW4uuYs0Yb7bhV9bvomuHsPp+vIXpQeJhnWiB423ImG0FNTx7829ZHy9tSCzwOKtmzZcnDQoIJNODETLehg5NjowQG4BvwH3wOZ3VPqGjICb2gXaZXtoEPHRyYdH3qGDK+eu2/3exeBYUB2aocq4JhlWfVm1qTZ9JgxDj0rTtd+F7FGF07XCaLuMXQtCt8a2vOlMSh7HWDghDUiDS46d5rgzBKReuCeFKwFiAIDU5/UDjWS87T+cwWaZwKJs4LVpBH51MTMP0rUX0XHS+GvQgMVVWRO/BtmoY3EFZE9LroOBej67AnsKytExJOy1QBalVKRr7hUdEERWb6S5PmHMIIWTgz0DLCunaRlQxVyOnw9dCz4/kFapU2g3EIsSDYZGDk1XK5b9Q0TksI7sh7foAn4h8Uwezm0b3PT9KfzkBj15XD1qruPzMkRMG20oI2rl4WeJXhHTr2NLKjwj66n34o2vvV+Mz1fbEPPtoGjQKaOv7wRMy+JnibET+rYLQYSfZbkhSW3FUHz31iHtA3GiQ/EOqdQHkhezUUS4xW+8hi+YRZKg/gZnY6PnkXCS+9I1q5oVRyauQbikzBCFlazRqTBVICDpyRJeoWBHqrh0mtLuLOlcJeswj9sEv4RMeLn9f8CDNDXOHI7wF8AAAAASUVORK5CYII='.unpack('m').join('')) }
 end
 
+location_image_file = File.join(map_dir, "location_image.png")
+unless File.exist?(location_image_file)
+  File.binwrite(location_image_file, "\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x00\x1D\x00\x00\x00\x1D\b\x06\x00\x00\x00V\x93g\x0F\x00\x00\x03\xD7IDATHK\xAD\x96ohNQ\x1C\xC7\xCFy\x0Ef\xF6x\xE6\xCFcF\x99\xCC\v\xA2\fC\x88\xBCP^(\xF1NY\b\xE5\x8DdbhX\ea\xC6l\xA5!)%/DJ\x96%\xBCx\xB2\x90?\x9B\x92\xD0V\xFE\xE4\xCF\f\xED\xFF\x10\xEE=\xBE\xBF{\xCF}\xDC\xFB\xDCs\xB7g\xB3[\xDF\xEE\xF3\x9Cs\xEE\xEFs\x7F\x7F\xEE9?\xCE\xF6\x85$\x93\xCC\xBE\xBE\xB3|\x96j\xD6Z\xBF\x0F\xB3z5\xFA\x7F\xB7B6\x9B\xB1P\x9D\xDB\b\xB7\xA0\xEE\xAB;\x15\xE0\xEE\x81\x01\x13\x90{\x81\x84\xE2l\x7F\x02\xD4\xF1x\xB8\xF2\xB8\xB8\x9F\x1E\x130\xE4\a\xDA\xD0\xA2\x04\xA8;\xD4\xFD\x05\x17\x03h$\x00]\xF1\x84\xA7l.B\xF0H\x9B\xB8\xEF<\x8F\x85\x8DW\xD6\\\xB2\x1E\xEB\x80n\xE3\xC2\xCC\xE50\x86\xB7b\x02\xA1\xD0\x83\x7F\xF2U\xB2\xF4\xCF-<7\x1E\x1A\n5q\xCE[\xC8\x8E\x942\x05\xB7lh\f\xF4\x86\x97\xF01\xCC\xD4\x87\xD4\xE2\x86\xCC\\;\xBC\xB6\x17\x04Nc\"t\xD7\xE3\xB1\n\xC9\x88\xA1\xD1\x8B\xAD{\x9Aobn,\xF4\x1A\xBAM&\xA0\x1Ch\x01\xF4\x8D\xC6y\xB1\x88i#f\x91l E\xCC\x86\xF6\x04V\xD3\xB1\xB5\x0F\xCA\x96d\xCF#o\x7F@5\n:\x03\xF7A\x04\xE5%\xA2\xC2\at\xF2\xE8\x02Z|\xCFB\xF2\xD8\x1A\xD5\x87\xE8\xEB\x8E\xE6K\xD1\xB4\xE8h\xAC\x88@&\xF4\x01z\x0E`I\xA0\x87\xEC\x9F\x87\xCE\x1A/\x14\xA3\xC8\x13\x85M\xF0\x83\xE2\x97\xC7\x90z\xEB\xA6m\x1Fc\x99\xE9\x99\x19\xEA\x85\e\xF8\x01\xB12\x10(\xFD@\xBF\xA76t\x14nT\x1CC\x00\xBE\xA73\xF8\xA7\xD0\xA8\x16\x82\xB19Us\xB3\xEBZ\xEA\xA7\xEB\xD6\xC8\xFD\x06\xA5\xA2\rEG\xE9\xF0\\:O'a\xC5Lh\xF2\xFB\xF6O,\xEB\xE4\x84c\xC1\xA1\xD3\xCC \"\x00n\xC5\xCCg\xE8\t\xA0o\x93\x81\x92\xA7\v\xA1yP\x86i\x9A\\\x1C\x19\xBC\xD9g\xDE\xBBy\xC6\xA7\xE5>\xE3\f\xFE\x18\xD0K\xE8\x16\xA0\x8D\xC9@)\xA7\x04^\n-\x87\xA6@\xED\xFC\x90X\xD6\x9B\xC7r\xAFq\x0Ek\xE8\x9B\xFD\x02]\x81\x1E\x02\xDA\xD1+\xD4Y\x80\xDC.\xC2\xEF\xED\xD0T\x886\x83\xDB\xFCpp\x95\xCAB\x83\nj54\x0Ez\f\x9D\x85\xDE\x03\xEA-H\f\xFArJP\x00\xA9:\t8\x1F\xA2]\xA7\x91\x1F\x11\xEB\x02=E\xA8\xB3\x86M\xBC\xFC.\xFFu\x13\xD6L\x86(\xBC\x0F\xA1\xAB\x806$\xE5)\xA0\xF4\xBDn\x80\xA8\xA8>\xF3R\xB1\xC9z0 \x8F\x8E\xD1\x15Y+N]\xCF\xBB6\x18\xFF\xD3\xA17P\r\xA0\xDE]\xAE\aO)\x8FTHQ\x00O\x04z\xA8\x99\x98\x9F\xB1\xF8\xFC\x83\x8D\xB1\xA7\x98j\x83j\x93\xAA^\x15\xDET\xDC\x87\xF1\xA3\x82\xF6T\xED%w\e[0_\xE5\x9BD4\x06\xFD\x8A\x14\xFD.j-\xA50\x03J;\x97\xE7\xF2\xE7\xB4Lm\x852\xF8\xB4\x90\xBB\x8C\e\xB0\x12\x86\xDE\x02\xBC^\xFBV]h}\"\xAA\x11\xD8\xE5m\x04\xBCP\a\xE8\xEEi\x12\xF2\b\xE0i@\xE8tq>\x8Dz^&h3\xF0_\x9D)\x00\xFF\xB0[\x1F\x17\xF8\x1FT\aL0#\v\x8C5\x18\xA2#*\xAA\xA0\xF4|\xC3\xB3\xE6g\xD59\x17f\xDD\xD1\x82;\xD0sET\xCF\xA5\xC06\xD4\x01\x06\x9C.\xB4D\xEE4\xE8,\xA5\xA3\x8C<\xA4\\\xD3\x9E:\rj\x87\xEE\xF3r\x9E\x89\x03\\\xDF\bt\x85\xF3Y\xB8#\xEE1\x8F\x03\x03\x9A(\xEB\xA5L3W\x16\xC8\x17\xF85\x12\xA2\xF3\xB3\x05\x05\xD2\xED\xF3\xEC8Z\x1F\x19\x00\xEE\x14\x00\xFF\xB6\xC0\x9CU\xA0p\x12[\fw\x1E\x01L\xCC\x896\x8C\xCE \x81Y\x00\xB8\x03\xC5\x156k9+\xD7\xB4\xA0\x8E\x01\xD5\xD3`o\xEA[\xE3\xDD\v\x98\xB3\x13\x01P\xA7\xC5\xE8+\xD0\xEDq@\x97\x89\xF0\xEA\xA0*\xA4\xFD\x05:\xE0J\x84ZS\\\x9CU*h<\x8F\x03\x04\xEC\x01\xFC\x17\xE7?X\x95\x14BJ\xB9\x00\x00\x00\x00IEND\xAEB`\x82")
+end
+
 Gtk.queue {
   _format, width, height = GdkPixbuf::Pixbuf.get_file_info(File.join(map_dir, "tag_img.png"))
   tag_img_width = width
   tag_img_height = height
   tag_img_pixbuf = GdkPixbuf::Pixbuf.new(:file => File.join(map_dir, "tag_img.png"))
+  
+  location_img_width = width
+  location_img_height = height
+  location_img_pixbuf = GdkPixbuf::Pixbuf.new(:file => location_image_file)
 }
 
 show_tag = proc { |tag|
@@ -414,6 +432,27 @@ show_tag = proc { |tag|
       tag_img_list.push(img)
       img.set_pixbuf(tag_img_pixbuf)
       layout.put(img, (((room.image_coords[0].to_i + room.image_coords[2].to_i) / 2) * scale) - (tag_img_width / 2) + map_offset_x, (((room.image_coords[1].to_i + room.image_coords[3].to_i) / 2) * scale) - (tag_img_height / 2) + map_offset_y)
+      img.show
+    }
+  end
+}
+
+show_location = proc { |location|
+  current_location = location
+  while (img = location_img_list.shift)
+    img.hide
+    img.destroy
+  end
+  if location
+    Map.list.each { |room|
+      next if room.nil?
+      next unless room.image == short_current_map
+      next if room.location.nil?
+      next unless room.location == location
+      img = Gtk::Image.new
+      location_img_list.push(img)
+      img.set_pixbuf(location_img_pixbuf)
+      layout.put(img, (((room.image_coords[0].to_i + room.image_coords[2].to_i) / 2) * scale) - (location_img_width / 2) + map_offset_x, (((room.image_coords[1].to_i + room.image_coords[3].to_i) / 2) * scale) - (location_img_height / 2) + map_offset_y)
       img.show
     }
   end
@@ -490,6 +529,41 @@ change_map = proc { |file_name, suppress_scroll = false|
       group.active = true
       show_tag.call(nil)
     end
+    location_list = Set.new
+    Map.list.each { |room|
+      next if room.nil?
+      next unless room.image == short_current_map
+      next if room.location.nil?
+      location_list.add(room.location)
+    }
+    menu_locations_list.children.each { |child| child.destroy }
+    group = Gtk::RadioMenuItem.new(nil, '(clear)')
+    menu_locations_list.append(group)
+    group.signal_connect('toggled') { |owner|
+      Gtk.queue {
+        show_location.call(nil) if owner.active?
+      }
+    }
+    location_list.sort_by { |location| location.downcase }.each { |location|
+      menu_location = Gtk::RadioMenuItem.new(group, location)
+      menu_locations_list.append(menu_location)
+      menu_location.signal_connect('toggled') { |owner|
+        Gtk.queue {
+          if owner.active?
+            show_location.call(location)
+          end
+        }
+      }
+      if current_location == location
+        menu_location.active = true
+        show_location.call(location)
+      end
+    }
+    menu_locations_list.show_all
+    unless location_list.include?(current_location)
+      group.active = true
+      show_location.call(nil)
+    end
   # }
   else
     echo "file not found: #{current_map}"
@@ -507,6 +581,9 @@ change_room = proc { |suppress_scroll = false|
       layout.move(image, map_offset_x, map_offset_y)
       if current_tag
         show_tag.call(current_tag)
+      end
+      if current_location
+        show_location.call(current_location)
       end
       # }
     end
@@ -777,6 +854,11 @@ Gtk.queue {
   menu_tags_list = Gtk::Menu.new
   menu_tags.submenu = menu_tags_list
 
+  menu_locations = Gtk::MenuItem.new(:label => 'locations')
+
+  menu_locations_list = Gtk::Menu.new
+  menu_locations.submenu = menu_locations_list
+
   menu_opacity_list = Gtk::Menu.new
   opacity_list.each { |num|
     if group
@@ -810,6 +892,7 @@ Gtk.queue {
   menu.append(menu_view_map)
   menu.append(menu_scale_map)
   menu.append(menu_tags)
+  menu.append(menu_locations)
 
   menu.show_all
 


### PR DESCRIPTION
Mirrors tags functionality to highlight specific locations on a map.
![image](https://github.com/user-attachments/assets/4387fce7-ac0f-4a76-b373-2d303e6b2366)

after selecting melghoren's valley:
![image](https://github.com/user-attachments/assets/56019e5e-f013-40c3-ad72-28ee28d72d18)

Works alongside tags fine. clear, etc. all have been working for me no issues but GTK sucks don't trust me.