### PR TITLE
fix(ecaster.lic): v1.1.4 GameObj.targets change

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -6,10 +6,11 @@
           tags: magic, spell, casting
           game: gs
       required: Lich > 5.7.0
-       version: 1.1.3
+       version: 1.1.4
 
   Version Control:
     Major_change.feature_addition.bugfix
+      1.1.4: change to use GameObj.targets instead of npcs
       1.1.3: change CharSettings.save to Settings.save calls
       1.1.2: bugfix change hide_me variable to hide_after_cast to not conflict with Lich5 method hide_me
       1.1.1: bugfix in hide option setting for existing ecaster users not working
@@ -323,7 +324,7 @@ module ECaster
   end
 
   def self.valid_targets?
-    GameObj.npcs.count { |npc| npc.type =~ /aggressive/ && npc.status !~ /dead|gone/ } || 0
+    GameObj.targets.count { |target| target.status !~ /dead|gone/ } || 0
   end
 
   def self.valid_target?(target)
@@ -343,9 +344,8 @@ module ECaster
         pattern = /#{s1}/
       end
     end
-    # candidate = GameObj.pcs.select {|pc| pc.noun =~ pattern }
-    candidate = GameObj.npcs.select { |npc| npc.name =~ pattern }.at(n)
-    candidate && candidate.status !~ /dead|gone/ && candidate.type =~ /aggressive/
+    candidate = GameObj.targets.select { |target| target.name =~ pattern }.at(n)
+    candidate && candidate.status !~ /dead|gone/
   end
 
   def self.cast(input)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ecaster.lic` to use `GameObj.targets` instead of `GameObj.npcs` for target selection, updating version to 1.1.4.
> 
>   - **Behavior**:
>     - Update `valid_targets?` in `ecaster.lic` to use `GameObj.targets` instead of `GameObj.npcs`.
>     - Update `valid_target?` in `ecaster.lic` to use `GameObj.targets` instead of `GameObj.npcs`.
>   - **Version**:
>     - Increment version to 1.1.4 in `ecaster.lic` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 0c13cb196d38b1a3d8a5f1aecd70200ef807d2c1. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->