### PR TITLE
fix(bigshot.lic): v5.9.4 final loot only when room claimed

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.9.3
+       version: 5.9.4
       required: Lich >= 5.12.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.9.4  (2025-07-08)
+    - bugfix for leader final loot to only work if claim is true
   v5.9.3  (2025-07-02)
     - bugfix for shield bash if using CMan instead of shield
     - bugfix for FORCE cmd to stop checking older lines if it found a proper attack messaging but failed the match
@@ -6754,7 +6756,7 @@ class Bigshot
       end
 
       # Final room loot by leader for any missed items by follower
-      if @FINAL_LOOT && leading? && !solo?
+      if @FINAL_LOOT && leading? && !solo? && bigclaim?
         loot()
         $looting_inactive = true
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `bigshot.lic` to ensure final loot by leader only occurs if room is claimed.
> 
>   - **Behavior**:
>     - Fixes bug in `bigshot.lic` where final loot by leader only occurs if `bigclaim?` is true.
>   - **Version**:
>     - Updates version to 5.9.4 in `bigshot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 73d50cb5f158b5bd36a52a7899f4077a2168ce23. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->