### PR TITLE
fix(map.lic): handle a location of false

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -15,9 +15,11 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich > 5.0.1
-      version: 1.4.0
+      version: 1.4.1
 
   changelog:
+    v1.4.1 (2025-07-08)
+      * Handle a location of false
     v1.4.0 (2025-07-04)
       * Add Locations drop down (similar to tags)
     v1.3.10 (2025-05-29)
@@ -534,7 +536,7 @@ change_map = proc { |file_name, suppress_scroll = false|
     Map.list.each { |room|
       next if room.nil?
       next unless room.image == short_current_map
-      next if room.location.nil?
+      next unless room.location
       location_list.add(room.location)
     }
     menu_locations_list.children.each { |child| child.destroy }


### PR DESCRIPTION
location have some bad data, should probably fix mapdb also but just in case we don't care if it's set to "false"

I just checked there are only 3 classes for location in the db presently (string, nil, false)