### PR TITLE
feat(crits.lic): Initial demonstration for CritRanks

### DIFF
--- a/scripts/crits.lic
+++ b/scripts/crits.lic
@@ -91,7 +91,7 @@ def resolve_crit_rank(results)
         str << ' --> ' unless crit_results[:location].nil?
         str << 'stunned, but who knows for how long? . . .' << monsterbold_end
       end
-      pp crit_results unless crit_results.empty? if $debug
+      pp crit_results if $debug && !crit_results.empty?
       crit_results = {}
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `crits.lic` script to demonstrate `CritRanks` module usage in Gemstone, parsing combat results for crit information with prototype limitations.
> 
>   - **New Script**:
>     - Adds `crits.lic` as a prototype script to demonstrate `CritRanks` module usage.
>     - Targets Gemstone game, requiring Lich > 5.11.0.
>   - **Functionality**:
>     - Implements `resolve_crit_rank()` to parse combat results and extract crit information.
>     - Handles specific combat actions using regex in `combat_regex`.
>     - Outputs crit details based on stun and fatality conditions.
>   - **Prototype Limitations**:
>     - Does not handle non-stun undead crits.
>     - Includes TODOs for better dead status handling, crit resolver/message builder separation, and XML tracking for multiple targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2957efb08362be6a6379d9589f5fa27f17340ad0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->