### PR TITLE
fix(eloot.lic): v2.4.2 f2p silver withdrawals fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -3111,7 +3111,7 @@ module ELoot # Game utility type methods
     # deposit the note(s) on hand to make enough silver available for the desired withdrawal.
 
     balance = 0
-    lines = ELoot.get_command("check balance", /The teller/, silent: true, quiet: true)
+    lines = ELoot.get_command("check balance", /(?:The|A prim) teller/, silent: true, quiet: true)
     if lines.find { |line| line.match(/Your balance is currently at (?<silver>[\d,]+)/) }
       balance = Regexp.last_match[:silver].gsub(',', '').to_i
     end
@@ -3135,7 +3135,7 @@ module ELoot # Game utility type methods
 
       # deposit the note and then attempt to withdraw the amount of silver needed
       Inventory.drag(note)
-      lines = ELoot.get_command("deposit ##{note.id}", /You deposit/, silent: true, quiet: true)
+      lines = ELoot.get_command("deposit ##{note.id}", /You (?:deposit|hand your)/, silent: true, quiet: true)
       break if lines.find { |line| line.match(/worth (?<silver>[\d,]+)/) }.nil?
       note_amount = Regexp.last_match[:silver].gsub(',', '').to_i
       withdraw_amount = note_amount >= amount ? amount : note_amount

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.4.1
+           version: 2.4.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.4.2 (2025-07-09)
+    - bugfix for silver withdrawals failing on f2p accounts with low bank balances
   v2.4.1 (2025-06-05)
     - bugfix for unable to lighten load during pool return and no silvers to deposit to allow more boxes to be returned
     - bugfix for box loot to deposit coins if too many coins on yourself to be able to loot coins from box
@@ -3102,6 +3104,47 @@ module ELoot # Game utility type methods
     ELoot.wait_rt
   end
 
+  def self.f2p_silver_withdraw(amount)
+    # f2p accounts have a max balance, and the silver_deposit() function will withdraw notes when the
+    # max balance is reached. sometimes eloot needs to withdraw sums such as 8k silvers to run errands,
+    # but a f2p bank account will frequently not have that much available. when that happens, this will
+    # deposit the note(s) on hand to make enough silver available for the desired withdrawal.
+   
+    balance = 0
+    lines = ELoot.get_command("check balance", /The teller/, silent: true, quiet: true)
+    if lines.find { |line| line.match(/Your balance is currently at (?<silver>[\d,]+)/) }
+      balance = Regexp.last_match[:silver].gsub(',', '').to_i
+    end
+
+    if balance >= amount
+      dothistimeout("withdraw #{amount} silver", 2, /The teller/)
+      return
+    end
+
+    bag = ELoot.data.sacks["default"]
+    5.times do
+      note = bag.contents.find { |obj| obj.noun =~ /^(?:note|scrip|chit)$/ }
+      break if note.nil?
+
+      # drain the account to make room for a note that could be as large as the f2p max balance
+      if balance > 0
+        dothistimeout("withdraw #{balance} silver", 2, /The teller/)
+        amount -= balance
+        balance = 0
+      end
+    
+      # deposit the note and then attempt to withdraw the amount of silver needed
+      Inventory.drag(note)
+      lines = ELoot.get_command("deposit ##{note.id}", /You deposit/, silent: true, quiet: true)
+      break if lines.find { |line| line.match(/worth (?<silver>[\d,]+)/) }.nil?
+      note_amount = Regexp.last_match[:silver].gsub(',', '').to_i  
+      withdraw_amount = note_amount >= amount ? amount : note_amount
+      dothistimeout("withdraw #{withdraw_amount} silver", 2, /The teller/)
+      amount -= withdraw_amount
+      break if amount <= 0
+    end
+  end
+
   def self.silver_withdraw(amount)
     if ELoot.silver_check >= amount && Char.percent_encumbrance < 20
       return
@@ -3113,6 +3156,8 @@ module ELoot # Game utility type methods
 
     if XMLData.room_title == '[Pinefar, Depository]'
       fput("ask banker for #{amount} silvers")
+    elsif ELoot.f2p?
+      f2p_silver_withdraw(amount)
     else
       fput("withdraw #{amount} silvers")
     end

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -3137,7 +3137,7 @@ module ELoot # Game utility type methods
       Inventory.drag(note)
       lines = ELoot.get_command("deposit ##{note.id}", /You deposit/, silent: true, quiet: true)
       break if lines.find { |line| line.match(/worth (?<silver>[\d,]+)/) }.nil?
-      note_amount = Regexp.last_match[:silver].gsub(',', '').to_i  
+      note_amount = Regexp.last_match[:silver].gsub(',', '').to_i
       withdraw_amount = note_amount >= amount ? amount : note_amount
       dothistimeout("withdraw #{withdraw_amount} silver", 2, /The teller/)
       amount -= withdraw_amount

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -3109,7 +3109,7 @@ module ELoot # Game utility type methods
     # max balance is reached. sometimes eloot needs to withdraw sums such as 8k silvers to run errands,
     # but a f2p bank account will frequently not have that much available. when that happens, this will
     # deposit the note(s) on hand to make enough silver available for the desired withdrawal.
-   
+
     balance = 0
     lines = ELoot.get_command("check balance", /The teller/, silent: true, quiet: true)
     if lines.find { |line| line.match(/Your balance is currently at (?<silver>[\d,]+)/) }
@@ -3132,7 +3132,7 @@ module ELoot # Game utility type methods
         amount -= balance
         balance = 0
       end
-    
+
       # deposit the note and then attempt to withdraw the amount of silver needed
       Inventory.drag(note)
       lines = ELoot.get_command("deposit ##{note.id}", /You deposit/, silent: true, quiet: true)


### PR DESCRIPTION
The 'eloot sell' script frequently fails on f2p accounts due to low bank account balances (typically for bank accounts with less than 8k silvers available).

f2p accounts have a max balance of 100k by default, and the silver_deposit() function will withdraw bank notes to say below that max balance, while also leaving the account with a 10k silver reserve. eloot needs to withdraw sums such as 8k silvers to run errands, but the available balance in a f2p bank account will frequently dip below that level, especially after a few errand runs. the silver_withdraw() function will fail when it needs to withdraw 8k silver but the bank account doesn't have that much available.

to fix this for f2p accounts, i modified silver_withdraw() so that when the account balance is too low, it will attempt to deposit any note(s) on hand to make enough silver available for the desired withdrawal.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes silver withdrawal failures on f2p accounts with low bank balances by depositing notes to make silver available in `eloot.lic`.
> 
>   - **Behavior**:
>     - Fixes silver withdrawal failures on f2p accounts with low bank balances in `eloot.lic`.
>     - `f2p_silver_withdraw(amount)` deposits notes to make silver available for withdrawal when balance is insufficient.
>   - **Functions**:
>     - Adds `f2p_silver_withdraw(amount)` to handle f2p account withdrawals.
>     - Modifies `silver_withdraw(amount)` to call `f2p_silver_withdraw(amount)` if account is f2p.
>   - **Misc**:
>     - Updates version to 2.4.2 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for d0225ff1d93b3359a89e4a7142a904f745269c7d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->