### PR TITLE
fix(gameobj-data.xml): Sailor's Grief stuff

### DIFF
--- a/type_data/migrations/65_sailors_grief.rb
+++ b/type_data/migrations/65_sailors_grief.rb
@@ -1,4 +1,5 @@
 migrate :aggressive_npc do
+  insert(:name, %{amaranthine kraken tentacle})
   insert(:name, %{brackish bilge mass})
   insert(:name, %{fulminating stormborn primordial})
   insert(:name, %{gigantic lightning whelk})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds new NPC names for aggressive, undead, and noncorporeal entities in `65_sailors_grief.rb`.
> 
>   - **Migration Additions**:
>     - Adds new aggressive NPC names: `brackish bilge mass`, `fulminating stormborn primordial`, `gigantic lightning whelk`, `grey-plumed steelwing harpy`, `hapless charmed corsair`, `kelp-tangled coral golem`, `scaly needle-toothed trenchling` in `65_sailors_grief.rb`.
>     - Adds new undead aggressive NPC names: `garish revenant buccaneer`, `milky-eyed drowned mariner`, `pallid fog-cloaked kelpie` in `65_sailors_grief.rb`.
>     - Adds new undead aggressive noncorporeal NPC name: `tenebrific wraith shark` in `65_sailors_grief.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 5cd6c79fa37e64ad5a5cffa46d4c764b5faa32a0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->