### PR TITLE
fix(kswole.lic): v1.1.1 Sailor's Grief additions

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -20,12 +20,14 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.0
+       version: 1.1.1
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.1 (2025-07-14)
+    - Add Sailor's Grief
   v1.1.0 (2025-05-08)
     - Feature Added support for Shield Mind Shield Specialization when Feat Absorb is unavailable or unknown.
   v1.0.11 (2024-12-05)
@@ -207,6 +209,12 @@ class KSwole
     /^A shan empath draws a large sign in the air before (?:her|his)..\./,
     /^A shan shaman utters an ancient prayer\./,
     /^A shan shaman waves a hand dismissively at you\!/,
+    # Sailor's Grief
+    /^An algae-draped merrow oracle gurgles in a lost tongue, crackles of blue-green energy tangling over (?:his|her) misshapen limbs\./,
+    /^A blubbery humpbacked merrow croaks deep in (?:his|her) throat, channeling a torrent of shimmering energy down one squamous arm\./,
+    /^A garish revenant buccaneer lifts a rattling voice in an old nautical chanty\./,
+    /^A brackish bilge mass pulses grotesquely, sprouting mouths that chant in an ugly arcane tongue\./,
+    /^A pallid fog-cloaked kelpie emits a strange bluish light as the music of rushing water echoes around (?:him|her)\./,
   )
 
   @dispelable_debuffs = [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for "Sailor's Grief" hunting area in `kswole.lic` by updating creature spell prep messages.
> 
>   - **Behavior**:
>     - Adds support for "Sailor's Grief" hunting area by including new creature spell prep messages in `@creature_spell_preps` in `KSwole` class.
>   - **Versioning**:
>     - Updates version from 1.1.0 to 1.1.1 in `kswole.lic`.
>   - **Documentation**:
>     - Adds version entry for v1.1.1 in `kswole.lic` with note on "Sailor's Grief" addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e4a801e065baf886ca025080c662a3803ebb4b77. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->