### PR TITLE
fix(eloot.lic): v2.4.3 town locksmith open box regex fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.4.2
+           version: 2.4.3
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.4.3 (2025-07-15)
+    - bugfix for town locksmith regex to open box after return being too generic
   v2.4.2 (2025-07-09)
     - bugfix for silver withdrawals failing on f2p accounts with low bank balances
   v2.4.1 (2025-06-05)
@@ -6152,7 +6154,7 @@ module ELoot # Sells the loot
       Inventory.drag(box) unless [GameObj.left_hand.type, GameObj.right_hand.type].include?("box")
       box = ELoot.box_unphase(box)
 
-      lines = ELoot.get_command("open ##{box.id}", /open|locked/, silent: true, quiet: true)
+      lines = ELoot.get_command("open ##{box.id}", /That is already open|You open|You throw back|It appears to be locked/, silent: true, quiet: true)
 
       if lines.any?(/locked/)
         res = dothistimeout(activator, 2, /Gimme ([\d,]+) silvers/)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes regex in `eloot.lic` for town locksmith to open boxes, updating version to 2.4.3.
> 
>   - **Bugfix**:
>     - Fixes regex in `eloot.lic` for town locksmith to open boxes, making it more specific.
>     - Handles cases: "That is already open", "You open", "You throw back", "It appears to be locked".
>   - **Version**:
>     - Updates version to 2.4.3 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 3b0402a051d85c81b6b3753c1b94aa772af860f2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->