### PR TITLE
feat(poisoncraft.lic): add initial version to community repo;

### DIFF
--- a/scripts/poisoncraft.lic
+++ b/scripts/poisoncraft.lic
@@ -1,0 +1,194 @@
+=begin
+  poisoncraft automation for Gemstone IV
+
+  ;poisoncraft --poison dreamer --limit 300
+
+  changelog:
+    1.0.0 - initial version with poison charge calculations from GSWiki
+    1.0.1 - updated calculate_applications with correct poison charges
+
+  version: 1.0.1
+  required: Lich 4.3.12
+  author: Ondreian
+  tags: rogue, poisoncraft, automation
+
+=end
+
+module Poisoncraft
+  module Opts
+    FLAG_PREFIX = "--"
+
+    def self.parse_command(h, c)
+      h[c.to_sym] = true
+    end
+
+    def self.parse_flag(h, f)
+      (name, val) = f[2..-1].split("=")
+      if val.nil?
+        h[name.to_sym] = true
+      else
+        val = val.split(",")
+
+        h[name.to_sym] = val.size == 1 ? val.first : val
+      end
+    end
+
+    def self.parse(args = Script.current.vars[1..-1])
+      OpenStruct.new(**args.to_a.reduce(Hash.new) do |opts, v|
+        if v.start_with?(FLAG_PREFIX)
+          Opts.parse_flag(opts, v)
+        else
+          Opts.parse_command(opts, v)
+        end
+        opts
+      end)
+    end
+
+    def self.as_list(key)
+      val = to_h.fetch(key.to_sym, [])
+      val = [val] if val.is_a?(String)
+      return val
+    end
+
+    def self.method_missing(method, *args)
+      parse.send(method, *args)
+    end
+  end
+
+  @poisons = {
+    :disabling => {
+      "dreamer" => "Dreamer's Milk",
+      "merrybud" => "Merrybud",
+      "snailspace" => "Snailspace Poison",
+      "dullard" => "Dullard's Folly",
+      "jester" => "Jester's Bane"
+    },
+    :deadly => {
+      "ravager" => "Ravager's Revenge",
+      "ophidian" => "Ophidian Kiss",
+      "shatterlimb" => "Shatterlimb Poison",
+      "fools" => "Fool's Deathwort",
+      "arachne" => "Arachne's Bite"
+    }
+  }
+
+  ValidDeadlyPoisons = @poisons[:deadly].keys
+  ValidDisablingPoisons = @poisons[:disabling].keys
+  ValidPoisonsString = "\tdeadly: " + ValidDeadlyPoisons.join(", ") + "\n" + "\tdisabling: " + ValidDisablingPoisons.join(", ")
+
+  def self.help
+    respond "Poisoncraft automation for Gemstone IV"
+    respond ""
+    respond "Usage: ;poisoncraft --poison <poison_name> [--limit <charges>]"
+    respond ""
+    respond "Arguments:"
+    respond "  --poison <name>    Required. The poison to create and apply"
+    respond "  --limit <charges>  Optional. Target charge limit (default: 300)"
+    respond "  --help             Show this help message"
+    respond ""
+    respond "Available poisons:"
+    @poisons.each do |type, poisons|
+      respond "  #{type}:"
+      poisons.each do |key, name|
+        respond "    #{key} - #{name}"
+      end
+    end
+    respond ""
+    respond "Examples:"
+    respond "  ;poisoncraft --poison dreamer --limit 300"
+    respond "  ;poisoncraft --poison ravager"
+    respond "  ;poisoncraft --help"
+  end
+
+  def self.calculate_applications(charges)
+    # Poison charges per creation based on GSWiki data
+    poison_charges = {
+      "dreamer" => 150,     # Dreamer's Milk
+      "merrybud" => 100,    # Merrybud
+      "snailspace" => 75,   # Snailspace Poison
+      "dullard" => 50,      # Dullard's Folly
+      "jester" => 50,       # Jester's Bane
+      "ravager" => 150,     # Ravager's Revenge
+      "ophidian" => 150,    # Ophidian Kiss
+      "shatterlimb" => 100, # Shatterlimb Poison
+      "fools" => 50,        # Fool's Deathwort
+      "arachne" => 50       # Arachne's Bite
+    }
+
+    poison = Opts["poison"]
+    charges_per_creation = poison_charges[poison] || 50 # default to 50 if unknown
+
+    # Calculate how many applications needed to reach the limit
+    limit = (Opts["limit"] || 300).to_i
+    remaining_charges = limit - charges
+
+    return 1 if remaining_charges <= 0
+
+    # Calculate applications needed, rounding up
+    applications = (remaining_charges.to_f / charges_per_creation).ceil
+
+    # Cap at reasonable maximum to avoid excessive purchases
+    [applications, 10].min
+  end
+
+  # It is coated with 50 charges of Fool's Deathwort poison.
+  def self.recall(item)
+    recall = Lich::Util.issue_command("recall ##{item.id}", /As you recall|You are unable/,
+      silent: Opts["verbose"] || true,
+      quiet: Opts["verbose"] || true,
+    )
+    match = recall.join("\n").match(/^It is coated with (?<charges>\d+) charges/)
+    return match.nil? ? 0 : match[:charges].to_i
+  end
+
+  # 1. <d cmd=\"order 1 color 0 material 0\">a black silk climbing pack</d>
+  def self.order_apothecary_kit()
+    output = Lich::Util.issue_command("order", /^\s+Catalog$/,
+      silent: Opts["verbose"] || true,
+      quiet: Opts["verbose"] || true,
+    )
+
+    menu = output.join("\n").scan(/(\d+)\. <d cmd="order \d+ color 0 material 0">(.*?)<\/d>/).map { |id, name| [name, id.to_i] }.to_h
+    menu["an unremarkable apothecary kit"] or fail "failed to find apothecary kit in rogue guild shop"
+    fput "order %s" % menu["an unremarkable apothecary kit"]
+    fput "buy"
+  end
+
+  def self.buy_and_apply(item, poison, applications)
+    @start = Room.current.id
+    Script.run("go2","bank")
+    fput "withdraw %s silver" % (10_000 * applications)
+    Script.run("go2", "rogue guild shop")
+    applications.times do
+      self.order_apothecary_kit()
+      fput "feat poisoncraft create #{poison}"
+      2.times { fput "feat poisoncraft apply" }
+    end
+  end
+
+  def self.main()
+    return self.help if Opts["help"]
+
+    poison = Opts["poison"] or fail "please pass --poison"
+    limit  = (Opts["limit"] or 300).to_i
+
+    unless @poisons[:deadly].include?(poison) or @poisons[:disabling].include?(poison)
+      fail "invalid poison: #{poison}, valid poisons are:\n#{ValidPoisonsString}"
+    end
+
+    fail "please hold the item you want to poison in your right hand" if GameObj.right_hand.nil?
+
+    if @poisons[:deadly].include?(poison) and !GameObj.right_hand.type.include?("weapon")
+      fail "invalid poison: #{poison}, you can only poison weapons with deadly poisons"
+    end
+
+    charges = self.recall(GameObj.right_hand).to_i
+    applications = self.calculate_applications(charges)
+    #Log.out("applications=%s" % applications, label: %i(applications))
+    self.buy_and_apply(GameObj.right_hand, poison, applications)
+    charges = self.recall(GameObj.right_hand).to_i
+    Log.out("#{GameObj.right_hand.name} has #{charges} charges")
+  end
+
+  self.main() unless Opts["test"]
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `poisoncraft.lic` script for automating poison crafting in Gemstone IV, including command-line parsing, poison application calculations, and user guidance.
> 
>   - **New Script**:
>     - Adds `poisoncraft.lic` for automating poison crafting in Gemstone IV.
>     - Supports command-line options parsing via `Opts` module.
>   - **Functionality**:
>     - `calculate_applications()` computes required poison applications based on current charges and target limit.
>     - `buy_and_apply()` handles purchasing and applying poisons to items.
>     - `recall()` retrieves current poison charges on an item.
>   - **User Guidance**:
>     - `help()` provides usage instructions and lists available poisons.
>     - Validates poison type and item compatibility before application.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for cd62470a9ba5b9e9f980f5a1c1d2b80d81154bf5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->