### PR TITLE
fix(BlackArts):v1.3.5 mortar return

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -7727,7 +7727,7 @@ module BlackArts
             sleep 0.05
             Actions.top_off_jars
           end
-          
+
           keep_looking = look_again
         end
       end

--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -6,10 +6,12 @@
   contributors: Deysh, Tysong, Gob
           game: Gemstone
           tags: alchemy
-       version: 1.3.4
+       version: 1.3.5
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.5 (2025-07-30)
+    - fix for returning mortar after grinding task
   v1.3.4 (2025-06-19)
     - fix bank_notes to include KF salt-stained kraken chit
   v1.3.3 (2025-05-09)
@@ -6003,7 +6005,6 @@ end
 
 # Main
 module BlackArts
-  BlackArts_version = '1.0.0'
   @@data ||= nil
 
   ##### Data & Setup Start #####
@@ -8865,7 +8866,7 @@ module BlackArts
         break unless give_result =~ /\[You have [0-9]+ repetitions? remaining\.\]/
       }
 
-      Util.get_res("put ##{task_mortar}", BlackArts.data.put_regex)
+      Util.get_res("put mortar", BlackArts.data.put_regex)
     end
 
     def self.grind_mine(reps)

--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -7681,7 +7681,7 @@ module BlackArts
         while keep_looking
           table_contents = Util.check_table(table)
           Util.msg("debug", "Actions.buy_elusive: table_contents - #{table_contents}")
-          keep_looking = false
+          look_again = false
           if table_contents.any? { |obj| obj.name =~ /#{UserVars.needed_reagents}/ }
             Inventory.free_hands(both: true)
             Inventory.drag(BlackArts.data.note)
@@ -7719,7 +7719,7 @@ module BlackArts
                     sleep 0.1
                   }
                   Inventory.store_item(BlackArts.data.sacks["reagent"], item) unless item.nil?
-                  keep_looking = true
+                  look_again = true
                 end
               end
             end
@@ -7727,6 +7727,8 @@ module BlackArts
             sleep 0.05
             Actions.top_off_jars
           end
+          
+          keep_looking = look_again
         end
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes mortar return command in `grind_mine` function and updates version to 1.3.5 in `BlackArts.lic`.
> 
>   - **Behavior**:
>     - Fixes mortar return command in `grind_mine` function in `BlackArts.lic`.
>     - Updates version to 1.3.5 in script header.
>   - **Misc**:
>     - Removes unused `BlackArts_version` variable in `BlackArts` module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for d27b1246d85ec749e187bc07c86b6321f08e2417. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->