### PR TITLE
fix(ebounty): v1.6.3 mana check for 650 and correction to 608/hiding logic

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,13 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       requires: Lich >= 5.9.0
-       version: 1.6.2
+       version: 1.6.3
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.6.3 (2025-08-03)
+    - bugfix mana check when changing aspect while 650 is active
+    - bugfix for hiding is 608 doesn't work
   v1.6.2 (2025-04-21)
     - bugfix for NPCs not populating quickly upon room entry with large amount of other characters
   v1.6.1 (2025-04-21)
@@ -455,7 +458,7 @@ module EBounty
       sleep 0.5
       waitcastrt?
       if Room.current.id == 2635 && UserVars.op['fog_rift'] && UserVars.op['resting_room_id'].to_i != 2635 && current_room != Room.current.id
-        mana_pulse(130)
+        EBounty.mana_pulse(130)
 
         Spell[130].cast() if Spell[130].known? && Spell[130].affordable?
         sleep 0.5
@@ -2780,20 +2783,19 @@ module EBounty
             if EBounty.data.settings[:forage_options].include?("use_650") && !Map.current.tags.include?("meta:nomagic")
               if Spell[650].known? && Spell[650].affordable? && !Spell[650].active? && !Spell[9039].active?
                 multifput("prep 650", "assume yierka")
-              elsif Spell[650].active? && !Spell[9039].active?
+              elsif Spell[650].active? && !Spell[9039].active? && Char.mana >= 25
                 waitcastrt?
                 fput "assume yierka"
               end
             end
 
-            if (EBounty.data.settings[:forage_options].include?("hiding") && !EBounty.data.settings[:forage_options].include?("use_608")) || EBounty.data.settings[:forage_options].include?("use_gambit")
+            if !Map.current.tags.include?("meta:nomagic") && EBounty.data.settings[:forage_options].include?("use_608") && Spell[608].known? && !(hidden?)
+              EBounty.mana_pulse(608)
+              Spell[608].cast if Spell[608].affordable?
+            end
+
+            if EBounty.data.settings[:forage_options].include?("use_gambit") || EBounty.data.settings[:forage_options].include?("hiding")
               fput "hide" unless hidden?
-            elsif EBounty.data.settings[:forage_options].include?("use_608")
-              unless Map.current.tags.include?("meta:nomagic")
-                Spell[608].cast if Spell[608].known? && Spell[608].affordable?
-              else
-                fput "hide" if !(hidden?) && EBounty.data.settings[:forage_options].include?("hiding")
-              end
             end
 
             forage_result = dothistimeout "forage for #{forage_item}", 2, EBounty.data.forage_result


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes mana check for Spell 650 and corrects hiding logic for Spell 608 in `ebounty.lic`.
> 
>   - **Behavior**:
>     - Fix mana check when changing aspect with active Spell 650 in `forage_bounty()`.
>     - Correct hiding logic when Spell 608 is not working in `forage_bounty()`.
>   - **Functions**:
>     - Update `mana_pulse()` call to `EBounty.mana_pulse()` in `fog_return_spirit()`.
>     - Add mana check `Char.mana >= 25` for active Spell 650 in `forage_bounty()`.
>     - Adjust hiding logic to check `!Map.current.tags.include?("meta:nomagic")` and `!(hidden?)` before casting Spell 608 in `forage_bounty()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for dc6fc9c3749033ed88f0e958d8814642532a203a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->