### PR TITLE
fix(map.lic): Stop stealing focus

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       requires: Lich >= 5.9.0
-       version: 1.6.3
+       version: 1.6.4
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.6.4 (2025-08-05)
+    - remove version check for bigshot
   v1.6.3 (2025-08-03)
     - bugfix mana check when changing aspect while 650 is active
     - bugfix for hiding is 608 doesn't work
@@ -132,62 +134,6 @@ module EBounty
   @@data ||= nil
 
   ##### Data & Setup Start #####
-
-  def self.version_check
-    needs_exit = false
-
-    scripts = {
-      "bigshot" => '5.6.0',
-    }
-
-    versions = {}
-    scripts.keys.each { |item|
-      file_name = nil
-
-      if File.exist?(File.join(SCRIPT_DIR, "custom", "#{item}.lic"))
-        file_name = File.join(SCRIPT_DIR, "custom", "#{item}.lic")
-      elsif File.exist?(File.join(SCRIPT_DIR, "#{item}.lic"))
-        file_name = File.join(SCRIPT_DIR, "#{item}.lic")
-      end
-
-      file_data = File.read(file_name)
-
-      comments = file_data[/^=begin\r?\n?(.+?)^=end/m, 1]&.lines&.map(&:chomp) || []
-
-      comments.each do |line|
-        if line =~ /^[\s\t#]*version:[\s\t]*([\w,\s\.\d]+)/i
-          versions[item] = $1.sub(/\s\(.*?\)/, '').strip
-        end
-      end
-
-      if versions[item] == "No file found"
-        needs_exit = true
-
-        respond
-        EBounty.msg "yellow", "########################################"
-        EBounty.msg "yellow", " Required Script: #{item.capitalize} was not found!"
-        EBounty.msg "yellow", " Please download the latest version."
-        EBounty.msg "yellow", " ;repository download #{item}"
-        EBounty.msg "yellow", "########################################"
-        respond
-      elsif Gem::Version.new(versions[item]) < Gem::Version.new(scripts[item])
-        needs_exit = true
-
-        respond
-        EBounty.msg "yellow", "########################################"
-        EBounty.msg "yellow", " Required Script: #{item.capitalize} needs version #{scripts[item]} to run."
-        respond
-        EBounty.msg "yellow", " Currently Running Version: #{versions[item]}"
-        EBounty.msg "yellow", " Please update to the latest version."
-        EBounty.msg "yellow", " ;repository download #{item}"
-        EBounty.msg "yellow", "########################################"
-        respond
-      end
-    }
-    EBounty.msg("debug", "EBounty Version: #{EBounty.get_script_version}")
-    exit if needs_exit
-  end
-
   def self.help
     rows = []
     rows << ["#{$lich_char}#{Script.current.name} setup", "UI configuration tool"]
@@ -3295,8 +3241,6 @@ module EBounty
     end
   end
 end
-
-EBounty.version_check
 
 current_op = UserVars.op
 

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -132,6 +132,11 @@ end
 
 require 'fiddle'
 require 'fiddle/import'
+require 'open3'
+
+def frontend_pid
+  defined?($frontend_pid) && $frontend_pid.to_i.positive? ? $frontend_pid.to_i : nil
+end
 
 def detect_platform
   case RUBY_PLATFORM
@@ -142,76 +147,83 @@ def detect_platform
   end
 end
 
-# Windows
 if detect_platform == :windows
   module WinAPI
     extend Fiddle::Importer
     dlload 'user32.dll'
     extern 'int EnumWindows(void*, long)'
-    extern 'int GetWindowTextA(void*, void*, int)'
+    extern 'int GetWindowThreadProcessId(void*, void*)'
     extern 'int IsWindowVisible(void*)'
     extern 'int SetForegroundWindow(void*)'
   end
 
-  def focus_wrayth_windows
-    hwnd_holder = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP)
-    enum_proc = Fiddle::Closure::BlockCaller.new(Fiddle::TYPE_INT, [Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG]) do |hwnd, _|
-      next 1 if WinAPI.IsWindowVisible(hwnd) == 0
-      buffer = "\0" * 512
-      WinAPI.GetWindowTextA(hwnd, buffer, 512)
-      title = buffer.delete("\0")
-      if title.include?("Wrayth") || title.include?("GemStone")
-        hwnd_holder[0, Fiddle::SIZEOF_VOIDP] = [hwnd].pack('L!')
-        0 # Stop
+  def focus_frontend_windows
+    pid = frontend_pid
+    echo pid
+    return nil unless pid
+
+    hwnd_buf = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP)
+
+    enum_cb = Fiddle::Closure::BlockCaller.new(
+      Fiddle::TYPE_INT, [Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG]
+    ) do |hwnd, _|
+      next 1 if WinAPI.IsWindowVisible(hwnd).zero?
+
+      pid_tmp = [0].pack('L')
+      WinAPI.GetWindowThreadProcessId(hwnd, pid_tmp)
+      win_pid = pid_tmp.unpack1('L')
+
+      if win_pid == pid
+        hwnd_buf[0, Fiddle::SIZEOF_VOIDP] = [hwnd].pack('L!')
+        0                    # stop EnumWindows
       else
-        1
+        1                    # keep enumerating
       end
     end
 
-    WinAPI.EnumWindows(enum_proc, 0)
-    hwnd = hwnd_holder[0, Fiddle::SIZEOF_VOIDP].unpack1('L!')
+    WinAPI.EnumWindows(enum_cb, 0)
+    hwnd = hwnd_buf[0, Fiddle::SIZEOF_VOIDP].unpack1('L!')
 
-    if hwnd && hwnd != 0
+    if hwnd != 0
       -> { WinAPI.SetForegroundWindow(hwnd) }
     else
-      puts "Wrayth window not found."
+      puts "Wrayth window for PID #{pid} not found."
       nil
     end
   end
 end
 
-# macOS
-def focus_wrayth_mac
-  if system("which osascript > /dev/null 2>&1")
-    -> {
-      system(%q[osascript -e 'tell application "System Events" to tell process "Wrayth" to set frontmost to true'])
-    }
+def focus_frontend_mac
+  pid = frontend_pid
+  return nil unless pid
+  if system('which osascript > /dev/null 2>&1')
+    script = %{tell application "System Events" to set frontmost of (first process whose unix id is #{pid}) to true}
+    -> { Open3.capture3('osascript', '-e', script) }
   else
-    puts "osascript not found."
+    puts 'osascript not found.'
     nil
   end
 end
 
-# Linux
-def focus_wrayth_linux
-  if system("which xdotool > /dev/null 2>&1")
-    -> {
-      system("xdotool search --name Wrayth windowactivate")
-    }
+def focus_frontend_linux
+  pid = frontend_pid
+  return nil unless pid
+  if system('which xdotool > /dev/null 2>&1')
+    -> { Open3.capture3('xdotool', 'search', '--pid', pid.to_s, 'windowactivate') }
   else
-    puts "xdotool not found. Install it with: sudo apt install xdotool"
+    puts 'xdotool not found. Install it with: sudo apt install xdotool'
     nil
   end
 end
 
 FOCUS_WRAYTH = case detect_platform
-               when :windows then defined?(focus_wrayth_windows) ? focus_wrayth_windows : nil
-               when :macos   then focus_wrayth_mac
-               when :linux   then focus_wrayth_linux
+               when :windows then defined?(focus_frontend_windows) ? focus_frontend_windows : nil
+               when :macos   then focus_frontend_mac
+               when :linux   then focus_frontend_linux
                else
-                 puts "Unsupported platform for Wrayth focus"
+                 puts 'Unsupported platform for Wrayth focus'
                  nil
-               end || -> {}
+               end || -> {} # fallback no-op
 
 refocus_wrayth = proc {
   GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -326,7 +326,7 @@ FOCUS_WRAYTH = case detect_platform
                end || -> {} # fallback no-op
 
 refocus_wrayth = proc {
-  GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+  GLib::Idle.add(50) { FOCUS_WRAYTH.call; false }
 }
 
 if Script.current.vars[1] == 'help'

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -138,6 +138,107 @@ def frontend_pid
   defined?($frontend_pid) && $frontend_pid.to_i.positive? ? $frontend_pid.to_i : nil
 end
 
+# ------------------------------------------------------------
+#  Auto-detect frontend PID when Lich was launched by another
+#  GUI client (e.g. Warlock) and $frontend_pid is nil.
+# ------------------------------------------------------------
+if !defined?($frontend_pid) || $frontend_pid.to_i <= 0
+  case RUBY_PLATFORM
+  when /mingw|mswin/ # ---------- Windows ----------
+    require 'win32ole'
+    require 'fiddle'
+    require 'fiddle/import'
+
+    module Win32Tool
+      extend Fiddle::Importer
+      dlload 'user32.dll'
+      extern 'int EnumWindows(void*, long)'
+      extern 'int IsWindowVisible(void*)'
+      extern 'int GetWindowThreadProcessId(void*, void*)'
+    end
+
+    WMI = WIN32OLE.connect('winmgmts://')
+
+    def parent_pid(pid)
+      q  = WMI.ExecQuery("SELECT ParentProcessId FROM Win32_Process WHERE ProcessId=#{pid}")
+      p  = nil; q.each { |row| p = row.ParentProcessId.to_i; break } # take first row
+      p || 0
+    end
+
+    def gui_process?(pid)
+      found = false
+      enum_cb = Fiddle::Closure::BlockCaller.new(Fiddle::TYPE_INT, [Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG]) do |hwnd, _|
+        next 1 if Win32Tool.IsWindowVisible(hwnd).zero?
+        buf = [0].pack('L')
+        Win32Tool.GetWindowThreadProcessId(hwnd, buf)
+        this_pid = buf.unpack1('L')
+        if this_pid == pid
+          found = true
+          0 # stop
+        else
+          1
+        end
+      end
+      Win32Tool.EnumWindows(enum_cb, 0)
+      found
+    end
+
+    pid = Process.pid
+    seen = []
+    until pid.zero? || seen.include?(pid)
+      if gui_process?(pid)
+        $frontend_pid = pid
+        break
+      end
+      seen << pid
+      pid = parent_pid(pid)
+    end
+
+  when /linux/ # ---------- Linux ----------
+    def parent_pid(pid)
+      File.read("/proc/#{pid}/status")[/PPid:\s+(\d+)/, 1].to_i rescue 0
+    end
+
+    def gui_process?(pid)
+      return false unless system('which xdotool > /dev/null 2>&1')
+      system("xdotool search --pid #{pid} > /dev/null 2>&1")
+    end
+
+    pid = Process.pid
+    seen = []
+    until pid.zero? || seen.include?(pid)
+      if gui_process?(pid)
+        $frontend_pid = pid
+        break
+      end
+      seen << pid
+      pid = parent_pid(pid)
+    end
+
+  when /darwin/ # ---------- macOS ----------
+    def parent_pid(pid)
+      `ps -o ppid= -p #{pid}`.to_i
+    end
+
+    def gui_process?(pid)
+      `osascript -e 'tell application "System Events" to count (windows of (processes whose unix id is #{pid}))'`.to_i.positive?
+    rescue
+      false
+    end
+
+    pid = Process.pid
+    seen = []
+    until pid.zero? || seen.include?(pid)
+      if gui_process?(pid)
+        $frontend_pid = pid
+        break
+      end
+      seen << pid
+      pid = parent_pid(pid)
+    end
+  end
+end
+
 def detect_platform
   case RUBY_PLATFORM
   when /mingw|mswin/ then :windows

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -159,7 +159,6 @@ if detect_platform == :windows
 
   def focus_frontend_windows
     pid = frontend_pid
-    echo pid
     return nil unless pid
 
     hwnd_buf = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP)

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -868,10 +868,6 @@ Gtk.queue {
       # echo "offsetx: #{window_offset_x} offsety: #{window_offset_y}"
     end
   end
-  window.signal_connect("focus-in-event") do |_widget, _event|
-    refocus_wrayth.call
-    false
-  end
 
   scroller = Gtk::ScrolledWindow.new
   scroller.border_width = 0

--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -213,6 +213,10 @@ FOCUS_WRAYTH = case detect_platform
                  nil
                end || -> {}
 
+refocus_wrayth = proc {
+  GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+}
+
 if Script.current.vars[1] == 'help'
   echo "Version: #{(Script.list.find { |x| x.name == Script.current.name }.inspect)[/version: (\d+\.\d+\.\d+)/i, 1]}                                                                              "
   echo "   ;map help                   - this output                                                "
@@ -753,7 +757,7 @@ Gtk.queue {
     end
   end
   window.signal_connect("focus-in-event") do |_widget, _event|
-    GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+    refocus_wrayth.call
     false
   end
 
@@ -1133,7 +1137,7 @@ Gtk.queue {
               size = ((([click_x, fix_click[0]].max - [click_x, fix_click[0]].min) + ([click_y, fix_click[1]].max - [click_y, fix_click[1]].min)) / 2).round
               current_room = $narost_fake_room || Room.current
               respond "#{current_room.id}; x: #{x}, y: #{y}, size: #{size}"
-              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+              refocus_wrayth.call
               if defined?(current_room.image_coords)
                 current_room.image = map_name
                 current_room.image_coords = [[fix_click[0].round, click_x.round].min, [fix_click[1].round, click_y.round].min, [fix_click[0].round, click_x.round].max, [fix_click[1].round, click_y.round].max]
@@ -1147,16 +1151,16 @@ Gtk.queue {
             end
           elsif ev.state.inspect =~ /control-mask/
             respond "x: #{click_x}, y: #{click_y}"
-            GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+            refocus_wrayth.call
           elsif ev.state.inspect =~ /shift-mask/
             if (clicked_room = find_clicked_room.call(click_x, click_y))
               respond
               respond clicked_room
               respond
-              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+              refocus_wrayth.call
             else
               respond '[map: no matching room found]'
-              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+              refocus_wrayth.call
             end
           else
             if (clicked_link = find_clicked_link(current_map, click_x, click_y))
@@ -1165,10 +1169,10 @@ Gtk.queue {
               scroller.vadjustment.value = clicked_link[2].to_i * scale
             elsif (clicked_room = find_clicked_room.call(click_x, click_y))
               start_script 'go2', [clicked_room.id.to_s, '_disable_confirm_']
-              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+              refocus_wrayth.call
             else
               respond '[map: no matching room found]'
-              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+              refocus_wrayth.call
             end
           end
         end


### PR DESCRIPTION
I'm not sure how everyone would feel about this being that it's not a universal solution and requires platform dependent api calls.
Thought I would put it up to see though. If worth it, maybe could be core lich and implemented into all the gtk windows.

Keeps full functionality and returns focus back to wrayth after clicks. Right click menu still works as expected.
Tested on Wrayth and Wizard.

Prevents gtk window from taking focus upon launch.
```
  window.accept_focus = false
  window.focus_on_map = false
```

Return focus to wrayth after clicking when using platform native api's 
fiddle for windows comes with ruby install
osascript for mac comes native with mac
xdotool for linux needs to be installed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR updates `map.lic` to prevent GTK window focus on launch and return focus to Wrayth after interactions using platform-specific APIs.
> 
>   - **Behavior**:
>     - Prevents GTK window from taking focus on launch by setting `window.accept_focus` and `window.focus_on_map` to `false` in `map.lic`.
>     - Returns focus to Wrayth after clicks using platform-specific APIs (`Fiddle` for Windows, `osascript` for macOS, `xdotool` for Linux).
>   - **Platform Detection**:
>     - Adds `detect_platform` function to determine the operating system.
>     - Implements `focus_wrayth_windows`, `focus_wrayth_mac`, and `focus_wrayth_linux` functions for respective platforms.
>   - **Misc**:
>     - Updates version to 1.4.2 in `map.lic` changelog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ada118f2436cb20f137305990b47844dcdaabee1. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->