### PR TITLE
fix(tdusk.lic): v1.26.3 redeemed entry fix

### DIFF
--- a/scripts/tdusk.lic
+++ b/scripts/tdusk.lic
@@ -1339,4 +1339,3 @@ loop {
     exit
   end
 }
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'bypass' option to `tdusk.lic` to skip item retrieval for redeemed entries, updating syntax, help messages, and version.
> 
>   - **Behavior**:
>     - Adds 'bypass' option to `tdusk.lic` to skip retrieving slip/token/booklet/jar/voucher for redeemed entries.
>     - Updates syntax and help messages to include 'bypass'.
>   - **Code Changes**:
>     - Modifies conditional checks in `loot()` and main script logic to handle 'bypass' option.
>     - Updates version to 1.26.3 in `tdusk.lic`.
>   - **Misc**:
>     - Updates changelog in `tdusk.lic` to document the new 'bypass' feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7ff399ffcfb1ca09ce7076787ae9a11f2a235827. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->