### PR TITLE
fix(tdusk.lic): v1.26.5 endless swarm bugfix

### DIFF
--- a/scripts/tdusk.lic
+++ b/scripts/tdusk.lic
@@ -14,9 +14,11 @@
      author: Tysong (horibu on PC), original Nylis
        name: tdusk
        tags: duskruin, arena, dusk ruin, tdusk
-    version: 1.26.4
+    version: 1.26.5
 
     changelog:
+        1.26.5 (2025-08-09)
+            Bugfix for endless swarm
         1.26.4 (2025-08-08)
             Completely remove token system as no longer usable with arena
         1.26.3 (2025-08-08)
@@ -92,7 +94,7 @@ end
 UserVars.tdusk                ||= {}
 UserVars.tdusk[:activescripts]  = ['stand'] if UserVars.tdusk[:activescripts].nil?
 UserVars.tdusk[:waggle_me]      = true      if UserVars.tdusk[:waggle_me].nil?
-UserVars.tdusk[:waggle_script]  = 'waggle'  if UserVars.tdusk[:waggle_script].nil?
+UserVars.tdusk[:waggle_script]  = 'ewaggle' if UserVars.tdusk[:waggle_script].nil?
 UserVars.tdusk[:pause_me]       = true      if UserVars.tdusk[:pause_me].nil?
 UserVars.tdusk[:enhancive_me]   = false     if UserVars.tdusk[:enhancive_me].nil?
 UserVars.tdusk[:high_ds]        = false     if UserVars.tdusk[:high_ds].nil?
@@ -1182,7 +1184,7 @@ end
 
 tdusk_hook = proc { |client_string|
   begin
-    if client_string =~ /^(?:<c>)?toggletdusk$/i
+    if client_string =~ /^(?:<c>)?;?toggletdusk$/i
       if UserVars.tdusk[:pause_me] == false
         UserVars.tdusk[:pause_me] = true
       else
@@ -1258,7 +1260,7 @@ loop {
     put "inventory enhancive on" if UserVars.tdusk[:enhancive_me]
     put "shout" if group_size == 1
 
-  elsif line =~ /^An announcer shouts\, \"(?:.*)\"  An iron portcullis is raised and .* (?:enter|enters) the arena\!/ || ((GameObj.targets.count { |npc| (npc.status !~ /dead|gone/) } >= 1) && Room.current.id == 24550 && UserVars.tdusk[:wave_number] != 0 && !UserVars.tdusk[:attack_script] && !UserVars.tdusk[:using_bigshot])
+  elsif line =~ /^An announcer shouts\, \"(?:.*)(?:\"  An iron portcullis is raised and .* (?:enter|enters) the arena)?!/ || ((GameObj.targets.count { |npc| (npc.status !~ /dead|gone/) } >= 1) && Room.current.id == 24550 && UserVars.tdusk[:wave_number] != 0 && !UserVars.tdusk[:attack_script] && !UserVars.tdusk[:using_bigshot])
     if (line =~ /An announcer shouts\, \"FIGHT\!\"  An iron portcullis is raised and .* (?:enter|enters) the arena\!/)
       (start_time = Time.now)
     elsif start_time == 0


### PR DESCRIPTION
fix for endless swarm
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix endless swarm bug in `tdusk.lic` and update default waggle script and command regex.
> 
>   - **Bugfix**:
>     - Fix endless swarm issue in `tdusk.lic` by adjusting regex in the main loop to correctly handle arena entry announcements.
>   - **Variables**:
>     - Change default `UserVars.tdusk[:waggle_script]` from `'waggle'` to `'ewaggle'`.
>   - **Regex**:
>     - Update regex in `tdusk_hook` to allow optional semicolon prefix for `toggletdusk` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ea9a6918e41e720f4bcd54fc14097f24ee4267ca. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->