### PR TITLE
fix(eloot.lic): v2.4.6 encumbered box process deposit silver

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.4.5
+           version: 2.4.6
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.4.6 (2025-08-12)
+    - fix encumbered after box opening by depositing silvers in process_boxes
   v2.4.5 (2025-07-22)
     - bugfix for default locksmith_withdrawl_amount
   v2.4.4 (2025-07-16)
@@ -6574,6 +6576,11 @@ module ELoot # Sells the loot
 
       # Sell off any remaining boxes
       Sell.locksmith(boxes) if ELoot.data.settings[:sell_locksmith] && boxes.length.positive?
+
+      # Deposit silvers if encumbered
+      if Char.percent_encumbrance > 80
+        ELoot.silver_deposit
+      end
     end
 
     def self.save_trash_box(box)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes encumbrance issue in `process_boxes` by depositing silvers when encumbrance exceeds 80% in `eloot.lic`.
> 
>   - **Behavior**:
>     - Fixes encumbrance issue in `process_boxes` by depositing silvers when `Char.percent_encumbrance` exceeds 80%.
>   - **Version**:
>     - Updates version to 2.4.6 in `eloot.lic`.
>   - **Misc**:
>     - Adds changelog entry for v2.4.6 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ec24d724113f621c508e61af479bbc98b493938b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->