### PR TITLE
fix(spellburst.lic): v1.0.1 force SKILL refresh before calc

### DIFF
--- a/scripts/spellburst.lic
+++ b/scripts/spellburst.lic
@@ -80,10 +80,10 @@ module Spellburst
 
   def self.spells(debug = false)
     outside_spells_worn = Hash.new
-    Spell.active.each { |x|
-      (respond "Skipped unrecognized spell:  #{x.name}" if debug; next) if !Spell[x.name].num
-      (respond "Excluded spell #{Spell[x.name].num}" if debug; next) if is_spell_excluded(Spell[x.name].num)
-      outside_spells_worn[Spell[x.name].num] = cost(Spell[x.name].num)
+    XMLData.active_spells.each { |x, _y|
+      (respond "Skipped unrecognized spell:  #{x}" if debug; next) if !Spell[x].num
+      (respond "Excluded spell #{Spell[x].num}" if debug; next) if is_spell_excluded(Spell[x].num)
+      outside_spells_worn[Spell[x].num] = cost(Spell[x].num)
     }
     respond outside_spells_worn if debug
     return outside_spells_worn


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Forces a SKILL refresh in `total_magical_ranks` in `spellburst.lic` to ensure updated skills before calculation.
> 
>   - **Behavior**:
>     - Forces a SKILL refresh in `total_magical_ranks` in `spellburst.lic` to ensure updated skills before calculation.
>   - **Version**:
>     - Update version to 1.0.1 in `spellburst.lic` to reflect the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 11c59e374a6b83ea06cee78b6ab12930201dc980. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->