### PR TITLE
fix(eloot.lic): v2.4.7 allow debug to file when started with parameters

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -18,6 +18,8 @@
            version: 2.4.7
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.4.7 (2025-08-15)
+    - if debug to file enabled, allow for when started with a parameter (sell/pool/etc)
   v2.4.6 (2025-08-12)
     - fix encumbered after box opening by depositing silvers in process_boxes
   v2.4.5 (2025-07-22)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Initialize debug logger in `ELoot` module command cases if `debug_file` setting is enabled, and update version to 2.4.7.
> 
>   - **Behavior**:
>     - Initialize `ELoot.data.debug_logger` with `ELoot::DebugLogger.new` if `ELoot.data.settings[:debug_file]` is set.
>     - Applied to command cases: `box`, `sell`, `pool`, `--(sellable|type|sell)`, `raid`, `(list|deposit|reset) (gem|reagent|alchemy)`, `bounty`, `deposit`, `skin`.
>   - **Version**:
>     - Increment version from 2.4.6 to 2.4.7 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 359cab0c65dc6862167003ebf6311eacd09df34b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->