### PR TITLE
fix(ebounty) v1.6.5 bugfix for stowing herbs

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       requires: Lich >= 5.9.0
-       version: 1.6.4
+       version: 1.6.5
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.6.5 (2025-08-15)
+    - bugfix for stowing herbs
   v1.6.4 (2025-08-05)
     - remove version check for bigshot
   v1.6.3 (2025-08-03)
@@ -2723,7 +2725,7 @@ module EBounty
 
             until kneeling?
               fput 'kneel'
-              sleep 0.2
+              EBounty.wait_rt
             end
 
             if EBounty.data.settings[:forage_options].include?("use_650") && !Map.current.tags.include?("meta:nomagic")
@@ -2749,15 +2751,14 @@ module EBounty
             if forage_result =~ /^You forage briefly and manage to find/
               item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.noun != nil }
 
-              if EBounty.data.gambits_available
-                5.times {
-                  fput "rgambit stealth put my #{item} in my #{EBounty.data.sacks["default"]}"
-                  EBounty.wait_rt
-                  break if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && EBounty.data.sacks["default"].contents.to_a.map(&:id).include?(item.id))
-                }
-              end
-              fput "stow left" if checkleft
-              fput "stow right" if checkright
+              gambit_stow = EBounty.data.gambits_available ? "rgambit stealth " : ""
+
+              5.times {
+                fput "#{gambit_stow}put my #{item.noun} in my #{EBounty.data.sacks["default"]}"
+
+                EBounty.wait_rt
+                break if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && EBounty.data.sacks["default"].contents.to_a.map(&:id).include?(item.id))
+              }
 
               EBounty.msg("debug", "forage_bounty: herb - #{herb} | location - #{location} | quantity - #{quantity} | Default sack: #{EBounty.data.sacks["default"].inspect} | contents: #{EBounty.data.sacks["default"].contents}")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes herb stowing bug in `forage_bounty` method of `ebounty.lic` by replacing `sleep` with `EBounty.wait_rt` and refactoring stowing logic.
> 
>   - **Behavior**:
>     - Fixes herb stowing bug in `forage_bounty` method in `ebounty.lic`.
>     - Replaces `sleep 0.2` with `EBounty.wait_rt` to ensure proper wait handling.
>     - Refactors stowing logic to use `gambit_stow` variable for conditional gambit usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ea36931ff9ed8bd14c25b43b638b0778576f589d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->