### PR TITLE
fix(spellwindows.lic): missing regex

### DIFF
--- a/scripts/SpellWindows.lic
+++ b/scripts/SpellWindows.lic
@@ -698,4 +698,3 @@ module SpellWindow
     sleep(0.25)
   }
 end
-


### PR DESCRIPTION
Accidentally removed a `^<popStream/>` from the END_INVENTORY_STREAM regex.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores missing `^<popStream/>` to `END_INVENTORY_STREAM` regex in `SpellWindows.lic`.
> 
>   - **Regex Fix**:
>     - Restores `^<popStream/>` to `END_INVENTORY_STREAM` regex in `SpellWindows.lic` to correctly identify end of inventory stream.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7a82a5780979a71032b704a0cf21138aeb73e2d0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->