### PR TITLE
fix(autostart.lic): v0.66 force show lich5 announcements

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -131,7 +131,7 @@ if script.vars.empty?
     Lich::Util::Update.request("--announce")
   end
 
-  if XMLData.game =~ /^DR/ && run_dependency == false
+  if XMLData.game =~ /^DR/
     begin
       did_dependency_install = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_dependency_install';")
     rescue SQLite3::BusyException
@@ -159,7 +159,6 @@ if script.vars.empty?
       Script.start('dependency') unless Script.running?('dependency')
       sleep 1
     end
-    true
   end
 
   for script_list in [Settings['scripts'], CharSettings['scripts']]
@@ -169,7 +168,6 @@ if script.vars.empty?
         if ['infomon', 'repository', 'dependency'].include?(script_info[:name])
           next
         elsif script_info[:name] == 'lich5-update' && Gem::Version.new(LICH_VERSION) > Gem::Version.new('5.6.2')
-          # Lich::Util::Update.request("#{script_info[:args].each { |arg| arg.gsub!('update', 'announce') }}")
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
           respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with '#{$clean_lich_char}autostart remove --global dependency'"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `autostart.lic` to always show Lich5 announcements and clean up script execution logic.
> 
>   - **Behavior**:
>     - Always show Lich5 announcements if updates are available in `autostart.lic`.
>     - Cleaned up single-run logic for script execution.
>   - **Logic**:
>     - Removed redundant flags and conditions for running `infomon`, `repository`, and `dependency` scripts.
>     - Simplified dependency installation check for DragonRealms (DR) in `autostart.lic`.
>   - **Versioning**:
>     - Updated version to 0.66 in `autostart.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 1336fd1cb0ce0206543015f39db9b27863a790a9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->