### PR TITLE
fix(kswole.lic): v1.1.3 regex corrections

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -20,12 +20,14 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.2
+       version: 1.1.3
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.3 (2025-09-01)
+    - Nelemar/Atoll regex corrections
   v1.1.2 (2025-07-18)
     - Regex optimizations to avoid non-npc preps
   v1.1.1 (2025-07-14)
@@ -85,10 +87,10 @@ class KSwole
   @creature_spell_preps = Regexp.union(
     # Atoll and Nelemar
     /^An? (?:.*)\belemental utters an incantation in an unfamiliar, bubbling language\./,
-    /^An? (?:.*)\bradical steeples (?:his|her) clawed fingers together, murmuring a quick incantation\./,
+    /^An? (?:.*)\b(?:fanatic|radical) steeples (?:his|her) clawed fingers together, murmuring a quick incantation\./,
     /^An? (?:.*)\bsiren begins singing a sweet song\./,
-    /^An? (?:.*)\bwarden makes a subtle gesture, drawing traces of faint blue-green light into (?:his|her) webbed hands\./,
-    /^An? (?:.*)\b(?:warlock|dissembler) chants in an incomprehensible language, causing streams of dim grey energy to lash about (?:his|her) (?:hands|golden claws)\./,
+    /^An? (?:.*)\b(?:magus|warden) makes a subtle gesture, drawing traces of faint blue-green light into (?:his|her) webbed hands\./,
+    /^An? (?:.*)\b(?:warlock|dissembler|sentry|psionicist) chants in an incomprehensible language, causing streams of dim grey energy to lash about (?:his|her) (?:hands|golden claws)\./,
     # Bonespear
     /^(?:.*) draws an ancient sigil in the air\./,
     # Bowels


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects regex patterns in `kswole.lic` for Atoll and Nelemar, updating version to 1.1.3.
> 
>   - **Regex Corrections**:
>     - Updated `@creature_spell_preps` in `kswole.lic` to include `fanatic` and `magus` for Atoll and Nelemar.
>     - Added `sentry` and `psionicist` to regex for Nelemar.
>   - **Version Update**:
>     - Incremented version to 1.1.3 in `kswole.lic` to reflect regex corrections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e45a514e6e24324094ff8131f8aa2d2e652e05d7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->