### PR TITLE
fix(eloot.lic): v2.4.9 regex fix in use_coin_hand

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.9.0
-           version: 2.4.8
+           version: 2.4.9
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.4.9 (2025-09-05)
+    - bugfix in regex for use_coin_hand method
   v2.4.8 (2025-08-30)
     - bugfix for setting ELoot.data.coin_bag_full to false when empty.
   v2.4.7 (2025-08-15)
@@ -3237,14 +3239,14 @@ module ELoot # Game utility type methods
           get_coins = "toss ##{ELoot.data.gambling_kit.id}"
         end
 
-        lines = Lich::Util.issue_command(get_coins, /You (?:place|toss)|There is only room|That might work better|needs to be open|cannot find room|coin (?:pouch|bag|purse) is already full!$/i)
+        lines = Lich::Util.issue_command(get_coins, /You (?:place|toss)|There is only room|That might work better|needs to be open|cannot find room|coin .+ is already full!$/i)
 
         ELoot.wait_rt if ELoot.data.gambling_kit
 
         if lines.any? { |l| l =~ /That might work better if you opened|needs to be open/i }
           ELoot.get_command("open ##{ELoot.data.coin_hand.id}", ELoot.data.silent_open)
           raise
-        elsif lines.find { |line| line.match(/coin (?:pouch|bag|purse) is already full!$/) }
+        elsif lines.find { |line| line.match(/coin .+ is already full!$/) }
           ELoot.data.coin_bag_full = true
         elsif lines.find { |line| line.match(/There is only room for (?<silver>[\d,]+) more coins inside/) }
           capacity = Regexp.last_match[:silver].gsub(',', '').to_i


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes regex in `use_coin_hand` method in `eloot.lic` to match broader coin container names and updates version to 2.4.9.
> 
>   - **Bugfix**:
>     - Fixes regex in `use_coin_hand` method in `eloot.lic` to match broader coin container names using `coin .+ is already full!$`.
>   - **Version Update**:
>     - Updates version to 2.4.9 in `eloot.lic` header.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 6410d72e9392635a8ae87411aea0d779905439ab. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->