### PR TITLE
fix(eloot.lic): v2.4.10 rework box content check.

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -20,6 +20,7 @@
   Major_change.feature_addition.bugfix
   v2.4.10 (2025-09-06)
     - rework box contents check to store box instead of pausing
+    - bugfix for looting coins on the ground
   v2.4.9 (2025-09-05)
     - bugfix in regex for use_coin_hand method
   v2.4.8 (2025-08-30)
@@ -4690,6 +4691,11 @@ module ELoot # Room looting
     def self.loot_regular(objs, from_where = nil, box = nil)
       valid = Loot.valid_objs(objs.clone)
       invalid = Loot.invalid_objs(objs.clone)
+
+      if from_where == "Room" && !ELoot.data.settings[:loot_types].include?("coins")
+        valid.reject! { |o| o.name =~ /silver coin/ }
+        invalid.concat(GameObj.loot.select { |o| o.name =~ /silver coin/ })
+      end
 
       ELoot.msg(type: "debug", text: " Loot.room - valid: #{valid}")
       ELoot.msg(type: "debug", text: " Loot.room - invalid: #{invalid}")


### PR DESCRIPTION
Returns false and stores the box instead of pausing the script
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Rework box content check in `eloot.lic` to return false and store the box instead of pausing the script, and update logging to use `ELoot.msg`.
> 
>   - **Behavior**:
>     - In `eloot.lic`, rework box content check to return false and store the box instead of pausing the script.
>     - Update `Inventory.container_contents` to return false if contents cannot be determined.
>   - **Logging**:
>     - Replace `echo` with `ELoot.msg` for logging in `eloot.lic`.
>   - **Version**:
>     - Update version to 2.4.10 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 6930bebaef2775a342bfc6dfdc22cff5a21e21ca. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->