### PR TITLE
fix(version.lic): v1.2.1 show autostart ARGS if any

### DIFF
--- a/scripts/version.lic
+++ b/scripts/version.lic
@@ -259,7 +259,7 @@ module VersionScript
       unless Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), ":".encode('UTF-8')).nil?
         scripts = []
         Marshal.load(Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), ":".encode('UTF-8')))['scripts'].each { |hash|
-          if hash[:args].empty?
+          if hash[:args].nil? || hash[:args].empty?
             scripts.push("#{hash[:name]}")
           else
             scripts.push("#{hash[:name]}(args: #{hash[:args].join(' ')})")
@@ -270,7 +270,7 @@ module VersionScript
       unless Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), "#{XMLData.game}:#{XMLData.name}".encode('UTF-8')).nil?
         scripts = []
         Marshal.load(Lich.db.get_first_value('SELECT hash FROM script_auto_settings WHERE script=? AND scope=?;', "autostart".encode('UTF-8'), "#{XMLData.game}:#{XMLData.name}".encode('UTF-8')))['scripts'].each { |hash|
-          if hash[:args].empty?
+          if hash[:args].nil? || hash[:args].empty?
             scripts.push("#{hash[:name]}")
           else
             scripts.push("#{hash[:name]}(args: #{hash[:args].join(' ')})")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `version.lic` now displays autostart script arguments if present, with version updated to 1.2.1.
> 
>   - **Behavior**:
>     - `version.lic` now shows autostart script arguments if present.
>     - Affects global and character-specific autostart script reporting in `VersionScript`.
>   - **Versioning**:
>     - Increment version to 1.2.1 in `version.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 505d37e40d05247d1bd76f447948dad94a4cc842. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->