### PR TITLE
fix(ebounty.lic): v1.7.2 heirloom correction

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -9,11 +9,13 @@
   contributors: Deysh, Nisugi, Tysong, Rinualdo
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
-      requires: Lich >= 5.9.0
-       version: 1.7.1
+      requires: Lich >= 5.12.5
+       version: 1.7.2
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.7.2 (2025-09-08)
+    - change requirement to 5.12.5 due to heirloom text change
   v1.7.1 (2025-09-07)
     - bugfix for change in Heirloom return messaging
   v1.7.0 (2025-09-05)
@@ -2198,12 +2200,6 @@ module EBounty
         sleep 0.5
       end
 
-      heirloom_found_verbiage_change = false
-
-      if checkbounty =~ /^You have located (?:an?|some) (?<item>.+) and should bring (?:it back|your find) to #{Bounty::Parser::GUARD_REGEX}\.$/
-        heirloom_found_verbiage_change = true
-      end
-
       case Bounty.type
       when :none
         Effects::Cooldowns.active?("Next Bounty") ? Task.wait_for_bounty : Task.bounty_get
@@ -2244,8 +2240,6 @@ module EBounty
           EBounty.msg("warn", "Unknown Result: Unable to match bounty_check.")
           EBounty.msg("warn", "checkbounty: #{checkbounty}")
           EBounty.exit_script
-        elsif heirloom_found_verbiage_change
-          Task.ask_guard
         else
           # in case checkbounty not populated...
           EBounty.get_lines("bounty", /<a exist=".*?your Adventurer's Guild information is as follows/i)


### PR DESCRIPTION
Require Lich 5.12.5 due to heirloom found messaging change
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ebounty.lic` to require Lich `>= 5.12.5` and remove obsolete heirloom verbiage change logic.
> 
>   - **Requirements**:
>     - Update Lich version requirement to `>= 5.12.5` in `ebounty.lic`.
>   - **Versioning**:
>     - Increment version to `1.7.2` in `ebounty.lic`.
>   - **Code Removal**:
>     - Remove `heirloom_found_verbiage_change` logic in `ebounty.lic` as it is no longer needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 3155d3f5f177a68ac83d3688135aebedcb599793. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->