### PR TITLE
fix(go2.lic): v2.2.12 additional stand messaging

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin
               game: any
               tags: core, movement
-           version: 2.2.11
+           version: 2.2.12
           required: Lich >= 5.4.1
 
    changelog:
+      2.2.12 (2025-09-11)
+        Additional stand messaging
       2.2.11 (2025-04-24)
         Bugfix in CLI gigas_min_number setting not working
       2.2.10 (2025-04-22)
@@ -2121,6 +2123,7 @@ module Go2
           /You'd tip the boat over!/,
           /...wait \d+ seconds?\./i,
           /You are overburdened and cannot manage to stand\./,
+          /You attempt to stand, but slip and fall flat in the slippery green gook!/,
         )
         result = dothistimeout('stand', 2, stand_regex)
         if result =~ /You cannot do that while mounted\./i


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `go2.lic` to version 2.2.12 with additional stand messaging handling in `stand_regex`.
> 
>   - **Behavior**:
>     - Update `stand_regex` in `Go2` module to include `/You attempt to stand, but slip and fall flat in the slippery green gook!/` pattern.
>   - **Version**:
>     - Increment version from `2.2.11` to `2.2.12` in `go2.lic`.
>     - Update changelog with new version entry for `2.2.12` noting additional stand messaging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ae9e8eacdeaf98b066db85dde2e175eb3e7bedba. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->