### PR TITLE
fix(gameobj-data.xml): additional Sailor's Grief gems

### DIFF
--- a/type_data/migrations/65_sailors_grief.rb
+++ b/type_data/migrations/65_sailors_grief.rb
@@ -21,10 +21,12 @@ end
 
 migrate :gem, :gemshop do
   insert(:name, %{asymmetrical rough grey pearl})
+  insert(:name, %{banana yellow citrine})
   insert(:name, %{banded mauve sugar stone})
   insert(:name, %{blue-veined volcanic obsidian})
   insert(:name, %{blue-whorled greenish ocean jasper})
   insert(:name, %{cabochon of striated grape jade})
+  insert(:name, %{chunk of indigo seaglass})
   insert(:name, %{clouded cream orange pearl})
   insert(:name, %{copper-veined royal azel})
   insert(:name, %{cracked shell-infused geode})
@@ -46,6 +48,7 @@ migrate :gem, :gemshop do
   insert(:name, %{smooth dolphin stone disc})
   insert(:name, %{tiny cut ametrine})
   insert(:name, %{uncut sanguine pyrope})
+  insert(:name, %{vibrant ocean jasper cabochon})
   insert(:name, %{volcanic blue larimar stone})
   insert(:name, %{whorled jungle malachite})
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add new gem entries to `65_sailors_grief.rb` migration for additional Sailor's Grief gems.
> 
>   - **Migration Updates**:
>     - Add new gem entries in `65_sailors_grief.rb`:
>       - `banana yellow citrine`
>       - `chunk of indigo seaglass`
>       - `vibrant ocean jasper cabochon`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 505fce055df1bc59df9f0c22d9469cf716545e92. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->