### PR TITLE
fix(gs): Killtracker fix timestamp validation

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -13,7 +13,7 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, tracking, gemstones, jewels, dust, klocks, data
-       version: 2.6
+       version: 2.8
 
 Change Log:
   v2.8 (2025-09-15)


### PR DESCRIPTION
Corrected timestamp validation to ignore timestamps below 100,000.

If someone did not log with timestamps, and they used the logsearch script to populate killtracker data, it would fill in the timestamps with the oversall ascension creature search # it has. This resulted in "timestamps" that are way out of an acceptable range. Corrected by ignoring any timestamp below 100,000..

The validation doesn't effect the script actually working, it's more of a check to alert you of possible corrupted data before migrating to the new format.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes timestamp validation in `Killtracker.lic` to ignore timestamps below 100,000, treating them as search numbers.
> 
>   - **Behavior**:
>     - Adjusts timestamp validation in `validate_data` to skip timestamps below 100,000, treating them as search numbers.
>     - Ensures only valid Unix timestamps are flagged as errors.
>   - **Documentation**:
>     - Updates version to 2.8 in `Killtracker.lic` with a change log entry for the validation correction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c4b11db7d0aa3c395adbf37e27d143c156ae8a03. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->