### PR TITLE
fix(gs): Killtracker correct search name

### DIFF
--- a/scripts/Killtracker.lic
+++ b/scripts/Killtracker.lic
@@ -1045,7 +1045,7 @@ module Killtracker
     %r{needle-toothed trenchling},
     %r{coral golem},
     %r{stormborn primordial},
-    %r{charmed corsair},
+    %r{corsair},
     %r{steelwing harpy},
     %r{bilge mass},
     %r{drowned mariner},
@@ -1238,3 +1238,4 @@ module Killtracker
     end
   end
 end
+


### PR DESCRIPTION
correct charmed corsair search name to just corsair.