### PR TITLE
fix(lnet.lic): v1.14 fix for non-valid XML usage with REXML gem

### DIFF
--- a/scripts/lnet.lic
+++ b/scripts/lnet.lic
@@ -73,20 +73,20 @@ class SafeXMLParser
 
   def parse_chunk(chunk)
     @buffer += chunk
-    
+
     # Process complete XML documents from the buffer
     while @buffer.length > 0
       # Look for complete XML elements
-      if match = @buffer.match(/^(<[^>]*>.*?<\/[^>]*>)/m)
+      if (match = @buffer.match(/^(<[^>]*>.*?<\/[^>]*>)/m))
         xml_fragment = match[1]
         @buffer = @buffer[match.end(0)..-1] || ''
-        
+
         process_xml_fragment(xml_fragment)
-      elsif match = @buffer.match(/^(<[^>]*\/>)/m)
+      elsif (match = @buffer.match(/^(<[^>]*\/>)/m))
         # Self-closing tags
         xml_fragment = match[1]
         @buffer = @buffer[match.end(0)..-1] || ''
-        
+
         process_xml_fragment(xml_fragment)
       else
         # Wait for more data if we don't have a complete element
@@ -100,14 +100,14 @@ class SafeXMLParser
   def process_xml_fragment(fragment)
     begin
       # Try to parse the fragment as-is first
-      test_doc = REXML::Document.new(fragment)
+      REXML::Document.new(fragment)
       REXML::Document.parse_stream(fragment, @handler)
     rescue REXML::ParseException, ArgumentError => e
       echo "XML parse error: #{e.message}" if $lnet_debug
-      
+
       # Attempt to fix common XML issues
       fixed_fragment = sanitize_xml(fragment)
-      
+
       begin
         # Wrap in root element if it's not well-formed
         if !fixed_fragment.match(/^<\?xml/) && !is_complete_document(fixed_fragment)
@@ -127,16 +127,16 @@ class SafeXMLParser
   def sanitize_xml(xml)
     # Remove control characters except tab, newline, carriage return
     xml = xml.gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F]/, '')
-    
+
     # Fix common encoding issues
     xml = xml.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
-    
+
     # Escape unescaped ampersands (but not already escaped ones)
     xml = xml.gsub(/&(?!(?:amp|lt|gt|quot|apos);)/, '&amp;')
-    
+
     # Fix unclosed tags by attempting basic repairs
     xml = fix_unclosed_tags(xml)
-    
+
     xml
   end
 
@@ -145,7 +145,7 @@ class SafeXMLParser
     # Stack to track open tags
     tag_stack = []
     result = ''
-    
+
     # Simple regex to find tags - this is basic and may need refinement
     xml.scan(/<\/?[^>]*>|[^<]+/) do |token|
       if token.start_with?('<')
@@ -163,12 +163,12 @@ class SafeXMLParser
       end
       result += token
     end
-    
+
     # Close any remaining open tags
     while !tag_stack.empty?
       result += "</#{tag_stack.pop}>"
     end
-    
+
     result
   end
 
@@ -208,7 +208,6 @@ class WrapperHandler
     @real_handler.send(method, *args) if @real_handler.respond_to?(method)
   end
 end
-
 
 class LNet
   @@server    ||= nil
@@ -1313,10 +1312,10 @@ Thread.new {
     last_connect_attempt = Time.now
     begin
       LNet.connect
-      
+
       # Create the safe XML parser
       safe_parser = SafeXMLParser.new(LNet.new)
-      
+
       # Read from server in chunks and parse safely
       while !LNet.server.closed?
         begin
@@ -1333,7 +1332,6 @@ Thread.new {
           break
         end
       end
-      
     rescue
       echo $!
       respond $!.backtrace[0..1]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `SafeXMLParser` in `lnet.lic` to handle non-valid XML, enabling compatibility with newer REXML gem versions and removing previous version checks.
> 
>   - **Behavior**:
>     - Introduces `SafeXMLParser` class to handle non-valid XML in `lnet.lic`, allowing compatibility with newer REXML gem versions.
>     - Removes version check and exit logic for REXML versions > 3.3.1.
>     - Updates connection thread to use `SafeXMLParser` for parsing server XML data.
>   - **Changelog**:
>     - Updates version to 1.14 with details on XML parsing improvements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9f8cfd6ea80301383a09ec12972b5fee8572f045. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->