### PR TITLE
fix(gameobj-data.xml): SG ancient/grizzled drop first adjective

### DIFF
--- a/type_data/migrations/65_sailors_grief.rb
+++ b/type_data/migrations/65_sailors_grief.rb
@@ -12,13 +12,13 @@ migrate :aggressive_npc do
 end
 
 migrate :undead, :aggressive_npc do
-  insert(:name, %{garish revenant buccaneer})
-  insert(:name, %{milky-eyed drowned mariner})
-  insert(:name, %{pallid fog-cloaked kelpie})
+  insert(:name, %{(?:garish )?revenant buccaneer})
+  insert(:name, %{(?:milky-eyed )?drowned mariner})
+  insert(:name, %{(?:pallid )?fog-cloaked kelpie})
 end
 
 migrate :undead, :aggressive_npc, :noncorporeal do
-  insert(:name, %{tenebrific wraith shark})
+  insert(:name, %{(?:tenebrific )?wraith shark})
 end
 
 migrate :gem, :gemshop do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Makes first adjectives optional in NPC and item names in `65_sailors_grief.rb` using regex.
> 
>   - **Behavior**:
>     - Makes first adjectives optional in NPC names in `65_sailors_grief.rb` using regex.
>     - Affects `aggressive_npc`, `undead`, `noncorporeal`, and `skin` categories.
>   - **Regex Changes**:
>     - Updates `insert(:name, ...)` to include optional adjectives using `(?:adjective )?` pattern.
>     - Examples: `(?:algae-draped )?merrow oracle`, `(?:garish )?revenant buccaneer`, `(?:iridescent )?whelk shell fragment`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9fb36f2ee7ee67090d98e2b91165b811501c7ad2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->