### PR TITLE
fix(eherbs.lic): v2.1.7 HW location name fix

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -14,7 +14,9 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 5.9.0
-           version: 2.1.6
+           version: 2.1.7
+  2.1.7  (2025-08-05)
+    - fix for Hinterwilds herbs mapdb location including "the"
   2.1.6  (2025-08-05)
     - add debug messaging to dead character healing
   2.1.5  (2025-05-13)
@@ -913,25 +915,25 @@ module EHerbs
 
       # Icemule 3363/4043866
       # Hinterwilds 31061/7503257
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'Dabbings Family special tart',      type: 'minor limb wound',    short_name: 'Family special tart',       store_doses: 10 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: "Leaftoe's lichen tart",             type: 'minor nerve wound',   short_name: 'lichen tart',               store_doses: 10 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'candied ptarmigan feather',         type: 'severed limb',        short_name: 'ptarmigan feather',         store_doses: 1 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'earthworm potion',                  type: 'major organ scar',    short_name: 'earthworm potion',          store_doses: 2 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'elk horn potion',                   type: 'minor head wound',    short_name: 'elk horn potion',           store_doses: 4 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'gelatinous elk fat tart',           type: 'minor limb scar',     short_name: 'elk fat tart',              store_doses: 10 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'iceberry tart',                     type: 'blood',               short_name: 'iceberry tart',             store_doses: 10 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'rock lizard potion',                type: 'minor organ scar',    short_name: 'rock lizard potion',        store_doses: 4 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: "slice of Ma Leaftoe's Special",     type: 'minor nerve scar',    short_name: "Ma Leaftoe's Special",      store_doses: 5 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'slice of pickled walrus blubber',   type: 'major limb scar',     short_name: 'pickled walrus blubber',    store_doses: 2 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'slice of sparrowhawk pie',          type: 'minor head scar',     short_name: 'sparrowhawk pie',           store_doses: 5 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'small egg and tundra grass tart',   type: 'minor organ wound',   short_name: 'tundra grass tart',         store_doses: 5 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'snowflake elixir',                  type: 'major nerve wound',   short_name: 'snowflake elixir',          store_doses: 4 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: "some frog's bone porridge",         type: 'major limb wound',    short_name: "frog's bone porridge",      store_doses: 4 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'starfish potion',                   type: 'missing eye',         short_name: 'starfish potion',           store_doses: 1 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'tiny cup of polar bear fat soup',   type: 'major head scar',     short_name: 'polar bear fat soup',       store_doses: 2 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'tiny flower-shaped tart',           type: 'major nerve scar',    short_name: 'flower-shaped tart',        store_doses: 2 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: 'tiny musk ox tart',                 type: 'major organ wound',   short_name: 'musk ox tart',              store_doses: 2 },
-      { location: ['Icemule Trace', 'Hinterwilds'], name: "tiny ram's bladder tart",           type: 'major head wound',    short_name: "ram's bladder tart",        store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'Dabbings Family special tart',      type: 'minor limb wound',    short_name: 'Family special tart',       store_doses: 10 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: "Leaftoe's lichen tart",             type: 'minor nerve wound',   short_name: 'lichen tart',               store_doses: 10 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'candied ptarmigan feather',         type: 'severed limb',        short_name: 'ptarmigan feather',         store_doses: 1 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'earthworm potion',                  type: 'major organ scar',    short_name: 'earthworm potion',          store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'elk horn potion',                   type: 'minor head wound',    short_name: 'elk horn potion',           store_doses: 4 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'gelatinous elk fat tart',           type: 'minor limb scar',     short_name: 'elk fat tart',              store_doses: 10 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'iceberry tart',                     type: 'blood',               short_name: 'iceberry tart',             store_doses: 10 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'rock lizard potion',                type: 'minor organ scar',    short_name: 'rock lizard potion',        store_doses: 4 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: "slice of Ma Leaftoe's Special",     type: 'minor nerve scar',    short_name: "Ma Leaftoe's Special",      store_doses: 5 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'slice of pickled walrus blubber',   type: 'major limb scar',     short_name: 'pickled walrus blubber',    store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'slice of sparrowhawk pie',          type: 'minor head scar',     short_name: 'sparrowhawk pie',           store_doses: 5 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'small egg and tundra grass tart',   type: 'minor organ wound',   short_name: 'tundra grass tart',         store_doses: 5 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'snowflake elixir',                  type: 'major nerve wound',   short_name: 'snowflake elixir',          store_doses: 4 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: "some frog's bone porridge",         type: 'major limb wound',    short_name: "frog's bone porridge",      store_doses: 4 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'starfish potion',                   type: 'missing eye',         short_name: 'starfish potion',           store_doses: 1 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'tiny cup of polar bear fat soup',   type: 'major head scar',     short_name: 'polar bear fat soup',       store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'tiny flower-shaped tart',           type: 'major nerve scar',    short_name: 'flower-shaped tart',        store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: 'tiny musk ox tart',                 type: 'major organ wound',   short_name: 'musk ox tart',              store_doses: 2 },
+      { location: ['Icemule Trace', 'the Hinterwilds'], name: "tiny ram's bladder tart",           type: 'major head wound',    short_name: "ram's bladder tart",        store_doses: 2 },
 
       # Pinefar 2782/4564010
       { location: ['the Pinefar Trading Post'], name: 'some acantha leaf tea',    type: 'blood',              short_name: 'acantha leaf tea',        store_doses: 10 },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes location name for herbs in `eherbs.lic` to include "the" in "the Hinterwilds" and updates version to 2.1.7.
> 
>   - **Behavior**:
>     - Fixes location name for herbs in `eherbs.lic` to include "the" in "the Hinterwilds".
>   - **Versioning**:
>     - Updates version to 2.1.7 in `eherbs.lic`.
>   - **Changelog**:
>     - Adds changelog entry for version 2.1.7 noting the location name fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9a1426c71ac3b4bbb4b5a03c5b340e3e846ac59b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->