### PR TITLE
fix(repository.lic): v2.66 Lich 5.12 DB save fix and flush old cache-…

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,12 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.65
+       version: 2.66
 
   changelog:
+    2.66 (2025-09-21):
+      Fix to flush old stale data in Settings
+      Fix for DB save issue with Lich 5.12
     2.65 (2025-06-16):
       Force dependency.lic to always be updatable for DR installs
     2.64 (2025-02-28):
@@ -87,6 +90,13 @@ rescue LoadError
   respond "Via your computer's local terminal/shell"
   exit
 end
+
+before_dying {
+  Settings["cached-list-comments"] = nil if Settings["cached-list-comments"] && !Settings["cached-list-comments"].nil?
+  Settings["cached-list"]          = nil if Settings["cached-list"] && !Settings["cached-list"].nil?
+  Settings["cached-list-offset"]   = nil if Settings["cached-list-offset"] && !Settings["cached-list-offset"].nil?
+  Settings["updatable"]
+}
 
 unless defined?(LICH_VERSION) # Lich < 4.5
   LICH_VERSION = $version


### PR DESCRIPTION
…list
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes DB save issue with Lich 5.12 and flushes stale data in `repository.lic`.
> 
>   - **Behavior**:
>     - Fixes DB save issue with Lich 5.12 in `repository.lic`.
>     - Flushes stale data in `Settings` by setting `cached-list-comments`, `cached-list`, and `cached-list-offset` to `nil` in `before_dying` block.
>   - **Version**:
>     - Updates version to 2.66 in `repository.lic`.
>   - **Changelog**:
>     - Adds entries for version 2.66 in `repository.lic` changelog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2ca7465e981ddcc6427b2760cd2fd962a4b23039. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->