### PR TITLE
fix(uberbar_eo.lic): v2.0.2 use Experience.txp instead of Stats.exp

### DIFF
--- a/scripts/uberbar_eo.lic
+++ b/scripts/uberbar_eo.lic
@@ -415,9 +415,9 @@ module UberBarEO
       if oldBounty != bounty_points then echo "updated bounty" if @settings["debug"]; oldBounty = bounty_points; ascTime = 0; doLines += ublinebountyv.call end
       if oldFavor != Resources.voln_favor then echo "updated favor" if @settings["debug"]; oldFavor = Resources.voln_favor; doLines += ublinefavorv.call end
 
-      if (@settings["display-resources"] || @settings["display-favor"] || @settings["display-fxp"] || @settings["display-atp"] || @settings["display-tp"]) && Time.now.to_i - ascTime > @settings['silent-check-interval']
+      if (@settings["display-resources"] || @settings["display-favor"] || @settings["display-fxp"] || @settings["display-atp"] || @settings["display-tp"] || @settings["display-percentcap"]) && Time.now.to_i - ascTime > @settings['silent-check-interval']
         ascTime = Time.now.to_i
-        if @settings["display-fxp"] || @settings["display-atp"] || @settings["display-tp"]
+        if @settings["display-fxp"] || @settings["display-atp"] || @settings["display-tp"] || @settings["display-percentcap"]
           res = Lich::Util.quiet_command_xml("exp", /<output class="mono"\/>/, /<prompt time=/)
           asc_next = $1.delete(',').to_i if res.any? { |line| line =~ /Exp to next ATP: ([\d,]+)/i }
           asc_tps = $1.delete(',').to_i if res.any? { |line| line =~ /ATPs: ([\d\,]+)/i }
@@ -511,7 +511,7 @@ if Script.current.vars[1] =~ /help/
   Lich::Messaging.mono(Lich::Messaging.xml_encode("     --display-debug=<on|off>         - Turns on/off debug messaging"))
   Lich::Messaging.mono(Lich::Messaging.xml_encode("     --silent-check-interval=<NUMBER> - Delay in seconds between checking EXP and/or RESOURCE"))
   Lich::Messaging.mono(Lich::Messaging.xml_encode(""))
-  Lich::Messaging.mono(Lich::Messaging.xml_encode("  Disabling atp, tp, fxp will prevent periodic EXPERIENCE checks"))
+  Lich::Messaging.mono(Lich::Messaging.xml_encode("  Disabling atp, tp, fxp, percentcap will prevent periodic EXPERIENCE checks"))
   Lich::Messaging.mono(Lich::Messaging.xml_encode("  Disabling favor & resources will prevent periodic RESOURCE checks"))
   Lich::Messaging.mono(Lich::Messaging.xml_encode(""))
 elsif Script.current.vars[1] =~ /list/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `uberbar_eo.lic` to use `Experience.txp` for percent capped calculation, including ascension experience.
> 
>   - **Behavior**:
>     - Update `ublinepcapped` lambda in `uberbar_eo.lic` to use `Experience.txp` instead of `Stats.exp` for percent capped calculation.
>     - Include `display-percentcap` in conditions for periodic experience checks in `uberbar_eo.lic`.
>   - **Versioning**:
>     - Increment version to 2.0.2 in `uberbar_eo.lic`.
>     - Add changelog entry for v2.0.2 in `uberbar_eo.lic` to document the update to percent capped calculation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 5b7bfec4d55be536ecf2f04f4c705c46e7152d44. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->