### PR TITLE
fix(bigshot) v5.9.7 typo in cast_signs

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.9.6
+       version: 5.9.7
       required: Lich >= 5.12.6
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.9.7  (2025-09-30)
+    - bugfix when Spell[597].active? in cast_signs
   v5.9.6  (2025-09-09)
     - add support for 902 and 411 (doesn't work with UAC)
     - remove custom issue_command for Lich method
@@ -6587,7 +6589,7 @@ class Bigshot
       end
 
       # There is a 5 mana penality if you ignore the 515 cooldown
-      if Spell[597].active? && Spell[id].mana_cost.positive? && Spell[id].mana_cost + 5 > Char.mana
+      if Spell[597].active? && Spell[i].mana_cost.positive? && Spell[i].mana_cost + 5 > Char.mana
         next
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `cast_signs` method of `Bigshot` class in `bigshot.lic`, updating version to 5.9.7.
> 
>   - **Bug Fix**:
>     - Fix typo in `cast_signs` method of `Bigshot` class in `bigshot.lic`, changing `Spell[id]` to `Spell[i]` to correctly check mana cost when `Spell[597].active?`.
>   - **Version Update**:
>     - Update version to 5.9.7 in `bigshot.lic` to reflect bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 3e4c611ef5a102977804be4e9a38e591043092c6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->