### PR TITLE
fix(eloot.lic): v2.5.1 ready/store 2weapon fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.7
-           version: 2.5.0
+           version: 2.5.1
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.5.1  (2025-09-30)
+    - bugfix for store/ready secondary_weapon to 2weapon
   v2.5.0  (2025-09-19)
     - switch to using Lich methods ReadyList and StowList
     - removed change log in script before 2.4.0. Full change log on the wiki
@@ -3330,7 +3332,7 @@ module ELoot # Inventory methods
 
     def self.return_ready_list(ready_item, item)
       10.times {
-        ELoot.get_res("ready #{ready_item}", ELoot.data.get_regex)
+        ELoot.get_res("ready #{ready_item.to_s == 'secondary_weapon' ? '2weapon' : ready_item}", ELoot.data.get_regex)
         sleep 0.2
         return true if [GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
       }
@@ -3525,7 +3527,7 @@ module ELoot # Inventory methods
       end
 
       10.times {
-        ELoot.get_res("store #{ready_item}", ELoot.data.put_regex)
+        ELoot.get_res("store #{ready_item.to_s == 'secondary_weapon' ? '2weapon' : ready_item}", ELoot.data.put_regex)
         sleep 0.2
         return true if ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of `secondary_weapon` in `eloot.lic` by interpreting it as `2weapon` in relevant methods.
> 
>   - **Bug Fix**:
>     - In `eloot.lic`, fix handling of `secondary_weapon` by interpreting it as `2weapon` in `return_ready_list` and `store` methods.
>   - **Version Update**:
>     - Update version to 2.5.1 in `eloot.lic` to reflect bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ea532ee2f59b065cea980ba26cba845c5605f97f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->