### PR TITLE
fix(bigshot.lic): v5.9.9 add missing $rest_reasons

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -7551,4 +7551,3 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
     end
   end
 end
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds missing `$rest_reasons` in `bigshot.lic` for conditions requiring rest, updating version to 5.9.9.
> 
>   - **Behavior**:
>     - Adds missing `$rest_reasons` in `bigshot.lic` for various conditions requiring rest.
>     - Conditions include: no fresh wands, too injured to wave wands, bounty completion, and box in hand.
>   - **Version**:
>     - Updates version to 5.9.9 in `bigshot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for f7e5ed0239ad46766b4c2754346ab49ee57b475f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->