### PR TITLE
fix(eloot.lic): v2.5.2 method call typo

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.7
-           version: 2.5.1
+           version: 2.5.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.5.2  (2025-10-02)
+    - bugfix for incorrect method call typo
   v2.5.1  (2025-09-30)
     - bugfix for store/ready secondary_weapon to 2weapon
   v2.5.0  (2025-09-19)
@@ -4762,7 +4764,7 @@ module ELoot # Room looting
       if type == :blunt
         # Check skinner and sheath in case ReadyList/StowList got updated
         ELoot.ensure_items(key: 'skin_weapon_blunt', list: ReadyList.ready_list, inventory: ELoot.data.weapon_inv)
-        Loot.ensure_items(key: 'skin_sheath_blunt', list: ReadyList.ready_list, check_hidden: true)
+        ELoot.ensure_items(key: 'skin_sheath_blunt', list: ReadyList.ready_list, check_hidden: true)
 
         skinner = ReadyList.ready_list[:skin_weapon_blunt]
         ELoot.msg(type: "debug", text: " blunt skinner: #{skinner} blunt skinner.id: #{skinner.id}")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes method call typo in `eloot.lic`, changing `Loot.ensure_items` to `ELoot.ensure_items` for `skin_sheath_blunt` key.
> 
>   - **Bug Fix**:
>     - Corrects method call typo in `eloot.lic`, changing `Loot.ensure_items` to `ELoot.ensure_items` for `skin_sheath_blunt` key.
>   - **Version Update**:
>     - Updates version to 2.5.2 in `eloot.lic` header.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 6f6e812f26ad07af7aee4f21fbce32788c236966. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->