### PR TITLE
fix(shatteredmap.lic): v1.6.1 move SG nexus entrance

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -6,9 +6,11 @@
 
        author: elanthia-online
          game: gs
-      version: 1.6.0
+      version: 1.6.1
 
   changelog:
+    1.6.1 (2025-10-02):
+      * Fix nexus entrance to new location in SG
     1.6.0 (2025-10-01):
       * Added Sailor's Grief nexus logic
     1.5.1 (2025-01-20):
@@ -103,7 +105,7 @@ def shattered_nexus
     "3619"          => 0.2, # Nexus Lodge
     "28813"         => StringProc.new("UserVars.shattered_nexus_exit == '28813' ? 5.0 : nil"),  # Kraken's Fall
     "29870"         => StringProc.new("UserVars.shattered_nexus_exit == '29870' ? 5.0 : nil"),  # Hinterwilds
-    "35603"         => StringProc.new("UserVars.shattered_nexus_exit == '35603' ? 5.0 : nil")   # Sailor's Grief
+    "35593"         => StringProc.new("UserVars.shattered_nexus_exit == '35593' ? 5.0 : nil")   # Sailor's Grief
   }
   Map[new_nexus].wayto = {
     "27"            => StringProc.new("move 'out'; UserVars.shattered_nexus_exit = nil"),
@@ -118,7 +120,7 @@ def shattered_nexus
     "3619"          => "go lodge",
     "28813"         => StringProc.new("move 'out'; UserVars.shattered_nexus_exit = nil"),
     "29870"         => StringProc.new("move 'out'; UserVars.shattered_nexus_exit = nil"),
-    "35603"         => StringProc.new("move 'out'; UserVars.shattered_nexus_exit = nil")
+    "35593"         => StringProc.new("move 'out'; UserVars.shattered_nexus_exit = nil")
   }
   Map[new_nexus].terrain = nil
   Map[new_nexus].climate = nil
@@ -180,8 +182,8 @@ def shattered_nexus
   Room[29870].timeto["#{new_nexus}"] = 0.2
 
   # Sailor's Grief - The Contempt, Crow's Nest
-  Room[35603].wayto["#{new_nexus}"] = StringProc.new("move 'go rift'; UserVars.shattered_nexus_exit = '35603'")
-  Room[35603].timeto["#{new_nexus}"] = 0.2
+  Room[35593].wayto["#{new_nexus}"] = StringProc.new("move 'go rift'; UserVars.shattered_nexus_exit = '35593'")
+  Room[35593].timeto["#{new_nexus}"] = 0.2
 
   ###################
   # Wayside Inn, Modifications


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes nexus entrance location for Sailor's Grief in `shatteredmap.lic` and updates version to 1.6.1.
> 
>   - **Behavior**:
>     - Fixes nexus entrance location for Sailor's Grief in `shattered_nexus` function by changing room ID from `35603` to `35593`.
>   - **Versioning**:
>     - Updates version to 1.6.1 in `shatteredmap.lic`.
>   - **Changelog**:
>     - Adds entry for version 1.6.1 noting the fix for the nexus entrance location.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 171f4dc56488bca0a0b534184fe70410f05de785. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->