### PR TITLE
fix(gameobj-data.xml): 65_sailors_grief.rb bilge mass is undead NCU

### DIFF
--- a/type_data/migrations/65_sailors_grief.rb
+++ b/type_data/migrations/65_sailors_grief.rb
@@ -2,7 +2,6 @@ migrate :aggressive_npc do
   insert(:name, %{(?:algae-draped )?merrow oracle})
   insert(:name, %{(?:amaranthine )?kraken tentacle})
   insert(:name, %{(?:blubbery )?humpbacked merrow})
-  insert(:name, %{(?:brackish )?bilge mass})
   insert(:name, %{(?:fulminating )?stormborn primordial})
   insert(:name, %{(?:gigantic )?lightning whelk})
   insert(:name, %{(?:grey-plumed )?steelwing harpy})
@@ -18,6 +17,7 @@ migrate :undead, :aggressive_npc do
 end
 
 migrate :undead, :aggressive_npc, :noncorporeal do
+  insert(:name, %{(?:brackish )?bilge mass})
   insert(:name, %{(?:tenebrific )?wraith shark})
 end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `bilge mass` from `:aggressive_npc` to `:undead, :aggressive_npc, :noncorporeal` in `65_sailors_grief.rb`.
> 
>   - **Migration Changes**:
>     - Move `bilge mass` from `:aggressive_npc` to `:undead, :aggressive_npc, :noncorporeal` in `65_sailors_grief.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for edf315263b5189038ba5c58c0831f0b56da88c56. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->