### PR TITLE
fix(eloot) v2.5.3 bugfix for return_hands

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -63,7 +63,7 @@
 =end
 
 # Check version of Lich for compatibility
-lich_gem_requires = '5.12.9'
+lich_gem_requires = Script.list.find { |x| x.name == Script.current.name }.inspect[/required: Lich >= (\d+\.\d+\.\d+)/i, 1]
 
 if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
   if $frontend == 'stormfront' || $frontend == 'profanity'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `return_hands` bug in `eloot.lic` and ensures hand flags are off at initialization, requiring Lich 5.12.9.
> 
>   - **Bugfixes**:
>     - Fix `return_hands` logic in `eloot.lic` by checking for non-nil hand IDs before comparison.
>     - Ensure `flag righthand` and `flag lefthand` are turned off at initialization in `ELoot` module.
>   - **Versioning**:
>     - Update minimum Lich version requirement to 5.12.9 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2380d3141bb791ea7a73e6b906d459e58b150612. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->