### PR TITLE
fix(eloot) v2.5.4 bugfix for nil items

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -3254,8 +3254,8 @@ module ELoot # Inventory methods
     def self.free_hands(right: false, left: false, both: false)
       if (right || both) && checkright
         # Are we holding a ready_list weapon? If so put it into its sheath
-        if (ready_item = ReadyList.ready_list.find { |_k, v| v.id == GameObj.right_hand.id }[0])
-          Inventory.stow_ready_list(ready_item, GameObj.right_hand) unless ready_item.nil?
+        if !GameObj.right_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |_k, v| v.id == GameObj.right_hand.id }[0])
+          Inventory.stow_ready_list(ready_item, GameObj.right_hand)
         end
         if checkright
           Inventory.single_drag(GameObj.right_hand) # drags single item into container
@@ -3263,8 +3263,8 @@ module ELoot # Inventory methods
       end
 
       if (left || both) && checkleft
-        if (ready_item = ReadyList.ready_list.find { |_k, v| v.id == GameObj.left_hand.id }[0])
-          Inventory.stow_ready_list(ready_item, GameObj.left_hand) unless ready_item.nil?
+        if !GameObj.left_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |_k, v| v.id == GameObj.left_hand.id }[0])
+          Inventory.stow_ready_list(ready_item, GameObj.left_hand)
         end
         if checkleft
           Inventory.single_drag(GameObj.left_hand) # drags single item into container
@@ -3344,6 +3344,7 @@ module ELoot # Inventory methods
     end
 
     def self.return_ready_list(ready_item, item)
+      return true if ReadyList.ready_list[ready_item.to_sym].nil?
       10.times {
         ELoot.get_res("ready #{ready_item.to_s == 'secondary_weapon' ? '2weapon' : ready_item}", ELoot.data.get_regex)
         sleep 0.2
@@ -3533,6 +3534,7 @@ module ELoot # Inventory methods
     end
 
     def self.stow_ready_list(ready_item, item)
+      return true if ReadyList.ready_list[ready_item.to_sym].nil?
       if ReadyList.store_list[ready_item.to_sym] =~ /put in sheath/
         Inventory.open_single_container(ReadyList.ready_list[:sheath])
       elsif ReadyList.store_list[ready_item.to_sym] =~ /put in secondary/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes nil item handling bugs in `eloot.lic` script, updating version to 2.5.4.
> 
>   - **Bug Fixes**:
>     - Fix nil item handling in `free_hands` by checking `GameObj.right_hand.id` and `GameObj.left_hand.id` before accessing.
>     - Correct logic in `return_ready_list` to handle nil `ELoot.data.right_hand.id` and `ELoot.data.left_hand.id`.
>     - Ensure `store_item` returns if `item` is nil or `item.name` is "Empty".
>     - Add nil check for `ready_item` in `stow_ready_list` and `return_ready_list`.
>   - **Version Update**:
>     - Update version to 2.5.4 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 64c3f1d0fa9bc48332b62b73bedb72939577e969. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->