### PR TITLE
fix(eloot) v2.5.5 bugfix for non-standard ready/stow list items

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -1954,6 +1954,10 @@ module ELoot # Sets Inventory
     ReadyList.check(silent: true, quiet: true) unless ReadyList.checked?
     StowList.check(silent: true, quiet: true) unless StowList.checked?
 
+    # Remove any extra keys and repopulate them
+    ReadyList.ready_list.delete_if { |k, _| [:skin_weapon, :skin_weapon_blunt, :skin_sheath, :skin_sheath_blunt].include?(k) }
+    StowList.stow_list.delete_if { |k, _| [:overflow_container, :secondary_overflow, :appraisal_container].include?(k) }
+
     # Find the stow containers we need: stow, overflow, appraisal
     ELoot.ensure_items(key: 'overflow_container', list: StowList.stow_list)
     ELoot.ensure_items(key: 'secondary_overflow', list: StowList.stow_list)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of non-standard ready/stow list items in `eloot.lic` by validating against `original_readylist`.
> 
>   - **Bugfix**:
>     - Fixes handling of non-standard ready/stow list items in `eloot.lic`.
>     - Introduces `original_readylist` to validate items in `free_hands` and `return_ready_list` methods.
>     - Ensures only items in `original_readylist` are processed for stowing and returning.
>   - **Version Update**:
>     - Updates version to 2.5.5 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 493920fea32c0d9b0dc3a92f9a5e0355d8738373. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->