### PR TITLE
fix(gameobj-data.xml): gem-encrusted boxes from rare/epic feeder

### DIFF
--- a/type_data/migrations/13_use_names_not_nouns_for_loot_boxes.rb
+++ b/type_data/migrations/13_use_names_not_nouns_for_loot_boxes.rb
@@ -10,9 +10,9 @@ migrate :box do
   insert(:prefix, %{shifting})
 
   create_key(:name)
-  insert(:name, %{(?:(?:acid-pitted|badly damaged|battered|corroded|dented|engraved|enruned|plain|scratched|sturdy) )?(?:brass|gold|iron|mithril|silver|steel) (?:box|chest|coffer|strongbox|trunk)})
-  insert(:name, %{(?:(?:badly damaged|engraved|enruned|iron-bound|plain|rotting|scratched|simple|sturdy|weathered) )?(?:fel|haon|maoral|modwir|monir|tanik|thanot|wooden) (?:box|chest|coffer|strongbox|trunk)})
-  insert(:name, %{(?:(?:austere|brass-inlaid|crude|gilded|ornate|scorched) )?(?:carved modwir|cracked|deeply-scored|deeply scored|delicate|red lacquered|stained) (?:box|chest|coffer|strongbox|trunk|case)})
+  insert(:name, %{(?:(?:acid-pitted|badly damaged|battered|corroded|dented|engraved|enruned|gem-encrusted|plain|scratched|sturdy) )?(?:brass|gold|iron|mithril|silver|steel) (?:box|chest|coffer|strongbox|trunk)})
+  insert(:name, %{(?:(?:badly damaged|engraved|enruned|gem-encrusted|iron-bound|plain|rotting|scratched|simple|sturdy|weathered) )?(?:fel|haon|maoral|modwir|monir|tanik|thanot|wooden) (?:box|chest|coffer|strongbox|trunk)})
+  insert(:name, %{(?:(?:austere|brass-inlaid|crude|gem-encrusted|gilded|ornate|scorched) )?(?:carved modwir|cracked|deeply-scored|deeply scored|delicate|red lacquered|stained) (?:box|chest|coffer|strongbox|trunk|case)})
 end
 
 # Exclude all boxes from uncommon


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'gem-encrusted' as a prefix for loot box names in `13_use_names_not_nouns_for_loot_boxes.rb`.
> 
>   - **Migration Changes**:
>     - In `13_use_names_not_nouns_for_loot_boxes.rb`, added `gem-encrusted` as a possible prefix for loot box names.
>     - Updated `insert(:name, ...)` statements to include `gem-encrusted` for various materials like `brass`, `gold`, `iron`, etc.
>   - **Behavior**:
>     - Loot boxes can now be named with the `gem-encrusted` prefix, affecting their categorization and appearance in the game.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for fd0427e08e3c2b4e496f201530f25f72e46535cb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->