### PR TITLE
fix(bigshot): encumbrance command check needs to use percent_encumbrance

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -18,7 +18,7 @@
   Version Control:
     Major_change.feature_addition.bugfix
   v5.9.11  (2025-10-11)
-    - bugfix or encumbrance command check
+    - bugfix for encumbrance command check
   v5.9.10  (2025-10-03)
     - bugfix in cmd_spell targetting to send proper gameobj ID# string
   v5.9.9  (2025-10-02)


### PR DESCRIPTION
Currently comparing against the string text (none, light, etc.) needs to be the integer.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix encumbrance check in `bigshot.lic` to use `Char.percent_encumbrance` for integer comparison.
> 
>   - **Bug Fix**:
>     - In `bigshot.lic`, change `Char.encumbrance` to `Char.percent_encumbrance` in `split_check` lambda functions for 'e' and '!e' to correctly compare integer percentages.
>   - **Version Update**:
>     - Update version to 5.9.11 in `bigshot.lic` to reflect bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 4baf2afdc5f8c69cd4d2733e785883886f908364. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->