### PR TITLE
fix(herbhunt.lic): v1.3.0 fix for keys converted to entries

### DIFF
--- a/scripts/herbhunt.lic
+++ b/scripts/herbhunt.lic
@@ -7,10 +7,12 @@
   contributors: Tysong, Alastir
           game: gemstone
           tags: herb hunt, ebon gate, ebongate, games
-       version: 1.2.0
+       version: 1.3.0
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.3.0 (2025-10-13)
+    - fix for using redeemed entries, so just go entrance now
   v1.2.0 (2023-10-03)
     - fix to continue foraging when no toadshade found
   v1.1.1 (2023-10-03)
@@ -54,10 +56,6 @@ module HerbHunt
     respond("  ;e echo UserVars.herbhunt[:experience] = 90")
     respond("")
     respond("Various Container Settings Used Below.")
-    _respond("We use UserVars.questsack to store your keys. Currently set to " + Lich::Messaging.monsterbold("\"#{UserVars.questsack}\""))
-    respond("You can change this by typing the following:")
-    respond("  ;e UserVars.questsack = \"brown bag\"")
-    respond("")
     _respond("We use UserVars.lootsack to store your winnings. Currently set to " + Lich::Messaging.monsterbold("\"#{UserVars.lootsack}\""))
     respond("You can change this by typing the following:")
     respond("  ;e UserVars.lootsack = \"giant cloak\"")
@@ -131,13 +129,11 @@ module HerbHunt
       elsif !Room.current.uid.include?(8086350)
         Script.run('go2', 'u8086350')
       end
-      result = dothistimeout("get my barrel key from my #{Vars.questsack}", 5, /You (?:remove|reach|discreetly remove)|Get what?/)
-      if result =~ /You (?:remove|reach|discreetly remove)/
-        move('go entry')
-        fput("put my key in my #{Vars.questsack}")
+      result = move('go entry')
+      if result
         HerbHunt.forage
-      elsif result =~ /Get what?/
-        echo('Out of keys!')
+      else
+        echo('Out of keys/entries or not in the right room!')
         exit
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `herbhunt.lic` to version 1.3.0, modifying entry logic to use redeemed entries and removing key handling.
> 
>   - **Behavior**:
>     - In `HerbHunt.main`, change logic to use redeemed entries by moving directly to the entrance with `move('go entry')`.
>     - Remove key retrieval logic and related messages.
>     - Update exit message to "Out of keys/entries or not in the right room!".
>   - **Version**:
>     - Update version to 1.3.0 in `herbhunt.lic`.
>   - **Misc**:
>     - Remove references to `UserVars.questsack` and related instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for b0ded0e2d81adcaa43493c96d076c2b0767d2950. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->