### PR TITLE
fix(herbhunt.lic): v1.3.1 herb sack looting fix

### DIFF
--- a/scripts/herbhunt.lic
+++ b/scripts/herbhunt.lic
@@ -7,10 +7,12 @@
   contributors: Tysong, Alastir
           game: gemstone
           tags: herb hunt, ebon gate, ebongate, games
-       version: 1.3.0
+       version: 1.3.1
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.3.1 (2025-10-14)
+    - check hands for herb sack if hunt ended early
   v1.3.0 (2025-10-13)
     - fix for using redeemed entries, so just go entrance now
   v1.2.0 (2023-10-03)
@@ -96,15 +98,20 @@ module HerbHunt
     end
   end
 
+  def self.hunt_ended?
+    waitrt?
+    if Room.current.uid.include?(8086351)
+      HerbHunt.loot
+      return true
+    end
+    return false
+  end
+
   def self.forage
     waitrt?
     result = dothistimeout("forage", 5, /see withered burgundy flowerheads scattered throughout the area\.|find no signs of toadshade in this area|find several withered toadshade leaves in this area|Having run out of time, you quickly search the area/)
+    return if HerbHunt.hunt_ended?
     if result =~ /find no signs of toadshade in this area|see withered burgundy flowerheads scattered throughout the area\.|Having run out of time, you quickly search the area/
-      waitrt?
-      if Room.current.uid.include?(8086351)
-        HerbHunt.loot
-        return
-      end
       walk
       HerbHunt.forage
     elsif result =~ /find several withered toadshade leaves in this area/
@@ -113,8 +120,8 @@ module HerbHunt
   end
 
   def self.search
-    waitrt?
-    result = dothistimeout("search", 10, /You search the area for herbs\./)
+    return if HerbHunt.hunt_ended?
+    result = dothistimeout("search", 10, /You search the area for herbs\.|You don't find anything of interest here\./)
     if result =~ /You search the area for herbs\./
       HerbHunt.loot
     end
@@ -132,6 +139,7 @@ module HerbHunt
       result = move('go entry')
       if result
         HerbHunt.forage
+        HerbHunt.loot if GameObj.right_hand.name =~ /herb sack/ || GameObj.left_hand.name =~ /herb sack/
       else
         echo('Out of keys/entries or not in the right room!')
         exit


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes herb sack looting when hunt ends early by checking hands and looting if in room `8086351`.
> 
>   - **Behavior**:
>     - Adds `hunt_ended?` method to check if the hunt ended early and loot the herb sack if in room `8086351`.
>     - Updates `forage` and `search` methods to call `hunt_ended?` to handle early hunt termination.
>     - In `main`, checks hands for herb sack and loots if found after moving to entry.
>   - **Version**:
>     - Bumps version from 1.3.0 to 1.3.1 in `herbhunt.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7fe9f4dc052f173dcca9ea1daef95f2a5928c2b1. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->