### PR TITLE
fix(ewaggle.lic): v2.1.4 bad target/spell logic correction

### DIFF
--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -1747,4 +1747,3 @@ module Ewaggle
     end
   end
 end
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes target and spell skipping logic in `ewaggle.lic`, updating version to 2.1.4.
> 
>   - **Behavior**:
>     - Fixes logic in `ewaggle.lic` to correctly skip targets and spells listed in `Ewaggle.data.skip_targets` and `Ewaggle.data.skip_spells`.
>     - Updates version to 2.1.4 in `ewaggle.lic`.
>   - **Logic**:
>     - Adds condition to skip targets and spells in `Casting.cast_stackable()` and `Casting.cast_solid()`.
>     - Corrects logical operators in `Casting.cast_stackable()` to ensure proper skipping of targets and spells.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ede1fd8c23be0a0516c2769709103e6be1df5c10. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->