### PR TITLE
fix(ecure.lic): v2.0.2 regex bug

### DIFF
--- a/scripts/ecure.lic
+++ b/scripts/ecure.lic
@@ -17,11 +17,13 @@
        author: elanthia-online
          game: Gemstone
          tags: heal, cure, empath, healing
-      version: 2.0.1
+      version: 2.0.2
      required: Lich >= 5.12.0
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.0.2  (2025-10-17)
+    - bugfix in regex for missing hand/arm/leg extra space
   v2.0.1  (2025-09-27)
     - bugfix in wait_for_mana infinite stack level
     - fix to attempt APPRAISE up to 3 times due to failure
@@ -317,7 +319,7 @@ module ECure
     end
 
     def extract_wound_array(wound_line)
-      wound_line.scan(/a (?:black-and-blue|severe bruises and swelling around|missing|blinded|swollen|bruised) (?:left|right) eye|old battle scars on (?:his|her) (?:left|right) (?:hand|arm|leg)|mangled (?:left|right) (?:hand|arm|leg)|missing (?:left|right) (?:hand|arm|leg) |deep lacerations across (?:his|her) \w+|deep gashes and serious bleeding (?:on|from|across) (?:his|her) \w+|minor cuts and bruises on (?:his|her) (?:left|right) (?:hand|arm|leg)|a (?:fractured and bleeding|completely severed) (?:left|right) (?:hand|arm|leg)|moderate bleeding from (?:his|her) neck|snapped bones and serious bleeding from the neck|minor bruises on (?:his|her) neck|scar across (?:his|her) neck|some old neck wounds|terrible scars from some serious neck injury|minor (?:bruises|lacerations) about the head|minor cuts and bruises on (?:his|her) (?:chest|back|abdominal area)|severe head trauma and bleeding from the ears|strange case of muscle twitching|case of (?:sporadic|uncontrollable) convulsions|scar across (?:his|her) face|several facial scars|old mutilation wounds about (?:his|her) head|old battle scar across (?:his|her) (?:chest|back|abdominal area)|several painful-looking scars across (?:his|her) (?:chest|back|abdominal area)|terrible, permanent mutilation of (?:his|her) (?:chest|back|abdominal area) muscles|developed slurred speech|constant muscle spasms|a very difficult time with muscle control|overexerted/)
+      wound_line.scan(/a (?:black-and-blue|severe bruises and swelling around|missing|blinded|swollen|bruised) (?:left|right) eye|old battle scars on (?:his|her) (?:left|right) (?:hand|arm|leg)|mangled (?:left|right) (?:hand|arm|leg)|missing (?:left|right) (?:hand|arm|leg)|deep lacerations across (?:his|her) \w+|deep gashes and serious bleeding (?:on|from|across) (?:his|her) \w+|minor cuts and bruises on (?:his|her) (?:left|right) (?:hand|arm|leg)|a (?:fractured and bleeding|completely severed) (?:left|right) (?:hand|arm|leg)|moderate bleeding from (?:his|her) neck|snapped bones and serious bleeding from the neck|minor bruises on (?:his|her) neck|scar across (?:his|her) neck|some old neck wounds|terrible scars from some serious neck injury|minor (?:bruises|lacerations) about the head|minor cuts and bruises on (?:his|her) (?:chest|back|abdominal area)|severe head trauma and bleeding from the ears|strange case of muscle twitching|case of (?:sporadic|uncontrollable) convulsions|scar across (?:his|her) face|several facial scars|old mutilation wounds about (?:his|her) head|old battle scar across (?:his|her) (?:chest|back|abdominal area)|several painful-looking scars across (?:his|her) (?:chest|back|abdominal area)|terrible, permanent mutilation of (?:his|her) (?:chest|back|abdominal area) muscles|developed slurred speech|constant muscle spasms|a very difficult time with muscle control|overexerted/)
     end
 
     def parse_body_parts(wound_array)


### PR DESCRIPTION
Updated version number to 2.0.2 and added a bugfix for regex handling of extra spaces in wound descriptions.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes regex bug in `extract_wound_array` in `ecure.lic` to handle extra spaces in wound descriptions, updating version to 2.0.2.
> 
>   - **Bugfix**:
>     - Fixes regex bug in `extract_wound_array` in `ecure.lic` to handle extra spaces in wound descriptions for hand/arm/leg.
>   - **Version Update**:
>     - Updates version to 2.0.2 in `ecure.lic` to reflect the bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 0a756f7dfd71e1559896cc0a981dbe43c2c017d4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->