### PR TITLE
fix(guidebook.lic): v1.0.8 support WHISPER guidebook functionality

### DIFF
--- a/scripts/guidebook.lic
+++ b/scripts/guidebook.lic
@@ -61,7 +61,7 @@ def find_room_by_title_and_uid(uid, title)
   }.each { |key, value|
     return value if key.to_s == title
   }
-  
+
   if Room[Map.ids_from_uid(uid).first].title.any? { |t| t =~ /#{title}/i }
     # echo "1: #{uid}"
     return uid
@@ -111,7 +111,7 @@ guidebook_output.each_with_index { |line, index|
   end
 }
 
-if (variable[1].downcase =~ /^m/ || variable[1].downcase !~ /^r/)
+if (Script.current.vars[1]&.downcase =~ /^m/ || Script.current.vars[1]&.downcase !~ /^r/)
   if guidebook_merchants.count == 0
     respond "No merchants working currently!"
   else
@@ -136,7 +136,7 @@ if (variable[1].downcase =~ /^m/ || variable[1].downcase !~ /^r/)
     loop {
       if table =~ /\|\s+(u?[\d]+)\s+\|/
         go2_cmd = $1
-        if variable[1].downcase =~ /^w/ || variable[2].downcase =~ /^w/
+        if Script.current.vars[1]&.downcase =~ /^w/ || Script.current.vars[2]&.downcase =~ /^w/
           go2_cmdbold = "<d cmd='whisper my guidebook service 1 999 #{go2_cmd.gsub('u', '')}'>" + Lich::Messaging.monsterbold(go2_cmd) + "</d>"
         else
           go2_cmdbold = "<d cmd=';go2 #{go2_cmd}'>" + Lich::Messaging.monsterbold(go2_cmd) + "</d>"
@@ -150,7 +150,7 @@ if (variable[1].downcase =~ /^m/ || variable[1].downcase !~ /^r/)
   end
 end
 
-if (variable[1].downcase !~ /^m/ || variable[1].downcase =~ /^r/)
+if (Script.current.vars[1]&.downcase !~ /^m/ || Script.current.vars[1]&.downcase =~ /^r/)
   if guidebook_raffles.count == 0
     respond "No raffles currently!"
   else
@@ -176,7 +176,7 @@ if (variable[1].downcase !~ /^m/ || variable[1].downcase =~ /^r/)
     loop {
       if table =~ /\|\s+(u?[\d]+)\s+\|/
         go2_cmd = $1
-        if variable[1].downcase =~ /^w/ || variable[2].downcase =~ /^w/
+        if Script.current.vars[1]&.downcase =~ /^w/ || Script.current.vars[2]&.downcase =~ /^w/
           go2_cmdbold = "<d cmd='whisper my guidebook raffle 1 999 #{go2_cmd.gsub('u', '')}'>" + Lich::Messaging.monsterbold(go2_cmd) + "</d>"
         else
           go2_cmdbold = "<d cmd=';go2 #{go2_cmd}'>" + Lich::Messaging.monsterbold(go2_cmd) + "</d>"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds whisper command option to `guidebook.lic` for guidebook functionality, requiring quest unlock.
> 
>   - **Behavior**:
>     - Adds `w(hisper)` option to `;guidebook` command to use whisper instead of GO2.
>     - Supports `;guidebook w`, `;guidebook m w`, and `;guidebook r w` for whisper functionality.
>     - Requires unlocking of guidebook quest to use whisper.
>   - **Logic**:
>     - Modifies command logic in `guidebook.lic` to check for `w` option and switch command from GO2 to whisper.
>     - Updates regex patterns for merchant and raffle commands to include whisper functionality.
>   - **Misc**:
>     - Updates version to 1.0.8 in `guidebook.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 1415debea4e1c677b7e020094afa3f58b4512514. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->