### PR TITLE
fix(herbhunt.lic): v1.3.2 and add item names

### DIFF
--- a/scripts/herbhunt.lic
+++ b/scripts/herbhunt.lic
@@ -7,10 +7,12 @@
   contributors: Tysong, Alastir
           game: gemstone
           tags: herb hunt, ebon gate, ebongate, games
-       version: 1.3.1
+       version: 1.3.2
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.3.2 (2025-10-19)
+    - additional corrections
   v1.3.1 (2025-10-14)
     - check hands for herb sack if hunt ended early
   v1.3.0 (2025-10-13)
@@ -31,6 +33,21 @@ module HerbHunt
   UserVars.herbhunt[:pause]      = true  if UserVars.herbhunt[:pause].nil?
   UserVars.herbhunt[:first_run]  = true  if UserVars.herbhunt[:first_run].nil?
   UserVars.herbhunt[:experience] = false if UserVars.herbhunt[:experience].nil?
+  @item_names = Regexp.union(
+    /pumpkin-etched token/,
+    /glowing orb/,
+    /potent blue-green potion/,
+    /Adventurer's Guild task waiver/,
+    /sun-etched gold ring/,
+    /locker runner contract/,
+    /larger locker contract/,
+    /urchin guide contract/,
+    /flexing arm token/,
+    /Elanthian Guilds voucher pack/,
+    /blue feather-shaped charm/,
+    /Adventurer's Guild voucher pack/,
+    /swirling yellow-green potion/,
+  )
 
   def self.pause
     respond("########################################")
@@ -76,7 +93,7 @@ module HerbHunt
       GameObj.right_hand.contents.each { |item|
         Lich::Messaging.stream_window("Found #{item.name}")
         fput("get ##{item.id}")
-        if item.name !~ /pumpkin-etched token|glowing orb|potent blue-green potion|Adventurer's Guild task waiver|sun-etched gold ring|locker runner contract|larger locker contract|urchin guide contract|flexing arm token|Elanthian Guilds voucher pack|blue feather-shaped charm|Adventurer's Guild voucher pack/
+        if item.name !~ @item_names
           echo("Unknown #{item.name} found, unsure what to do, placing in #{UserVars.lootsack}!")
           echo("Please report this to elanthia-online team!")
           HerbHunt.pause
@@ -84,11 +101,15 @@ module HerbHunt
         fput("put ##{item.id} in my #{UserVars.lootsack}")
       }
       if GameObj.right_hand.contents.empty?
-        fput('drop my herb sack')
+        fput('toss my herb sack')
       else
         echo("Something still left inside herb sack! Report the contents to elanthia-online!")
         fput('look in my herb sack')
         echo(GameObj.right_hand.contents)
+        HerbHunt.pause
+      end
+      unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+        echo("Couldn't store item in hands, likely full container. Empty your stuff!")
         HerbHunt.pause
       end
     elsif result !~ /There is nothing in there\./
@@ -101,7 +122,7 @@ module HerbHunt
   def self.hunt_ended?
     waitrt?
     if Room.current.uid.include?(8086351)
-      HerbHunt.loot
+      HerbHunt.loot if GameObj.right_hand.name =~ /herb sack/ || GameObj.left_hand.name =~ /herb sack/
       return true
     end
     return false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves `herbhunt.lic` by adding item name regex, updating item handling, and making minor corrections.
> 
>   - **Behavior**:
>     - Introduced `@item_names` regex in `HerbHunt` module to handle item name matching, replacing inline regex in `loot()`.
>     - Changed `fput('drop my herb sack')` to `fput('toss my herb sack')` in `loot()`.
>     - Added check for full hands in `loot()` and pauses if items can't be stored.
>     - Modified `hunt_ended?()` to only call `loot()` if a `herb sack` is in hand.
>   - **Version**:
>     - Updated version to 1.3.2 with additional corrections noted in version control.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for eb21fc331c7507899b98beb91849d9df2f84a624. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->