### PR TITLE
fix(eloot) v2.5.7 bugfix for debt when entering locker

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.5.6
+           version: 2.5.7
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.5.7  (2025-10-19)
+    - bugfix for debt when entering locker
   v2.5.6  (2025-10-08)
     - bugfix for store/ready ranged_weapon to ranged
   v2.5.5  (2025-10-05)
@@ -3709,7 +3711,7 @@ module ELoot # Gem and Reagent hoarding
       end
 
       unless ELoot.data.account_type =~ /premium/i
-        ELoot.silver_withdraw(1500)
+        ELoot.silver_withdraw(2500)
       end
 
       index = 0
@@ -3724,7 +3726,7 @@ module ELoot # Gem and Reagent hoarding
         ELoot.wait_rt
 
         # some rooms go directly to the locker instead of just outside
-        break if GameObj.loot.find { |item| item.name == "dark stained antique oak trunk" }
+        break if (GameObj.room_desc.to_a + GameObj.loot.to_a).any? { |obj| obj.name =~ /locker|counter/ }
 
         if ELoot.data.use_house_locker
           way_in = ELoot.data.che_entry
@@ -3737,6 +3739,20 @@ module ELoot # Gem and Reagent hoarding
         result = move "#{way_in}"
 
         break if result == true
+
+        if reget(10).reverse.any? { |line| line =~ /pay off (your|that) debt/i }
+          wealth_pattern = /^You have (no|[,\d]+|but one) silver with you/
+          wealth_lines = ELoot.get_command("wealth quiet", wealth_pattern, silent: true, quiet: true).join(" ")
+          if wealth_lines.to_s =~ /In the back of your mind you remember you owe a debt of ([\d,]+) silver/
+            amount = $1.gsub(',', '').to_i
+            ELoot.silver_withdraw(amount)
+            ELoot.go2("debt")
+            ELoot.wait_rt
+            fput("pay #{amount}")
+            ELoot.silver_withdraw(2500)
+            redo
+          end
+        end
 
         if index == lockers.length - 1 # Pause for 10 seconds if it's the last iteration
           respond


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes debt handling bug in `eloot.lic` when entering locker, increases silver withdrawal, and updates version to 2.5.7.
> 
>   - **Behavior**:
>     - Fixes bug in `eloot.lic` for handling debt when entering locker.
>     - Increases `ELoot.silver_withdraw` from 1500 to 2500 for non-premium accounts.
>     - Modifies loop break condition to check for `locker` or `counter` in `GameObj.room_desc` and `GameObj.loot`.
>     - Adds logic to detect and pay off debt if `pay off (your|that) debt` is found in recent lines.
>   - **Version**:
>     - Updates version to 2.5.7 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for a59bdac12d27a30a71e89bf31b86052e3f0e4a7f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->