### PR TITLE
fix(shatteredmap.lic): v1.7.0 various fixes

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -6,9 +6,12 @@
 
        author: elanthia-online
          game: gs
-      version: 1.6.1
+      version: 1.7.0
 
   changelog:
+    1.7.0 (2025-10-20):
+      * Add urchin fixes
+      * additional corrections to Ta'Illistim keep
     1.6.1 (2025-10-02):
       * Fix nexus entrance to new location in SG
     1.6.0 (2025-10-01):
@@ -477,6 +480,12 @@ def misc_corrections
   Room[29865].timeto["2487"] = StringProc.new("UserVars.mapdb_hinterwilds_location == 'IM' ? 240 : nil;")
 end
 
+def urchin_fixes
+  # Remove grocer from Solhaven urchin usage
+  Room[30710].wayto.delete("32600")
+  Room[30710].timeto.delete("32600")
+end
+
 def illistim_corrections
   # BANK STUFF
   Room[13].wayto["12"] = "go bank"
@@ -532,11 +541,67 @@ def illistim_corrections
   Room[13231].timeto.delete("24555")
   Room[623].wayto["17841"] = "climb staircase"
   Room[623].timeto["17841"] = 0.2
+  Room[26].wayto["1439"] = "go cottage"
+
+  Room[18139].timeto.delete("18138")
+  Room[18139].wayto.delete("18138")
+  Room[18139].timeto.delete("28478")
+  Room[18139].wayto.delete("28478")
+  Room[18139].timeto["18137"] = 0.2
+  Room[18139].wayto["18137"] = "go mistwood door"
+
+  Room[18137].wayto["18138"] = "go westerly door"
+  Room[18137].timeto["18138"] = 0.2
+  Room[18137].wayto["18139"] = "go easterly door"
+  Room[18137].timeto["18139"] = 0.2
+  Room[18137].wayto["17841"] = "go ogee arch"
+  Room[18137].timeto["17841"] = 0.2
+  Room[18137].wayto.delete("18136")
+  Room[18137].timeto.delete("18136")
+
+  Room[18138].wayto.delete("17841")
+  Room[18138].timeto.delete("17841")
+  Room[18138].wayto.delete("18139")
+  Room[18138].timeto.delete("18139")
+  Room[18138].wayto.delete("18136")
+  Room[18138].timeto.delete("18136")
+  Room[18138].wayto.delete("18141")
+  Room[18138].timeto.delete("18141")
+  Room[18138].wayto.delete("32534")
+  Room[18138].timeto.delete("32534")
+  Room[18138].wayto["18137"] = "go mistwood door"
+  Room[18138].timeto["18137"] = 0.2
+  Room[18138].wayto["18140"] = "go silver staircase"
+  Room[18138].timeto["18140"] = 0.2
+  Room[18138].wayto["18146"] = "go cerulean-tiled arch"
+  Room[18138].timeto["18146"] = 0.2
+  Room[18138].wayto["18147"] = "go azure-tiled arch"
+  Room[18138].timeto["18147"] = 0.2
+  Room[18138].wayto["18148"] = "go lapis-tiled arch"
+  Room[18138].timeto["18148"] = 0.2
+  Room[18138].wayto["18149"] = "go sapphire-tiled arch"
+  Room[18138].timeto["18149"] = 0.2
+
   Room[17841].wayto.delete("16961")
   Room[17841].timeto.delete("16961")
-  Room[17841].wayto["623"] = "climb staircase"
+  Room[17841].wayto.delete("18138")
+  Room[17841].timeto.delete("18138")
+  Room[17841].wayto.delete("26830")
+  Room[17841].timeto.delete("26830")
+  Room[17841].wayto.delete("32741")
+  Room[17841].timeto.delete("32741")
+  Room[17841].wayto["623"] = "climb westerly staircase"
   Room[17841].timeto["623"] = 0.2
-  Room[26].wayto["1439"] = "go cottage"
+  Room[17841].wayto["742"] = "climb easterly staircase"
+  Room[17841].timeto["742"] = 0.2
+  Room[17841].wayto["18137"] = "go ogee arch"
+  Room[17841].timeto["18137"] = 0.2
+
+  Room[18140].wayto.delete("18144")
+  Room[18140].timeto.delete("18144")
+  Room[18140].wayto["18138"] = "go silver staircase"
+  Room[18140].timeto["18138"] = 0.2
+
   # Pig & Whistle
   Room[613].wayto["13311"] = "go cottage"
   # Maaghara's Tower Exit lag
@@ -571,6 +636,7 @@ shattered_nexus
 playershop_modifications
 premium_portals
 landing_tunnels
+urchin_fixes
 misc_corrections
 illistim_corrections
 


### PR DESCRIPTION
Updated version to 1.7.0 and added urchin fixes and additional Ta'Illistim fixes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `shatteredmap.lic` to version 1.7.0 with urchin and Ta'Illistim keep fixes.
> 
>   - **Version Update**:
>     - Update version to 1.7.0 in `shatteredmap.lic`.
>   - **Urchin Fixes**:
>     - Remove grocer from Solhaven urchin usage in `urchin_fixes` function.
>   - **Ta'Illistim Corrections**:
>     - Modify room connections and pathing logic in `illistim_corrections` function, including changes to rooms 18139, 18137, 18138, 17841, and 18140.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e23fde5aa802a390ce4384d0cd23662dc074bac8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->