### PR TITLE
fix(ecleanse): v2.2.5 fix regex issue

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.11.1
-       version: 2.2.4
+       version: 2.2.5
 
   Improvements:
+  v2.2.5  (2025-10-27)
+    - bugfix in hive apparatus trap disarm regex when no trap
   v2.2.4  (2025-10-01)
     - disarm messaging for hisska warriors
     - hive traps search logic updates
@@ -817,9 +819,9 @@ module Ecleanse
 
       search_count = 0
       loop do
-        results = Util.get_command("disarm apparatus", /d100/)
+        results = Util.get_command("disarm apparatus", /d100|You want to disarm what\?/)
         search_count += 1
-        break if results.any? { |l| l =~ /Success|You want to disarm what?/ }
+        break if results.any? { |l| l =~ /Success|You want to disarm what\?/ }
         return if search_count >= 10
         Util.wait_rt
       end


### PR DESCRIPTION
Updated version to 2.2.5 and added a bugfix for hive apparatus trap disarm regex.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ecleanse.lic` to version 2.2.5 and fix regex issue for hive apparatus trap disarm when no trap is present.
> 
>   - **Behavior**:
>     - Update version to 2.2.5 in `ecleanse.lic`.
>     - Fix regex in `hive_traps_apparatus` method to handle cases where no trap is present.
>   - **Misc**:
>     - Update changelog in `ecleanse.lic` to reflect the bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c5cf3671351e591f1ff9aa4ed1e489ba57839ffc. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->