### PR TITLE
fix(uberbar_eo.lic): v2.0.3 clean up XP history

### DIFF
--- a/scripts/uberbar_eo.lic
+++ b/scripts/uberbar_eo.lic
@@ -8,13 +8,15 @@
     contributors: Dantax, Tysong, Gibreficul, Bait, Xanlin, Khazaann, Dissonance
             game: gemstone
             tags: uberbar, bar, uber, vitals, paperdoll
-         version: 2.0.2
+         version: 2.0.3
         required: Lich >= 5.11.0
 
   Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v2.0.3 (2025-10-29)
+    - remove saving of XP history into UserVars as not used for anything
   v2.0.2 (2025-09-24)
     - update percent capped to use total experience, so it includes ascension experience
   v2.0.1 (2025-07-04)
@@ -303,11 +305,9 @@ module UberBarEO
     sizey = 15
 
     time = Time.new
-    UserVars.uberbar_xp_history = Hash.new if UserVars.uberbar_xp_history.nil?
     UserVars.uberbar_date = time - 3600 * 24 if UserVars.uberbar_date.nil?
 
     if time.hour > 5 && UserVars.uberbar_day != time.day && UserVars.uberbar_xp_per_day != 0
-      UserVars.uberbar_xp_history[UserVars.uberbar_date.to_date] = UserVars.uberbar_xp_per_day
       UserVars.uberbar_xp_per_day = 0
       UserVars.uberbar_day = time.day
       UserVars.uberbar_date = time


### PR DESCRIPTION
Updated version to 2.0.3 and removed unused XP history saving.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `uberbar_eo.lic` to version 2.0.3 and remove unused XP history saving.
> 
>   - **Behavior**:
>     - Update version to `2.0.3` in `uberbar_eo.lic`.
>     - Remove unused XP history saving in `UberBarEO` module.
>   - **Misc**:
>     - Add version history entry for `v2.0.3` in `uberbar_eo.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for d8896f18d0f37bb25167dd08abe20ba6248d52e0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->