### PR TITLE
fix(eherbs.lic): v2.1.8 buy_herb qty fix when not enough funds

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -1176,7 +1176,7 @@ module EHerbs
       when /^But you do not have enough silver!/
         Actions.withdraw
         Utility.go2('herbalist')
-        return Actions.buy_herb(herb_type)
+        return Actions.buy_herb(herb_type, amount)
       when /You're going to need a free hand/
         EHerbs.data[:done_empty_hand] = true
         empty_hands


### PR DESCRIPTION
Updated version to 2.1.8 and added changelog entry for buy_herb fix.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `buy_herb` in `eherbs.lic` to rebuy correct amount when funds are insufficient, update version to 2.1.8.
> 
>   - **Behavior**:
>     - Fix `buy_herb` in `eherbs.lic` to rebuy the correct amount when funds are insufficient, instead of defaulting to qty 1.
>   - **Versioning**:
>     - Update version to 2.1.8 in `eherbs.lic`.
>     - Add changelog entry for version 2.1.8 detailing the `buy_herb` fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ddaad7f3680862aa4d9da8b049b4353beeca9191. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->