### PR TITLE
fix(bodega.lic): fixed inventory getting mixed up

### DIFF
--- a/scripts/bodega.lic
+++ b/scripts/bodega.lic
@@ -1044,13 +1044,13 @@ module Bodega
 
       # Remove items with invalid timestamps only
       @added_items_data = @added_items_data.select do |_item_id, timestamp_str|
-                            begin
-                              Time.parse(timestamp_str)
-                              true
-                            rescue
-                              false # Remove items with invalid timestamps
-                            end
-                          end
+        begin
+          Time.parse(timestamp_str)
+          true
+        rescue
+          false # Remove items with invalid timestamps
+        end
+      end
 
       begin
         Assets.write_local_json(@added_items_data, "added_items")


### PR DESCRIPTION
v0.6 - Fix shop ID swap handling during maintenance reboots
       - Smart scan now automatically syncs room_title with preamble
       - Prevents stale room metadata when shop IDs are reassigned
       - Maintains shop type detection during synchronization
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes shop ID swap handling and enhances smart scan synchronization in `bodega.lic`.
> 
>   - **Behavior**:
>     - Fixes shop ID swap handling during maintenance reboots in `bodega.lic`.
>     - Smart scan now syncs `room_title` with `preamble` to prevent stale metadata.
>     - Maintains shop type detection during synchronization.
>   - **Parsing**:
>     - Updates `ITEM` regex in `Messages` to capture item ID and price.
>     - Modifies `add_item()` in `Parser` to store item ID and price.
>     - Enhances `smart_scan_inv()` in `Parser` to update `room_title` based on `preamble`.
>   - **Misc**:
>     - Updates version to 0.6 in `bodega.lic`.
>     - Adds changelog entry for version 0.6.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 4822ab4ad1f6459f82e8f2e91ee6ad2f4f47ff05. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->