### PR TITLE
fix(shatteredmap.lic): v1.7.1 additional corrections

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -498,7 +498,7 @@ def misc_corrections
 
   # Frozen Bramble - No access in Shattered
   Room[3111].wayto.delete("24519")
-  Room[3111].timeto.delete("24519")  
+  Room[3111].timeto.delete("24519")
 end
 
 def urchin_fixes


### PR DESCRIPTION
Updated version to 1.7.1 and added changelog entries for Darkstone Castle and Frozen Brambles access fixes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `shatteredmap.lic` to version 1.7.1 with fixes for Darkstone Castle access and removal of Frozen Brambles link.
> 
>   - **Version Update**:
>     - Update version to 1.7.1 in `shatteredmap.lic`.
>   - **Changelog**:
>     - Add entries for Darkstone Castle entrance fix and removal of Frozen Brambles link.
>   - **Corrections**:
>     - In `misc_corrections`, fix Darkstone Castle access by deleting `wayto` and `timeto` for Rooms `7927` and `6997`.
>     - Remove non-existent Frozen Brambles link by deleting `wayto` and `timeto` for Room `3111`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2debc60e1ce00b294fc002ad82d0716634c80a71. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->