### PR TITLE
fix(shatteredmap.lic): v1.7.2 teras nexus routing

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -6,9 +6,11 @@
 
        author: elanthia-online
          game: gs
-      version: 1.7.1
+      version: 1.7.2
 
   changelog:
+    1.7.2 (2025-11-07):
+      * Fix for Teras routing for Nexus
     1.7.1 (2025-11-05):
       * Fix Darkstone Castle entrance access
       * Remove link to IMT Frozen Brambles area, non-existent
@@ -162,6 +164,10 @@ def shattered_nexus
   # Teras - Krodera and Dragonseye
   Room[1933].wayto["#{new_nexus}"] = StringProc.new("move 'go rift'; UserVars.shattered_nexus_exit = '1933'")
   Room[1933].timeto["#{new_nexus}"] = 0.2
+  Room[1932].timeto["1933"] = 0.2
+  Room[1932].timeto["1898"] = 0.2
+  Room[1932].timeto["1931"] = 0.2
+  Room[1932].timeto["1944"] = 0.2
 
   # Icemule Trace, South Road
   Room[2302].wayto["#{new_nexus}"] = StringProc.new("move 'go rift'; UserVars.shattered_nexus_exit = '2302'")


### PR DESCRIPTION
Updated version to 1.7.2 and added changelog entry for Teras routing fix.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `shatteredmap.lic` to version 1.7.2 with a fix for Teras Nexus routing by adding `timeto` entries for Room 1932.
> 
>   - **Version Update**:
>     - Update version to 1.7.2 in `shatteredmap.lic`.
>     - Add changelog entry for Teras routing fix.
>   - **Routing Fix**:
>     - In `shattered_nexus`, add `timeto` entries for Room 1932 to Rooms 1933, 1898, 1931, and 1944 with a time of 0.2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for f42c9c609250792dfa366da2940e29b676dc8d00. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->