### PR TITLE
fix(ebounty) v1.7.4 bugfix for go2_rest variable types

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       requires: Lich >= 5.12.10
-       version: 1.7.3
+       version: 1.7.4
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.7.4 (2025-11-11)
+    - bugfix for go2_rest - settings[:resting_room] converted to array and current_room a string
   v1.7.3 (2025-10-01)
    - updates for Sailor's Grief
    - added support for uids
@@ -700,7 +702,7 @@ module EBounty
 
   def self.go2_rest
     town_uid = "u#{Room[Room.current.find_nearest_by_tag("town")].uid.first}"
-    current_room = Room.current.id
+    current_room = Room.current.id.to_s
 
     EBounty.msg("debug", " #{__method__} | caller: #{caller[0]} | town_id: #{town_uid}")
 
@@ -1019,6 +1021,9 @@ module EBounty
         :hw_resting,
         :contempt_resting
       ]
+
+      # convert custom resting to an array
+      @settings[:resting_room] = @settings[:resting_room].split(",").map(&:strip)
 
       # converts any uids to room ids
       resting_keys.each do |key|


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `go2_rest` by converting `settings[:resting_room]` to an array and ensuring `current_room` is a string in `ebounty.lic`.
> 
>   - **Behavior**:
>     - Fixes bug in `go2_rest` by converting `settings[:resting_room]` to an array and ensuring `current_room` is a string.
>   - **Version**:
>     - Updates version to 1.7.4 in `ebounty.lic`.
>   - **Misc**:
>     - Adds version control entry for v1.7.4 in `ebounty.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e88b469fe8e11c0ea49799e677e63106c2ec243d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->