### PR TITLE
fix(ecleanse.lic): v2.2.6 TWC disarm recovery fixes

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -972,7 +972,7 @@ module Ecleanse
       # Change to defensive stance
       Action.change_stance(100)
 
-      # It might be a bonded weapon2
+      # It might be a bonded weapon
       if Feat.weapon_bonding == 5 || Spell[1625].known? # Fixme: Making an assumption you'd be using the bonded weapon
         wait_time = Time.now + 10
         until [GameObj.right_hand.noun, GameObj.left_hand.noun].include?(item) || wait_time < Time.now


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes weapon recovery bugs in `ecleanse.lic` for two-weapon combat and updates Lich version requirement.
> 
>   - **Behavior**:
>     - Fixes weapon recovery bug for two-weapon combat in `ecleanse.lic`.
>     - Ensures hands are filled after weapon recovery.
>   - **Data Handling**:
>     - Replaces `recover_item` and `recover_room` with `recover_stuff` hash in `Ecleanse::Data`.
>     - Updates disarm recovery logic to use `recover_stuff` in `recover`, `recover_weapon_webbing`, and `telekinetic_recover` methods.
>   - **Versioning**:
>     - Updates Lich version requirement to `>= 5.12.10`.
>     - Bumps script version to `2.2.6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 256cb50e2da2052463d64e4fc57cf95d3f52bdb2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->