### PR TITLE
fix(eloot) v2.6.1 bugfix for open container and inventory  messaging

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.6.0
+           version: 2.6.1
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.6.1  (2025-11-11)
+    - bugfix in open_loot_containers
+    - bugfix in get_weapon_inv
   v2.6.0  (2025-10-26)
     - add bloodband support
     - bugfix for save_trash_box method
@@ -1895,7 +1898,7 @@ module ELoot # Sets Inventory
     # Need the weapon inventory for skinning
     exist = %r{<a exist=(?:'|")(?<id>.*?)(?:'|") noun=(?:'|")(?<noun>.*?)(?:'|")>(?<name>.*?)</a>}
 
-    lines = ELoot.get_command("inventory full weapons", /You are currently wearing:/, silent: true, quiet: true)
+    lines = ELoot.get_command("inventory full weapons", /You are currently wearing:|You are carrying no weapons at this time\./, silent: true, quiet: true)
 
     lines.each do |line|
       line.scan(exist) do |id, noun, name|
@@ -3351,7 +3354,7 @@ module ELoot # Inventory methods
       containers = Array.new
       item.each { |loot|
         loot_type = loot.type.to_sym
-        next if StowList.stow_list[loot.type].nil?
+        next if StowList.stow_list[loot_type].nil?
 
         unless containers.include?(StowList.stow_list[loot_type].id)
           Inventory.open_single_container(StowList.stow_list[loot_type])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bugs in `eloot.lic` for weapon inventory handling and container opening logic, updating version to 2.6.1.
> 
>   - **Bug Fixes**:
>     - Fix `get_weapon_inv` in `eloot.lic` to handle cases where no weapons are carried by updating the regex pattern.
>     - Fix `open_loot_containers` in `eloot.lic` by correcting the type symbol conversion for `StowList.stow_list` lookup.
>   - **Version Update**:
>     - Update version to 2.6.1 in `eloot.lic` to reflect bug fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ffedf8df1dc9098d67c45fd98fe1811a2ff331c8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->