### PR TITLE
feat(ecaster.lic): v1.2.0 migrate to Spell class for casting

### DIFF
--- a/scripts/ecaster.lic
+++ b/scripts/ecaster.lic
@@ -430,6 +430,7 @@ module ECaster
 
     if @@stance[spell_alias] || @@stance[spell_number] || @@options[:stance] && spell.stance
       stance = 'guarded'
+      waitrt?
       result = dothistimeout "stance #{stance}", 2, STANCE_RX until result =~ STANCE_RX
     end
 


### PR DESCRIPTION
Use Spell class for smarter casting and handling of errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ecaster.lic` to use `Spell` class for casting, replacing manual `put` statements with `Spell.force_cast` and `Spell.force_incant` methods.
> 
>   - **Behavior**:
>     - Update `cast` method in `ecaster.lic` to use `Spell.force_cast` and `Spell.force_incant` for casting spells.
>     - Replaces manual `put` statements with `Spell` class methods for improved error handling.
>   - **Version**:
>     - Update version to 1.2.0 in `ecaster.lic`.
>     - Add version control comment for 1.2.0 to reflect changes to `Spell` class usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 91e32f56441501700a5acd1da0b3a9afc5572d71. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->