### PR TITLE
fix(eforgery.lic): v1.2.3 get note deposit if existing

### DIFF
--- a/scripts/eforgery.lic
+++ b/scripts/eforgery.lic
@@ -746,7 +746,7 @@ class << forger
       waitrt?
       afk_wait if @afk and line =~ /best work|into the tempering trough|hanging crystal and spreads|tongs on the anvil|tongs to the anvil|anvil as you shake your head/
       ## more return handlers
-      done = line =~ /shake your head and /
+      # done = line =~ /shake your head and /
       exit if line =~ /need to be holding|material you want to work/
       if line =~ /this would be a real waste|will be ruined if you try to set the temper with|trough is empty/
         oil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes note deposit bug and replaces `start_script` with `Script.run` for efficiency in `eforgery.lic`.
> 
>   - **Behavior**:
>     - Fixes bug in `get_note()` to deposit existing notes if present.
>     - Replaces `start_script` and `wait_while` with `Script.run` in `bank()`, `get_note()`, and 10 other places for efficiency.
>   - **Version**:
>     - Updates version to 1.2.3 in `eforgery.lic`.
>   - **Misc**:
>     - Updates changelog in `eforgery.lic` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 4c185b6eba9ff990463476866b227b2995c5026f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->