### PR TITLE
feat(ebounty.lic): v1.8.0 add option to get new bounty before quitting

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.7.5
+       version: 1.8.0
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v.1.8.0 (2025-11-18)
+    - added option to get a new bounty before quitting when set to "Run one bounty and quit"
   v1.7.5 (2025-11-11)
     - bugfix in minimum Lich required checks
   v1.7.4 (2025-11-11)


### PR DESCRIPTION
Added additional option to get a new bounty before quitting when set to "run one bounty and quit"
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `new_bounty_on_exit` option to `ebounty.lic` to fetch a new bounty before quitting when "Run one bounty and quit" is enabled, with UI and logic updates.
> 
>   - **Behavior**:
>     - Adds `new_bounty_on_exit` option to `ebounty.lic` to get a new bounty before quitting when "Run one bounty and quit" is enabled.
>     - Updates `bounty_check` and `bounty_complete` in `Task` to handle `new_bounty_on_exit`.
>     - Implements `get_new_bounty_before_exit` in `Task` to fetch a new bounty if conditions are met.
>   - **UI**:
>     - Adds `GtkCheckButton` for `new_bounty_on_exit` in the UI setup.
>     - Updates UI logic to enable/disable `new_bounty_on_exit` based on `once_and_done` state.
>   - **Version**:
>     - Bumps version to 1.8.0 in `ebounty.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 60d3dd0da106069df5c58cb57c46cf490b31d02e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->