### PR TITLE
feat(shatteredmap.lic): v1.8.0 Add WL graveyard gate fix to push

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -59,7 +59,7 @@ def load_prime_mapdb
   sleep(1) until ($login_time + 10) < Time.now
   FileUtils.mkdir_p(File.join(DATA_DIR, "GSIV"))
   XMLData.instance_variable_set(:@game, "GSIV")
-  Script.run("repository", "download-mapdb")
+  Script.run('repository', 'download-mapdb')
   XMLData.instance_variable_set(:@game, "GSF")
 
   file_list = Dir.entries(File.join(DATA_DIR, "GSIV")).find_all { |fn| fn =~ /^map\-[0-9]+\.(?:dat|xml|json)$/i }.collect { |fn| File.join(DATA_DIR, "GSIV", "#{fn}") }.sort.reverse


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `landing_graveyard_gate` to `shatteredmap.lic` for handling Wehnimer's Landing graveyard gate, updating version to 1.8.0.
> 
>   - **Behavior**:
>     - Adds `landing_graveyard_gate` function to `shatteredmap.lic` to handle Wehnimer's Landing graveyard gate.
>     - Forces gate to be pushed open, optionally casting spells 304, 407, 1207, or 1604 if known.
>   - **Version**:
>     - Updates version to 1.8.0 in `shatteredmap.lic`.
>   - **Misc**:
>     - Adds changelog entry for version 1.8.0 in `shatteredmap.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 7e9780b47a5942751c6bf7cbb65e95046f8a25a5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->