### PR TITLE
fix(eloot.lic): v2.6.2 force bounty heirloom item pickup

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.6.1
+           version: 2.6.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.6.2  (2025-11-21)
+    - force looting of bounty heirloom items if found
   v2.6.1  (2025-11-11)
     - bugfix in open_loot_containers
     - bugfix in get_weapon_inv
@@ -4747,6 +4749,7 @@ module ELoot # Room looting
 
       objs.reject do |obj|
         next if ELoot.data.settings[:loot_keep].length.positive? && obj.name =~ Regexp.union(ELoot.data.settings[:loot_keep])
+        next if Bounty.task.heirloom? && obj.name =~ /#{Bounty.task.requirements[:item]}/i
 
         obj.name =~ /\b#{name_regex}\b/i ||
           obj.name =~ /[A-Z][a-z]+ #{ELoot.data.disk_nouns_regex}\b/ ||
@@ -4770,6 +4773,9 @@ module ELoot # Room looting
 
       # Keep it if it's a type we want
       return true if thing.type =~ Regexp.union(ELoot.data.settings[:loot_types])
+
+      # Keep it if it's our current bounty heirloom assignment
+      return true if Bounty.task.heirloom? && thing.name =~ /#{Bounty.task.requirements[:item]}/i
 
       # If the type is something we don't want return false
       not_wanted = ELoot.data.all_loot_categories - ELoot.data.settings[:loot_types]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Force looting of bounty heirloom items in `eloot.lic` by checking `Bounty.task.heirloom?` and matching item name with `Bounty.task.requirements[:item]`.
> 
>   - **Behavior**:
>     - Force looting of bounty heirloom items in `eloot.lic` if found, by checking `Bounty.task.heirloom?` and matching item name with `Bounty.task.requirements[:item]`.
>   - **Version**:
>     - Update version to 2.6.2 in `eloot.lic` to reflect the new functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 78c9f4118648f25c5b28da4870acc4ac6f27a5c7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->