### PR TITLE
fix(shatteredmap.lic): v1.8.4 wayside garret fix

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -9,7 +9,7 @@
       version: 1.8.4
 
   changelog:
-    1.8.3 (2025-11-20):
+    1.8.4 (2025-11-20):
       * Bugfix for wayside garret
     1.8.3 (2025-11-20):
       * Bugfix in nexus WL entrance tracking logic


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes wayside garret issue in `shatteredmap.lic` by removing specific entries for Room 3619 and updates version to 1.8.4.
> 
>   - **Behavior**:
>     - Fixes wayside garret issue by removing `wayto` and `timeto` entries for Room 3619 in `shatteredmap.lic`.
>   - **Versioning**:
>     - Updates version to 1.8.4 in `shatteredmap.lic`.
>   - **Changelog**:
>     - Adds entry for version 1.8.3 noting bugfix for wayside garret.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 1d5d415f08554cfbf25019720346d3e1c09ed0aa. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->