### PR TITLE
fix(ewaggle) v2.1.5 add disk casting

### DIFF
--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -763,9 +763,9 @@ module Ewaggle
 
   def self.test
     echo "test"
-    target_list = Ewaggle.target_list(Script.current.vars)
-    target_info = Ewaggle.target_info(target_list)
-    echo target_list
+    # target_list = Ewaggle.target_list(Script.current.vars)
+    # target_info = Ewaggle.target_info(target_list)
+    # echo target_list
   end
 end
 
@@ -1034,7 +1034,6 @@ module Ewaggle
 
         unless disk
           dry_run[name] ||= Hash.new
-          existing_duration = "Indefinite"
           dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
         end
       end

--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -8,10 +8,12 @@
           game: gs
           tags: magic, utility, spell
       required: Lich >= 5.9.0
-       version: 2.1.4
+       version: 2.1.5
 
   Version Control:
     Major_change.feature_addition.bugfix
+  2.1.5 (2025-11-25)
+    - add disk casting support
   2.1.4 (2025-10-16)
     - bugfix in logic bad target/spell
   2.1.3 (2025-04-24)
@@ -89,10 +91,7 @@ waggle.lic prior release notes
 # fixme: option to cast high level spells first
 
 # Check version of Lich for compatibility
-lich_gem_requires = '5.9.0'
-
-require 'yaml'
-require 'terminal-table'
+lich_gem_requires = Script.list.find { |x| x.name == Script.current.name }.inspect[/required: Lich >= (\d+\.\d+\.\d+)/i, 1]
 
 if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
   if $frontend == 'stormfront' || $frontend == 'profanity'
@@ -114,6 +113,9 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
   end
   exit
 end
+
+require 'yaml'
+require 'terminal-table'
 
 # Data
 module Ewaggle
@@ -361,6 +363,7 @@ if defined?(Gtk)
 
         gtk_spells = []
         Spell.list.each { |spell| gtk_spells.push(spell) if (spell.known? && spell.time_per > 0 && spell.num.to_s =~ /(?:[1-4][0-9]|50|0[1-9])$/) }
+        gtk_spells.push(Spell[511]) if Spell[511].known?
         gtk_spells.sort_by!(&:num)
 
         # Rebuild the not to cast list
@@ -679,6 +682,7 @@ module Ewaggle
 
     gtk_spells = []
     Spell.list.each { |spell| gtk_spells.push(spell) if (spell.known? && spell.time_per > 0 && spell.num.to_s =~ /(?:[1-4][0-9]|50|0[1-9])$/) }
+    gtk_spells.push(Spell[511]) if Spell[511].known?
     gtk_spells.sort_by!(&:num)
 
     gtk_spells.each do |spell|
@@ -759,7 +763,9 @@ module Ewaggle
 
   def self.test
     echo "test"
-    echo Script.current.vars[2]
+    target_list = Ewaggle.target_list(Script.current.vars)
+    target_info = Ewaggle.target_info(target_list)
+    echo target_list
   end
 end
 
@@ -779,6 +785,7 @@ module Ewaggle
     bonus_list.push "#{'+' if spell.sorcerer_td > 0}#{spell.sorcerer_td} soTD" unless spell.sorcerer_td.zero?
     bonus_list.push "#{'+' if spell.strength.to_i > 0}#{spell.strength} str" unless spell.strength.to_i.zero?
     bonus_list.push "#{'+' if spell.dodging.to_i > 0}#{spell.dodging} dodge" unless spell.dodging.to_i.zero?
+    bonus_list.push 'Utility' if spell.num == 511
 
     # Armor buffs
     bonus_list.push 'Can prevent further wounds from magical attacks.' if spell.num == 9510
@@ -1016,6 +1023,23 @@ module Ewaggle
       end
     end
 
+    # Disk
+    Ewaggle.data.cast_list.each do |spell|
+      spell = Ewaggle.fix_spell(spell)
+      target_info.keys.each do |name|
+        next unless spell.num == 511
+
+        disk_nouns_regex = /\b(?:bassinet|cassone|chest|coffer|coffin|coffret|disk|hamper|saucer|sphere|trunk|tureen)\b/
+        disk = GameObj.loot.find { |l| l.name =~ /#{name} #{disk_nouns_regex}\b/ }
+
+        unless disk
+          dry_run[name] ||= Hash.new
+          existing_duration = "Indefinite"
+          dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
+        end
+      end
+    end
+
     dry_run.each do |name, hash|
       if hash.empty?
         respond
@@ -1034,8 +1058,12 @@ module Ewaggle
           total_casts += casts
           total_mana += casts * spell.mana_cost
 
-          spell_duration = (spell.time_per(target: name) * casts * 60).to_i
-          spell_time = "%d:%02d" % [spell_duration / 3600, (spell_duration % 3600) / 60]
+          if spell.num == 511
+            spell_time = "Indef"
+          else
+            spell_duration = (spell.time_per(target: name) * casts * 60).to_i
+            spell_time = "%d:%02d" % [spell_duration / 3600, (spell_duration % 3600) / 60]
+          end
 
           rows << ["#{spell.num} #{spell.name}", { value: casts, alignment: :right }, { value: spell.mana_cost * casts, alignment: :right }, { value: spell_time, alignment: :right }, Ewaggle.determine_bonus(spell)]
         end
@@ -1319,7 +1347,7 @@ module Ewaggle
   end
 
   def self.valid_spell?(spell)
-    unless (Spell[spell] && Spell[spell].known? && Spell[spell].time_per > 0) || (Spell[spell].name =~ /Armor/i && Spell[spell].name !~ /sonic|mage/i && Armor.known?(Spell[spell].name))
+    unless (Spell[spell] && Spell[spell].known? && Spell[spell].time_per > 0) || (Spell[spell].name =~ /Armor/i && Spell[spell].name !~ /sonic|mage/i && Armor.known?(Spell[spell].name) || (Spell[spell].num == 511 && Spell[spell].known?))
       respond
       if Spell[spell].known?
         Lich::Messaging.msg('plain', "#{Spell[spell].num} #{Spell[spell].name} is not a buff spell.")
@@ -1410,7 +1438,6 @@ module Ewaggle
 
         next if spell.stackable?(:target => target)
         next unless spell.available?(:target => target)
-
         next unless spell.time_per(:target => target) > Ewaggle.data.short_spell_time
         next if Ewaggle.data.skip_targets.include?(target) || Ewaggle.data.skip_spells.include?(spell.num)
         next if (target == Char.name) && (spell.circlename == 'Bard') and spell.active?
@@ -1469,7 +1496,6 @@ module Ewaggle
 
     def self.cast_stackable(target, info)
       Ewaggle.data.cast_list = Ewaggle.data.cast_list.sort_by { |n| n == 625 ? 0 : n }
-
       Ewaggle.data.cast_list.each do |spell|
         spell = Ewaggle.fix_spell(spell)
 
@@ -1518,6 +1544,24 @@ module Ewaggle
         if spell.num == 712 && target == Char.name && !Ewaggle.data.settings[:retribution_spell].empty?
           fput "chant retribution #{Ewaggle.data.settings[:retribution_spell]}"
         end
+      end
+    end
+
+    def self.cast_disk(target)
+      return unless Ewaggle.data.cast_list.include?(511)
+
+      spell = Ewaggle.fix_spell(511)
+
+      disk_nouns_regex = /\b(?:bassinet|cassone|chest|coffer|coffin|coffret|disk|hamper|saucer|sphere|trunk|tureen)\b/
+      disk = GameObj.loot.find { |l| l.name =~ /#{target} #{disk_nouns_regex}\b/ }
+
+      return if disk
+
+      cast_result = Casting.cast_spell(spell, target)
+      if cast_result == :bad_spell
+        Ewaggle.data.skip_spells.push(spell.num)
+      elsif cast_result == :bad_target
+        Ewaggle.data.skip_targets.push(target)
       end
     end
 
@@ -1740,10 +1784,12 @@ module Ewaggle
 
     target_list = Ewaggle.target_list(Script.current.vars)
     target_info = Ewaggle.target_info(target_list)
+
     target_info.each do |target, info|
       Casting.cast_stackable(target, info)
       Casting.cast_refreshable(target, info)
       Casting.cast_solid(target, info)
+      Casting.cast_disk(target)
     end
   end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds disk casting support for spell 511 in `ewaggle.lic`, updating version to 2.1.5 and modifying several functions to handle the new spell.
> 
>   - **Behavior**:
>     - Adds disk casting support for spell 511 in `ewaggle.lic`.
>     - Updates version to 2.1.5.
>   - **Functions**:
>     - Modifies `Ewaggle::Casting.cast_disk()` to handle disk casting logic.
>     - Updates `Ewaggle::Casting.cast_stackable()`, `cast_refreshable()`, and `cast_solid()` to include disk casting.
>     - Adds disk check in `Ewaggle.info()` and `Ewaggle.test()`.
>   - **Misc**:
>     - Moves `require 'yaml'` and `require 'terminal-table'` to after Lich version check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ebc002e22eea801ddcc0ba86b738ef3235533630. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->