### PR TITLE
fix(repository.lic): v2.68 Bugfix in author change array lookups

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.67
+       version: 2.68
 
   changelog:
+    2.68 (2025-11-26):
+      Bugfix in author change array lookups
     2.67 (2025-11-05):
       Remove showing Lich in show-updatable
       Show all current mapdb updatables for current game type DR/GS logged into
@@ -144,14 +146,16 @@ if (Settings['updatable'][:mapdb] == Hash.new)
 end
 
 Settings['updatable'][:mapdb]['GST'] = true if XMLData.game =~ /^GS/ && Settings['updatable'][:mapdb]['GST'].nil?
-if (s = Settings['updatable'][:scripts].find { |script_updatable| script_updatable[:filename] == 'gameobj-data.xml' && script_updatable[:author] == 'Tillmen' })
-  echo "updating ownership of #{s[:filename]} from Tillmen to elanthia-online"
-  s[:author] = 'elanthia-online'
+if (s = Settings['updatable'][:scripts].find_index { |script_updatable| script_updatable[:filename] == 'gameobj-data.xml' && script_updatable[:author] == 'Tillmen' })
+  echo "updating ownership of #{Settings['updatable'][:scripts][s][:filename]} from Tillmen to elanthia-online"
+  Settings['updatable'][:scripts][s][:author] = 'elanthia-online'
 end
-if (s = Settings['updatable'][:scripts].find { |script_updatable| script_updatable[:filename] =~ /^(?:repository|lnet|alias|vars|go2|autostart|log|logxml)\.lic$/ && script_updatable[:author] != 'elanthia-online' })
-  echo "updating ownership of #{s[:filename]} to elanthia-online"
-  s[:author] = 'elanthia-online'
-  s[:game] = 'gs'
+['repository.lic', 'lnet.lic', 'alias.lic', 'vars.lic', 'go2.lic', 'autostart.lic', 'log.lic', 'logxml.lic'].each do |script_name|
+  if (s = Settings['updatable'][:scripts].find_index { |script_updatable| script_updatable[:filename] == script_name && script_updatable[:author] != 'elanthia-online' })
+    echo "updating ownership of #{Settings['updatable'][:scripts][s][:filename]} to elanthia-online"
+    Settings['updatable'][:scripts][s][:author] = 'elanthia-online'
+    Settings['updatable'][:scripts][s][:game] = 'gs'
+  end
 end
 if XMLData.game =~ /^GS/ && (Gem::Version.new(LICH_VERSION) >= Gem::Version.new("5.7.0")) && !(Settings['updatable'][:scripts].any? { |script_updatable| script_updatable[:filename] == 'effect-list.xml' }) && (Settings['updatable'][:scripts].any? { |script_updatable| script_updatable[:filename] == 'spell-list.xml' })
   echo "adding effect-list.xml to updatable list as spell-list.xml no longer used by Lich 5.7+"
@@ -159,10 +163,10 @@ if XMLData.game =~ /^GS/ && (Gem::Version.new(LICH_VERSION) >= Gem::Version.new(
 end
 
 # Updating dependency.lic to be always updatable for DR instances
-if (s = Settings['updatable'][:scripts].find { |script_updatable| script_updatable[:filename] == 'dependency.lic' && script_updatable[:author] != 'elanthia-online' })
-  echo "updating ownership of #{s[:filename]} to elanthia-online"
-  s[:author] = 'elanthia-online'
-  s[:game] = 'dr'
+if (s = Settings['updatable'][:scripts].find_index { |script_updatable| script_updatable[:filename] == 'dependency.lic' && script_updatable[:author] != 'elanthia-online' })
+  echo "updating ownership of #{Settings['updatable'][:scripts][s][:filename]} to elanthia-online"
+  Settings['updatable'][:scripts][s][:author] = 'elanthia-online'
+  Settings['updatable'][:scripts][s][:game] = 'dr'
 end
 if XMLData.game =~ /^DR/ && !(Settings['updatable'][:scripts].any? { |script_updatable| script_updatable[:filename] == 'dependency.lic' })
   echo "adding dependency.lic to updatable list"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `repository.lic` by replacing `find` with `find_index` for author change array lookups, ensuring correct index handling for script ownership updates.
> 
>   - **Bugfix**:
>     - Replace `find` with `find_index` for author change array lookups in `repository.lic`.
>     - Affects ownership updates for `gameobj-data.xml`, `repository.lic`, `lnet.lic`, and 7 other scripts.
>     - Ensures correct index handling when updating script authors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 45a52bf57562e5128d48e4f4e902db5158c45a7c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->