### PR TITLE
fix(ecleanse.lic): v2.2.7 ME globe/rift non-targetable

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.12.10
-       version: 2.2.6
+       version: 2.2.7
 
   Improvements:
+  v2.2.7  (2025-11-29)
+    - bugfix for silvery blue globe not being targetable
   v2.2.6  (2025-11-11)
     - bugfix in weapon recovery with two-weapon combat
     - bugfix in weapon recovery to fill hands after emptying
@@ -692,10 +694,12 @@ module Ecleanse
       return unless globe_dispel_ready || spell_cleave_ready || spell_thieve_ready
 
       # Return unless able to target object
-      result = dothistimeout("target ##{Ecleanse.data.globe.id}", 2, Ecleanse.data.target_regex)
-      unless result.is_a?(String) && result =~ /^Suspecting that .+ is the origin of .+, you turn your attention towards \w+!$/
-        Ecleanse.data.bad_targets << Ecleanse.data.globe.id
-        return
+      unless Ecleanse.data.globe.name =~ /silvery blue globe|spiraling ghostly rift/
+        result = dothistimeout("target ##{Ecleanse.data.globe.id}", 2, Ecleanse.data.target_regex)
+        unless result.is_a?(String) && result =~ /^Suspecting that .+ is the origin of .+, you turn your attention towards \w+!$/
+          Ecleanse.data.bad_targets << Ecleanse.data.globe.id
+          return
+        end
       end
 
       System.scripts_pause
@@ -764,7 +768,7 @@ module Ecleanse
       spell_cleave_ready = CMan.known?("Spell Cleave") && Char.stamina >= 10
       spell_thieve_ready = CMan.known?("Spell Thieve") && Char.stamina >= 10
 
-      # Return unless able to perform an action to remove globes
+      # Return unless able to perform an action to remove clouds
       return unless cloud_dispel_ready || spell_cleave_ready || spell_thieve_ready
 
       # Return unless able to target object


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix targeting issue for 'silvery blue globe' and 'spiraling ghostly rift' in `ecleanse.lic` and update version to 2.2.7.
> 
>   - **Bug Fix**:
>     - Fix targeting issue for 'silvery blue globe' and 'spiraling ghostly rift' in `avoid_globe()` function in `ecleanse.lic`.
>     - Update version to 2.2.7 in `ecleanse.lic` to reflect the bug fix.
>   - **Misc**:
>     - Update comments in `ecleanse.lic` to reflect changes from 'globes' to 'clouds'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 605e357a061dbb64df3ba46022fc62d18a913d44. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->