### PR TITLE
fix(eloot) v2.6.3 debug update and child skin bugfix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -21,6 +21,7 @@
   v2.6.3  (2025-12-2)
     - bugfix trying to skin/loot failed bounty children npcs
     - update debug messaging
+    - bugfix in blood band/bracer settings
   v2.6.2  (2025-11-21)
     - force looting of bounty heirloom items if found
   v2.6.1  (2025-11-11)
@@ -1938,7 +1939,7 @@ module ELoot # Sets Inventory
       break if bracer && ELoot.data.blood_band
     end
 
-    ELoot.data.settings[:use_bloodbands] = (bracer && ELoot.data.blood_band)
+    ELoot.data.settings[:use_bloodbands] = (bracer && ELoot.data.blood_band.is_a?(GameObj))
   end
 
   def self.find_coin_containers


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes child NPC handling in skinning/looting and updates debug messaging in `eloot.lic`.
> 
>   - **Bug Fixes**:
>     - Skip child NPCs during skinning/looting in `loot_regular()` and `skin()`.
>   - **Debug Messaging**:
>     - Simplified debug messages by removing caller information in `msg()`.
>     - Added parameter-specific information to debug messages in various methods like `get_command()`, `find_boxes()`, and `loot_regular()`.
>   - **Misc**:
>     - Updated version to 2.6.3 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 37d65048fc1d3837945a9cc9aa9fd4315ad63139. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->