### PR TITLE
fix(jinx.lic): v0.7.3 force require Pathname gem

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -13,9 +13,12 @@
 
    author: elanthia-online
      tags: utility, util, repository, repo, update, upgrade, meta, ruby, development
-  version: 0.7.2
+  version: 0.7.3
 
   Changelog:
+  0.7.3 (2025-12-14)
+    require pathname gem explicitly incase not loaded as part of Ruby std library
+
   0.7.2 (2025-12-05)
     prevent script running when load called on file
     add new GS/DR mapdb-backup repositories
@@ -61,6 +64,7 @@ require 'net/https'
 require 'net/http'
 require 'open-uri'
 require 'cgi'
+require 'pathname'
 
 module ::Lich
   module Common


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Explicitly require `pathname` gem in `scripts/jinx.lic` to ensure it is loaded, updating version to `0.7.3`.
> 
>   - **Behavior**:
>     - Explicitly require `pathname` gem in `scripts/jinx.lic` to ensure it is loaded, even if not part of Ruby's standard library.
>   - **Versioning**:
>     - Update version to `0.7.3` in `scripts/jinx.lic`.
>     - Add changelog entry for version `0.7.3` in `scripts/jinx.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 599d69b32edd8d1dc48ce2975b87083619db151c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->