### PR TITLE
feat(creaturebar): v1.1 - alt+drag window and tracker warning

### DIFF
--- a/scripts/creaturebar.lic
+++ b/scripts/creaturebar.lic
@@ -5,10 +5,13 @@
   contributors: Nisugi
           game: Gemstone
           tags: hunting, combat, creatures
-       version: 1.0
+       version: 1.1
       required: Lich >= 5.13.0
 
   Change Log:
+  v1.1 (2025/12/21)
+    - Alt + drag to move window around
+    - Warning if combat tracking disabled
   v1.0 (2025/11/30)
     - Shows current target (XMLData.current_target_id)
     - Visual injury doll with wound overlays
@@ -909,10 +912,14 @@ module CreatureBar
 
       menu.show_all
 
-      # Right-click to show menu
+      # Right-click to show menu, Alt+left-click to move window
       @@window.add_events(Gdk::EventMask::BUTTON_PRESS_MASK)
       @@window.signal_connect('button-press-event') do |_, event|
-        if event.button == 3
+        if event.button == 1 && (event.state & Gdk::ModifierType::MOD1_MASK) != 0
+          # Alt+left-click: begin window drag
+          @@window.begin_move_drag(event.button, event.x_root.to_i, event.y_root.to_i, event.time)
+          true
+        elsif event.button == 3
           menu.popup_at_pointer(event)
           true
         else
@@ -3033,6 +3040,15 @@ if Script.current.name.downcase == 'creaturebar'
   unless defined?(Creature)
     echo "Error: Creature module not found. Make sure creature.rb is loaded."
     exit
+  end
+
+  # Check if Combat::Tracker is enabled (required for wound/HP/status tracking)
+  if defined?(Combat::Tracker) && !Combat::Tracker.enabled?
+    respond ""
+    respond "[CreatureBar] Warning: Combat::Tracker is not enabled."
+    respond "  Wounds, HP, and status effects will not update."
+    respond "  To enable: ;e Combat::Tracker.enable!"
+    respond ""
   end
 
   # Handle help command


### PR DESCRIPTION
- Alt+left-click to drag/move the CreatureBar window
- Show warning on startup if Combat::Tracker is not enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Alt+left-click window dragging and startup warning for disabled `Combat::Tracker` in `CreatureBar`.
> 
>   - **Behavior**:
>     - Alt+left-click to drag/move the `CreatureBar` window in `scripts/creaturebar.lic`.
>     - Display warning on startup if `Combat::Tracker` is not enabled, affecting wound, HP, and status tracking.
>   - **Version**:
>     - Update version to 1.1 in `scripts/creaturebar.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 5aaacfbc5a627a4792fc622b3296b19a4aa7b200. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->