### PR TITLE
fix(ebounty) v1.8.1 add option to regroup if started grouped

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -598,7 +598,7 @@ module EBounty
   end
 
   def self.regroup
-    return if EBounty.data.settings[:leader] == :self
+    return if EBounty.data.settings[:leader].to_s.empty? || EBounty.data.settings[:leader] == "Self"
     return unless checkpcs.include?(EBounty.data.settings[:leader])
     return if Lich::Gemstone::Group.leader.to_s == EBounty.data.settings[:leader]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds regrouping feature to `ebounty.lic` allowing users to rejoin their group leader before quitting if started in a group.
> 
>   - **Behavior**:
>     - Adds `regroup` function in `ebounty.lic` to rejoin group leader before quitting if `return_to_group` is enabled.
>     - Updates `before_dying` block to call `regroup` and return to start room if `basic` is set.
>     - Sets `leader` setting to current group leader if `return_to_group` is enabled.
>   - **Settings**:
>     - Adds `return_to_group` setting to `EBounty.data.settings` with default `false`.
>     - Adds `leader` to `EBounty.data` to track group leader.
>   - **Version**:
>     - Updates version to 1.8.1 in `ebounty.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 082ffbbe9c8f0bea4728217a6a2addd2b8dc25e7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->