### PR TITLE
fix(familiar.lic) - updates to check if 920 is known and script syntax modernization

### DIFF
--- a/scripts/familiar.lic
+++ b/scripts/familiar.lic
@@ -17,25 +17,25 @@
     Contributors: Tysong, Dissonance
       name: familiar
       tags: familiar, 920, wizard
-  version: 1.4.6
+  version: 1.46.0
 
   changelog:
-    1.4.6 (2025-12-28)
+    1.46.0 (2025-12-28)
       Added check that 920 is known before attempting to cast to prevent infinite error loop.
       Fixed header format and version formatting.
       Updated to more current scripting standards.
       removed hide_me, no reason to hide script
-    1.4.5 (2024-05-06)
+    1.45 (2024-05-06)
       Add support for ewaggle
       Change checkmana to Char.mana call
-    1.4.4 (2023-06-05)
+    1.44 (2023-06-05)
       Fix for Lich 5.7.0 infomon update
       rubocop cleanup
-    1.4.3 (2022-03-09)
+    1.43 (2022-03-09)
       change to use Effects
-    1.4.2 (2018-10-07)
+    1.42 (2018-10-07)
       fixed bug in checkmana being 5 instead of 20
-    1.4.1 (2018-10-05)
+    1.41 (2018-10-05)
       fixed bug in logic of --allowmove being backwards
     1.4 (2018-08-20)
       Added additional interference detection


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updates `familiar.lic` to check if spell 920 is known before casting, modernizes script syntax, and updates documentation.
> 
>   - **Behavior**:
>     - Added check in `familiar.lic` to ensure spell 920 is known before casting, preventing infinite error loop.
>     - Removed `hide_me` as it was unnecessary.
>   - **Syntax Modernization**:
>     - Updated script syntax for better readability and adherence to current standards.
>     - Replaced `echo` with `Lich::Messaging.msg` for consistent messaging.
>   - **Documentation**:
>     - Updated version to 1.46.0 and changelog to reflect changes.
>     - Fixed header format and version formatting in `familiar.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 373ddacfc7304b47271a787085b3b3a26f930043. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->