### PR TITLE
fix(ecleanse) v2.2.8 convert stunman to CMan.use

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.12.10
-       version: 2.2.7
+       version: 2.2.8
 
   Improvements:
+  v2.2.8  (2026-01-03)
+    - convert stunmaneuvers to CMan.use
   v2.2.7  (2025-11-29)
     - bugfix for silvery blue globe not being targetable
   v2.2.6  (2025-11-11)
@@ -1180,24 +1182,37 @@ module Ecleanse
     end
 
     def self.remove_stun
-      Action.mana_pulse(1040) if Spell[1040].known? && Ecleanse.data.settings[:use_stunned1040]
+      stunned1040 = barkskin = beseech_1635 = berserk = stance1 = stance2 = flee = hide = false
       not_escape_rooms = checkroom("The Belly of the Beast").nil? && checkroom("Ooze, Innards").nil?
 
-      barkskin = Ecleanse.data.settings[:use_stunned_barkskin] && Spell[605].known? && !Effects::Cooldowns.active?("Barkskin: Commune") && !Effects::Cooldowns.active?("Barkskin") && !Spell[605].active? && Skills.slblessings >= 15
-      berserk = Ecleanse.data.settings[:use_berserk_stunned] && CMan.known?("Berserk") && Char.stamina >= 21 && not_escape_rooms
-      stunned1040 = Ecleanse.data.settings[:use_stunned1040] && Spell[1040].known? && Spell[1040].affordable?
-      stance1 = Ecleanse.data.settings[:use_stance1] && CMan.known?("Stun Maneuvers") && CMan.stun_maneuvers > 2 && Char.stamina >= 10 && not_escape_rooms
-      stance2 = Ecleanse.data.settings[:use_stance2] && CMan.known?("Stun Maneuvers") && CMan.stun_maneuvers > 3 && Char.stamina >= 10 && not_escape_rooms
-      flee = Ecleanse.data.settings[:use_flee] && CMan.known?("Stun Maneuvers") && CMan.stun_maneuvers > 4 && Char.stamina >= 10 && not_escape_rooms
-      hide = Ecleanse.data.settings[:use_hide] && CMan.known?("Stun Maneuvers") && CMan.stun_maneuvers > 4 && Char.stamina >= 10 && not_escape_rooms && !checkhidden
-      beseech_1635 = Ecleanse.data.settings[:use_1635] && Spell[1635].known? && Spell[1635].affordable?
+      if Ecleanse.data.settings[:use_stunned1040] && Spell[1040].known?
+        Action.mana_pulse(1040)
+        stunned1040 = Spell[1040].available?
+      end
+
+      if Ecleanse.data.settings[:use_stunned_barkskin] && Spell[605].known? && !Effects::Cooldowns.active?("Barkskin: Commune") && !Effects::Cooldowns.active?("Barkskin") && !Spell[605].active? && Skills.slblessings >= 15
+        Action.mana_pulse(605)
+        barkskin = Spell[605].available?
+      end
+
+      if Ecleanse.data.settings[:use_1635] && Spell[1635].known?
+        Action.mana_pulse(1635)
+        beseech_1635 = Spell[1635].available?
+      end
+
+      if not_escape_rooms
+        berserk = Ecleanse.data.settings[:use_berserk_stunned] && CMan.available?("Berserk")
+        stance1 = Ecleanse.data.settings[:use_stance1] && CMan.available?("Stun Maneuvers", min_rank: 3)
+        stance2 = Ecleanse.data.settings[:use_stance2] && CMan.available?("Stun Maneuvers", min_rank: 4)
+        flee = Ecleanse.data.settings[:use_flee] && CMan.available?("Stun Maneuvers", min_rank: 5)
+        hide = Ecleanse.data.settings[:use_hide] && CMan.available?("Stun Maneuvers", min_rank: 5) && !checkhidden
+      end
 
       return unless barkskin || berserk || stunned1040 || stance1 || stance2 || flee || hide || beseech_1635
 
       System.scripts_pause
 
       if barkskin
-        Action.mana_pulse(605)
         Util.wait_rt
         fput "commune barkskin" if stunned?
         sleep 0.1 until !checkstunned
@@ -1296,20 +1311,20 @@ module Ecleanse
       Action.stunman_stand
 
       case type
-      when 'stance1'
-        fput 'stunman stance1'
-      when 'stance2'
-        fput 'stunman stance2'
+      when 'stance1', 'stance2'
+        CMan.use('stunman', type)
       when 'flee'
         current_room = Room.current.id
         until Room.current.id != current_room || !checkstunned
           Action.stunman_stand
-          fput "stunman flee"
+          CMan.use('stunman', 'flee')
           sleep 0.5
         end
+        CMan.use('stunman', 'stance2')
       when 'hide'
         until checkhidden || !checkstunned
-          fput "stunman hide"
+          Action.stunman_stand
+          CMan.use('stunman', 'hide')
           Util.wait_rt
         end
       end
@@ -1319,7 +1334,7 @@ module Ecleanse
 
     def self.stunman_stand
       until standing? || !checkstunned
-        put "stunman stand"
+        CMan.use('stunman', 'stand')
         Util.wait_rt
       end
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `stunmaneuvers` to `CMan.use` in `ecleanse.lic`, updating stun handling and version to 2.2.8.
> 
>   - **Behavior**:
>     - Convert `stunmaneuvers` to `CMan.use` in `remove_stun` and `stunman_perform` methods.
>     - Update version to 2.2.8 in `ecleanse.lic`.
>   - **Functions**:
>     - Replace `fput` with `CMan.use` for `stance1`, `stance2`, `flee`, and `hide` in `stunman_perform`.
>     - Use `CMan.available?` to check for `Stun Maneuvers` in `remove_stun`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for a5a08931cf14cd77868a2dba6e4b3d1f8c5e38a0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->