### PR TITLE
fix(bigshot.lic) Clean up UTF-8 characters

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8136,4 +8136,3 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
     end
   end
 end
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clean up UTF-8 characters in `bigshot.lic` by adjusting whitespace at the end of the file.
> 
>   - **Misc**:
>     - Clean up UTF-8 characters in `bigshot.lic` by adjusting whitespace at the end of the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ff999bd8b03e7e6663334051e0b2df1c54ca5379. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->