### PR TITLE
feat(ebounty.lic) v1.9.0 add support for ranger track

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,11 +10,11 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.8.2
+       version: 1.9.0
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v1.8.2 (2025-01-08)
+  v1.9.0 (2025-01-08)
     - added support for ranger track
   v1.8.1 (2025-12-24)
     - added option to regroup before quiting if started in group


### PR DESCRIPTION
Added checkbox in misc section to launch bigshot with the bounty target to utilize ranger track.
Locked behind profession check.
<img width="344" height="235" alt="image" src="https://github.com/user-attachments/assets/dbe279e2-9138-4d77-8dcc-253d7da99ae1" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds ranger track support to `ebounty.lic`, enabling `bigshot` to launch with bounty target when ranger track is enabled.
> 
>   - **Behavior**:
>     - Adds `ranger_track` checkbox in the Misc section of the UI to enable ranger track feature.
>     - Modifies `go_hunting` in `EBounty` to launch `bigshot` with bounty target if `ranger_track` is enabled.
>   - **Settings**:
>     - Adds `ranger_track` to default settings in `EBounty`.
>     - Disables `ranger_track` checkbox if the character is not a ranger.
>   - **Version**:
>     - Updates version to 1.8.2 in `ebounty.lic` to reflect new feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 20f831f2b25e6bed5953802df6a856cdb40c7730. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->