### PR TITLE
fix(bigshot.lic): v5.11.2 update find_valid_neighbors to include time…

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.11.1
+       version: 5.11.2
       required: Lich >= 5.12.6
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.11.2  (2026-01-09)
+    - optimize get_valid_neighbors to eval timeto as being valid numerics
   v5.11.1  (2026-01-09)
     - bugfix in sort_npcs
   v5.11.0  (2025-11-29)
@@ -568,7 +570,19 @@ class Bigshot
       room = Room[room_id]
       return Set[] unless room
 
-      room.wayto.keys.map(&:to_i).to_set - @boundaries
+      valid_neighbors = room.wayto.keys.map(&:to_i).to_set - @boundaries
+
+      # Keep only rooms with valid numeric travel times
+      valid_neighbors.select do |neighbor_id|
+        time_value = room.timeto[neighbor_id.to_s]
+
+        if time_value.is_a?(StringProc)
+          evaluated = time_value.call
+          evaluated.is_a?(Numeric)
+        else
+          time_value.is_a?(Numeric)
+        end
+      end.to_set
     end
 
     def build


### PR DESCRIPTION
…to eval
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `get_valid_neighbors` in `bigshot.lic` to filter rooms with valid numeric travel times, updating version to 5.11.2.
> 
>   - **Behavior**:
>     - Update `get_valid_neighbors` in `Bigshot` class to filter rooms with valid numeric travel times.
>     - Evaluates `time_value` using `StringProc` if applicable, ensuring it returns a `Numeric`.
>   - **Versioning**:
>     - Update version to 5.11.2 in `bigshot.lic`.
>     - Document change in version control section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for f356919cbbf3cf86ac756e578b37e498c56a41ae. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->