### PR TITLE
fix(bigshot) v5.11.2 eval timeto when creating boundaries

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.11.1
+       version: 5.11.2
       required: Lich >= 5.12.6
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v5.22.2  (2026-01-10)
+    - add timeto check for boundaries
   v5.11.1  (2026-01-09)
     - bugfix in sort_npcs
   v5.11.0  (2025-11-29)
@@ -568,7 +570,19 @@ class Bigshot
       room = Room[room_id]
       return Set[] unless room
 
-      room.wayto.keys.map(&:to_i).to_set - @boundaries
+      valid_neighbors = room.wayto.keys.map(&:to_i).to_set - @boundaries
+
+      # Keep only rooms with valid numeric travel times
+      valid_neighbors.select do |neighbor_id|
+        time_value = room.timeto[neighbor_id.to_s]
+
+        if time_value.is_a?(StringProc)
+          evaluated = time_value.call
+          evaluated.is_a?(Numeric)
+        else
+          time_value.is_a?(Numeric)
+        end
+      end.to_set
     end
 
     def build
@@ -6631,11 +6645,11 @@ class Bigshot
     GameObj.targets.each do |creature|
       next unless creature.type.include?("boon")
 
-      # Convert adjectives -> trait names
+      # Convert adjectives to trait names
       abilities = check_boons(creature)
       next unless abilities
 
-      # If any ability appears in your flee list -> flee
+      # If any ability appears in your flee list then flee
       return true if (abilities & @BOONS_FLEE).any?
     end
 
@@ -8051,7 +8065,7 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
           # Make sure follower is joined
           bs.group_all_followers
 
-          # Sync to leader's target if available, or find one
+          # Sync to leader's target if available or find one
           leader_tgt = group.leader_target
           unless leader_tgt.nil? || leader_tgt.status =~ /dead|gone/
             target = leader_tgt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check for valid numeric travel times in `Bigshot` class when creating boundaries, ensuring only valid rooms are considered.
> 
>   - **Behavior**:
>     - Add check for valid numeric travel times in `Bigshot` class when creating boundaries.
>     - Only rooms with valid numeric travel times are considered as valid neighbors.
>   - **Misc**:
>     - Update version to 5.11.2 in `bigshot.lic`.
>     - Improve comments for clarity in `Bigshot` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c299e4adaa2e03d66bdf4643118898567a63bdec. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->