### PR TITLE
fix(signore.lic): Disabled Settings.save deprecated command

### DIFF
--- a/scripts/signore.lic
+++ b/scripts/signore.lic
@@ -183,13 +183,13 @@ module Signore
       list = Settings[:antimagic_rooms]
       list.push num
       Settings[:antimagic_rooms] = list
-      Settings.save DEPRECATED and to be removed in 0.8.3 update
+      # Settings.save DEPRECATED and to be removed in 0.8.3 update
     end
   end
 
   def self.reset_anti_magic_rooms!
     Settings[:antimagic_rooms] = []
-    Settings.save DEPRECATED and to be removed in 0.8.3 update
+    # Settings.save DEPRECATED and to be removed in 0.8.3 update
   end
 
   def self.berserk_timeout!


### PR DESCRIPTION
Updated contributors and version in signore.lic. Marked Settings.save as deprecated.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Commented out deprecated `Settings.save` in `signore.lic` and updated version and contributors.
> 
>   - **Deprecation**:
>     - Commented out `Settings.save` in `Signore.save`, `Signore.add_anti_magic_room`, `Signore.reset_anti_magic_rooms!`, and `room:rm` section.
>     - Added comment indicating `Settings.save` will be removed in version 0.8.3.
>   - **Metadata**:
>     - Updated version to `0.8.2`.
>     - Added `EO` to contributors list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 0c417f40b996fce955389dbb8421f4ca4bb07874. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->