### PR TITLE
fix(gameobj_data.xml): add new loot treasure box descriptors

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,8 +1,8 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add migration script `66_loot_box_changes.rb` to define new loot box descriptors and update exclusions.
> 
>   - **Migration Script**:
>     - Adds `66_loot_box_changes.rb` to define new loot box descriptors.
>     - Creates a new key `:name` for `:box` with specific descriptors.
>     - Updates `:uncommon` to exclude specific loot box descriptors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 401002ccf5f09514bacb3b421c4b91a182ea7b92. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->