### PR TITLE
fix(gameobj_data.xml): space correction in 66_loot_box_changes.rb

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,8 +1,8 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{(?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes space placement in regex pattern in `66_loot_box_changes.rb` for accurate matching in `migrate :box` and `migrate :uncommon`.
> 
>   - **Behavior**:
>     - Corrects space placement in regex pattern in `66_loot_box_changes.rb` for `insert(:name, ...)` and `insert(:exclude, ...)`.
>     - Ensures space is inside non-capturing group for accurate pattern matching.
>   - **Functions**:
>     - Affects `migrate :box` and `migrate :uncommon` blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c1db6ca75a8ba8ef49ab7dd8435e6cfe2986d9a6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->