### PR TITLE
fix(gameobj_data.xml): additional box updates

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,8 +1,8 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|maoral|cooper|wooden|cedar|maple|steel|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update regex patterns in `66_loot_box_changes.rb` to include new adjectives and materials for loot boxes.
> 
>   - **Regex Pattern Updates**:
>     - Added `engraved` and `simple` to adjectives in `:box` and `:uncommon` migrations in `66_loot_box_changes.rb`.
>     - Added `mithril` and `haon` to materials in `:box` and `:uncommon` migrations in `66_loot_box_changes.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for b7a566b36c64ef00b30afa0422dce5ad8edaffa7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->