### PR TITLE
fix(gameobj_data.xml): add weathered to box adjectives

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,8 +1,8 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|waterlogged|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'weathered' to box adjectives in `66_loot_box_changes.rb`, affecting both `:box` and `:uncommon` migrations.
> 
>   - **Behavior**:
>     - Adds 'weathered' to the list of adjectives for boxes in `66_loot_box_changes.rb`.
>     - Affects both `:box` and `:uncommon` migrations, allowing 'weathered' boxes to be recognized and excluded appropriately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9059206d9ebe9a99c7bcc4a241c6628dc190a266. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->