### PR TITLE
fix(gameobj-data.xml): add more adjectives for boxes

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -6,3 +6,7 @@ end
 migrate :uncommon do
   insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|waterlogged|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|iron-bound|rusted|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
+
+migrate :valuable, :gemshop do
+  insert(:name, %{bright gold ingot})
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new adjectives and materials for loot boxes and a new item to gemshop in `66_loot_box_changes.rb`.
> 
>   - **Migration Changes in `66_loot_box_changes.rb`:**
>     - Added adjectives `badly damaged`, `corroded` to `:box` and `:uncommon` migrations.
>     - Added materials `iron-bound`, `rusted` to `:box` and `:uncommon` migrations.
>     - Added `bright gold ingot` to `:valuable, :gemshop` migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for e374986ff491439a0a9af1a45e4ab538a41e4c55. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->