### PR TITLE
fix(gameobj-data.xml): fix box material to adjective

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,10 +1,10 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|waterlogged|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|iron-bound|rusted|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|waterlogged|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|iron-bound|rusted|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :valuable, :gemshop do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes regex in `66_loot_box_changes.rb` to categorize 'iron-bound' and 'rusted' as adjectives in box names.
> 
>   - **Behavior**:
>     - Adjusts regex in `66_loot_box_changes.rb` for `:box` and `:uncommon` to categorize 'iron-bound' and 'rusted' as adjectives.
>   - **Migrations**:
>     - Updates `:box` migration to reflect changes in box name pattern.
>     - Updates `:uncommon` migration to reflect changes in exclusion pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 3efaa22194635a81d1e22cefb96dd5271db7508d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->