### PR TITLE
fix(repository.lic): v2.70 check for proper version format

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -365,7 +365,7 @@ module RepositoryTillmen
             begin
               needed_version = Gem::Version.new(version)
             rescue StandardError
-              needed_version = version.to_i
+              needed_version = version.split('.').collect { |num| num.rjust(5, '0') }.join('.')
             end
 
             case op


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes version format check in `repository.lic` to handle `Gem::Version` format with error handling, updates version to 2.70.
> 
>   - **Behavior**:
>     - Fixes version format check in `repository.lic` to handle `Gem::Version` format with optional 'v' prefix and additional suffixes.
>     - Adds error handling for invalid version formats in `check_lich_requirement()` and `sort_versions()`.
>   - **Versioning**:
>     - Updates version to 2.70 in `repository.lic`.
>     - Adds changelog entry for version 2.70 noting the fix for version format check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c34591b40ff9b4495760e392b9bd5a52483b3794. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->