### PR TITLE
fix(eloot)v2.6.6 bugfix for pool withdraw and f2p restriction

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.6.5
+           version: 2.6.6
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.6.6  (2026-01-17)
+    - bugfix for bank withdraw
+    - disable f2p locksmith pool
   v2.6.5  (2026-01-16)
     - update for new loot commands in locksmith pool
   v2.6.4  (2026-01-12)
@@ -6171,6 +6174,8 @@ module ELoot # Sells the loot
     end
 
     def self.locksmith_pool(boxes, deposit = false)
+      return if ELoot.f2p?
+
       # are we starting with a box in hand?
       box_in_hand = [GameObj.right_hand, GameObj.left_hand].any? { |hand| hand&.type =~ /box/ }
 
@@ -6189,7 +6194,7 @@ module ELoot # Sells the loot
       ELoot.data.disk_full = false
 
       if boxes.length.positive? && ELoot.data.settings[:use_standard_tipping]
-        amount = ELoot.data.settings[:sell_locksmith_pool_tip_percent] ? ELoot.data.settings[:locksmith_withdraw_amount] : boxes.length * ELoot.data.settings[:sell_locksmith_pool_tip].to_i
+        amount = ELoot.data.settings[:locksmith_withdraw_amount]
         ELoot.silver_withdraw(amount)
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bank withdrawal bug and disables locksmith pool for f2p users in `eloot.lic`.
> 
>   - **Behavior**:
>     - Fixes bank withdrawal bug in `locksmith_pool` by using `locksmith_withdraw_amount` directly.
>     - Disables locksmith pool for f2p users by adding `return if ELoot.f2p?` in `locksmith_pool`.
>   - **Version**:
>     - Updates version to 2.6.6 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2797dd4c238bc2fcd0969779c3c5d6e8b8046934. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->