### PR TITLE
fix(gameobj-data.xml): add additional box adjective 66_loot_box_chang…

### DIFF
--- a/type_data/migrations/66_loot_box_changes.rb
+++ b/type_data/migrations/66_loot_box_changes.rb
@@ -1,10 +1,10 @@
 migrate :box do
   create_key(:name)
-  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:name, %{((?:gold-trimmed|copper-(?:edged|trimmed)|acid-pitted|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :uncommon do
-  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
+  insert(:exclude, %{((?:gold-trimmed|copper-(?:edged|trimmed)|acid-pitted|rune-incised|badly damaged|corroded|iron-bound|waterlogged|rusted|weathered|engraved|simple|blackened|lacquered|scratched|battered|riveted|enruned|charred|painted|rotting|scuffed|jeweled|scarred|ornate|singed|fluted|banded|sturdy|plain) )?(?:cherrywood|white oak|mahogany|hickory|bronze|modwir|walnut|silver|mithril|maoral|cooper|wooden|cedar|maple|steel|haon|thanot|monir|tanik|brass|iron|gold|fel) (?:strongbox|coffer|chest|trunk|box)})
 end
 
 migrate :valuable, :gemshop do


### PR DESCRIPTION
…es.rb
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'acid-pitted' adjective to box names in `66_loot_box_changes.rb` for `:box` and `:uncommon` migrations.
> 
>   - **Behavior**:
>     - Adds 'acid-pitted' adjective to box names in `66_loot_box_changes.rb` for `:box` and `:uncommon` migrations.
>     - Ensures boxes with 'acid-pitted' are recognized in both `:box` and `:uncommon` contexts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for b2cf98de253029b230d23a879ab37e90992d4a4a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->