### PR TITLE
fix(eloot.lic): v2.6.7 silver breakdown nil resolution

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.6.6
+           version: 2.6.7
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.6.7  (2026-01-18)
+    - bugfix in silver breakdown
   v2.6.6  (2026-01-17)
     - bugfix for bank withdraw
     - disable f2p locksmith pool
@@ -297,7 +299,7 @@ module ELoot # Data
 
       # Misc
       @account_type = nil
-      @silver_breakdown = {}
+      @silver_breakdown = Hash.new(0)
       @inv_save = true
 
       $sell_ignore = []
@@ -5094,6 +5096,7 @@ module ELoot # Sells the loot
             begin
               total_silver += amount
             rescue
+              echo "ELoot: #{ELoot.data.version}"
               echo "location: #{location.inspect}"
               echo "amount: #{amount.inspect}"
               echo "index: #{index.inspect}"
@@ -6712,7 +6715,7 @@ module ELoot # Starts the script
   end
 
   $sell_ignore ||= Array.new
-  ELoot.data.silver_breakdown = Hash.new
+  ELoot.data.silver_breakdown = Hash.new(0)
 
   case Script.current.vars[0]
   when /debug/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix nil error in silver breakdown by initializing with `Hash.new(0)` in `eloot.lic`.
> 
>   - **Bug Fix**:
>     - Initialize `@silver_breakdown` with `Hash.new(0)` in `eloot.lic` to prevent nil errors.
>     - Update `ELoot.data.silver_breakdown` to `Hash.new(0)` to ensure default values.
>   - **Logging**:
>     - Add version logging in error handling block in `eloot.lic`.
>   - **Version Update**:
>     - Update version to 2.6.7 in `eloot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 9d67a3ca02b5c4b7ad467573988f75fbbbb34f53. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->