### PR TITLE
fix(ebounty)v1.9.1 bugfix for gem tracking script

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -15,7 +15,7 @@
   Version Control:
   Major_change.feature_addition.bugfix
   v1.9.1 (2025-01-18)
-    - bugfix for running gem tracking script 
+    - bugfix for running gem tracking script
   v1.9.0 (2025-01-08)
     - added support for ranger track
   v1.8.1 (2025-12-24)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `ebounty.lic` by moving gem history script execution to `gem_ask`, ensuring it runs during gem assignment requests.
> 
>   - **Behavior**:
>     - Fixes bug in `ebounty.lic` by moving gem history script execution from `check_removal` to `gem_ask`.
>     - Ensures gem history script runs when asking for gem assignment, not when gem is excluded.
>   - **Version**:
>     - Updates version to 1.9.1 in `ebounty.lic` for bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 91ccd3ae5ed04aaaf26553c33f61c14b262e31fb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->