### PR TITLE
fix(keymaster.lic): add delay and checks during unlocking

### DIFF
--- a/scripts/keymaster.lic
+++ b/scripts/keymaster.lic
@@ -286,9 +286,8 @@ module KeyMaster
       if [GameObj.right_hand.noun, GameObj.left_hand.noun].include?("bauble")
         fput("break my bauble")
         fput("break my bauble")
-
         sleep(0.5) until ![GameObj.right_hand.noun, GameObj.left_hand.noun].include?("bauble")
-        # Collect rewards and track by tier
+
         # Collect rewards and track by tier
         if GameObj.left_hand.id
           @rewards.push(GameObj.left_hand)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add delay and checks in `unlock_pair` function of `keymaster.lic` to ensure proper handling of baubles during unlocking.
> 
>   - **Behavior**:
>     - In `unlock_pair` function, replace `fput("open my lock")` with `dothistimeout("open my lock", 3, /^You slowly insert /)` to add a timeout and check for successful lock opening.
>     - Add `sleep(0.5)` loop to wait until a bauble is in hand before breaking it, ensuring the script only proceeds when ready.
>     - Add `sleep(0.5)` loop to wait until baubles are no longer in hand after breaking, ensuring the script only proceeds when baubles are removed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 55e1649acb003e045e4ae0720b0ca6b1868dae8a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->