### PR TITLE
feat(tags.lic): v1.7.0 add splashy option

### DIFF
--- a/scripts/tags.lic
+++ b/scripts/tags.lic
@@ -33,11 +33,11 @@
   Tags: tags
   Author: elanthia-online
   Contibutors: Ondreian, Xanlin
-  Version: 1.6.7
+  Version: 1.7.0
 
 =end
 =begin
-  Version: 1.6.6 (2026-01-20): Tysong: added 'splashy' option, adds meta:splashy to room for anti-lightning and other checks
+  Version: 1.7.0 (2026-01-20): Tysong: added 'splashy' option, adds meta:splashy to room for anti-lightning and other checks
   Version: 1.6.6 (2023-02-08): Xanlin: ignore tag adjustments
   Version: 1.6.5 (2023-02-07): Xanlin: now removes herbs not present (with support for day/night only)
   Version: 1.6.4 (2023-02-02): Xanlin: added 'noskip' option


### PR DESCRIPTION
Checks for response from `SPLASH` command and if splashy, adds meta tag to room. Useful for knowing if a room is wet and to avoid behavior that interacts badly with wet rooms (like lightning based attacks)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a `splashy` option to `tags.lic` to tag rooms allowing the SPLASH verb, updating room tags based on SPLASH command response.
> 
>   - **Behavior**:
>     - Adds `splashy` option to `tags.lic` for checking if rooms allow the SPLASH verb.
>     - If SPLASH is successful, adds `meta:splashy` tag to the room; removes it if not.
>   - **Functions**:
>     - Adds `splashy_sense()` to handle SPLASH command response and update room tags.
>     - Updates `sense()` to call `splashy_sense()` when `@check_splashy` is true.
>   - **Misc**:
>     - Updates version to 1.7.0 in `tags.lic`.
>     - Minor formatting changes in `tags.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c2eeb2dc445b5fe5547793225e9cb753c60dea32. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->