### PR TITLE
fix(ebounty.lic): v1.9.2 expand CLI forage options

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3704,7 +3704,13 @@ when 'forage'
   return_room = Room.current.id
   EBounty.load(EBounty.load_profile)
   EBounty.set_variables(load_profile: false)
-  if Script.current.vars[2] == 'bounty' && Bounty.task.herb?
+  if Script.current.vars[2] == 'bounty'
+    unless Bounty.task.herb?
+      EBounty.msg "error", ' Started ebounty with ;ebounty forage bounty'
+      EBounty.msg "error", ' But you have no bounty!'
+      EBounty.msg "error", " #{Bounty.task.inspect}"
+      exit
+    end
     EBounty::Task.forage_bounty(Bounty.task.herb, Bounty.task.number, Bounty.task.area)
   elsif Script.current.vars[4].is_a?(String)
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i, Script.current.vars[4])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Expand CLI forage options in `ebounty.lic` to support new commands and fix various bugs.
> 
>   - **CLI Enhancements**:
>     - Add CLI support for `;ebounty forage bounty` and `;ebounty forage "herb" <qty> "location"`.
>   - **Bug Fixes**:
>     - Use `Claim.mine?` instead of `checkpcs` in `heirloom_search` and `forage_bounty`.
>     - Anchor gem names in search functions to prevent false matches.
>     - Fix resting spot for SG shattered and forage tag crash in starting room.
>     - Correct erroneous commas between script parameters in `run_scripts()`.
>   - **Miscellaneous**:
>     - Update version to 1.9.2 in `ebounty.lic`.
>     - Adjust `resting_spots` logic for `Sailor's Grief` based on game type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 603326cf25a77b0b1d14467b4554430056d087ab. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->