### PR TITLE
fix(gameobj-data.xml): gemshop fixes

### DIFF
--- a/type_data/migrations/67_gemshop_fixes.rb
+++ b/type_data/migrations/67_gemshop_fixes.rb
@@ -1,3 +1,3 @@
 migrate :gemshop do
-  exclude(:name, %{praying white ora figurine})
+  insert(:exclude, %{praying white ora figurine})
 end


### PR DESCRIPTION
* remove praying white ora figurine from gemshop sellable
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Excludes `praying white ora figurine` from being sellable in the gemshop via a new migration.
> 
>   - **Behavior**:
>     - Excludes `praying white ora figurine` from being sellable in the gemshop.
>   - **Migration**:
>     - Adds `67_gemshop_fixes.rb` to implement the exclusion logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for cf9f41498457377c5d24edb6d1eaf81c27388c78. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->