### PR TITLE
fix(shatteredmap.lic): v1.8.5 SG town tag fix

### DIFF
--- a/scripts/shatteredmap.lic
+++ b/scripts/shatteredmap.lic
@@ -6,9 +6,11 @@
 
        author: elanthia-online
          game: gs
-      version: 1.8.4
+      version: 1.8.5
 
   changelog:
+    1.8.5 (2026-01-28:
+      * Move SG town tag to below the mast climb (same as nexus entrance)
     1.8.4 (2025-11-20):
       * Bugfix for wayside garret
     1.8.3 (2025-11-20):
@@ -515,6 +517,11 @@ def misc_corrections
   # Frozen Bramble - No access in Shattered
   Room[3111].wayto.delete("24519")
   Room[3111].timeto.delete("24519")
+
+  # Sailor's Grief "town" tag
+  # move to bottom of climb to avoid accidental climbs with over-encumbrance
+  Room[35603].tags.delete("town")
+  Room[35593].tags.push("town")
 end
 
 def urchin_fixes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move "town" tag in `shatteredmap.lic` to prevent accidental climbs in Sailor's Grief, updating to version 1.8.5.
> 
>   - **Behavior**:
>     - Move "town" tag from `Room[35603]` to `Room[35593]` in `misc_corrections` to prevent accidental climbs in Sailor's Grief due to over-encumbrance.
>   - **Version**:
>     - Update version to 1.8.5 in `shatteredmap.lic` header.
>   - **Changelog**:
>     - Add entry for version 1.8.5 noting the SG town tag adjustment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 71f0160240e4a76702a1b9db56e530fe062dac31. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->