### PR TITLE
fix(briefcombat.lic): v1.0.2 relax standard mode keep combat numbers/body part damage

### DIFF
--- a/scripts/briefcombat.lic
+++ b/scripts/briefcombat.lic
@@ -16,13 +16,15 @@
   contributors: Tysong, Ragz, Gemini AI
           name: briefcombat
           tags: brief, briefcombat, condensing, condense, combat, squelch
-       version: 1.0.0
+       version: 1.0.2
 
     changelog:
-      1.0.1 (2026-01-31)
+      1.0.2 (2026-01-31)
         - Standard mode now keeps numbers and body part damage.
         - Standard mode now separates aoe damage to each target affected.
         - Added recognition for a few more actions
+      1.0.1 (2026-01-29)
+        - Bugfix in @instance variable location
       1.0.0 (2026-01-25)
         - Refactor into a module instead of using global variables
         - Refactor most regex patterns to the top of the file
@@ -96,7 +98,7 @@ module BriefCombat
                    grows dim as s?he falls to the (?:ground|floor)|
                    falls to the (?:ground|floor) motionless|
                    lets out a ragged gasp before collapsing/x
-      }.freeze
+      }
 
       his_or_her = '(?:<a[^>]+>)?(?:his|her)(?:<\/a>)?'
       himself_or_herself = '(?:<a[^>]+>)?(?:himself|herself)(?:<\/a>)?'
@@ -106,7 +108,7 @@ module BriefCombat
       # when a line matches, it will begin a new "combat block", which we will try to shorten
       # this line will be the first line in the new shortened block, unless overridden by a "spell guess"
       @verbs_standard = [
-        'gestures? at',                # generic spell casting
+        'gestures? at', # generic spell casting
         'gestures?\.',                 # generic spell casting without target
         'channels? at',
         'waves? (?:your|an?) .+? at',  # wand casting (self: "wave your wand", others: "waves a wand")
@@ -126,8 +128,8 @@ module BriefCombat
         'take aim and fire an? [\w \-\']+', # aimed ranged attack
         'turns and sweeps', # executioner's stance follow up
         'lashes out again and again with the force of a reaping whirlwind', # weapon whirlwind
-        'charges? forward at', # shield charge
-        'lunges? forward at', # shield bash
+        'charges? forward at',           # shield charge
+        'lunges? forward at',            # shield bash
         'takes? a menacing step toward', # weapon pummel
         "brings #{his_or_her} .+? around in a tight arc to batter", # weapon thrash cycle
         'takes quick assessment and raises', # weapon pindown
@@ -139,14 +141,14 @@ module BriefCombat
         "hurls #{himself_or_herself} at", # cman tackle
         "slowly moves #{his_or_her} hand in a (?:waving|pushing|throwing|slapping|clenching|pounding) motion", # 514
         "weaves? (?:your|#{his_or_her}) .+? in a two-handed under arm spin, swiftly picking up speed until it becomes a blurred cyclone of .+" # weapon cyclone
-      ].freeze
+      ]
 
-      # Verbs that match in a reverse order: "[Player] ... [target] ... [verb]"W
+      # Verbs that match in a reverse order: "[Player] ... [target] ... [verb]"
       # where the target is before the verb in the sentence
       @verbs_target_first = [
         'calls? down(?: the)? excoriating power', # paladin feat excoriate
         'deliver a sound thrashing', # weapon thrash
-      ].freeze
+      ]
 
       # Ambient damage messaging, verb first and then target, no player noun
       @verbs_ambient = [
@@ -167,7 +169,7 @@ module BriefCombat
         'flaming rocks burst from the sky and smite the area', # 525
         'Ripples of cold white flame flare up around', # cleric cycle
         'several faintly glowing snowflakes settle upon', # 335 cycle
-      ].freeze
+      ]
 
       # Ambient damage messaging, target first and then verb, no player noun
       @verbs_ambient_2 = [
@@ -176,7 +178,7 @@ module BriefCombat
         'Large hailstones pound relentlessly',
         'spiritual malady wracks',
         'appear to be in a violent mental struggle',
-      ].freeze
+      ]
 
       # --- Spell Guessing Data Structure ---
       # Format: [Regex, Spell ID, Include Line?]
@@ -215,8 +217,7 @@ module BriefCombat
         [/(?:hurl|fire|hurtles forth)s? an? [\w \-\']+ at/, 'ball', false], # special case for "ball" spells, replace "gesture" line with this line
         [/an invisible force guides|considerably more powerful|feel the magic surge through you/, nil, false],
         [/overwhelmed by some burdening force/, '1602', false]
-
-      ].freeze
+      ]
 
       # --- Regex Components ---
       pc_or_you_pattern = '<a exist="(-?\d+)" noun="[^"]+">[^<]+<\/a>|You'
@@ -251,7 +252,7 @@ module BriefCombat
         /In a breathtaking display of ability and combat mastery|spins about looking mighty stirred up|looks determined and focused/, # mstrike prep
         /removes a single(.*)from/, # get arrow
         /nocks? an?/, # arrow nock
-      ].freeze
+      ]
 
       # Initialize or load settings from CharSettings
       CharSettings['briefcombat'] ||= {}
@@ -627,7 +628,7 @@ module BriefCombat
 
             if damage > 0
               if !msgs.empty?
-                @compressed.push("  .. #{damage} damage! #{msgs[0].strip}")
+                @compressed.push("  .. #{damage} damage!  #{msgs[0].strip}")
                 msgs[1..-1].each { |m| @compressed.push("   #{m}") }
               else
                 @compressed.push("  .. #{damage} damage!")
@@ -779,7 +780,7 @@ module BriefCombat
       @simple_filters.each { |regex| return nil if line =~ regex }
 
       # Try compress_combat
-      echo "DEBUG: Calling compress_combat for: #{line[0..100]}" if @debug
+      echo "DEBUG: Calling compress_combat for: #{line}" if @debug
       compressed_result = compress_combat(line)
       return compressed_result if compressed_result.nil?
 
@@ -805,8 +806,8 @@ module BriefCombat
       # Debug: show what we're trying to match
       if @debug && line =~ /wave.*wand/i
         echo "DEBUG: Wand line detected!"
-        echo "  Original: #{line[0..120]}"
-        echo "  Cleaned:  #{clean_line[0..120]}"
+        echo "  Original: #{line}"
+        echo "  Cleaned:  #{clean_line}"
       end
 
       if clean_line =~ @combat_regex
@@ -814,7 +815,7 @@ module BriefCombat
         @is_self = Regexp.last_match(1) == 'You'
 
         if @debug
-          echo "DEBUG: COMBAT_REGEX matched!"
+          echo "DEBUG: @combat_regex matched!"
           echo "  Player: #{Regexp.last_match(1)}"
           echo "  Verb: #{Regexp.last_match(3)}"
           echo "  Target: #{target_string}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `briefcombat.lic` to retain combat numbers and body part damage in standard mode, separate AOE damage, and recognize more actions.
> 
>   - **Behavior**:
>     - Standard mode now retains combat numbers and body part damage, and separates AOE damage per target.
>     - Extreme mode description updated to include hiding numbers and flares.
>   - **Functionality**:
>     - Added new verbs and patterns to `@verbs_standard`, `@verbs_target_first`, `@verbs_ambient`, and `@verbs_ambient_2` for better action recognition.
>     - Updated `end_compress()` to handle non-extreme mode by outputting combat numbers and status changes for each target.
>     - Added `flush_pending_smr()` to handle pending SMR lines before processing damage or target changes.
>   - **Misc**:
>     - Version updated to 1.0.2 in `briefcombat.lic`.
>     - Updated changelog to reflect new features and changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for cc1bbd917cb7c032644bdb157f61c56b916eebd5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->