### PR TITLE
Update eloot.lic

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -4563,7 +4563,7 @@ module ELoot # Room looting
 
       box_list.each do |box|
         line = ELoot.get_res("open ##{box.id}", /open|locked/)
-        next if line&.match?(/That is locked/)
+        next if line&.match?(/It appears to be locked/)
 
         quiet_msg = ELoot.data.settings[:display_box_contents] ? false : true
         ELoot.get_command("look in ##{box.id}", ELoot.data.look_regex, silent: quiet_msg, quiet: quiet_msg)


### PR DESCRIPTION
Fixing the line match for box_loot_ground
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes line match for `box_loot_ground` in `eloot.lic` by updating regex pattern to correctly identify locked boxes.
> 
>   - **Behavior**:
>     - Fixes line match for `box_loot_ground` in `eloot.lic` by changing regex pattern in `match?` method from `/That is locked/` to `/It appears to be locked/`.
>   - **Misc**:
>     - No other changes or additions in the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2088671f4df37f2fdd7ca60e617bd1f076c7bbc9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->