### PR TITLE
fix(gameobj-data.xml): gemshop fix for slab of gold

### DIFF
--- a/type_data/migrations/67_gemshop_fixes.rb
+++ b/type_data/migrations/67_gemshop_fixes.rb
@@ -1,3 +1,7 @@
 migrate :gemshop do
   insert(:exclude, %{praying white ora figurine})
 end
+
+migrate :gemshop, :valuable do
+  insert(:name, %{rough slab of gold})
+end


### PR DESCRIPTION
when 125 lightning opening boxes with gold ingots, creates `rough slab of gold`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `rough slab of gold` to the gemshop's valuable items in `67_gemshop_fixes.rb`.
> 
>   - **Migration**:
>     - In `67_gemshop_fixes.rb`, adds `rough slab of gold` to the `valuable` category in the gemshop.
>     - Retains exclusion of `praying white ora figurine` from the gemshop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for dba326492458a735d166782906dbefe1ac938195. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->