### PR TITLE
feat(ebestiary.lic): convert to using a static hash

### DIFF
--- a/scripts/ebestiary.lic
+++ b/scripts/ebestiary.lic
@@ -2412,7 +2412,7 @@ class EBestiary
   end
 
   def get_creatures_by_level(level)
-    @creatures.select { |name, data| data["level"] == level }.map do |name, data|
+    @creatures.select { |_name, data| data["level"] == level }.map do |name, data|
       { name: name.capitalize, link: "#{@base_url}#{data['link']}", level: data["level"] }
     end
   end
@@ -2420,7 +2420,7 @@ class EBestiary
   def pretty_print_level(lvl, type_filter = nil)
     add_sep = false
     creatures = get_creatures_by_level(lvl)
-    
+
     creatures.each do |mob|
       add_sep = true
       fake_mobj = fake_obj(mob[:name])


### PR DESCRIPTION
also has some weird workarounds for things that should maybe just need gameobj updates. have a seperate ruby script to just poop out the list as a json object for parsing. Seems like a lot less overhead since we get 1 area a year. Also really feels like just a stopgap until the creature module stuff and more people are updated.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `ebestiary.lic` now uses a static JSON hash for creature data, removing web parsing and caching logic, and updates functions to handle static data.
> 
>   - **Behavior**:
>     - `ebestiary.lic` now uses a hardcoded JSON hash for creature data instead of web parsing.
>     - Removed `refresh_cache` and related functions for web data retrieval.
>     - `get_creatures_by_level()` retrieves creatures from the static hash.
>   - **Functions**:
>     - `load_creatures()` loads hardcoded creature data.
>     - `search_mobs()` and `pretty_print_level()` updated to use static data.
>     - `name_override()` updated with additional overrides.
>   - **Misc**:
>     - Version updated to 2.0 in `ebestiary.lic`.
>     - Removed unused imports and variables related to web parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 8bda3fb5529aa670ff5f1ded15185e98543a64a4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->