### PR TITLE
fix(kswole.lic): v1.1.6 added WL Graveyard's Shadow Valley

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -142,7 +142,7 @@ class KSwole
     # Graveyard, Shadow Valley
     /^An? (?:.*)\bshadow mare fades visibly, flicking (?:his|her) tail\.\.\./,
     /^An? (?:.*)\bshadow steed shakes (?:his|her) mane\./,
-    /^An? (?:.*)\bnight mare flares (?:his|her nostrils\./,
+    /^An? (?:.*)\bnight mare flares (?:his|her) nostrils\./,
 
     # Grimswarm
     /^An? (?:.*)\b(?:witch|sorcerer|sorceress) gestures and utters a phrase of magic\./,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for WL Graveyard's Shadow Valley in `kswole.lic` with new creature spell prep regex patterns.
> 
>   - **Behavior**:
>     - Adds support for WL Graveyard's Shadow Valley in `kswole.lic` by including new creature spell prep regex patterns.
>   - **Versioning**:
>     - Updates version from 1.1.5 to 1.1.6 in `kswole.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for f57f7eeac5375e1dfd9819d059b66dbc2146a895. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->