### PR TITLE
fix(ebounty.lic): v1.9.3 and fix room ID comparison

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.9.2
+       version: 1.9.3
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.9.3 (2025-02-04)
+    - bugfix in forage_find room
   v1.9.2 (2025-01-27)
     - add CLI support for ;ebounty forage bounty
     - add CLI support for ;ebounty forage "herb" <qty> "location"
@@ -2956,7 +2958,7 @@ module EBounty
         location_list = location_list.first(10)
 
         location_list.each do |room|
-          next if room.id.eql?(Room.current.id)
+          next if room.eql?(Room.current.id)
           if Room.current.path_to(room).nil?
             location_list.delete(room)
           else
@@ -2978,7 +2980,7 @@ module EBounty
       location_list = location_list.sort { |a, b| shortest_distances[a] <=> shortest_distances[b] }
 
       location_list.each do |room|
-        next if room.id.eql?(Room.current.id)
+        next if room.eql?(Room.current.id)
         if Room.current.path_to(room).nil?
           location_list.delete(room)
         else


### PR DESCRIPTION
Updated version to 1.9.3 and fixed comparison method for room ID.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ebounty.lic` to version 1.9.3 and fix room ID comparison in `forage_find` method.
> 
>   - **Behavior**:
>     - Update version to 1.9.3 in `ebounty.lic`.
>     - Fix room ID comparison in `forage_find` method by changing `room.id.eql?(Room.current.id)` to `room.eql?(Room.current.id)`.
>   - **Version Control**:
>     - Add entry for v1.9.3 in version control notes, mentioning the bugfix in `forage_find` room.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for ebe1e14edc85731e0a759b9fa0b3db8927db92e0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->