### PR TITLE
fix(lumnismon.lic): v1.2.3 fix resource highlight

### DIFF
--- a/scripts/lumnismon.lic
+++ b/scripts/lumnismon.lic
@@ -9,8 +9,10 @@
   author: elanthia-online
   contributors: Vailan, Demandred
   tags: character, information
-  version: 1.2.2
+  version: 1.2.3
 
+  1.2.3 (2025-01-27)
+    * Fix capped total resource highlight not working
   1.2.2 (2025-01-27)
     * Fix for additional cycle detection in LUMNIS INFO output
   1.2.1 (2025-01-23)
@@ -990,7 +992,7 @@ module MyInfo
                           "<preset id=\"speech\">#{value}</preset>"
                         elsif value =~ /^(RSN|ATN)$/
                           "<preset id=\"thought\">#{value}</preset>"
-                        elsif value == "200000*"
+                        elsif value == "200000!"
                           "<preset id=\"speech\">#{value}</preset>"
                         elsif value.to_i > 150_000 && value.to_i < 200_000
                           "<pushBold/>#{value}<popBold/>"


### PR DESCRIPTION
Updated version to 1.2.3 and added a fix for capped total resource highlight.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes capped total resource highlight issue in `lumnismon.lic` and updates version to 1.2.3.
> 
>   - **Behavior**:
>     - Fixes issue with capped total resource highlight in `lumnismon.lic` by changing the condition from `200000*` to `200000!`.
>   - **Version**:
>     - Updates version to 1.2.3 in `lumnismon.lic` to reflect the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for b3cfa78379113f272accdb224c539df595efd7a6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->