### PR TITLE
fix(ebounty.lic): v1.9.5 forage_bounty when using optional location i…

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.9.4
+       version: 1.9.5
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.9.5 (2025-02-06)
+    - bugfix in forage_bounty when using optional location in CLI argument
   v1.9.4 (2025-02-04)
     - optimize location_list finding in forage_find room logic
   v1.9.3 (2025-02-04)
@@ -2952,7 +2954,7 @@ module EBounty
       end
 
       # Apply location filter if not "nearest"
-      if location != "nearest"
+      if !location.eql?("nearest")
         location_pattern = /#{Regexp.escape(location.strip)}/
         location_list.select! do |room_id|
           Room[room_id].location.to_s =~ location_pattern
@@ -2968,12 +2970,12 @@ module EBounty
       end.sort_by { |room_id| shortest_distances[room_id] }
 
       # Limit to 10 nearest if location is "nearest"
-      location_list = location_list.first(10) if location == "nearest"
+      location_list = location_list.first(10) if location.eql?("nearest")
 
       location_list
     end
 
-    def self.forage_bounty(herb, quantity, location = "nearest")
+    def self.forage_bounty(herb, quantity, location = "nearest", bounty_bypass: false)
       EBounty.msg("debug", " #{__method__} | caller: #{caller[0]} | herb: #{herb} | quantity: #{quantity} | location: #{location}")
 
       herb = herb == "trollear mushroom" ? "trollfear mushroom" : herb
@@ -2984,7 +2986,7 @@ module EBounty
       current_room = Room.current.id
       amount = StowList.stow_list[:default].contents.find_all { |i| i.name =~ /#{herb}/ }.length
 
-      if location == "nearest"
+      if location.eql?("nearest") || bounty_bypass
         forage_item = herb
         if (amount >= quantity.to_i)
           EBounty.msg("yellow", " Default container has #{amount} #{amount > 1 ? forage_item + 's' : forage_item}. Quantity requested: #{quantity.to_i}")
@@ -3002,8 +3004,8 @@ module EBounty
       location_list = Task.forage_find(herb, forage_item, location)
 
       unless location_list.length.positive?
-        echo "No #{herb} found at #{location}" if location != "nearest"
-        echo "No #{herb} found" if location == "nearest"
+        echo "No #{herb} found at #{location}" if !location.eql?("nearest")
+        echo "No #{herb} found" if location.eql?("nearest")
         EBounty.exit_script
       end
 
@@ -3113,7 +3115,7 @@ module EBounty
             if (XMLData.injuries.any? { |_a, h| h['wound'] > 1 || h['scar'] > 1 } || Char.percent_health < 70) && !EBounty.data.settings[:skip_healing]
               return_room = Room.current.id
               EBounty.go2_rest
-              if location == 'nearest'
+              if location.eql?('nearest') || bounty_bypass
                 EBounty.check_health
               else
                 Task.prep
@@ -3145,10 +3147,10 @@ module EBounty
         fput "stop 1011" if lines.grep(/Song of Peace/).any?
       end
 
-      if location != "nearest"
-        Task.forage_return
-      else
+      if location.eql?("nearest") || bounty_bypass
         EBounty.go2(current_room)
+      else
+        Task.forage_return
       end
     end
 
@@ -3696,7 +3698,7 @@ when 'forage'
     end
     EBounty::Task.forage_bounty(Bounty.task.herb, Bounty.task.number, Bounty.task.area)
   elsif Script.current.vars[4].is_a?(String)
-    EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i, Script.current.vars[4])
+    EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i, Script.current.vars[4], bounty_bypass: true)
   else
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i)
   end


### PR DESCRIPTION
…n CLI argument
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix bug in `forage_bounty` with optional location in CLI by using `eql?` for comparison and adding `bounty_bypass` parameter.
> 
>   - **Behavior**:
>     - Fix bug in `forage_bounty` when using optional location in CLI argument by replacing `==` with `eql?` for string comparison.
>     - Add `bounty_bypass` parameter to `forage_bounty()` to allow bypassing location checks.
>   - **Functions**:
>     - Update `forage_find()` and `forage_bounty()` to use `eql?` for location comparison.
>     - Modify `forage_bounty()` to handle `bounty_bypass` parameter.
>   - **Misc**:
>     - Update version to 1.9.5 in `ebounty.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 192248ed43307073f01dc7b6b9da1f4787530f93. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->