### PR TITLE
fix(jinx.lic): v0.8.1 only define constants on first run

### DIFF
--- a/scripts/jinx.lic
+++ b/scripts/jinx.lic
@@ -63,7 +63,7 @@ require 'net/https'
 require 'net/http'
 require 'open-uri'
 require 'cgi'
-require 'pathname'
+require 'pathname' # rubocop:disable Lint/RedundantRequireStatement
 
 module ::Lich
   module Common


### PR DESCRIPTION
Bump version to 0.8.1 and update changelog.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix constant redefinition issue in `jinx.lic` by checking if constants are already defined, update version to 0.8.1, and update changelog.
> 
>   - **Behavior**:
>     - Fix constant redefinition issue in `jinx.lic` by checking if constants are already defined before defining them.
>     - Affected constants include `FLAG_PREFIX`, `ElanthiaOnlineCore`, `ElanthiaOnlineExtras`, `FFNGLichRepoArchiveMirror`, `Gtk3ScriptUpdates`, `MapdbBackupGS`, `MapdbBackupDR`, `LOCK`, `FILE`, `HOOKS`, `DEFAULT_ENGINE`, and `MAX_LOG_LINES`.
>   - **Versioning**:
>     - Bump version to 0.8.1 in `jinx.lic`.
>     - Update changelog to include fix for constant redefinition on subsequent launches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for a667264b8bb5fd53152287530a90f912197a443e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->