### PR TITLE
feat(bigshot.lic): v5.12.0 add Effects command checks for ANYTHING!

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.11.4
+       version: 5.12.0
       required: Lich >= 5.13.0
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.12.0  (2026-02-08)
+    - add ES/EB/EC/ED for spell, buff, cooldown, and debuff command checks
   v5.11.4  (2026-01-14)
     - add splashy command check for Rooms that are splashy(wet)
     - add essence command check to check for sorcerer shadow essence
@@ -2572,7 +2574,7 @@ class Bigshot
   end
 
   def initialize_command_data
-    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
+    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
 
     @COMMAND_AMOUNT_REGEX = /((?:!?e|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
@@ -3461,7 +3463,7 @@ class Bigshot
     return false unless match
 
     command = match[1].strip
-    modifiers = command.split(" ")
+    modifiers = command.scan(/(?:[^\s"]|"[^"]*")+/)
 
     # Process each modifier
     modifiers.each do |modifier|
@@ -3497,6 +3499,23 @@ class Bigshot
   end
 
   def check_state_condition(modifier, command, npc, original_command)
+    # Generic Effects checks: ES"text", EB"text", EC"text", ED"text" (and negated !ES, !EB, !EC, !ED)
+    if (effects_match = modifier.match(/^(!?E[SBCD])"(.+)"$/i))
+      check_type = effects_match[1].upcase
+      text = effects_match[2]
+      pattern = /#{text}/i
+      case check_type
+      when 'ES'  then return !Effects::Spells.active?(pattern)
+      when '!ES' then return Effects::Spells.active?(pattern)
+      when 'EB'  then return !Effects::Buffs.active?(pattern)
+      when '!EB' then return Effects::Buffs.active?(pattern)
+      when 'EC'  then return !Effects::Cooldowns.active?(pattern)
+      when '!EC' then return Effects::Cooldowns.active?(pattern)
+      when 'ED'  then return !Effects::Debuffs.active?(pattern)
+      when '!ED' then return Effects::Debuffs.active?(pattern)
+      end
+    end
+
     case modifier.downcase
     # Active spell/effect checks
     when '506'        then !Spell[506].active?


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds new effect command checks for spells, buffs, cooldowns, and debuffs in `bigshot.lic`, updating version to 5.12.0.
> 
>   - **Behavior**:
>     - Adds command checks for effects: `ES`, `EB`, `EC`, `ED` in `bigshot.lic` for spells, buffs, cooldowns, and debuffs.
>     - Supports negation with `!ES`, `!EB`, `!EC`, `!ED`.
>   - **Regex**:
>     - Updates `@COMMAND_MODIFIER_REGEX` in `initialize_command_data` to include new effect checks.
>     - Modifies `modifiers` parsing in `check_state_condition` to handle quoted strings.
>   - **Version**:
>     - Bumps version to 5.12.0 in `bigshot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c3f3d3214d59dc38455c83e9cdaf0023d1d9612b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->