### PR TITLE
refactor: replace $fake_stormfront with monsterbold_start/end variables

### DIFF
--- a/scripts/lumnismon.lic
+++ b/scripts/lumnismon.lic
@@ -114,13 +114,13 @@ module MyInfo
     # @param text [String] the message to display
     # @return [void]
     def message(text)
-      string = $fake_stormfront ? "\034GSL\r\n " : "<pushBold/>"
+      string = monsterbold_start ? "\034GSL\r\n " : "<pushBold/>"
       string << if text.include?('\n')
                   text.split('\n').join
                 else
                   text
                 end
-      string << ($fake_stormfront ? "\034GSM\r\n " : "<popBold/>")
+      string << (monsterbold_end ? "\034GSM\r\n " : "<popBold/>")
       _respond string
     end
 

--- a/scripts/mybounty.lic
+++ b/scripts/mybounty.lic
@@ -40,9 +40,9 @@ Please report any difficulties or bugs to Luxelle, this was a huge update or thr
 #
 
 def message(message)
-  if $fake_stormfront then puts("\034GSL\r\n") else puts("<pushBold\/>") end
+  if monsterbold_start then puts("\034GSL\r\n") else puts("<pushBold\/>") end
   puts("" + message)
-  if $fake_stormfront then puts("\034GSM\r\n") else puts("<popBold\/>") end
+  if monsterbold_end then puts("\034GSM\r\n") else puts("<popBold\/>") end
 end
 
 gtk2_Active = (Gtk::Version::STRING.chr == '2')


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `$fake_stormfront` with `monsterbold_start` and `monsterbold_end` for message formatting in `lumnismon.lic` and `mybounty.lic`.
> 
>   - **Behavior**:
>     - Replaces `$fake_stormfront` with `monsterbold_start` and `monsterbold_end` in `message()` function in `lumnismon.lic` and `mybounty.lic`.
>     - Affects message formatting by changing the conditions for applying bold formatting.
>   - **Misc**:
>     - No other functional changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 4f419e4ac766bbd437352e09ad0f42a5fa09ca04. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->