### PR TITLE
fix(map.lic): v2.0.1 various bugfixes

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -20,7 +20,7 @@ Tracks your current room on visual maps
     v2.0.1 (2025-02-12)
       * Fix GTK crash on long running sessions
       * Fix follow_me getting disabled when opening with specific room#
-      * Fix showing empty canvas/layout around the map
+      * Fix showing empty canvas/layout around the map as toggleable option
     v2.0.0 (2025-01-21)
       * Complete refactor into ElanthiaMap namespace
       * Added proper module/class architecture
@@ -102,6 +102,7 @@ if Script.current.vars[1] == 'help'
   respond "   ;map reset                  - resets map settings to default values                      "
   respond "                                      keep_above = true                                     "
   respond "                                      keep_centered = true                                  "
+  respond "                                      expanded_canvas = true                                "
   respond "                                      follow_mode = true                                    "
   respond "                                      global_scale = 1                                      "
   respond "                                      global_scale_enabled = false                          "
@@ -739,6 +740,7 @@ module ElanthiaMap
       # Only save follow_mode if it wasn't temporarily disabled
       Settings['follow_mode'] = @follow_mode unless @temp_follow_disabled
       Settings['dynamic_indicator_size'] = @settings[:dynamic_indicator_size]
+      Settings['expanded_canvas'] = @settings[:expanded_canvas]
 
       Settings.save
 
@@ -772,6 +774,7 @@ module ElanthiaMap
       Settings['keep_centered'] = true
       Settings['follow_mode'] = true
       Settings['dynamic_indicator_size'] = false
+      Settings['expanded_canvas'] = true
 
       # Reset character-specific settings
       CharSettings['window_width'] = DEFAULT_WIDTH
@@ -797,7 +800,8 @@ module ElanthiaMap
         hide_scrollbars: Settings['hide_scrollbars'] || false,
         keep_centered: Settings['keep_centered'].nil? ? true : Settings['keep_centered'],
         follow_mode: Settings['follow_mode'].nil? ? true : Settings['follow_mode'],
-        dynamic_indicator_size: Settings['dynamic_indicator_size'] || false
+        dynamic_indicator_size: Settings['dynamic_indicator_size'] || false,
+        expanded_canvas: Settings['expanded_canvas'].nil? ? true : Settings['expanded_canvas']
       }
 
       @char_settings = {
@@ -868,6 +872,21 @@ module ElanthiaMap
         @settings[:keep_centered] = menu_keep_centered.active?
       end
       @menu.append(menu_keep_centered)
+
+      # Expanded canvas toggle
+      menu_expanded_canvas = Gtk::CheckMenuItem.new(label: 'Expanded Canvas')
+      menu_expanded_canvas.active = @settings[:expanded_canvas]
+      menu_expanded_canvas.signal_connect('activate') do
+        @settings[:expanded_canvas] = menu_expanded_canvas.active?
+        # Reload current map to apply new canvas size
+        if @current_map
+          temp_map = @current_map
+          @current_map = nil
+          change_map(temp_map)
+          update_room_marker
+        end
+      end
+      @menu.append(menu_expanded_canvas)
 
       # Keep above toggle
       menu_keep_above = Gtk::CheckMenuItem.new(label: 'Keep window on top')
@@ -1708,35 +1727,46 @@ module ElanthiaMap
           GdkPixbuf::InterpType::BILINEAR
         )
 
-        # Make layout 200% of image size to allow dragging in all directions
-        layout_width = (scaled_width * 2).to_i
-        layout_height = (scaled_height * 2).to_i
+        # Layout size and offset depend on expanded_canvas setting
+        if @settings[:expanded_canvas]
+          # Make layout 200% of image size to allow dragging in all directions
+          layout_width = (scaled_width * 2).to_i
+          layout_height = (scaled_height * 2).to_i
 
-        # Center the image within the layout
-        @map_offset_x = (layout_width - scaled_width) / 2
-        @map_offset_y = (layout_height - scaled_height) / 2
+          # Center the image within the layout
+          @map_offset_x = (layout_width - scaled_width) / 2
+          @map_offset_y = (layout_height - scaled_height) / 2
+        else
+          # Legacy mode: layout matches image size exactly
+          layout_width = scaled_width
+          layout_height = scaled_height
+          @map_offset_x = 0
+          @map_offset_y = 0
+        end
 
         Gtk.queue do
           @map_image.pixbuf = scaled_pixbuf
           @layout.set_size(layout_width, layout_height)
           @layout.move(@map_image, @map_offset_x, @map_offset_y)
 
-          # Center the viewport on the map image
+          # Center the viewport on the map image (only if expanded canvas is enabled)
           # Calculate center point of the image within the layout
-          center_x = @map_offset_x + (scaled_width / 2)
-          center_y = @map_offset_y + (scaled_height / 2)
+          if @settings[:expanded_canvas]
+            center_x = @map_offset_x + (scaled_width / 2)
+            center_y = @map_offset_y + (scaled_height / 2)
 
-          # Only center if this is a new map or if keep_centered is disabled
-          # (if keep_centered is enabled, the room marker display will handle centering)
-          unless @settings[:keep_centered]
-            # Wait a moment for the layout to be realized with new size
-            GLib::Timeout.add(50) do
-              begin
-                center_viewport_on(center_x, center_y)
-              rescue StandardError
-                # Ignore if window is being destroyed
+            # Only center if this is a new map or if keep_centered is disabled
+            # (if keep_centered is enabled, the room marker display will handle centering)
+            unless @settings[:keep_centered]
+              # Wait a moment for the layout to be realized with new size
+              GLib::Timeout.add(50) do
+                begin
+                  center_viewport_on(center_x, center_y)
+                rescue StandardError
+                  # Ignore if window is being destroyed
+                end
+                false # Don't repeat
               end
-              false # Don't repeat
             end
           end
         end


### PR DESCRIPTION
      * Fix GTK crash on long running sessions
      * Fix follow_me getting disabled when opening with specific room#
      * Fix showing empty canvas/layout around the map
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix GTK crash, `follow_mode` issue, and add `expanded_canvas` option in `map.lic`.
> 
>   - **Bug Fixes**:
>     - Fix GTK crash in `destroy()` by cleaning up markers and widgets properly in `Window` class.
>     - Fix `follow_mode` getting disabled when opening with specific room# by introducing `temp_follow_disabled` attribute in `Window` class.
>     - Fix showing empty canvas/layout around the map by adding `expanded_canvas` option in `Window` class.
>   - **Settings**:
>     - Add `expanded_canvas` to default settings in `reset_all_settings()` and `load_settings()`.
>     - Ensure `follow_mode` is not saved if `temp_follow_disabled` is true in `save_settings()`.
>   - **UI Changes**:
>     - Add `Expanded Canvas` toggle to the context menu in `create_menu()`.
>     - Adjust map layout and offsets based on `expanded_canvas` setting in `update_map_display()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for da2bb4d9d44d5a742b702f6ab15858356176121b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->