### PR TITLE
fix(bigshot.lic): v5.12.1 cast_signs/cmd_rapid prevent double casting

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,8 +8,8 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.12.0
-      required: Lich >= 5.13.0
+       version: 5.12.1
+      required: Lich >= 5.14.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
       Full Changelog: https://gswiki.play.net/Script_Bigshot/Changelog
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.12.1  (2026-02-08)
+    - fix for cast_signs/cmd_rapid to prevent double casting due to 0sec castRT.
   v5.12.0  (2026-02-08)
     - add ES/EB/EC/ED for spell, buff, cooldown, and debuff command checks
   v5.11.4  (2026-01-14)
@@ -356,7 +358,7 @@
 lich_gem_requires = Script.list.find { |x| x.name == Script.current.name }.inspect[/required: Lich >= (\d+\.\d+\.\d+)/i, 1]
 
 if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
-  if $frontend == 'stormfront' || $frontend == 'profanity'
+  if %w[stormfront wrayth profanity].include?($frontend)
     _respond "\<preset id=\"speech\"\>" + "########################################" + "\<\/preset\>"
     _respond "\<preset id=\"thought\"\>" + "Script:#{script.name} now requires a newer version of Lich(#{lich_gem_requires}+) to run." + "\<\/preset\>"
     _respond "\<preset id=\"thought\"\>" + "Please update to a newer version." + "\<\/preset\>"
@@ -4939,6 +4941,7 @@ class Bigshot
     return unless Spell[515].affordable?
     return if Effects::Buffs.active?("Rapid Fire") && Effects::Buffs.time_left("Rapid Fire") > 0.05
     return if Effects::Cooldowns.active?("Rapid Fire Recovery") && ignore.to_s.empty?
+    return unless (Time.now > Spell[515].last_cast + 1.5)
 
     waitrt?
     waitcastrt?
@@ -7327,6 +7330,7 @@ class Bigshot
 
       if (!sign.active? && sign.affordable?)
         next if (Stats.prof == "Bard" && !(Char.mana >= (bard_renewal + sign.mana_cost)))
+        next unless Time.now > sign.last_cast + 1.5
         loop do
           result = sign.cast
           break if (result.to_s !~ /Spell Hindrance/ || !sign.affordable? || !(Char.mana >= (bard_renewal + sign.mana_cost)) || dead?)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes double casting issue in `bigshot.lic` by adding a delay after casting in `Bigshot` class and updates version requirements.
> 
>   - **Bug Fix**:
>     - Prevents double casting in `cast_signs` and `cmd_rapid` by adding a 1.5-second delay after the last cast in `Bigshot` class.
>   - **Version Update**:
>     - Updates version to 5.12.1 and requires Lich >= 5.14.1.
>   - **Frontend Check**:
>     - Adds `wrayth` to frontend check in `bigshot.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for c0bfabb2c56f0cda6e39f4dfbd836e443bb2f7e3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->