### PR TITLE
fix(map.lic): v2.0.2 correct Linux stickiness

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -14,9 +14,12 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich >= 5.13.0
-      version: 2.0.1
+      version: 2.0.2
 
   changelog:
+    v2.0.2 (2025-02-12)
+      * Fix Linux window sticking to all workspaces - removed incorrect stick() calls
+      * Fix GTK menu detach warning on cleanup
     v2.0.1 (2025-02-12)
       * Fix GTK crash on long running sessions
       * Fix follow_me getting disabled when opening with specific room#
@@ -580,8 +583,7 @@ module ElanthiaMap
 
           # Destroy menu before window
           if @menu && !@menu.destroyed?
-            # Detach menu from any parent to prevent signal issues
-            @menu.detach if @menu.respond_to?(:detach) rescue nil
+            # No need to detach - menus created with Gtk::Menu.new aren't attached
             @menu.destroy
           end
           @menu = nil
@@ -893,31 +895,11 @@ module ElanthiaMap
       menu_keep_above.active = @settings[:keep_above]
       menu_keep_above.signal_connect('activate') do
         @settings[:keep_above] = menu_keep_above.active?
-        # Use full apply_window_settings for better X11 compatibility
+        # Apply keep_above setting (stays on top of other windows)
         Gtk.queue do
-          if @settings[:keep_above]
-            @gtk_window.keep_above = true
-            # Try additional methods for stubborn window managers
-            # Skip stick on macOS and native Windows as it's X11/Wayland specific
-            if USE_X11_FEATURES
-              begin
-                @gtk_window.stick if @gtk_window.respond_to?(:stick)
-                @gtk_window.set_keep_above(true)
-              rescue StandardError
-                # Ignore errors
-              end
-            end
-          else
-            @gtk_window.keep_above = false
-            # Skip unstick on macOS and native Windows as it's X11/Wayland specific
-            if USE_X11_FEATURES
-              begin
-                @gtk_window.unstick if @gtk_window.respond_to?(:unstick)
-              rescue StandardError
-                # Ignore errors
-              end
-            end
-          end
+          @gtk_window.keep_above = @settings[:keep_above]
+          # Note: stick/unstick controls workspace behavior (all workspaces vs single)
+          # which is separate from keep_above (z-order). Don't link them.
         end
       end
       @menu.append(menu_keep_above)
@@ -2195,21 +2177,11 @@ module ElanthiaMap
     # @return [void]
     def apply_window_settings
       Gtk.queue do
-        if @settings[:keep_above]
-          @gtk_window.keep_above = true
-          # Try multiple approaches for X11 forwarding compatibility
-          # Skip UTILITY hint and stick on macOS and native Windows as they can cause issues
-          if USE_X11_FEATURES
-            begin
-              @gtk_window.set_type_hint(Gdk::WindowTypeHint::UTILITY)
-              @gtk_window.stick if @gtk_window.respond_to?(:stick)
-            rescue StandardError
-              # Ignore if these methods don't work in current environment
-            end
-          end
-        else
-          @gtk_window.keep_above = false
-        end
+        # Apply keep_above setting (window stays on top in z-order)
+        @gtk_window.keep_above = @settings[:keep_above]
+        # Note: We don't call stick here. keep_above (z-order) and stick (workspace behavior)
+        # are separate concepts and should not be linked. Users can manually unstick via
+        # window manager if they want single-workspace behavior.
 
         @gtk_window.opacity = @settings[:opacity]
         @gtk_window.decorated = !@settings[:borderless]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Linux window sticking and GTK menu detach warning in `map.lic` by removing `stick()` and `detach()` calls.
> 
>   - **Behavior**:
>     - Fix Linux window sticking to all workspaces by removing `stick()` calls in `apply_window_settings` and `menu_keep_above.signal_connect`.
>     - Fix GTK menu detach warning by removing `detach()` calls in `destroy`.
>   - **Version**:
>     - Update version to 2.0.2 in `map.lic` to reflect these fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2b40faab8e7e206872e9d7b713c0b47b318374ee. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->