### PR TITLE
fix(version.lic): v1.2.2 show Lich branch/repo if known

### DIFF
--- a/scripts/version.lic
+++ b/scripts/version.lic
@@ -5,10 +5,12 @@
   contributors: LostRanger, Doug, Tysong
           game: gs
           tags: utility, version
-       version: 1.2.1
+       version: 1.2.2
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.2.2 (2026-02-14)
+    - show Lich branch/repo info if available
   v1.2.1 (2025-09-08)
     - show autostart args, if any, in output
   v1.2.0 (2025-08-24)
@@ -172,6 +174,8 @@ module VersionScript
       report["Ruby platform"]        = const_get(:RUBY_PLATFORM, missing: 'unknown')
       report["Ruby engine"]          = const_get(:RUBY_ENGINE, missing: 'unknown')
       report["Lich version"]         = const_get(:LICH_VERSION, missing: 'unknown')
+      report["Lich branch"]          = const_get(:LICH_BRANCH, missing: 'unknown') if defined?(LICH_BRANCH)
+      report["Lich repo"]            = const_get(:LICH_BRANCH_REPO, missing: 'unknown') if defined?(LICH_BRANCH_REPO)
       report["Dependency"]           = $DEPENDENCY_VERSION if XMLData.game =~ /^DR/
       report["SQLite3 version"]      = module_version(:SQLite3)
       report["Gtk version"]          = gtk_version


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `version.lic` to v1.2.2 to display Lich branch and repo info if available.
> 
>   - **Behavior**:
>     - Update `version.lic` to v1.2.2 to show Lich branch and repo info if available.
>     - Adds `Lich branch` and `Lich repo` to the report in `VersionScript.main` if `LICH_BRANCH` and `LICH_BRANCH_REPO` are defined.
>   - **Versioning**:
>     - Increment version from 1.2.1 to 1.2.2 in `version.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 07c9189b3aeee89c7727cdbf8fb9389a6e8d0e9f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->