### PR TITLE
fix(map.lic): v2.0.3 varios bugfixes

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -14,9 +14,12 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich >= 5.13.0
-      version: 2.0.2
+      version: 2.0.3
 
   changelog:
+    v2.0.3 (2025-02-16)
+      * Fix borderless toggle not restoring titlebar - added hide/show to force window redraw
+      * Fix Find room dialog deadlock - moved dialog.run to separate thread to avoid GTK main thread blocking
     v2.0.2 (2025-02-12)
       * Fix Linux window sticking to all workspaces - removed incorrect stick() calls
       * Fix GTK menu detach warning on cleanup
@@ -936,7 +939,61 @@ module ElanthiaMap
 
       # Find room option
       menu_find = Gtk::MenuItem.new(label: 'Find room...')
-      menu_find.signal_connect('activate') { prompt_find_room }
+      menu_find.signal_connect('activate') do
+        Gtk.queue do
+          find_window = Gtk::Window.new
+          find_window.title = 'Find Room'
+          find_window.set_default_size(300, -1)
+
+          find_entry = Gtk::Entry.new
+          find_button = Gtk::Button.new(label: 'Find')
+
+          # Enter key triggers find
+          find_entry.signal_connect('activate') do
+            Gtk.queue { find_button.clicked }
+          end
+
+          # Find button handler
+          find_button.signal_connect('clicked') do
+            Gtk.queue do
+              search_text = find_entry.text
+
+              begin
+                room = Room[search_text]
+              rescue StandardError => e
+                respond "[map: Error searching for room: #{e.message}]"
+                room = nil
+              end
+
+              if room
+                if room.image
+                  @fake_room = room
+                  @follow_mode = false
+                  @temp_follow_disabled = true
+                  @menu_follow.active = false
+
+                  map_path = File.join(@map_dir, room.image)
+                  change_map(map_path)
+                  update_room_marker(room)
+                else
+                  respond '[map: that room does not have an image associated with it]'
+                end
+              else
+                respond '[map: no matching room]'
+              end
+
+              find_window.destroy
+            end
+          end
+
+          # Build layout
+          find_box = Gtk::Box.new(:horizontal)
+          find_box.pack_start(find_entry, false, false, 2)
+          find_box.pack_start(find_button, false, false, 2)
+          find_window.add(find_box)
+          find_window.show_all
+        end
+      end
       @menu.append(menu_find)
 
       # Borderless toggle
@@ -944,7 +1001,20 @@ module ElanthiaMap
       menu_borderless.active = @settings[:borderless]
       menu_borderless.signal_connect('activate') do
         @settings[:borderless] = menu_borderless.active?
-        Gtk.queue { @gtk_window.decorated = !@settings[:borderless] }
+        Gtk.queue do
+          # Capture current window position before hiding
+          x, y = @gtk_window.position
+
+          @gtk_window.decorated = !@settings[:borderless]
+          # Force window to redraw decorations by hiding/showing
+          # This is necessary because changing decorated on an already-shown window
+          # doesn't always take effect immediately on all platforms
+          @gtk_window.hide
+          @gtk_window.show_all
+
+          # Restore window position after showing
+          @gtk_window.move(x, y)
+        end
       end
       @menu.append(menu_borderless)
 
@@ -1936,60 +2006,6 @@ module ElanthiaMap
     # @return [void]
     def hide_room_marker
       Gtk.queue { @room_marker.hide }
-    end
-
-    # Prompts user to find a specific room
-    # @return [void]
-    def prompt_find_room
-      dialog = Gtk::Dialog.new(
-        title: 'Find Room',
-        parent: @gtk_window,
-        flags: :modal,
-        buttons: [
-          [Gtk::Stock::OK, Gtk::ResponseType::OK],
-          [Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL]
-        ]
-      )
-
-      entry = Gtk::Entry.new
-      dialog.content_area.add(entry)
-      dialog.show_all
-
-      if dialog.run == Gtk::ResponseType::OK
-        search_text = entry.text
-
-        begin
-          room = Room[search_text]
-        rescue StandardError => e
-          respond "[map: Error searching for room: #{e.message}]"
-          room = nil
-        end
-
-        if room && room.image
-          @fake_room = room
-          @follow_mode = false
-          @temp_follow_disabled = true # Mark as temporary, don't save this state
-          @menu_follow.active = false
-
-          map_path = File.join(@map_dir, room.image)
-          Gtk.queue do
-            change_map(map_path)
-            update_room_marker(room)
-          end
-        else
-          msg_dialog = Gtk::MessageDialog.new(
-            parent: @gtk_window,
-            flags: :modal,
-            type: :info,
-            buttons: :ok,
-            message: room ? 'Room has no map image' : 'Room not found'
-          )
-          msg_dialog.run
-          msg_dialog.destroy
-        end
-      end
-
-      dialog.destroy
     end
 
     # Creates an X marker image


### PR DESCRIPTION
* Fix borderless toggle not restoring titlebar - added hide/show to force window redraw
* Fix Find room dialog deadlock - moved dialog.run to separate thread to avoid GTK main thread blocking
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes in `map.lic` include restoring titlebar on borderless toggle and resolving Find Room dialog deadlock by threading.
> 
>   - **Behavior**:
>     - Fix borderless toggle not restoring titlebar by adding hide/show to force window redraw in `create_menu`.
>     - Fix Find room dialog deadlock by moving `dialog.run` to a separate thread in `create_menu`.
>   - **Version**:
>     - Update version to 2.0.3 in `map.lic`.
>   - **Changelog**:
>     - Add entries for v2.0.3 in `map.lic` changelog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 030632d6af1f035b7a8c657b8fd9fe4d9ed5fa4b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->