### PR TITLE
fix(ebounty.lic): v1.9.6 SG taskmaster prevent re-search

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -2557,36 +2557,33 @@ module EBounty
         7150616, 7150617, 7150621, 7150622
       ]
 
-      unless Room.current.tags.include?('advguild') || sailors_grief_locations.include?(Room.current.uid.first)
+      current_room = Room.current.uid.first
+
+      unless Room.current.tags.include?('advguild') || sailors_grief_locations.include?(current_room)
         EBounty.go2('advguild')
         EBounty.wait_rt
+        current_room = Room.current.uid.first
       end
 
-      case Room.current.uid.first
-      when 7503207
-        return "Halfwhistle"
-      when sailors_grief_locations.include?(Room.current.uid.first)
-        return "Seldit" if GameObj.npcs.any? { |npc| npc.name =~ /Seldit/i }
-        3.times do
-          locations.each do |spot|
-            EBounty.go2("u#{spot}")
-            if GameObj.npcs.any? { |npc| npc.name =~ /Seldit/i }
-              return "Seldit"
-            end
+      return "Halfwhistle" if current_room == 7503207
+      return "Taskmaster" unless sailors_grief_locations.include?(current_room)
 
-            echo "Looking for the lousy First Mate Seldit in #{spot}"
-          end
+      # We're on Sailor's Grief - search for Seldit
+      return "Seldit" if GameObj.npcs.any? { |npc| npc.name =~ /Seldit/i }
+
+      3.times do
+        sailors_grief_locations.each do |spot|
+          EBounty.go2("u#{spot}")
+          return "Seldit" if GameObj.npcs.any? { |npc| npc.name =~ /Seldit/i }
+          echo "Looking for the lousy First Mate Seldit in #{spot}"
         end
-
-        # Still here, then we didn't find Seldit
-        EBounty.msg("yellow", "Searched the boat 3 times and couldn't find Seldit")
-        EBounty.msg("yellow", "Please report this to EO")
-        EBounty.msg("yellow", "Rooms searched: #{locations.join(', ')}")
-        EBounty.exit_script
-
-      else
-        return "Taskmaster"
       end
+
+      # Still here, then we didn't find Seldit
+      EBounty.msg("yellow", "Searched the boat 3 times and couldn't find Seldit")
+      EBounty.msg("yellow", "Please report this to EO")
+      EBounty.msg("yellow", "Rooms searched: #{sailors_grief_locations.join(', ')}")
+      EBounty.exit_script
     end
 
     def self.find_npc(npc_names)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes a bug in `find_taskmaster` in `ebounty.lic` to prevent unnecessary taskmaster searches in Sailor's Grief, updating version to 1.9.6.
> 
>   - **Behavior**:
>     - Fixes bug in `find_taskmaster` in `ebounty.lic` to prevent searching for taskmaster in Sailor's Grief if already in the correct room.
>     - Checks `Room.current.uid.first` against `sailors_grief_locations` before searching.
>   - **Version**:
>     - Updates version to 1.9.6 in `ebounty.lic` to reflect bugfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 18900727cf07fb140e6a3f6dc1b401afe2f2a42c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->