### PR TITLE
fix(map.lic): v2.0.4 nillclass crash and find room follow ignore

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -973,7 +973,7 @@ module ElanthiaMap
                   @fake_room = room
                   @follow_mode = false
                   @menu_follow.active = false
-                  @temp_follow_disabled = true  # Must be set AFTER @menu_follow.active= to avoid activate signal resetting it
+                  @temp_follow_disabled = true # Must be set AFTER @menu_follow.active= to avoid activate signal resetting it
 
                   map_path = File.join(@map_dir, room.image)
                   change_map(map_path)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix nil map path issue and adjust follow mode behavior in `map.lic` for the find room feature.
> 
>   - **Behavior**:
>     - Fix nil map path issue in `resolve_map_path()` in `map.lic` by converting `map_path` to string before substitution.
>     - Adjust `find room` feature in `map.lic` to set `@temp_follow_disabled` after `@menu_follow.active` to prevent signal reset.
>   - **UI**:
>     - Update `find_box.pack_start()` calls in `map.lic` to use keyword arguments for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for d4c2b5e0adb0a23a8543195462acac6c380a2f03. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->