### PR TITLE
fix(map.lic): v2.0.5 fix drag errors when no map shown

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -14,9 +14,11 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich >= 5.13.0
-      version: 2.0.4
+      version: 2.0.5
 
   changelog:
+    v2.0.5 (2025-02-20)
+      * Fix map drag errors when no map currently shown
     v2.0.4 (2025-02-20)
       * Fix for nil map path in location/tag marker lookup
       * re-correct temporary follow uncheck when using find room to not save on close
@@ -1547,46 +1549,47 @@ module ElanthiaMap
 
       # Start drag monitoring thread with captured local variables
       Thread.new do
-        return unless @current_map && File.exist?(@current_map)
+        if @current_map && File.exist?(@current_map)
 
-        # Continue while drag is active (button not released)
-        while @drag_state && @drag_state[:active]
-          sleep 0.05
+          # Continue while drag is active (button not released)
+          while @drag_state && @drag_state[:active]
+            sleep 0.05
 
-          # Get current pointer position
-          pointer = nil
-          Gtk.queue { pointer = get_pointer_position }
-          sleep 0.01 while pointer.nil?
+            # Get current pointer position
+            pointer = nil
+            Gtk.queue { pointer = get_pointer_position }
+            sleep 0.01 while pointer.nil?
 
-          # Break if drag was ended
-          break unless @drag_state && @drag_state[:active]
+            # Break if drag was ended
+            break unless @drag_state && @drag_state[:active]
 
-          # Check if drag threshold exceeded
-          if dragging.nil?
-            dx = (pointer[0] - start_x).abs
-            dy = (pointer[1] - start_y).abs
-            if dx > 10 || dy > 10
-              dragging = true
-              @drag_state[:dragging] = true if @drag_state
-            end
-          end
-
-          # Update scroll position during drag
-          if dragging
-            diff_x = start_x - pointer[0]
-            diff_y = start_y - pointer[1]
-
-            new_x = start_hadj + diff_x
-            new_y = start_vadj + diff_y
-
-            if @trouble_mode
-              respond "[map drag: diff=(#{diff_x},#{diff_y}) new=(#{new_x},#{new_y}) start=(#{start_hadj},#{start_vadj})]"
+            # Check if drag threshold exceeded
+            if dragging.nil?
+              dx = (pointer[0] - start_x).abs
+              dy = (pointer[1] - start_y).abs
+              if dx > 10 || dy > 10
+                dragging = true
+                @drag_state[:dragging] = true if @drag_state
+              end
             end
 
-            Gtk.queue do
-              # Don't constrain to image size - let GTK handle the scroll limits naturally
-              @scroller.hadjustment.value = [new_x, 0].max
-              @scroller.vadjustment.value = [new_y, 0].max
+            # Update scroll position during drag
+            if dragging
+              diff_x = start_x - pointer[0]
+              diff_y = start_y - pointer[1]
+
+              new_x = start_hadj + diff_x
+              new_y = start_vadj + diff_y
+
+              if @trouble_mode
+                respond "[map drag: diff=(#{diff_x},#{diff_y}) new=(#{new_x},#{new_y}) start=(#{start_hadj},#{start_vadj})]"
+              end
+
+              Gtk.queue do
+                # Don't constrain to image size - let GTK handle the scroll limits naturally
+                @scroller.hadjustment.value = [new_x, 0].max
+                @scroller.vadjustment.value = [new_y, 0].max
+              end
             end
           end
         end


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->

Fixes the following error when attempting to drag the map window when no visible map in the window
```
#<Thread:0x000001b1977c6ba0 map:1549 run> terminated with exception (report_on_exception is true):
map:1550:in 'block in Lich::Common::ElanthiaMap::Window#start_drag': unexpected return (LocalJumpError)
```


> [!IMPORTANT]
> Fixes drag errors in `map.lic` when no map is shown by checking for map existence before drag operations.
> 
>   - **Behavior**:
>     - Fixes drag errors in `map.lic` when no map is shown by checking `@current_map` existence before drag operations.
>   - **Version**:
>     - Updates version to 2.0.5 in `map.lic`.
>   - **Changelog**:
>     - Adds entry for v2.0.5 in `map.lic` changelog noting the fix for drag errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 97990fb5844311d33c2c079ce1e14a246b256524. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->