### PR TITLE
refactor(elogin.lic): v2.0.2 custom launch handling in login script

### DIFF
--- a/scripts/elogin.lic
+++ b/scripts/elogin.lic
@@ -514,13 +514,6 @@ when :login
                         char_entry[:_requested_game_code]
                       end
 
-  # Determine frontend override: CLI arg takes precedence, else use stored entry
-  if parsed[:custom_launch].nil?
-    frontend_override = parsed[:frontend] || char_entry[:frontend]
-  else
-    frontend_override = parsed[:frontend] || :__unset
-  end
-
   # Determine effective custom launch (stored value becomes default)
   effective_custom_launch = parsed[:custom_launch]
   if effective_custom_launch.nil? && char_entry[:custom_launch] && !char_entry[:custom_launch].to_s.empty?


### PR DESCRIPTION
Resolved an error when the only saved entry for a character was a custom launch command. Previously was defaulting to Stormfront as the front end. Now it will look at the saved login data and grab the one that exists.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `elogin.lic` to fix error with custom launch commands by defaulting to the first saved character entry when no frontend is specified.
> 
>   - **Behavior**:
>     - Fixes error when only saved entry is a custom launch command by defaulting to the first saved character entry if no frontend is specified.
>     - Adjusts logic to determine `effective_custom_launch` and `frontend_override` in the main execution block.
>   - **Misc**:
>     - Updates version to 2.0.2 in `elogin.lic`.
>     - Adds `Lucullan` as a contributor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fscripts&utm_source=github&utm_medium=referral)<sup> for 2d857a0b923974e4a206621b5d2a963b7c0c73a9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->