### PR TITLE
fix(ejoustsmart.lic): v2.0.4 swap faction names

### DIFF
--- a/scripts/ejoustsmart.lic
+++ b/scripts/ejoustsmart.lic
@@ -15,9 +15,11 @@ See the help info for options and configurations.
   contributors: Tovklar, Elkiros, Rjex, Tysong, Dissonance, ChatGPT
           game: Gemstone
           tags: jousting, rumor woods
-       version: 2.0.3
+       version: 2.0.4
 
 Changelog
+  v2.0.4 - 4/11/2026
+    - Minor correction on which type is for which room
   v2.0.3 - 4/11/2026
     - Fixes for 2026 mount names and redeemed entry mechanic
   v2.0.2 - 4/19/2025
@@ -49,10 +51,10 @@ module EJoustSmart
   ##########
   @faction_year = "2026"
 
-  @faction_1_name = "scorpion"
+  @faction_1_name = "jerboa"
   @faction_1_room = 8208002 # Use real room id.  Generally this should not need to be changed.
 
-  @faction_2_name = "jerboa"
+  @faction_2_name = "scorpion"
   @faction_2_room = 8208001 # Use real room id.  Generally this should not need to be changed.
 
   ##########


### PR DESCRIPTION
Updated version number to 2.0.4 and corrected faction names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.0.4.
  * Faction-to-room type mappings have been reconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->