### PR TITLE
fix(repository.lic): v2.72 auto-update DRT mapdb

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.71
+       version: 2.72
 
   changelog:
+    2.72 (2026-04-11):
+      Fix to have DRT mapdb auto-update
     2.71 (2026-02-02):
       Fix delete/rate due to using @variables in method parameters
     2.70 (2026-01-17):
@@ -2189,9 +2191,11 @@ module RepositoryTillmen
     end
 
     def self.migrate_old_settings
-      # Update GST mapdb setting
+      # Update Test mapdb setting
       if XMLData.game =~ /^GS/ && Settings['updatable'][:mapdb]['GST'].nil?
         Settings['updatable'][:mapdb]['GST'] = true
+      elsif XMLData.game =~ /^DR/ && Settings['updatable'][:mapdb]['DRT'].nil?
+        Settings['updatable'][:mapdb]['DRT'] = true
       end
 
       # Update gameobj-data.xml ownership

--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -2134,9 +2134,7 @@ module RepositoryTillmen
       Settings['updatable'][:scripts] ||= []
       Settings['updatable'][:mapdb] ||= {}
 
-      return unless Settings['updatable'][:mapdb].empty?
-
-      setup_default_settings
+      setup_default_settings if Settings['updatable'][:mapdb].empty?
       migrate_old_settings
       ensure_required_scripts
     end
@@ -2191,7 +2189,7 @@ module RepositoryTillmen
     end
 
     def self.migrate_old_settings
-      # Update Test mapdb setting
+      # Update GST/DRT mapdb settings
       if XMLData.game =~ /^GS/ && Settings['updatable'][:mapdb]['GST'].nil?
         Settings['updatable'][:mapdb]['GST'] = true
       elsif XMLData.game =~ /^DR/ && Settings['updatable'][:mapdb]['DRT'].nil?


### PR DESCRIPTION
Updated version to 2.72 and modified changelog entry. Changed comment from 'GST' to 'Test' in migrate_old_settings method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DRT map database auto-update initialization when the mapdb setting was previously unset.

* **Chore**
  * Bumped script metadata version and added corresponding changelog entry (2.72).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->