### PR TITLE
feat(ebounty.lic): v1.10.0 enhance FORAGE BOUNTY support

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3697,14 +3697,21 @@ when 'forage'
   EBounty.load(EBounty.load_profile)
   EBounty.set_variables(load_profile: false)
   if Script.current.vars[2] == 'bounty'
-    if Script.current.vars[3]
-      bounty_info = Bounty::Task.new(Bounty::Parser.parse(Script.current.vars[3]))
-    else
-      bounty_info = Bounty.task
-    end
-    unless bounty_info.herb?
+    bounty_info =
+      if Script.current.vars[3].to_s.strip.empty?
+        Bounty.task
+      else
+        begin
+          Bounty::Task.new(Bounty::Parser.parse(Script.current.vars[3]))
+        rescue StandardError => e
+          EBounty.msg "error", " Unable to parse manual BOUNTY text: #{e.message}"
+          exit
+        end
+      end
+
+    unless bounty_info&.herb?
       EBounty.msg "error", ' Started ebounty with ;ebounty forage bounty'
-      EBounty.msg "error", ' But you have no bounty!'
+      EBounty.msg "error", ' But you have no herb bounty!'
       EBounty.msg "error", " #{bounty_info.inspect}"
       exit
     end
@@ -3714,7 +3721,7 @@ when 'forage'
   else
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i)
   end
-  EBounty.go2(return_room) 
+  EBounty.go2(return_room)
 when /location/i
   if Bounty.task.requirements[:area].nil?
     respond

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -15,7 +15,8 @@
   Version Control:
   Major_change.feature_addition.bugfix
   v1.10.0 (2026-04-16)
-    -  add support to use alternative BOUNTY text with ;ebounty forage bounty "BOUNTY output here"
+    - add support to use alternative BOUNTY text with ;ebounty forage bounty "BOUNTY output here"
+    - fix new mushroom PnC issues not calculating proper amounts in forage_bounty
   v1.9.7 (2026-03-01)
     - bugfix expedite vouchers when already ready to get new task
   v1.9.6 (2026-02-17)
@@ -2981,6 +2982,15 @@ module EBounty
       location_list
     end
 
+    def self.forage_amount(herb)
+      herb = "white hook mushroom"     if herb == "white mushroom"
+      herb = "black trafel mushroom"   if herb == "trafel mushroom"
+      herb = "withered black mushroom" if herb == "withered mushroom"
+      herb = "soft white mushroom"     if herb == "soft mushroom"
+
+      StowList.stow_list[:default].contents.find_all { |item| item.name =~ /#{herb}/ }.length
+    end
+
     def self.forage_bounty(herb, quantity, location = "nearest", bounty_bypass: false)
       EBounty.msg("debug", " #{__method__} | caller: #{caller[0]} | herb: #{herb} | quantity: #{quantity} | location: #{location}")
 
@@ -2990,7 +3000,7 @@ module EBounty
       creatures = []
 
       current_room = Room.current.id
-      amount = StowList.stow_list[:default].contents.find_all { |i| i.name =~ /#{herb}/ }.length
+      amount = forage_amount(herb)
 
       if location.eql?("nearest") || bounty_bypass
         forage_item = herb
@@ -3101,7 +3111,7 @@ module EBounty
 
               EBounty.msg("debug", "forage_bounty: herb - #{herb} | location - #{location} | quantity - #{quantity} | Default sack: #{StowList.stow_list[:default].inspect} | contents: #{StowList.stow_list[:default].contents}")
 
-              amount = StowList.stow_list[:default].contents.find_all { |i| i.name =~ /#{forage_item}/ }.length
+              amount = forage_amount(herb)
               EBounty.msg("yellow", " #{amount} of #{quantity.to_i} #{amount > 1 ? forage_item + 's' : forage_item} foraged")
               break if amount >= quantity.to_i
 
@@ -3143,8 +3153,7 @@ module EBounty
             end
           end
 
-          break if StowList.stow_list[:default].contents.find_all { |i| i.name =~ /#{forage_item}/ }.length >= quantity.to_i
-
+          break if forage_amount(herb) >= quantity.to_i
         end
       end
 

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,21 +10,23 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.9.7
+       version: 1.10.0
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v1.9.7 (2025-03-01)
+  v1.10.0 (2026-04-16)
+    -  add support to use alternative BOUNTY text with ;ebounty forage bounty "BOUNTY output here"
+  v1.9.7 (2026-03-01)
     - bugfix expedite vouchers when already ready to get new task
-  v1.9.6 (2025-02-17)
+  v1.9.6 (2026-02-17)
     - bugfix to not try searching SG for taskmaster when already in room
-  v1.9.5 (2025-02-06)
+  v1.9.5 (2026-02-06)
     - bugfix in forage_bounty when using optional location in CLI argument
-  v1.9.4 (2025-02-04)
+  v1.9.4 (2026-02-04)
     - optimize location_list finding in forage_find room logic
-  v1.9.3 (2025-02-04)
+  v1.9.3 (2026-02-04)
     - bugfix in forage_find room
-  v1.9.2 (2025-01-27)
+  v1.9.2 (2026-01-27)
     - add CLI support for ;ebounty forage bounty
     - add CLI support for ;ebounty forage "herb" <qty> "location"
     - bugfix in heirloom_search and forage_bounty to use Claim.mine? instead of checkpcs
@@ -32,9 +34,9 @@
     - fix resting spot for SG shattered
     - fix forage tag in starting room crash
     - fix between script(s) added erroneous commas between script parameters
-  v1.9.1 (2025-01-18)
+  v1.9.1 (2026-01-18)
     - bugfix for running gem tracking script
-  v1.9.0 (2025-01-08)
+  v1.9.0 (2026-01-08)
     - added support for ranger track
   v1.8.1 (2025-12-24)
     - added option to regroup before quiting if started in group
@@ -3686,6 +3688,7 @@ when 'forage'
     EBounty.msg "error", ' Please use one of the following proper syntax for the forage option:'
     EBounty.msg "error", ' To search closest 10 rooms for foraged herb:'
     EBounty.msg "error", ' Autodetect Bounty:     ;ebounty forage bounty'
+    EBounty.msg "error", ' Manual Bounty:         ;ebounty forage bounty "Output here from BOUNTY output"'
     EBounty.msg "error", ' Closest 10 Rooms:      ;ebounty forage "herb to find" <how many>'
     EBounty.msg "error", ' All Rooms At Location: ;ebounty forage "herb to find" <how many> "location to search"'
     exit
@@ -3694,19 +3697,24 @@ when 'forage'
   EBounty.load(EBounty.load_profile)
   EBounty.set_variables(load_profile: false)
   if Script.current.vars[2] == 'bounty'
-    unless Bounty.task.herb?
+    if Script.current.vars[3]
+      bounty_info = Bounty::Task.new(Bounty::Parser.parse(Script.current.vars[3]))
+    else
+      bounty_info = Bounty.task
+    end
+    unless bounty_info.herb?
       EBounty.msg "error", ' Started ebounty with ;ebounty forage bounty'
       EBounty.msg "error", ' But you have no bounty!'
-      EBounty.msg "error", " #{Bounty.task.inspect}"
+      EBounty.msg "error", " #{bounty_info.inspect}"
       exit
     end
-    EBounty::Task.forage_bounty(Bounty.task.herb, Bounty.task.number, Bounty.task.area)
+    EBounty::Task.forage_bounty(bounty_info.herb, bounty_info.number, bounty_info.area)
   elsif Script.current.vars[4].is_a?(String)
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i, Script.current.vars[4], bounty_bypass: true)
   else
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i)
   end
-  EBounty.go2(return_room)
+  EBounty.go2(return_room) 
 when /location/i
   if Bounty.task.requirements[:area].nil?
     respond

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3111,7 +3111,7 @@ module EBounty
 
               EBounty.msg("debug", "forage_bounty: herb - #{herb} | location - #{location} | quantity - #{quantity} | Default sack: #{StowList.stow_list[:default].inspect} | contents: #{StowList.stow_list[:default].contents}")
 
-              amount = forage_amount(herb)
+              amount = forage_amount(forage_item)
               EBounty.msg("yellow", " #{amount} of #{quantity.to_i} #{amount > 1 ? forage_item + 's' : forage_item} foraged")
               break if amount >= quantity.to_i
 
@@ -3153,7 +3153,7 @@ module EBounty
             end
           end
 
-          break if forage_amount(herb) >= quantity.to_i
+          break if forage_amount(forage_item) >= quantity.to_i
         end
       end
 

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -3715,7 +3715,7 @@ when 'forage'
       EBounty.msg "error", " #{bounty_info.inspect}"
       exit
     end
-    EBounty::Task.forage_bounty(bounty_info.herb, bounty_info.number, bounty_info.area)
+    EBounty::Task.forage_bounty(bounty_info.herb, bounty_info.number, bounty_info.area, bounty_bypass: !Script.current.vars[3].to_s.strip.empty?)
   elsif Script.current.vars[4].is_a?(String)
     EBounty::Task.forage_bounty(Script.current.vars[2], Script.current.vars[3].to_i, Script.current.vars[4], bounty_bypass: true)
   else

--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -2982,13 +2982,13 @@ module EBounty
       location_list
     end
 
-    def self.forage_amount(herb)
+    def self.find_herb_stow_list(herb)
       herb = "white hook mushroom"     if herb == "white mushroom"
       herb = "black trafel mushroom"   if herb == "trafel mushroom"
       herb = "withered black mushroom" if herb == "withered mushroom"
       herb = "soft white mushroom"     if herb == "soft mushroom"
 
-      StowList.stow_list[:default].contents.find_all { |item| item.name =~ /#{herb}/ }.length
+      StowList.stow_list[:default].contents.find_all { |item| item.name =~ /#{herb}/ || ((herb.start_with? item.name) && (herb =~ /ayana/)) }
     end
 
     def self.forage_bounty(herb, quantity, location = "nearest", bounty_bypass: false)
@@ -3000,7 +3000,7 @@ module EBounty
       creatures = []
 
       current_room = Room.current.id
-      amount = forage_amount(herb)
+      amount = find_herb_stow_list(herb).length
 
       if location.eql?("nearest") || bounty_bypass
         forage_item = herb
@@ -3111,7 +3111,7 @@ module EBounty
 
               EBounty.msg("debug", "forage_bounty: herb - #{herb} | location - #{location} | quantity - #{quantity} | Default sack: #{StowList.stow_list[:default].inspect} | contents: #{StowList.stow_list[:default].contents}")
 
-              amount = forage_amount(forage_item)
+              amount = find_herb_stow_list(forage_item).length
               EBounty.msg("yellow", " #{amount} of #{quantity.to_i} #{amount > 1 ? forage_item + 's' : forage_item} foraged")
               break if amount >= quantity.to_i
 
@@ -3153,7 +3153,7 @@ module EBounty
             end
           end
 
-          break if forage_amount(forage_item) >= quantity.to_i
+          break if find_herb_stow_list(forage_item).length >= quantity.to_i
         end
       end
 
@@ -3185,7 +3185,7 @@ module EBounty
       herb = herb.gsub(/^some /, "")
 
       EBounty.open_container(StowList.stow_list[:default])
-      herbs = StowList.stow_list[:default].contents.find_all { |i| (i.name.end_with? herb) || ((herb.start_with? i.name) && (herb =~ /ayana/)) }
+      herbs = find_herb_stow_list(herb)
 
       if herbs.length.positive?
         EBounty.go2(room)
@@ -3231,7 +3231,7 @@ module EBounty
       herb = herb.gsub(/^some /, "")
 
       EBounty.open_container(StowList.stow_list[:default])
-      herbs = StowList.stow_list[:default].contents.find_all { |i| (i.name.end_with? herb) || ((herb.start_with? i.name) && (herb =~ /ayana/)) }
+      herbs = find_herb_stow_list(herb)
 
       if herbs.length.positive?
 


### PR DESCRIPTION
Updated version to 1.10.0 and added support for alternative BOUNTY text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow supplying alternate BOUNTY text to the forage command: `;ebounty forage bounty "BOUNTY output"`, which is parsed and applied to the forage run (parse errors are reported).

* **Bug Fixes**
  * Fixed forage counting for mushroom/herb name variants by centralizing name matching so totals and loop break conditions are accurate.

* **Documentation**
  * Added manual-syntax help for the forage bounty command and improved validation/error messaging (now indicates "no herb bounty" when appropriate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->