### PR TITLE
fix(elore.lic): v2.1.2 capture additional RETRY in dothistimeout result

### DIFF
--- a/scripts/elore.lic
+++ b/scripts/elore.lic
@@ -10,7 +10,7 @@
 
   Changelog:
     2.1.2 - 2026-04-19:
-      - Fix for retrying loresong on additional "something" can be detected
+      - Capture additional RETRY variants in dothistimeout result so loresong retries trigger correctly
     2.1.1 - 2026-03-12:
       - Force open/look in on a container contents that's nil/empty
     2.1.0 - 2026-03-11:

--- a/scripts/elore.lic
+++ b/scripts/elore.lic
@@ -5,10 +5,12 @@
   contributors: DrunkenDurfin, Tysong, Nisugi
           game: Gemstone
           tags: bard, loresing, loresong, magic
-       version: 2.1.1
+       version: 2.1.2
       required: Lich >= 5.0.0
 
   Changelog:
+    2.1.2 - 2026-04-19:
+      - Fix for retrying loresong on additional "something" can be detected
     2.1.1 - 2026-03-12:
       - Force open/look in on a container contents that's nil/empty
     2.1.0 - 2026-03-11:
@@ -339,7 +341,7 @@ module ELore
                 else
                   "loresing #{verse}"
                 end
-      result = dothistimeout(command, 5, /Roundtime|has more to share|falters and fades|failed to resonate|simply resonates with what you previously learned|\.\.\.wait \d+/)
+      result = dothistimeout(command, 5, /Roundtime|has more to share|could probably find out|falters and fades|failed to resonate|simply resonates with what you previously learned|\.\.\.wait \d+/)
 
       # Return the result type
       if result.nil?


### PR DESCRIPTION
Updated version to 2.1.2 and added changelog entry for the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry detection accuracy to reduce false positives.
* **Chores**
  * Version bumped to 2.1.2 with updated changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->