### PR TITLE
fix(ecleanse.lic): v2.2.9 enhance dispel functionality for acidic mist

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -792,7 +792,7 @@ module Ecleanse
 
       if breeze_wind_ready && Ecleanse.data.cloud.name.eql?("cloud of acidic mist") && Ecleanse.data.breeze_wind.affordable?
         Ecleanse.data.breeze_wind.force_incant if Ecleanse.data.breeze_wind.num.eql?(912)
-        Ecleanse.data.breeze_wind.force_evoke if Ecleanse.data.breeze_wind.num.eql?(612)
+        Ecleanse.data.breeze_wind.cast("at ##{Ecleanse.data.cloud.id}") if Ecleanse.data.breeze_wind.num.eql?(612)
       elsif cloud_dispel_ready
         Action.mana_pulse(Ecleanse.data.dispel.num)
         Ecleanse.data.dispel.cast("at ##{Ecleanse.data.cloud.id}") if Ecleanse.data.dispel.affordable?

--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.12.10
-       version: 2.2.8
+       version: 2.2.9
 
   Improvements:
+  v2.2.9  (2026-04-21)
+    - fix to support dispelling cloud of acidic mist
   v2.2.8  (2026-01-03)
     - convert stunmaneuvers to CMan.use
   v2.2.7  (2025-11-29)
@@ -186,7 +188,7 @@ end
 module Ecleanse
   class Data
     attr_accessor :settings, :did_something, :event_stack, :disease, :dispel, :poison, :webs, :injury_locations, :cloud, :globe, :web, :debuffs, :magic_globes,
-                  :recover_stuff, :creature, :target_regex, :bad_targets, :escape_artist_available, :hive_trap_room, :invalid_clouds
+                  :recover_stuff, :creature, :target_regex, :bad_targets, :escape_artist_available, :hive_trap_room, :invalid_clouds, :breeze_wind
 
     def initialize(settings)
       @settings = settings
@@ -198,6 +200,7 @@ module Ecleanse
       @dispel = [417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }
       @poison = [114].map { |s| Spell[s] }.find { |s| s.known? }
       @webs = [209, 417, 1218, 119].map { |s| Spell[s] }.find { |s| s.known? }
+      @breeze_wind = [912, 612].map { |s| Spell[s] }.find { |s| s.known? }
 
       @escape_artist_available = false
       if Feat.known?("escapeartist")
@@ -222,7 +225,7 @@ module Ecleanse
       )
       @invalid_clouds = [
         "cloud of acidic mist",
-        "cloud of thick ethereal fog"
+        "cloud of thick ethereal fog",
       ]
 
       # action variables
@@ -767,22 +770,30 @@ module Ecleanse
       return unless Ecleanse.data.settings[:dispel_magic]
 
       cloud_dispel_ready = !Ecleanse.data.dispel.nil? && Util.able_to_cast
+      breeze_wind_ready  = !Ecleanse.data.breeze_wind.nil? && Util.able_to_cast
       spell_cleave_ready = CMan.known?("Spell Cleave") && Char.stamina >= 10
       spell_thieve_ready = CMan.known?("Spell Thieve") && Char.stamina >= 10
 
-      # Return unless able to perform an action to remove clouds
-      return unless cloud_dispel_ready || spell_cleave_ready || spell_thieve_ready
+      if Ecleanse.data.cloud.name.eql?("cloud of acidic mist")
+        return unless breeze_wind_ready
+      else
+        # Return unless able to perform an action to remove clouds
+        return unless cloud_dispel_ready || spell_cleave_ready || spell_thieve_ready
 
-      # Return unless able to target object
-      result = dothistimeout("target ##{Ecleanse.data.cloud.id}", 2, Ecleanse.data.target_regex)
-      unless result.is_a?(String) && result =~ /^Suspecting that .+ is the origin of .+, you turn your attention towards \w+!$/
-        Ecleanse.data.bad_targets << Ecleanse.data.cloud.id
-        return
+        # Return unless able to target object
+        result = dothistimeout("target ##{Ecleanse.data.cloud.id}", 2, Ecleanse.data.target_regex)
+        unless result.is_a?(String) && result =~ /^Suspecting that .+ is the origin of .+, you turn your attention towards \w+!$/
+          Ecleanse.data.bad_targets << Ecleanse.data.cloud.id
+          return
+        end
       end
 
       System.scripts_pause
 
-      if cloud_dispel_ready
+      if breeze_wind_ready && Ecleanse.data.cloud.name.eql?("cloud of acidic mist") && Ecleanse.data.breeze_wind.affordable?
+        Ecleanse.data.breeze_wind.force_incant if Ecleanse.data.breeze_wind.num.eql?(912)
+        Ecleanse.data.breeze_wind.force_evoke if Ecleanse.data.breeze_wind.num.eql?(612)
+      elsif cloud_dispel_ready
         Action.mana_pulse(Ecleanse.data.dispel.num)
         Ecleanse.data.dispel.cast("at ##{Ecleanse.data.cloud.id}") if Ecleanse.data.dispel.affordable?
       elsif CMan.known?("Spell Cleave") && Char.stamina >= 10
@@ -1644,6 +1655,7 @@ module Ecleanse
       dispell_debuffs = debuffs.any? { |k| k =~ Ecleanse.data.debuffs }
       webbed_bound = checkwebbed || checkbound
       Ecleanse.data.cloud = GameObj.loot.find { |l| l.name =~ /cloud/i && !Ecleanse.data.invalid_clouds.include?(l.name) && l.type !~ /\bgem\b/i && !Ecleanse.data.bad_targets.include?(l.id) }
+      Ecleanse.data.cloud = GameObj.loot.find { |l| l.name.eql?("cloud of acidic mist" && !Ecleanse.data.breeze_wind.nil? }
       Ecleanse.data.globe = GameObj.loot.find { |l| l.name =~ Ecleanse.data.magic_globes && !Ecleanse.data.bad_targets.include?(l.id) }
       Ecleanse.data.web = GameObj.loot.find { |l| l.noun =~ /web/i && !Ecleanse.data.bad_targets.include?(l.id) }
       determination_injury = Ecleanse.data.settings[:determination] && Ecleanse.data.injury_locations.any? { |limb| XMLData.injuries[limb]["wound"] > 1 }

--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -1655,7 +1655,9 @@ module Ecleanse
       dispell_debuffs = debuffs.any? { |k| k =~ Ecleanse.data.debuffs }
       webbed_bound = checkwebbed || checkbound
       Ecleanse.data.cloud = GameObj.loot.find { |l| l.name =~ /cloud/i && !Ecleanse.data.invalid_clouds.include?(l.name) && l.type !~ /\bgem\b/i && !Ecleanse.data.bad_targets.include?(l.id) }
-      Ecleanse.data.cloud = GameObj.loot.find { |l| l.name.eql?("cloud of acidic mist" && !Ecleanse.data.breeze_wind.nil? }
+      if Ecleanse.data.cloud.nil? && !Ecleanse.data.breeze_wind.nil?
+        Ecleanse.data.cloud = GameObj.loot.find { |l| l.name.eql?("cloud of acidic mist") && !Ecleanse.data.bad_targets.include?(l.id) }
+      end
       Ecleanse.data.globe = GameObj.loot.find { |l| l.name =~ Ecleanse.data.magic_globes && !Ecleanse.data.bad_targets.include?(l.id) }
       Ecleanse.data.web = GameObj.loot.find { |l| l.noun =~ /web/i && !Ecleanse.data.bad_targets.include?(l.id) }
       determination_injury = Ecleanse.data.settings[:determination] && Ecleanse.data.injury_locations.any? { |limb| XMLData.injuries[limb]["wound"] > 1 }


### PR DESCRIPTION
Updated version to 2.2.9 and added support for dispelling 'cloud of acidic mist'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dispelling "cloud of acidic mist" using wind-based dispelling that selects the appropriate wind spell when available.

* **Improvements**
  * Version bumped to 2.2.9 with improved targeting and fallback: if the generic cloud search fails, the system will try a loot-based lookup and ensure wind dispelling is ready before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->