### PR TITLE
fix(log.lic): v1.1.0 timestamp reget lines and filter stream tags

### DIFF
--- a/scripts/log.lic
+++ b/scripts/log.lic
@@ -16,10 +16,13 @@
        author: elanthia-online
  contributors: Tillmen, Tysong, Xanlin
          game: gs
-      version: 1.0.0
+      version: 1.1.0
      required: Lich > 5.0.1
 
   changelog:
+    1.1.0 (2026-04-23):
+      * Timestamp reget lines with $login_time instead of dumping them raw
+      * Filter pushStream/popStream tags from reget output
     1.0.0 (2025-04-08):
       * Fix --rnum to better match only room titles
       * Add --exclude=288,u7199 support to exclude logging in rooms designated.
@@ -153,7 +156,15 @@ module GameLogger
       file.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%L %:z")}\n"
       unless started
         if (Time.now - $login_time) < 30
-          file.puts(reget)
+          reget.each do |line|
+            next if line =~ /^<(?:push|pop)Stream/
+
+            if stamp_enable
+              file.puts "#{$login_time.strftime(stamp_format)}: #{line}"
+            else
+              file.puts line
+            end
+          end
           file.puts "<!-- Above contents from reget; full logging now active -->\n"
         end
 

--- a/scripts/log.lic
+++ b/scripts/log.lic
@@ -16,10 +16,12 @@
        author: elanthia-online
  contributors: Tillmen, Tysong, Xanlin
          game: gs
-      version: 1.1.0
+      version: 1.2.0
      required: Lich > 5.0.1
 
   changelog:
+    1.2.0 (2026-04-23):
+      * Use --timestamp format for log file header/footer lines when enabled
     1.1.0 (2026-04-23):
       * Timestamp reget lines with $login_time instead of dumping them raw
       * Filter pushStream/popStream tags from reget output
@@ -153,7 +155,11 @@ module GameLogger
       filename = File.join(dir, "#{Time.now.strftime("%Y-%m-%d_%H-%M-%S")}.log")
       file = File.open(filename, 'a')
       file.sync = true
-      file.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%L %:z")}\n"
+      if stamp_enable
+        file.puts "#{Time.now.strftime(stamp_format)}\n"
+      else
+        file.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%L %:z")}\n"
+      end
       unless started
         if (Time.now - $login_time) < 30
           reget.each do |line|
@@ -194,7 +200,11 @@ module GameLogger
           end
           break if Time.now.strftime("%Y-%m-%d") != thisdate
         }
-        file.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%L %:z")}\n"
+        if stamp_enable
+          file.puts "#{Time.now.strftime(stamp_format)}\n"
+        else
+          file.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%L %:z")}\n"
+        end
       ensure
         begin
           file.close

--- a/spec/log/log_spec.rb
+++ b/spec/log/log_spec.rb
@@ -46,6 +46,9 @@ end
 script_path = File.join(__dir__, '..', '..', 'scripts', 'log.lic')
 script_content = File.read(script_path)
 module_code = script_content[/^module GameLogger.*?^end/m]
+raise "Failed to extract GameLogger module from #{script_path}" if module_code.nil?
+raise "Extracted code does not look like a single module" unless module_code.scan(/^module GameLogger/).one?
+
 eval(module_code, binding, script_path,
      script_content.lines.index { |l| l.start_with?('module GameLogger') } + 1)
 
@@ -77,7 +80,8 @@ RSpec.describe GameLogger do
         expect(result.exclude).to eq('288')
       end
 
-      it 'parses --lines with numeric value' do
+      # parse_flag returns strings; main calls .to_i on the result
+      it 'parses --lines as string (coerced later by caller)' do
         result = described_class.parse(['--lines=50000'])
         expect(result.lines).to eq('50000')
       end

--- a/spec/log/log_spec.rb
+++ b/spec/log/log_spec.rb
@@ -1,0 +1,224 @@
+require 'tmpdir'
+require 'fileutils'
+require 'ostruct'
+
+$login_time = Time.new(2026, 4, 23, 10, 0, 0)
+
+module XMLData
+  def self.game;       "GSIV";          end
+  def self.name;       "TestChar";      end
+  def self.room_id;    1234;            end
+  def self.room_title; "[Town Square]"; end
+end
+
+module Lich
+  def self.log(_msg); end
+end
+
+class Script
+  def self.current
+    @current ||= OpenStruct.new(
+      want_script_output: nil,
+      want_upstream: nil,
+      vars: [""],
+      downstream_buffer: [],
+      name: "log"
+    )
+  end
+end
+
+def hide_me; end
+def echo(_msg); end
+
+$reget_lines = []
+def reget
+  $reget_lines
+end
+
+def get
+  raise StopIteration
+end
+
+def upstream_get
+  raise StopIteration
+end
+
+script_path = File.join(__dir__, '..', '..', 'scripts', 'log.lic')
+script_content = File.read(script_path)
+module_code = script_content[/^module GameLogger.*?^end/m]
+eval(module_code, binding, script_path,
+     script_content.lines.index { |l| l.start_with?('module GameLogger') } + 1)
+
+RSpec.describe GameLogger do
+  describe GameLogger::Opts do
+    describe '.parse' do
+      it 'parses --timestamp flag with value' do
+        result = described_class.parse(['--timestamp=%F %T %Z'])
+        expect(result.timestamp).to eq('%F %T %Z')
+      end
+
+      it 'parses --rnum as boolean flag' do
+        result = described_class.parse(['--rnum'])
+        expect(result.rnum).to be true
+      end
+
+      it 'parses --roomnum as boolean flag' do
+        result = described_class.parse(['--roomnum'])
+        expect(result.roomnum).to be true
+      end
+
+      it 'parses --exclude with comma-separated values' do
+        result = described_class.parse(['--exclude=288,2300,u7199'])
+        expect(result.exclude).to eq(%w[288 2300 u7199])
+      end
+
+      it 'parses --exclude with single value as string' do
+        result = described_class.parse(['--exclude=288'])
+        expect(result.exclude).to eq('288')
+      end
+
+      it 'parses --lines with numeric value' do
+        result = described_class.parse(['--lines=50000'])
+        expect(result.lines).to eq('50000')
+      end
+
+      it 'returns nil for unset options' do
+        result = described_class.parse([])
+        expect(result.timestamp).to be_nil
+        expect(result.rnum).to be_nil
+        expect(result.exclude).to be_nil
+      end
+
+      it 'parses multiple flags together' do
+        result = described_class.parse(['--timestamp=%F %T', '--rnum', '--lines=10000'])
+        expect(result.timestamp).to eq('%F %T')
+        expect(result.rnum).to be true
+        expect(result.lines).to eq('10000')
+      end
+
+      it 'parses positional commands as true' do
+        result = described_class.parse(['something'])
+        expect(result.something).to be true
+      end
+    end
+  end
+
+  describe '.main' do
+    let(:log_dir) { Dir.mktmpdir }
+    let(:frozen_time) { Time.new(2026, 4, 23, 10, 0, 5) }
+
+    before do
+      stub_const('LICH_DIR', log_dir)
+      allow(Time).to receive(:now).and_return(frozen_time)
+      $login_time = Time.new(2026, 4, 23, 10, 0, 0)
+    end
+
+    after do
+      FileUtils.rm_rf(log_dir)
+    end
+
+    def run_main
+      GameLogger.main
+    end
+
+    def find_log_file
+      Dir.glob(File.join(log_dir, '**', '*.log')).first
+    end
+
+    def log_content
+      File.read(find_log_file)
+    end
+
+    context 'with timestamps enabled' do
+      before do
+        GameLogger.instance_variable_set(:@options, OpenStruct.new(timestamp: '%F %T'))
+      end
+
+      it 'timestamps reget lines with $login_time' do
+        $reget_lines = ['You see a door.', 'Obvious exits: north, south.']
+        run_main
+        expect(log_content).to include('2026-04-23 10:00:00: You see a door.')
+        expect(log_content).to include('2026-04-23 10:00:00: Obvious exits: north, south.')
+      end
+
+      it 'filters pushStream tags from reget lines' do
+        $reget_lines = ['<pushStream id="room"/>', 'You see a door.', '<popStream/>']
+        run_main
+        expect(log_content).not_to include('pushStream')
+        expect(log_content).not_to include('popStream')
+        expect(log_content).to include('2026-04-23 10:00:00: You see a door.')
+      end
+
+      it 'uses $login_time not current time for reget timestamps' do
+        $login_time = Time.new(2026, 1, 1, 12, 30, 45)
+        allow(Time).to receive(:now).and_return(Time.new(2026, 1, 1, 12, 30, 50))
+        $reget_lines = ['Test line']
+        run_main
+        expect(log_content).to include('2026-01-01 12:30:45: Test line')
+      end
+    end
+
+    context 'without timestamps' do
+      before do
+        GameLogger.instance_variable_set(:@options, OpenStruct.new)
+      end
+
+      it 'writes reget lines without timestamps' do
+        $reget_lines = ['You see a door.']
+        run_main
+        door_line = log_content.lines.find { |l| l.include?('You see a door.') }
+        expect(door_line).to start_with('You see a door.')
+      end
+
+      it 'still filters pushStream/popStream from reget' do
+        $reget_lines = ['<pushStream id="room"/>', 'content line', '<popStream/>']
+        run_main
+        expect(log_content).not_to include('pushStream')
+        expect(log_content).not_to include('popStream')
+        expect(log_content).to include('content line')
+      end
+    end
+
+    context 'when login was more than 30 seconds ago' do
+      before do
+        $login_time = frozen_time - 60
+        GameLogger.instance_variable_set(:@options, OpenStruct.new(timestamp: '%F %T'))
+      end
+
+      it 'does not write reget lines' do
+        $reget_lines = ['Should not appear']
+        run_main
+        expect(log_content).not_to include('Should not appear')
+      end
+
+      it 'does not write reget marker comment' do
+        $reget_lines = ['ignored']
+        run_main
+        expect(log_content).not_to include('Above contents from reget')
+      end
+    end
+
+    it 'writes reget marker comment when reget is used' do
+      $login_time = frozen_time - 5
+      $reget_lines = ['test']
+      GameLogger.instance_variable_set(:@options, OpenStruct.new)
+      run_main
+      expect(log_content).to include('<!-- Above contents from reget; full logging now active -->')
+    end
+
+    it 'creates log directory with game and character name' do
+      $reget_lines = []
+      GameLogger.instance_variable_set(:@options, OpenStruct.new)
+      run_main
+      expect(find_log_file).to include('GSIV-TestChar')
+    end
+
+    it 'handles empty reget buffer' do
+      $reget_lines = []
+      GameLogger.instance_variable_set(:@options, OpenStruct.new(timestamp: '%F %T'))
+      run_main
+      expect(log_content).to include('<!-- Above contents from reget; full logging now active -->')
+      expect(log_content.lines.count { |l| l.include?('2026-04-23 10:00:00:') }).to eq(0)
+    end
+  end
+end

--- a/spec/log/log_spec.rb
+++ b/spec/log/log_spec.rb
@@ -220,5 +220,23 @@ RSpec.describe GameLogger do
       expect(log_content).to include('<!-- Above contents from reget; full logging now active -->')
       expect(log_content.lines.count { |l| l.include?('2026-04-23 10:00:00:') }).to eq(0)
     end
+
+    context 'log file header/footer format' do
+      it 'uses --timestamp format for header when enabled' do
+        $reget_lines = []
+        GameLogger.instance_variable_set(:@options, OpenStruct.new(timestamp: '%F %T %Z'))
+        run_main
+        header_line = log_content.lines.first.chomp
+        expect(header_line).to eq(frozen_time.strftime('%F %T %Z'))
+      end
+
+      it 'uses default format for header when timestamps disabled' do
+        $reget_lines = []
+        GameLogger.instance_variable_set(:@options, OpenStruct.new)
+        run_main
+        header_line = log_content.lines.first.chomp
+        expect(header_line).to eq(frozen_time.strftime("%Y-%m-%d %H:%M:%S.%L %:z"))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Reget lines are now timestamped with `$login_time` when `--timestamp` is enabled, instead of being dumped raw without timestamps
- `pushStream`/`popStream` XML tags are filtered from reget output, matching the behavior of the main logging loop
- Version bumped to 1.1.0

## Context
Previously, `log.lic` used `file.puts(reget)` to dump the pre-launch buffer in bulk. This meant the first portion of every log file had no timestamps, even when `--timestamp` was enabled. Now each reget line is processed individually with the same filtering and timestamping as the main loop, using `$login_time` as the timestamp (since the lines arrived between login and script start).

## Test plan
- [x] Added comprehensive RSpec specs (`spec/log/log_spec.rb`) covering:
  - `Opts.parse` argument parsing (flags, values, comma-separated lists, positional commands)
  - Reget timestamping with `$login_time` when `--timestamp` is enabled
  - Reget lines written plain when timestamps are disabled
  - `pushStream`/`popStream` filtering from reget output
  - Skipping reget when login was more than 30 seconds ago
  - Reget marker comment presence
  - Log directory structure creation
  - Empty reget buffer handling
- [x] All 19 specs pass
- [x] Rubocop clean (0 offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced reget payload processing to filter stream markers and support per-line timestamping in logs

* **Tests**
  * Comprehensive test coverage added for logging functionality, validating timestamp handling, payload filtering, and log file creation

* **Chores**
  * Version updated to 1.1.0 with corresponding changelog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->