### PR TITLE
fix(eloot.lic): v2.8.1 with gem hoarding fix

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.12.9
-           version: 2.8.0
+           version: 2.8.1
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.8.1  (2026-04-23)
+    - bugfix to only count gems once in hoarding store items
   v2.8.0  (2026-01-27)
     - replaced overflow_container and secondary_overflow with single overflow_containers setting (comma-separated)
     - added configurable "Trash to Dump" section, instead of hardcoded herb/food/junk
@@ -4502,8 +4504,9 @@ module ELoot # Gem and Reagent hoarding
         end
 
         items_to_hoard = Hoard.hoarding_list(item.name)
-
         items_to_hoard = Hoard.process_gems(items_to_hoard) unless deposit
+        items_to_hoard.uniq! { |uniq_item| uniq_item.id }
+
         next if items_to_hoard.length.zero?
 
         bottle = ELoot.data.stash.contents.find { |obj| obj.noun =~ /^(?:jar|bottle|beaker)$/ && Hoard.normalize_name(obj.after_name) =~ /^#{item_name}$/ }


### PR DESCRIPTION
Updated version to 2.8.1 and added a bugfix for gem counting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where gems were counted multiple times when storing items in the hoarding system, ensuring accurate inventory tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->