### PR TITLE
feat(ewander.lic): v1.1.0 priority matching and other fixes

### DIFF
--- a/scripts/ewander.lic
+++ b/scripts/ewander.lic
@@ -10,7 +10,7 @@
   Use   ;ewander add              and
           ;ewander remove           to set up boundaries to keep you in your hunting area.
   Use   ;ewander delay <number>   to set the movement delay
-  Use   ;ewander <npc1> <npc2>    to stop only for specific npcs.
+  Use   ;ewander <npc1> <npc2>    to stop and target specific npcs (priority order, left to right).
   Use   ;ewander <pc>             to stop for another specific character.
   Use   ;ewander                  to stop for any targetable npcs.
 
@@ -18,9 +18,14 @@
      game: Gemstone
      tags: movement
  required: Lich >= 5.11.0
-  version: 1.0.0
+  version: 1.1.0
 
   changelog:
+    1.1.0 (2026-03-27):
+      - when given NPC name arguments, auto-target the matched creature before stopping
+      - NPC name arguments are treated as priority order (first arg = highest priority)
+      - check for matching NPCs before moving, catching creatures that enter mid-room
+      - skip player-controlled animates (names containing "animated")
     1.0.0 (2025-03-19):
       - initial fork of wander.lic
 =end
@@ -272,16 +277,41 @@ elsif script.vars.empty?
     end
   }
 else
+  find_target = proc {
+    result = nil
+    script.vars[1..-1].each do |name|
+      result = GameObj.npcs.find { |npc|
+        npc.status != 'dead' &&
+        npc.name =~ /#{name}/i &&
+        npc.name !~ /\banimated\b/i
+      }
+      break if result
+    end
+    result
+  }
   loop {
+    # Check before moving — catches NPCs that entered while still in this room
+    if Claim.mine? && !GameObj.pcs.any? { |pc| pc.noun =~ /#{script.vars[1..-1].join('|')}/i }
+      if (found_npc = find_target.call)
+        fput "target ##{found_npc.id}"
+        waitrt?
+        break
+      end
+    end
     wander.call
     if GameObj.pcs.any? { |pc| pc.noun =~ /#{script.vars[1..-1].join('|')}/i }
       break
     elsif !Claim.mine?
       sleep CharSettings['delay']
-    elsif GameObj.npcs.any? { |npc| (npc.status != 'dead') and npc.name =~ /#{script.vars[1..-1].join('|')}/ }
-      break
     else
-      sleep CharSettings['delay']
+      # Find first live NPC matching arguments in priority order (first arg = highest priority)
+      if (found_npc = find_target.call)
+        fput "target ##{found_npc.id}"
+        waitrt?
+        break
+      else
+        sleep CharSettings['delay']
+      end
     end
   }
 end


### PR DESCRIPTION
Added 4 features:
- Target the NPC name that you're wandering for (if applicable)
- If multiple NPC name arguments, target the highest priority one (left to right) when any are found
- Checks for NPC's before wandering OUT of a room, in case they have walked in after you
- Ignores sorcerer animates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `;ewander` command to auto-target matched NPCs with priority-based selection. NPCs are now automatically targeted in the order provided as arguments, with animated NPCs excluded from matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->