### PR TITLE
fix(bigshot.lic): v5.12.6 add new status during inbounds creation

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.12.5
+       version: 5.12.6
       required: Lich >= 5.14.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.12.6  (2026-05-02)
+    - fix for boundary building to set a new status while building boundary list, useful for scripts like teleport.lic
   v5.12.5  (2026-04-22)
     - fix final_loot to now work for solo as well, helps pickup left behind loot by other players, poof'd creature loot, etc.
   v5.12.4  (2026-04-10)
@@ -2685,8 +2687,14 @@ class Bigshot
     convert_from_uid
 
     unless $bigshot_quick
-      @inbounds = BSAreaRooms.new(@HUNTING_ROOM_ID, @HUNTING_BOUNDARIES)
-      @inbounds.build
+      before_status = $bigshot_status
+      begin
+        $bigshot_status = :boundary_building
+        @inbounds = BSAreaRooms.new(@HUNTING_ROOM_ID, @HUNTING_BOUNDARIES)
+        @inbounds.build
+      ensure
+        $bigshot_status = before_status
+      end
     end
 
     # initialize group module


### PR DESCRIPTION
New $bigshot_status during inbounds creation that can be used by other scripts (mainly mapdb based ones) to allow for smarter timeto/wayto calculations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the reliability of status state management and restoration during the boundary room graph building initialization. The application now properly maintains and restores status context throughout the entire operation with improved error handling.

* **Chores**
  * Version incremented to 5.12.6 with corresponding changelog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->