### PR TITLE
fix(autostart.lic): load dependency before DR scripts

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.68
+       version: 0.69
       required: Lich >= 4.6.58
 
   changelog:
+    0.69 (2026-05-06):
+      fix: start dependency before autostart scripts so parse_args() bridge is available
     0.68 (2026-05-05):
       game-agnostic YAML autostarts, wayto overrides, and double-start guard
     0.67 (2026-04-03):
@@ -136,34 +138,10 @@ if script.vars.empty?
     Lich::Util::Update.request("--announce")
   end
 
-  # YAML-based autostarts, UserVars autostarts, and wayto overrides.
-  # Game-agnostic -- requires modern Lich with get_settings support.
-  if respond_to?(:get_settings, true)
-    UserVars.autostart_scripts ||= []
-    all_autostarts = (UserVars.autostart_scripts.to_a +
-                      get_settings.autostarts.to_a).uniq
-
-    Map.apply_wayto_overrides if Map.respond_to?(:apply_wayto_overrides)
-
-    all_autostarts.each do |script_name|
-      next if script_name == 'dependency'
-      next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
-      next if Script.running?(script_name)
-
-      unless Script.exists?(script_name)
-        respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
-        next
-      end
-
-      start_script(script_name)
-    end
-    did_something = true unless all_autostarts.empty?
-  end
-
+  # DR: load dependency before other scripts.
+  # dependency.lic defines the parse_args() bridge that DR scripts need.
   if XMLData.game =~ /^DR/
     if respond_to?(:start_scripts_if_available, true)
-      # Start dependency for remaining runtime helpers (bankbot, slackbot, etc.)
-      # It will detect core sentinels and skip its inline definitions.
       start_scripts_if_available('dependency') if Script.exists?('dependency')
       did_something = true
     else
@@ -196,6 +174,30 @@ if script.vars.empty?
         sleep 1
       end
     end
+  end
+
+  # YAML-based autostarts, UserVars autostarts, and wayto overrides.
+  # Game-agnostic -- requires modern Lich with get_settings support.
+  if respond_to?(:get_settings, true)
+    UserVars.autostart_scripts ||= []
+    all_autostarts = (UserVars.autostart_scripts.to_a +
+                      get_settings.autostarts.to_a).uniq
+
+    Map.apply_wayto_overrides if Map.respond_to?(:apply_wayto_overrides)
+
+    all_autostarts.each do |script_name|
+      next if script_name == 'dependency'
+      next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
+      next if Script.running?(script_name)
+
+      unless Script.exists?(script_name)
+        respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
+        next
+      end
+
+      start_script(script_name)
+    end
+    did_something = true unless all_autostarts.empty?
   end
 
   for script_list in [Settings['scripts'], CharSettings['scripts']]


### PR DESCRIPTION
## Summary

- v0.68 moved the YAML autostart loop above the DR dependency block, causing DR scripts (tome, moonwatch, etc.) to start before `dependency.lic` loads
- These scripts call `parse_args()`, a bridge function defined in `dependency.lic:148` that wraps `ArgParser.new.parse_args(...)` -- it is not provided by lich-5 core
- Swaps the two blocks to restore the v0.67 ordering: start dependency first, then user scripts

## Root cause

v0.67 (correct order):
```
start_scripts_if_available('dependency')  # 1. dependency loads, defines parse_args()
dr_autostarts.each { start_script(...) }  # 2. scripts can call parse_args()
```

v0.68 (broken order):
```
all_autostarts.each { start_script(...) } # 1. scripts call parse_args() -- undefined!
start_scripts_if_available('dependency')  # 2. too late
```

## Errors observed

```
--- Lich: error: undefined method 'parse_args' for an instance of Lich::Common::Tome
    tome:18:in 'Lich::Common::Tome#initialize'

--- Lich: error: undefined method 'parse_args' for module Lich::Common
    moonwatch:23:in 'Lich::Common#_script'
```

## Test plan

- [ ] Login to DR and verify dependency loads before tome/moonwatch
- [ ] Verify `parse_args()` errors no longer appear on startup
- [ ] Verify non-DR games still get the game-agnostic autostart loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autostart dependency loading for DragonRealms to ensure dependencies are available early
  * Removed legacy first-run path

* **Refactor**
  * Reorganized autostart configuration structure and YAML formatting while preserving existing startup behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->