### PR TITLE
fix(ledger.lic): v1.4.1 change lootcap estimate from monthly to weekly

### DIFF
--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.4.0
+        version: 1.4.1
    requirements:
     - sequel gem
     - terminal-table
@@ -20,6 +20,10 @@
   Help Contribute: https://github.com/elanthia-online/scripts
   Version Control:
   Major_change.feature_addition.bugfix
+    v1.4.1 - 2026-05-06
+      - Change estimate_loot_cap from monthly to weekly window (Monday 00:00 - Sunday 23:59:59, EST/EDT).
+        Week boundaries are computed in America/New_York via tzinfo (DST-aware).
+        New runtime dependency: tzinfo
     v1.4.0 - 2026-01-19
       - Add database indexes to speed up database queries on large transaction databases
       - Add comprehensive YARD documentation
@@ -62,7 +66,7 @@
 =end
 
 # Load required gems with safety checks
-gems_to_load = ["sequel", "terminal-table"]
+gems_to_load = ["sequel", "terminal-table", "tzinfo"]
 optional_gems = ["ascii_charts"]
 failed_to_load = []
 
@@ -320,20 +324,37 @@ module Ledger
         .sum(:amount) || 0
     end
 
-    # Estimates loot cap earnings for a given month
+    # Estimates loot cap earnings for the current week (Monday through Sunday, EST/EDT)
     #
     # Calculates silver gained from creature kills (excluding large deposits/withdrawals)
-    # to estimate progress toward the monthly loot cap.
+    # to estimate progress toward the weekly loot cap. The week boundary is computed
+    # in America/New_York (which observes EST/EDT, including DST transitions) and then
+    # converted to the machine's local time to match how `created_at` is stored.
     #
-    # @param year [Integer] the year to query (default: current year)
-    # @param month [Integer] the month to query (default: current month)
+    # @param year [Integer] ignored, retained for backward compatibility
+    # @param month [Integer] ignored, retained for backward compatibility
     # @param character [String] character name (default: current character)
     # @param game [String] game code (default: current game)
-    # @return [Integer] estimated loot cap earnings
+    # @return [Integer] estimated loot cap earnings for the current week
     # @note Filters out transactions over 1,000,000 silver (likely bank transactions)
     def self.estimate_loot_cap(year: Time.now.year, month: Time.now.month, character: Char.name, game: XMLData.game)
+      _ = year; _ = month # accepted for backward compatibility, no longer used
+
+      # Compute the start of the current week (Monday 00:00) in EST/EDT,
+      # then convert back to the machine's local time so it matches `created_at`,
+      # which is stored as Time.now in machine-local time.
+      tz                  = TZInfo::Timezone.get('America/New_York')
+      now_est             = tz.utc_to_local(Time.now.utc)
+      # Time#wday: Sunday=0, Monday=1 ... Saturday=6
+      days_since_monday   = (now_est.wday + 6) % 7
+      week_start_est_date = Time.utc(now_est.year, now_est.month, now_est.day) - (days_since_monday * 86_400)
+      # Build a naive EST/EDT time at midnight Monday (Time.utc avoids machine-local DST math)
+      monday_midnight_est = Time.utc(week_start_est_date.year, week_start_est_date.month, week_start_est_date.day)
+      week_start_local    = tz.local_to_utc(monday_midnight_est).getlocal
+
       Ledger::History::Transactions
-        .where(year: year, month: month, type: "silver", character: character, game: game)
+        .where(type: "silver", character: character, game: game)
+        .where { created_at >= week_start_local }
         .where { amount < 1_000_000 }
         .where { amount > 0 }
         .sum(:amount) || 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transitioned loot cap calculations from monthly to weekly basis.
  * Added Daylight Saving Time-aware timezone handling for accurate week-boundary detection in America/New_York region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->