### PR TITLE
fix(autostart.lic): block on dependency with Script.run before DR scripts

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.69
+       version: 0.70
       required: Lich >= 4.6.58
 
   changelog:
+    0.70 (2026-05-07):
+      fix: use Script.run to block until dependency finishes before starting DR scripts
     0.69 (2026-05-06):
       fix: start dependency before autostart scripts so parse_args() bridge is available
     0.68 (2026-05-05):
@@ -142,7 +144,7 @@ if script.vars.empty?
   # dependency.lic defines the parse_args() bridge that DR scripts need.
   if XMLData.game =~ /^DR/
     if respond_to?(:start_scripts_if_available, true)
-      start_scripts_if_available('dependency') if Script.exists?('dependency')
+      Script.run('dependency') if Script.exists?('dependency') && !Script.running?('dependency')
       did_something = true
     else
       # Legacy path: dependency.lic handles everything (script sync, autostarts, map edits)


### PR DESCRIPTION
## Summary

- [#2312](https://github.com/elanthia-online/scripts/pull/2312) fixed the ordering (dependency before autostart scripts) but `start_scripts_if_available` is async -- it only waits 0.25s before moving on
- `dependency.lic` takes longer than that, so `parse_args()` is still undefined when autostart scripts begin
- Switches to `Script.run('dependency')`, which blocks until the script fully exits the `@@running` list

## Root cause

`start_scripts_if_available` (lich-5 `global_defs.rb:42-57`) calls `start_script` then polls for up to 0.25s:

```ruby
start_script(script_name)
pause 0.05
snapshot = Time.now
until !Script.running?(script_name) || Time.now - snapshot > 0.25
  pause 0.05
end
```

`Script.run` (`script.rb:365-369`) blocks indefinitely until the script finishes:

```ruby
def Script.run(*args)
  if (s = @@elevated_script_start.call(args))
    sleep 0.1 while @@running.include?(s)
  end
end
```

## Test plan

- [ ] Login to DR and verify dependency fully loads before tome/moonwatch start
- [ ] Verify `parse_args()` errors no longer appear on startup
- [ ] Verify non-DR games are unaffected (they skip the DR block entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)