### PR TITLE
fix(bigshot.lic): v5.12.7 cmd_wandolier support RESERVE system

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,8 +8,8 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.12.6
-      required: Lich >= 5.14.1
+       version: 5.12.7
+      required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
       Full Changelog: https://gswiki.play.net/Script_Bigshot/Changelog
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.12.7  (2026-05-07)
+    - allow for wandolier command to take a noreserve option, defaults to use RESERVE system
   v5.12.6  (2026-05-02)
     - fix for boundary building to set a new status while building boundary list, useful for scripts like teleport.lic
   v5.12.5  (2026-04-22)
@@ -3386,7 +3388,7 @@ class Bigshot
       cmd_weed(command, npc)
     elsif (command =~ /^wand\b/i)
       cmd_wand(npc)
-    elsif (command =~ /^wandolier\s?(\w+)?/i)
+    elsif (command =~ /^wandolier((?:\s+\w+){0,2})/i)
       cmd_wandolier(npc, $1)
     elsif (command =~ /^hide\s?(\d+)?/i)
       cmd_hide($1.to_i)
@@ -4897,13 +4899,15 @@ class Bigshot
     end
   end
 
-  def cmd_wandolier(target, stance)
-    debug_msg(@DEBUG_COMMANDS, "cmd_wandolier | target: #{target} | stance: #{stance}")
-    if stance.empty? || stance.nil?
-      stance = 'offensive'
-    end
+  def cmd_wandolier(target, args)
+    debug_msg(@DEBUG_COMMANDS, "cmd_wandolier | target: #{target} | args: #{args}")
+    tokens    = args.to_s.downcase.split(/\s+/).reject(&:empty?)
+    noreserve = tokens.include?('noreserve')
+    stance    = (tokens & %w[offensive advance forward neutral guarded defensive]).first || 'offensive'
+
     if (@FRESH_WAND_CONTAINER)
-      until ((GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i)
+      fput("reserve list") if GameObj.reserve.nil?
+      until ((GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i) || GameObj.reserve.any? { |item| item.name =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i }
         result = dothistimeout("get #{@WAND[$bigshot_wand]} from my #{@FRESH_WAND_CONTAINER}", 3, /You (?:remove|slip|slide)|Get what/)
         if (result =~ /Get what/)
           fput("rub my #{@FRESH_WAND_CONTAINER}")
@@ -4912,9 +4916,12 @@ class Bigshot
         end
       end
 
+      if !noreserve && ((GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i)
+        fput("reserve  my #{@WAND[$bigshot_wand]}")
+      end
+
       change_stance(stance)
-      # result = get_res("wave my #{@WAND[$bigshot_wand]} at ##{target.id}", /d100|You hurl|is already dead|You do not see that here|You are in no condition|I could not find/)
-      result = get_res("wave my #{@WAND[$bigshot_wand]}", /d100|You hurl|is already dead|You do not see that here|You are in no condition|I could not find/)
+      result = get_res("wave my #{@WAND[$bigshot_wand]}", /d100|You hurl|is already dead|You do not see that here|You are in no condition|I could not find|What were you referring to/)
       change_stance(@HUNTING_STANCE)
 
       if (result =~ /You are in no condition/)
@@ -4922,6 +4929,8 @@ class Bigshot
         $bigshot_should_rest = true
         $rest_reason = "Too injured to wave wands!"
         return
+      elsif result =~ /What were you referring to/
+        fput('reserve list')
       end
     else
       message("yellow", "ERROR: Wandolier command called but fresh wand container not defined.")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `noreserve` option to wandolier command (defaults to standard RESERVE behavior).

* **Chores**
  * Version bumped to 5.12.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->