### PR TITLE
refactor(egemhoarder): v2.0.0 address persistent bugs and clean up code

### DIFF
--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -190,7 +190,7 @@ module EGemHoarder
     result =~ /You see nothing unusual/i ? true : false
   end
 
-  def self.go_to_locker
+def self.go_to_locker
     return true if at_locker?
 
     echo "EGemHoarder: navigating to public lockers..."
@@ -200,18 +200,18 @@ module EGemHoarder
     10.times do
       ["opening", "curtain"].each do |exit_name|
         result = dothistimeout "go #{exit_name}", 3,
-                               /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
+                               /^You (?:step|go|enter|pass|slip)|You'll have to wait|^There is no|^Sorry|^What/
         if result =~ /^You (?:step|go|enter|pass|slip)/i
           echo "EGemHoarder: entered locker room via #{exit_name}."
           return true
         end
       end
 
-      echo "EGemHoarder: locker occupied, trying next room..."
+      # Occupied or not found -- move to next room in hallway
       moved = false
-      ["north", "south", "east", "west"].each do |dir|
+      ["east", "west", "north", "south"].each do |dir|
         result = dothistimeout "go #{dir}", 2,
-                               /^You (?:go|head|move|walk|step)|^You can't|^A closed|^What/
+                               /^You (?:go|head|move|walk|step)|^You can't|^What/
         if result =~ /^You (?:go|head|move|walk|step)/i
           moved = true
           break
@@ -219,19 +219,10 @@ module EGemHoarder
       end
 
       unless moved
-        echo "EGemHoarder: could not find an available locker room."
+        echo "EGemHoarder: could not move to next locker room."
         return false
       end
-
-      pause 0.5
-
-      room_nouns = GameObj.loot.map(&:noun) + GameObj.npcs.map(&:noun)
-      exits      = Room.current.exits rescue []
-      unless room_nouns.any? { |n| n =~ /opening|curtain/i } ||
-             exits.any? { |e| e =~ /opening|curtain/i }
-        echo "EGemHoarder: no locker in this room, wrong direction."
-        return false
-      end
+      pause 0.3
     end
 
     echo "EGemHoarder: could not find an available locker room after 10 tries."

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -87,15 +87,13 @@ module GemHoarder
     name.to_s.sub(JAR_PREFIX, '').gsub(SIZE_PREFIX, '').strip
   end
 
-  # Pluralize only the last word so "uncut emerald" matches "uncut emeralds",
-  # "ruby" matches "rubies", "topaz" matches "topazes", etc.
   def self.gem_regex(name)
     words = clean_name(name).split
     last  = words.pop
     last  = case last
             when /ies\z/i then last.sub(/ies\z/i, '(?:y|ies)')
             when /ves\z/i then last.sub(/ves\z/i, '(?:f|ves)')
-            when /es\z/i  then last.sub(/es\z/i,  '(?:e|es)')
+            when /es\z/i  then last.sub(/es\z/i,  '(?:es)?')
             when /s\z/i   then last.sub(/s\z/i,   's?')
             when /y\z/i   then last.sub(/y\z/i,   '(?:y|ies)')
             when /z\z/i   then last + 'es?'
@@ -295,12 +293,6 @@ module GemHoarder
   end
 
   # ── Scan + Sort Locker ────────────────────────────────────────────────────────
-  #
-  # Scans chest, bin, and wardrobe. Catalogs every labeled jar found.
-  # Simultaneously sorts jars into correct slots:
-  #   full    -> wardrobe
-  #   partial -> bin
-  #   empty   -> chest
 
   def self.scan_locker(data, location)
     echo "GemHoarder: scanning locker at #{location}..."
@@ -317,7 +309,6 @@ module GemHoarder
       slot_id, slot_contents = result
 
       slot_contents.select { |o| o.noun =~ JAR_NOUNS }.each do |jar|
-        # Empty jar -- move to chest if not already there
         if jar.after_name.nil? || jar.after_name.strip.empty?
           if slot != :chest
             get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
@@ -354,7 +345,6 @@ module GemHoarder
 
         found += 1
 
-        # Move to correct slot if needed
         if slot != correct
           get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
           if get_r =~ /^You remove/
@@ -385,9 +375,6 @@ module GemHoarder
     end
     echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
-    # strict -- never jar a gem tracked at any other locker
-    # normal -- jar a gem if all other locker jars for it are full
-    # loose  -- always jar regardless of other lockers
     other_loc_names = case locker_mode
     when :strict
       (data[:jars] || [])
@@ -480,7 +467,7 @@ module GemHoarder
     }
     return if gems.empty?
 
-    # ── Phase 2: Start new jars from chest for gem types without a partial jar ─
+    # ── Phase 2: Start new jars from chest ───────────────────────────────────
 
     gem_groups = Hash.new { |h, k| h[k] = [] }
     gems.each do |g|
@@ -597,113 +584,132 @@ module GemHoarder
   # ── Raid ──────────────────────────────────────────────────────────────────────
 
   def self.raid(data, location)
-    gem_name = Script.current.vars[2].to_s.strip
+    args     = Script.current.vars[2..-1].to_a
+    count    = args.last =~ /^\d+$/ ? args.pop.to_i : 1
+    gem_name = args.join(' ').strip
+
     if gem_name.empty?
       echo "GemHoarder: usage: ;egemhoarder raid <gem> [count]"
       return
     end
 
-    count = Script.current.vars[3].to_i
-    count = 1 if count < 1
-
     sack = find_gemsack
     return unless sack
 
-    matching_records = (data[:jars] || []).select { |j|
+    all_matching = (data[:jars] || []).select { |j|
       clean_name(j[:gem]) =~ gem_regex(gem_name)
     }
 
-    if matching_records.empty?
+    if all_matching.empty?
       echo "GemHoarder: no jars found for '#{gem_name}'."
       return
     end
 
-    # Warn about same gem at other lockers
-    other = matching_records.select { |j| j[:location] != location }
-    unless other.empty?
-      echo "GemHoarder: '#{gem_name}' is also tracked at other lockers:"
-      other.each { |j| echo "  -> #{j[:location]} (#{j[:count]} portions, full=#{j[:full]})" }
-    end
-
-    local_records = matching_records.select { |j| j[:location] == location }
-    if local_records.empty?
-      echo "GemHoarder: no jars for '#{gem_name}' at #{location}."
+    local = all_matching.select { |j| j[:location] == location }
+    unless local.any?
+      other = all_matching.map { |j| j[:location] }.uniq
+      echo "GemHoarder: '#{gem_name}' not at #{location}. Found at: #{other.join(', ')}"
       return
     end
 
-    total_available = local_records.sum { |j| j[:count].to_i }
+    total_available = local.sum { |j| j[:count].to_i }
     if total_available < count
       echo "GemHoarder: requested #{count} but only #{total_available} available at #{location}."
       return
     end
 
-    raided    = 0
-    remaining = count
+    # Prefer full jar; otherwise use partial with most gems
+    jar_record = local.find { |j| j[:full] } ||
+                 local.max_by { |j| j[:count].to_i }
 
-    [:wardrobe, :bin].each do |slot|
-      break if remaining <= 0
-
-      result = open_locker_part(slot.to_s)
-      unless result
-        echo "GemHoarder: could not open #{slot}."
-        next
-      end
-      slot_id, slot_contents = result
-
-      matching_jars = slot_contents.select { |o|
-        o.noun =~ JAR_NOUNS &&
-        !o.after_name.to_s.strip.empty? &&
-        clean_name(o.after_name) =~ gem_regex(gem_name)
-      }
-
-      matching_jars.each do |jar|
-        break if remaining <= 0
-
-        record = (data[:jars] || []).find { |j|
-          clean_name(j[:gem]) =~ gem_regex(gem_name) && j[:location] == location
-        }
-        next unless record
-
-        get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
-        unless get_r =~ /^You remove/
-          echo "GemHoarder: could not retrieve jar from #{slot}."
-          next
-        end
-
-        remaining.times do
-          break if remaining <= 0
-          res = dothistimeout "shake ##{jar.id}", 4, /^You shake|nothing happens|already empty/
-          if res =~ /^You shake/
-            pause 0.25
-            dropped = GameObj.loot.find { |o|
-              o.type =~ /gem/i && clean_name(o.name) =~ gem_regex(gem_name)
-            }
-            if dropped
-              fput "get ##{dropped.id}"
-              fput "put ##{dropped.id} in ##{sack.id}"
-              record[:count] = record[:count].to_i - 1
-              raided    += 1
-              remaining -= 1
-            end
-          elsif res =~ /nothing happens|already empty/
-            record[:count] = 0
-            break
-          end
-        end
-
-        # Route jar to correct slot
-        if record[:count].to_i <= 0
-          record[:full] = false
-          data[:jars].delete(record)
-          fput "put ##{jar.id} in chest"
-        else
-          record[:full] = false
-          fput "put ##{jar.id} in bin"
-        end
-      end
-
-      close_locker
+    unless jar_record
+      echo "GemHoarder: could not find a suitable jar record."
+      return
     end
+
+    slot = jar_record[:full] ? :wardrobe : :bin
+
+    result = open_locker_part(slot.to_s)
+    unless result
+      echo "GemHoarder: could not open #{slot}."
+      return
+    end
+    slot_id, slot_contents = result
+
+    jar = slot_contents.find { |o|
+      o.noun =~ JAR_NOUNS &&
+      !o.after_name.to_s.strip.empty? &&
+      clean_name(o.after_name) =~ gem_regex(gem_name)
+    }
+
+    unless jar
+      echo "GemHoarder: could not find jar in #{slot}."
+      close_locker
+      return
+    end
+
+    get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
+    unless get_r =~ /^You remove/
+      echo "GemHoarder: could not retrieve jar."
+      close_locker
+      return
+    end
+
+    raided   = 0
+    jar_noun = jar.noun
+
+    count.times do
+      unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
+        echo "GemHoarder: lost jar from hand, stopping."
+        break
+      end
+
+      res = dothistimeout "shake ##{jar.id}", 4,
+        /fall into your|free hand|nothing falls out|realize that it is empty/
+      case res
+      when /fall into your/
+        dropped = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
+          o.id != jar.id && o.type =~ /gem/i
+        }
+        if dropped
+          hand = GameObj.left_hand&.id == dropped.id ? "left" : "right"
+          fput "put my #{dropped.noun} in my #{sack.noun}"
+          jar_record[:count] = jar_record[:count].to_i - 1
+          raided += 1
+        else
+          echo "GemHoarder: shook jar but gem did not appear in hand, stopping."
+          break
+        end
+      when /free hand/
+        held = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
+          o.id != jar.id && o.type =~ /gem/i
+        }
+        if held
+          hand = GameObj.left_hand&.id == held.id ? "left" : "right"
+          fput "put my #{hand} hand #{held.noun} in my #{sack.noun}"
+          jar_record[:count] = jar_record[:count].to_i - 1
+          raided += 1
+        else
+          echo "GemHoarder: need free hand but no gem found to stow, stopping."
+          break
+        end
+      when /nothing falls out|realize that it is empty/
+        jar_record[:count] = 0
+        break
+      end
+    end
+
+    # Route jar to correct slot using noun in case ID changed
+    jar_record[:full] = false
+    if jar_record[:count].to_i <= 0
+      data[:jars].delete(jar_record)
+      fput "put ##{jar.id} in chest"
+      echo "GemHoarder: jar emptied, returned to chest."
+    else
+      fput "put ##{jar.id} in bin"
+    end
+    
+    close_locker
 
     echo "GemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
     save_data(data)

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -10,6 +10,7 @@
     - collects gems from a configurable gem sack
     - full jars move to wardrobe; partial jars stay in bin; empty jars stay in chest
     - multi-locker support
+    - multiple jars per gem type supported
     - configurable via UserVars (gemsack, gemhoarder_exclude, gemhoarder_lockermode)
     - commands: help, list, search, newlocker, forget, set, raid
     - reports which locker gems are reserved for when left in gemsack
@@ -19,7 +20,7 @@
   contributors: Caithris, Falicor, elanthia-online
   game: gs
   tags: gems, hoarding, locker, jars
-  version: 3.0.0
+  version: 2.0.0
 
   Version Control:
   Major_change.feature_addition.bugfix
@@ -27,12 +28,10 @@
     - complete refactor
     - fixed gem_regex mangling internal spaces (pluralize last word only)
     - fixed deposit counter (^You put.*into.*jar response)
-    - fixed "I could not find" mid-drag handling
     - added lockermode strict/normal/loose
     - added list location filter
     - added forget [all] option
     - added location reporting for gems left in gemsack
-    - sort integrated into newlocker scan
   v1.2.0 (2025-09-09)
     - convert to yaml instead of using lich.db3
   v1.1.0 (2025-09-08)
@@ -188,7 +187,7 @@ module GemHoarder
 
   def self.show_help
     respond ""
-    respond "EGemHoarder v3.0 - Gem jar management for your locker"
+    respond "EGemHoarder v3.1 - Gem jar management for your locker"
     respond "-" * 55
     respond ""
     respond "Locker layout:"
@@ -232,6 +231,8 @@ module GemHoarder
   end
 
   # ── List / Search ─────────────────────────────────────────────────────────────
+  # Groups multiple jar records for the same gem+location into one display row,
+  # summing counts and marking full only if ALL jars for that gem are full.
 
   def self.show_list(jars, filter: nil, location: nil)
     display = jars.dup
@@ -244,18 +245,40 @@ module GemHoarder
       matcher = Regexp.new(f, Regexp::IGNORECASE)
       display.select! { |j| j[:gem].to_s.downcase =~ matcher }
     end
-    display.sort_by! { |j| [-j[:count].to_i, j[:gem].to_s] }
+
+    # Group by gem+location, summing counts
+    grouped = {}
+    display.each do |j|
+      key = "#{clean_name(j[:gem])}||#{j[:location]}"
+      if grouped[key]
+        grouped[key][:count] += j[:count].to_i
+        grouped[key][:full]   = false unless j[:full]
+        grouped[key][:jars]  += 1
+      else
+        grouped[key] = {
+          gem:      j[:gem].to_s,
+          count:    j[:count].to_i,
+          full:     j[:full] ? true : false,
+          location: j[:location].to_s,
+          jars:     1,
+        }
+      end
+    end
+
+    rows = grouped.values.sort_by { |r| [-r[:count], r[:gem]] }
+
     respond ""
-    respond format("  %-38s %5s  %-5s  %s", "Gem", "Count", "Full?", "Location")
-    respond "  " + "-" * 65
-    if display.empty?
+    respond format("  %-38s %5s  %-5s  %-4s  %s", "Gem", "Count", "Full?", "Jars", "Location")
+    respond "  " + "-" * 70
+    if rows.empty?
       respond "  (none)"
     else
-      display.each do |j|
-        respond format("  %-38s %5d  %-5s  %s",
-                       j[:gem].to_s, j[:count].to_i,
-                       j[:full] ? "yes" : "no",
-                       j[:location].to_s)
+      rows.each do |r|
+        respond format("  %-38s %5d  %-5s  %-4d  %s",
+                       r[:gem], r[:count],
+                       r[:full] ? "yes" : "no",
+                       r[:jars],
+                       r[:location])
       end
     end
     respond ""
@@ -293,6 +316,8 @@ module GemHoarder
   end
 
   # ── Scan + Sort Locker ────────────────────────────────────────────────────────
+  # One record per physical jar. Existing records for this location are cleared
+  # before scanning so we don't accumulate stale entries.
 
   def self.scan_locker(data, location)
     echo "GemHoarder: scanning locker at #{location}..."
@@ -300,6 +325,9 @@ module GemHoarder
     found  = 0
     moved  = { chest: 0, bin: 0, wardrobe: 0 }
     failed = []
+
+    # Collect new records separately; only commit if all slots succeed
+    new_records = []
 
     [:wardrobe, :bin, :chest].each do |slot|
       result = open_locker_part(slot.to_s)
@@ -326,7 +354,7 @@ module GemHoarder
         next if gem_name.empty?
 
         look = dothistimeout "look in ##{jar.id} from ##{slot_id}", 5,
-                            /Inside.*?you see \d+ portion|I could not find|That is not/
+                             /Inside.*?you see \d+ portion|I could not find|That is not/
         unless look =~ /Inside.*?you see (\d+) portion/
           next
         end
@@ -335,16 +363,8 @@ module GemHoarder
         is_full = (look =~ /It is full|filling it/) ? true : false
         correct = is_full ? :wardrobe : :bin
 
-        existing = data[:jars].find { |j|
-          clean_name(j[:gem]).casecmp?(gem_name) && j[:location] == location
-        }
-        if existing
-          existing[:count] = existing[:count].to_i + count
-          existing[:full]  = is_full if is_full
-        else
-          data[:jars] << { gem: gem_name, count: count, full: is_full, location: location }
-        end
-
+        # One record per physical jar
+        new_records << { gem: gem_name, count: count, full: is_full, location: location }
         found += 1
 
         if slot != correct
@@ -365,10 +385,15 @@ module GemHoarder
       return false
     end
 
+    # Commit: replace all records for this location
+    data[:jars].delete_if { |j| j[:location] == location }
+    data[:jars].concat(new_records)
+
     echo "GemHoarder: scan complete -- #{found} jar(s) catalogued, " \
-        "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
+         "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
     true
   end
+
   # ── Deposit Loop ──────────────────────────────────────────────────────────────
 
   def self.deposit_gems(data, location)
@@ -385,12 +410,12 @@ module GemHoarder
     other_loc_names = case locker_mode
                       when :strict
                         (data[:jars] || [])
-                      .select { |j| j[:location] != location }
-                      .map    { |j| clean_name(j[:gem]) }
+                          .select { |j| j[:location] != location }
+                          .map    { |j| clean_name(j[:gem]) }
                       when :normal
                         (data[:jars] || [])
-                      .select { |j| j[:location] != location && !j[:full] }
-                      .map    { |j| clean_name(j[:gem]) }
+                          .select { |j| j[:location] != location && !j[:full] }
+                          .map    { |j| clean_name(j[:gem]) }
                       when :loose
                         []
                       end
@@ -410,9 +435,9 @@ module GemHoarder
         next if jar_gem.empty?
 
         record = (data[:jars] || []).find { |j|
-          clean_name(j[:gem]).casecmp?(jar_gem) && j[:location] == location
+          clean_name(j[:gem]).casecmp?(jar_gem) && j[:location] == location && !j[:full]
         }
-        next if record && record[:full]
+        next unless record
 
         matching = gems.select { |g|
           !not_suitable.include?(g.id) &&
@@ -422,13 +447,6 @@ module GemHoarder
 
         get_r = dothistimeout "get ##{jar.id} from ##{bin_id}", 4, /^You remove|Get what/
         next unless get_r =~ /^You remove/
-
-        record ||= begin
-          r = { gem: jar_gem, count: 0, full: false, location: location }
-          data[:jars] ||= []
-          data[:jars] << r
-          r
-        end
 
         filled = false
         matching.each do |gem|
@@ -480,9 +498,10 @@ module GemHoarder
     gems.each do |g|
       cn = clean_name(g.name)
       next if other_loc_names.any? { |ol| cn =~ gem_regex(ol) }
+      # Skip if any non-full jar record exists for this gem at this location
       next if (data[:jars] || []).any? { |j|
         j[:location] == location && !j[:full] &&
-        clean_name(j[:gem]) =~ gem_regex(cn)
+          clean_name(j[:gem]) =~ gem_regex(cn)
       }
       gem_groups[cn] << g
     end
@@ -589,6 +608,9 @@ module GemHoarder
   end
 
   # ── Raid ──────────────────────────────────────────────────────────────────────
+  # Works across multiple jars of the same gem type until the requested count
+  # is met. Prefers full jars (wardrobe) then partial jars (bin) by descending
+  # count. Opens each jar, shakes out the required number, then routes it back.
 
   def self.raid(data, location)
     args     = Script.current.vars[2..-1].to_a
@@ -625,96 +647,105 @@ module GemHoarder
       return
     end
 
-    # Prefer full jar; otherwise use partial with most gems
-    jar_record = local.find { |j| j[:full] } ||
-                 local.max_by { |j| j[:count].to_i }
+    # Sort: full jars first, then by descending count
+    jar_records = local.sort_by { |j| [j[:full] ? 0 : 1, -j[:count].to_i] }
 
-    unless jar_record
-      echo "GemHoarder: could not find a suitable jar record."
-      return
-    end
+    raided    = 0
+    remaining = count
 
-    slot = jar_record[:full] ? :wardrobe : :bin
+    jar_records.each do |jar_record|
+      break if remaining <= 0
 
-    result = open_locker_part(slot.to_s)
-    unless result
-      echo "GemHoarder: could not open #{slot}."
-      return
-    end
-    slot_id, slot_contents = result
+      slot = jar_record[:full] ? :wardrobe : :bin
 
-    jar = slot_contents.find { |o|
-      o.noun =~ JAR_NOUNS &&
-        !o.after_name.to_s.strip.empty? &&
-        clean_name(o.after_name) =~ gem_regex(gem_name)
-    }
+      result = open_locker_part(slot.to_s)
+      unless result
+        echo "GemHoarder: could not open #{slot}, skipping."
+        next
+      end
+      slot_id, slot_contents = result
 
-    unless jar
-      echo "GemHoarder: could not find jar in #{slot}."
-      close_locker
-      return
-    end
+      jar = slot_contents.find { |o|
+        o.noun =~ JAR_NOUNS &&
+          !o.after_name.to_s.strip.empty? &&
+          clean_name(o.after_name) =~ gem_regex(gem_name)
+      }
 
-    get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
-    unless get_r =~ /^You remove/
-      echo "GemHoarder: could not retrieve jar."
-      close_locker
-      return
-    end
-
-    raided = 0
-    jar.noun
-
-    count.times do
-      unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
-        echo "GemHoarder: lost jar from hand, stopping."
-        break
+      unless jar
+        echo "GemHoarder: could not find jar in #{slot}, skipping."
+        close_locker
+        next
       end
 
-      res = dothistimeout "shake ##{jar.id}", 4,
-                          /fall into your|free hand|nothing falls out|realize that it is empty/
-      case res
-      when /fall into your/
-        dropped = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
-          o.id != jar.id && o.type =~ /gem/i
-        }
-        if dropped
-          fput "put my #{dropped.noun} in my ##{sack.id}"
-          jar_record[:count] = jar_record[:count].to_i - 1
-          raided += 1
-        else
-          echo "GemHoarder: shook jar but gem did not appear in hand, stopping."
-          break
-        end
-      when /free hand/
-        held = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
-          o.id != jar.id && o.type =~ /gem/i
-        }
-        if held
-          fput "put my #{held.noun} in my ##{sack.id}"
-          jar_record[:count] = jar_record[:count].to_i - 1
-          raided += 1
-        else
-          echo "GemHoarder: need free hand but no gem found to stow, stopping."
-          break
-        end
-      when /nothing falls out|realize that it is empty/
-        jar_record[:count] = 0
-        break
+      get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
+      unless get_r =~ /^You remove/
+        echo "GemHoarder: could not retrieve jar from #{slot}, skipping."
+        close_locker
+        next
       end
-    end
 
-    # Route jar to correct slot using noun in case ID changed
-    jar_record[:full] = false
-    if jar_record[:count].to_i <= 0
-      data[:jars].delete(jar_record)
-      fput "put ##{jar.id} in chest"
-      echo "GemHoarder: jar emptied, returned to chest."
-    else
-      fput "put ##{jar.id} in bin"
-    end
+      # Locker stays open -- bin/chest accessible for routing after shaking
 
-    close_locker
+      need_from_this_jar = [remaining, jar_record[:count].to_i].min
+
+      need_from_this_jar.times do
+        break if remaining <= 0
+
+        unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
+          echo "GemHoarder: lost jar from hand, stopping."
+          remaining = 0
+          break
+        end
+
+        res = dothistimeout "shake ##{jar.id}", 4,
+                            /fall into your|free hand|nothing falls out|realize that it is empty/
+        case res
+        when /fall into your/
+          dropped = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
+            o.id != jar.id && o.type =~ /gem/i
+          }
+          if dropped
+            fput "put my #{dropped.noun} in my ##{sack.id}"
+            jar_record[:count] = jar_record[:count].to_i - 1
+            raided    += 1
+            remaining -= 1
+          else
+            echo "GemHoarder: shook jar but gem did not appear in hand, stopping."
+            remaining = 0
+            break
+          end
+        when /free hand/
+          held = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
+            o.id != jar.id && o.type =~ /gem/i
+          }
+          if held
+            fput "put my #{held.noun} in my ##{sack.id}"
+            jar_record[:count] = jar_record[:count].to_i - 1
+            raided    += 1
+            remaining -= 1
+          else
+            echo "GemHoarder: need free hand but no gem found to stow, stopping."
+            remaining = 0
+            break
+          end
+        when /nothing falls out|realize that it is empty/
+          jar_record[:count] = 0
+          break
+        end
+      end
+
+      # Route jar to correct slot
+      jar_record[:full] = false
+      if jar_record[:count].to_i <= 0
+        data[:jars].delete(jar_record)
+        fput "put ##{jar.id} in chest"
+        echo "GemHoarder: jar emptied, returned to chest."
+      else
+        fput "put ##{jar.id} in bin"
+      end
+
+      close_locker
+    end
 
     echo "GemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
     save_data(data)
@@ -776,7 +807,7 @@ module GemHoarder
       location = current_location
       data[:jars]          ||= []
       data[:known_lockers] ||= []
-      data[:jars].delete_if { |j| j[:location] == location }
+      # Records cleared inside scan_locker only on success
       if scan_locker(data, location)
         data[:known_lockers] |= [location]
         save_data(data)
@@ -795,9 +826,10 @@ module GemHoarder
 
       unless data[:known_lockers].include?(location)
         echo "GemHoarder: #{location} is a new locker -- scanning first..."
-        scan_locker(data, location)
-        data[:known_lockers] |= [location]
-        save_data(data)
+        if scan_locker(data, location)
+          data[:known_lockers] |= [location]
+          save_data(data)
+        end
       end
 
       deposit_gems(data, location)

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -7,31 +7,29 @@
     Wardrobe = full jars (complete, archived)
 
   Features:
-    - collects gems from a configurable gem sack
-    - full jars move to wardrobe; partial jars stay in bin; empty jars stay in chest
-    - multi-locker support
-    - multiple jars per gem type supported
-    - configurable via UserVars (gemsack, gemhoarder_exclude, gemhoarder_lockermode)
-    - commands: help, list, search, newlocker, forget, set, raid
-    - reports which locker gems are reserved for when left in gemsack
-    - raid pulls a specific gem type from locker back into gemsack
+    - deposits gems into labeled jars; chest=empty, bin=partial, wardrobe=full
+    - multi-locker, multi-jar support with per-jar tracking
+    - auto-navigates to locker, stows hands, returns to origin after deposit/raid
+    - raid pulls gems from locker back into gemsack
+    - configurable via UserVars: gemsack, gemhoarder_exclude, gemhoarder_lockermode
 
   author: elanthia-online
   contributors: Caithris, Falicor, Yalathanil
   game: gs
   tags: gems, hoarding, locker, jars
-  version: 2.0.0
+  version: 3.2.0
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v2.0.0 (2026-05-08)
-    - complete refactor
-    - fixed gem_regex mangling internal spaces (pluralize last word only)
-    - fixed deposit counter (^You put.*into.*jar response)
-    - added lockermode strict/normal/loose
-    - added list location filter
-    - added forget [all] option
-    - added location reporting for gems left in gemsack
+  v3.0.0 (2026-05-11)
+    - complete rewrite from egemhoarder v1.x
+    - auto-navigate to locker, stow hands, return to origin on deposit/raid
+    - multi-jar tracking; raid spans jars; list groups by gem
+    - chest=empty jars, bin=partial, wardrobe=full
+    - lockermode strict/normal/loose for multi-locker gem assignment
+    - search and raid support multi-word gem names
+    - scan is atomic -- rolls back on partial failure
+    - sort integrated into newlocker scan
   v1.2.0 (2025-09-09)
     - convert to yaml instead of using lich.db3
   v1.1.0 (2025-09-08)
@@ -149,11 +147,97 @@ module GemHoarder
 
   # ── Location ──────────────────────────────────────────────────────────────────
 
-  def self.current_location
-    fput "location"
-    matchfind "current location is ? or somewhere close to it."
-  rescue
-    "Unknown"
+def self.current_location
+  fput "location"
+  result = matchfind "current location is ? or somewhere close to it."
+  # Strip common town prefixes that vary by room
+  result.to_s
+        .sub(/^the (?:town|city|village|keep) of /i, '')
+        .strip
+rescue
+  "Unknown"
+end
+
+  # ── Hand Management ───────────────────────────────────────────────────────────
+
+  def self.stow_hands
+    stowed = []
+    { right: GameObj.right_hand, left: GameObj.left_hand }.each do |side, obj|
+      next if obj.nil? || obj.name.to_s.strip.empty? || obj.name =~ /^Empty$/i
+      fput "stow #{side}"
+      pause 0.3
+      stowed << { side: side, id: obj.id, noun: obj.noun, name: obj.name }
+    end
+    stowed
+  end
+
+  def self.restore_hands(stowed)
+    return if stowed.empty?
+    stowed.reverse.each do |item|
+      # Check if already in hand
+      next if [GameObj.right_hand, GameObj.left_hand].compact.any? { |o| o.id == item[:id] }
+      fput "get ##{item[:id]}"
+      pause 0.3
+    end
+  end
+
+  # ── Locker Navigation ─────────────────────────────────────────────────────────
+
+  def self.go_to_locker
+    echo "GemHoarder: navigating to public lockers..."
+    Script.run("go2", "publiclockers")
+    pause 0.5
+
+    # Try to enter a locker room; if occupied try adjacent rooms
+    10.times do
+      # Try opening first, then curtain
+      ["opening", "curtain"].each do |exit_name|
+        result = dothistimeout "go #{exit_name}", 3,
+          /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
+        if result =~ /^You (?:step|go|enter|pass|slip)/i
+          echo "GemHoarder: entered locker room via #{exit_name}."
+          return true
+        end
+      end
+
+      # Neither worked -- locker occupied, try next room in hallway
+      echo "GemHoarder: locker occupied, trying next room..."
+      moved = false
+      ["north", "south", "east", "west"].each do |dir|
+        result = dothistimeout "go #{dir}", 2,
+          /^You (?:go|head|move|walk|step)|^You can't|^A closed|^What/
+        if result =~ /^You (?:go|head|move|walk|step)/i
+          moved = true
+          break
+        end
+      end
+
+      unless moved
+        echo "GemHoarder: could not find an available locker room."
+        return false
+      end
+
+      pause 0.5
+
+      # Check if new room has a locker entrance -- if not, wrong direction
+      room_nouns = GameObj.loot.map(&:noun) + GameObj.npcs.map(&:noun)
+      exits      = Room.current.exits rescue []
+      unless room_nouns.any? { |n| n =~ /opening|curtain/i } ||
+             exits.any? { |e| e =~ /opening|curtain/i }
+        echo "GemHoarder: no locker in this room, wrong direction."
+        return false
+      end
+    end
+
+    echo "GemHoarder: could not find an available locker room after 10 tries."
+    false
+  end
+
+  def self.go_to_origin(origin_id)
+    return if XMLData.room_id == origin_id
+    echo "GemHoarder: returning to original location..."
+    Script.run("go2", origin_id.to_s)
+    pause 0.5
   end
 
   # ── Locker Helpers ────────────────────────────────────────────────────────────
@@ -187,7 +271,7 @@ module GemHoarder
 
   def self.show_help
     respond ""
-    respond "EGemHoarder v3.1 - Gem jar management for your locker"
+    respond "EGemHoarder v3.2 - Gem jar management for your locker"
     respond "-" * 55
     respond ""
     respond "Locker layout:"
@@ -216,17 +300,23 @@ module GemHoarder
     respond "    normal = store here if other locker jar is full"
     respond "    loose  = always store regardless of other lockers"
     respond ""
+    respond "Notes:"
+    respond "  Deposit and raid auto-navigate to public lockers via go2,"
+    respond "  stow held items, and return you to your original location."
+    respond "  newlocker must be run from inside the locker room."
+    respond ""
     respond "Examples:"
     respond "  ;vars set gemsack=canvas gem pouch"
     respond "  ;vars set gemhoarder_exclude=doomstone,urglaes fang"
     respond "  ;vars set gemhoarder_lockermode=normal"
     respond "  ;egemhoarder set \"fire opals\" 12 false Solhaven"
     respond "  ;egemhoarder search ruby"
+    respond "  ;egemhoarder search green amber"
     respond "  ;egemhoarder list Wehnimer's"
     respond "  ;egemhoarder forget"
     respond "  ;egemhoarder forget all"
     respond "  ;egemhoarder raid ruby 5"
-    respond "  ;egemhoarder raid \"uncut emerald\" 3"
+    respond "  ;egemhoarder raid green amber 5"
     respond ""
   end
 
@@ -251,7 +341,6 @@ module GemHoarder
               end
       pattern = (words.map { |w| Regexp.escape(w) } + [last]).join('.*')
       matcher = Regexp.new(pattern, Regexp::IGNORECASE)
-      echo "DEBUG filter=#{filter} pattern=#{pattern} matcher=#{matcher}"
       display.select! { |j| j[:gem].to_s =~ matcher }
     end
 
@@ -417,17 +506,17 @@ module GemHoarder
     echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
     other_loc_names = case locker_mode
-                      when :strict
-                        (data[:jars] || [])
-                      .select { |j| j[:location] != location }
-                      .map    { |j| clean_name(j[:gem]) }
-                      when :normal
-                        (data[:jars] || [])
-                      .select { |j| j[:location] != location && !j[:full] }
-                      .map    { |j| clean_name(j[:gem]) }
-                      when :loose
-                        []
-                      end
+    when :strict
+      (data[:jars] || [])
+        .select { |j| j[:location] != location }
+        .map { |j| clean_name(j[:gem]) }
+    when :normal
+      (data[:jars] || [])
+        .select { |j| j[:location] != location && !j[:full] }
+        .map { |j| clean_name(j[:gem]) }
+    when :loose
+      []
+    end
 
     not_suitable = []
     deposited    = 0
@@ -507,7 +596,6 @@ module GemHoarder
     gems.each do |g|
       cn = clean_name(g.name)
       next if other_loc_names.any? { |ol| cn =~ gem_regex(ol) }
-      # Skip if any non-full jar record exists for this gem at this location
       next if (data[:jars] || []).any? { |j|
         j[:location] == location && !j[:full] &&
         clean_name(j[:gem]) =~ gem_regex(cn)
@@ -617,9 +705,6 @@ module GemHoarder
   end
 
   # ── Raid ──────────────────────────────────────────────────────────────────────
-  # Works across multiple jars of the same gem type until the requested count
-  # is met. Prefers full jars (wardrobe) then partial jars (bin) by descending
-  # count. Opens each jar, shakes out the required number, then routes it back.
 
   def self.raid(data, location)
     args     = Script.current.vars[2..-1].to_a
@@ -692,8 +777,6 @@ module GemHoarder
         close_locker
         next
       end
-
-      # Locker stays open -- bin/chest accessible for routing after shaking
 
       need_from_this_jar = [remaining, jar_record[:count].to_i].min
 
@@ -815,20 +898,36 @@ module GemHoarder
       cmd_set(data)
 
     when "raid"
+      origin_id = Room.current.id
+      stowed    = stow_hands
+
+      unless go_to_locker
+        restore_hands(stowed)
+        exit
+      end
+
       location = current_location
       data[:known_lockers] ||= []
       data[:jars]          ||= []
+
       unless data[:known_lockers].include?(location)
         echo "GemHoarder: #{location} is not a registered locker. Run ;egemhoarder newlocker first."
+        close_locker
+        go_to_origin(origin_id)
+        restore_hands(stowed)
         exit
       end
+
       raid(data, location)
+
+      close_locker
+      go_to_origin(origin_id)
+      restore_hands(stowed)
 
     when "newlocker"
       location = current_location
       data[:jars]          ||= []
       data[:known_lockers] ||= []
-      # Records cleared inside scan_locker only on success
       if scan_locker(data, location)
         data[:known_lockers] |= [location]
         save_data(data)
@@ -838,6 +937,14 @@ module GemHoarder
     when "", "none"
       if UserVars.gemsack.to_s.strip.empty?
         echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+        exit
+      end
+
+      origin_id = Room.current.id
+      stowed    = stow_hands
+
+      unless go_to_locker
+        restore_hands(stowed)
         exit
       end
 
@@ -855,6 +962,10 @@ module GemHoarder
 
       deposit_gems(data, location)
       save_data(data)
+
+      close_locker
+      go_to_origin(origin_id)
+      restore_hands(stowed)
 
     else
       echo "GemHoarder: unknown command '#{cmd}'. Run ;egemhoarder help for usage."

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -21,7 +21,7 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v3.0.0 (2026-05-11)
+  v2.0.0 (2026-05-11)
     - complete rewrite from egemhoarder v1.x
     - auto-navigate to locker, stow hands, return to origin on deposit/raid
     - multi-jar tracking; raid spans jars; list groups by gem

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -86,12 +86,14 @@ module EGemHoarder
 
   def self.pluralize_word(w)
     case w
-    when /ies\z/i        then w.sub(/ies\z/i, '(?:y|ies)')
-    when /ves\z/i        then w.sub(/ves\z/i, '(?:f|ves)')
-    when /y\z/i          then w.sub(/y\z/i,   '(?:y|ies)')
-    when /z\z/i          then w + 'es?'
-    when /es\z/i, /s\z/i then w.sub(/s\z/i,   's?')
-    else                      w + 's?'
+    when /ies\z/i then w.sub(/ies\z/i, '(?:y|ies)')
+    when /ves\z/i then w.sub(/ves\z/i, '(?:f|ves)')
+    when /y\z/i   then w.sub(/y\z/i,   '(?:y|ies)')
+    when /z\z/i   then w + 'es?'
+    when /zes\z/i then w.sub(/es\z/i,  '') + '(?:es)?'
+    when /es\z/i  then w.sub(/s\z/i,   's?')
+    when /s\z/i   then w.sub(/s\z/i,   's?')
+    else               w + 's?'
     end
   end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -11,7 +11,7 @@
     - multi-locker, multi-jar support with per-jar tracking
     - auto-navigates to locker, stows hands, returns to origin after deposit/raid
     - raid pulls gems from locker back into gemsack
-    - configurable via UserVars: gemsack, gemhoarder_exclude, gemhoarder_lockermode
+    - configurable via UserVars: gemsack, egemhoarder_exclude, egemhoarder_lockermode
 
   author: elanthia-online
   contributors: Caithris, Falicor, Yalathanil
@@ -46,8 +46,8 @@ silence_me
 
 require 'yaml'
 
-module GemHoarder
-  YAML_FILE   = File.join(DATA_DIR, XMLData.game, XMLData.name, 'gemhoarder.yaml')
+module EGemHoarder
+  YAML_FILE   = File.join(DATA_DIR, XMLData.game, XMLData.name, 'egemhoarder.yaml')
   JAR_NOUNS   = /^(?:jar|beaker|bottle)$/i
   SIZE_PREFIX = /\b(?:large|medium|small|tiny|some)\s+/i
   JAR_PREFIX  = /^(?:containing\s+)/i
@@ -61,7 +61,7 @@ module GemHoarder
       default_data
     end
   rescue => e
-    echo "GemHoarder: error loading data (#{e}), starting fresh."
+    echo "EGemHoarder: error loading data (#{e}), starting fresh."
     default_data
   end
 
@@ -74,7 +74,7 @@ module GemHoarder
     Dir.mkdir(dir) unless Dir.exist?(dir)
     File.open(YAML_FILE, 'w') { |f| f.write(data.to_yaml) }
   rescue => e
-    echo "GemHoarder: error saving data (#{e})"
+    echo "EGemHoarder: error saving data (#{e})"
   end
 
   # -- Name Helpers -------------------------------------------------------------
@@ -104,15 +104,15 @@ module GemHoarder
   def self.find_gemsack
     name = UserVars.gemsack.to_s.strip
     if name.empty?
-      echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+      echo "EGemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
       return nil
     end
     sack = GameObj.inv.find { |o| o.name =~ /\b#{Regexp.escape(name)}$/i } ||
            GameObj.inv.find { |o| o.name =~ /#{Regexp.escape(name)}/i } ||
            GameObj.inv.find { |o| o.noun =~ /^#{Regexp.escape(name.split.last)}$/i }
     unless sack
-      echo "GemHoarder: could not find '#{name}' in inventory."
-      echo "GemHoarder: known containers:"
+      echo "EGemHoarder: could not find '#{name}' in inventory."
+      echo "EGemHoarder: known containers:"
       GameObj.inv.each do |o|
         echo "  noun=#{o.noun}  name=#{o.name}" if GameObj.containers.key?(o.id)
       end
@@ -129,7 +129,7 @@ module GemHoarder
   end
 
   def self.excluded_gems
-    UserVars.gemhoarder_exclude.to_s.split(',').map { |s| s.strip.downcase }
+    UserVars.egemhoarder_exclude.to_s.split(',').map { |s| s.strip.downcase }
   end
 
   def self.gem_excluded?(gem_name)
@@ -138,7 +138,7 @@ module GemHoarder
   end
 
   def self.locker_mode
-    case UserVars.gemhoarder_lockermode.to_s.strip.downcase
+    case UserVars.egemhoarder_lockermode.to_s.strip.downcase
     when "loose"  then :loose
     when "normal" then :normal
     else               :strict
@@ -193,7 +193,7 @@ module GemHoarder
       return true
     end
 
-    echo "GemHoarder: navigating to public lockers..."
+    echo "EGemHoarder: navigating to public lockers..."
     Script.run("go2", "publiclockers")
     pause 0.5
 
@@ -204,13 +204,13 @@ module GemHoarder
         result = dothistimeout "go #{exit_name}", 3,
                                /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
         if result =~ /^You (?:step|go|enter|pass|slip)/i
-          echo "GemHoarder: entered locker room via #{exit_name}."
+          echo "EGemHoarder: entered locker room via #{exit_name}."
           return true
         end
       end
 
       # Neither worked -- locker occupied, try next room in hallway
-      echo "GemHoarder: locker occupied, trying next room..."
+      echo "EGemHoarder: locker occupied, trying next room..."
       moved = false
       ["north", "south", "east", "west"].each do |dir|
         result = dothistimeout "go #{dir}", 2,
@@ -222,7 +222,7 @@ module GemHoarder
       end
 
       unless moved
-        echo "GemHoarder: could not find an available locker room."
+        echo "EGemHoarder: could not find an available locker room."
         return false
       end
 
@@ -233,18 +233,18 @@ module GemHoarder
       exits      = Room.current.exits rescue []
       unless room_nouns.any? { |n| n =~ /opening|curtain/i } ||
              exits.any? { |e| e =~ /opening|curtain/i }
-        echo "GemHoarder: no locker in this room, wrong direction."
+        echo "EGemHoarder: no locker in this room, wrong direction."
         return false
       end
     end
 
-    echo "GemHoarder: could not find an available locker room after 10 tries."
+    echo "EGemHoarder: could not find an available locker room after 10 tries."
     false
   end
 
   def self.go_to_origin(origin_id)
     return if XMLData.room_id == origin_id
-    echo "GemHoarder: returning to original location..."
+    echo "EGemHoarder: returning to original location..."
     Script.run("go2", origin_id.to_s)
     pause 0.5
   end
@@ -303,8 +303,8 @@ module GemHoarder
     respond ""
     respond "UserVars (;vars set key=value):"
     respond "  gemsack                  Container holding loose gems (REQUIRED)"
-    respond "  gemhoarder_exclude       Comma-separated gems to never jar"
-    respond "  gemhoarder_lockermode    strict/normal/loose (default: strict)"
+    respond "  egemhoarder_exclude      Comma-separated gems to never jar"
+    respond "  egemhoarder_lockermode   strict/normal/loose (default: strict)"
     respond "    strict = never store same gem in multiple lockers"
     respond "    normal = store here if other locker jar is full"
     respond "    loose  = always store regardless of other lockers"
@@ -316,8 +316,8 @@ module GemHoarder
     respond ""
     respond "Examples:"
     respond "  ;vars set gemsack=canvas gem pouch"
-    respond "  ;vars set gemhoarder_exclude=doomstone,urglaes fang"
-    respond "  ;vars set gemhoarder_lockermode=normal"
+    respond "  ;vars set egemhoarder_exclude=doomstone,urglaes fang"
+    respond "  ;vars set egemhoarder_lockermode=normal"
     respond "  ;egemhoarder set \"fire opals\" 12 false Solhaven"
     respond "  ;egemhoarder search ruby"
     respond "  ;egemhoarder search green amber"
@@ -402,7 +402,7 @@ module GemHoarder
     vars     = Script.current.vars
     gem_name = vars[2].to_s.strip
     if gem_name.empty?
-      echo "GemHoarder: usage: ;egemhoarder set <gem> <count> [full] [location]"
+      echo "EGemHoarder: usage: ;egemhoarder set <gem> <count> [full] [location]"
       return
     end
     count = vars[3] ? vars[3].to_i : 0
@@ -410,7 +410,7 @@ module GemHoarder
     loc   = vars[5].to_s.strip
     if loc.empty?
       loc = current_location
-      echo "GemHoarder: location not specified, using '#{loc}'"
+      echo "EGemHoarder: location not specified, using '#{loc}'"
     end
 
     data[:jars] ||= []
@@ -420,9 +420,9 @@ module GemHoarder
 
     if count > 0
       data[:jars] << { gem: clean_name(gem_name), count: count, full: full, location: loc }
-      echo "GemHoarder: '#{gem_name}' => count=#{count}, full=#{full}, location=#{loc}"
+      echo "EGemHoarder: '#{gem_name}' => count=#{count}, full=#{full}, location=#{loc}"
     else
-      echo "GemHoarder: removed '#{gem_name}' from jar list for #{loc}."
+      echo "EGemHoarder: removed '#{gem_name}' from jar list for #{loc}."
     end
     save_data(data)
   end
@@ -432,7 +432,7 @@ module GemHoarder
   # before scanning so we don't accumulate stale entries.
 
   def self.scan_locker(data, location)
-    echo "GemHoarder: scanning locker at #{location}..."
+    echo "EGemHoarder: scanning locker at #{location}..."
     data[:jars] ||= []
     found  = 0
     moved  = { chest: 0, bin: 0, wardrobe: 0 }
@@ -444,7 +444,7 @@ module GemHoarder
     [:wardrobe, :bin, :chest].each do |slot|
       result = open_locker_part(slot.to_s)
       unless result
-        echo "GemHoarder: could not open #{slot} -- skipping."
+        echo "EGemHoarder: could not open #{slot} -- skipping."
         failed << slot
         next
       end
@@ -492,8 +492,8 @@ module GemHoarder
     end
 
     if failed.any?
-      echo "GemHoarder: scan incomplete -- could not open: #{failed.join(', ')}."
-      echo "GemHoarder: locker data for #{location} was NOT updated to avoid overwriting good data."
+      echo "EGemHoarder: scan incomplete -- could not open: #{failed.join(', ')}."
+      echo "EGemHoarder: locker data for #{location} was NOT updated to avoid overwriting good data."
       return false
     end
 
@@ -501,7 +501,7 @@ module GemHoarder
     data[:jars].delete_if { |j| j[:location] == location }
     data[:jars].concat(new_records)
 
-    echo "GemHoarder: scan complete -- #{found} jar(s) catalogued, " \
+    echo "EGemHoarder: scan complete -- #{found} jar(s) catalogued, " \
          "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
     true
   end
@@ -514,10 +514,10 @@ module GemHoarder
 
     gems = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
     if gems.empty?
-      echo "GemHoarder: no eligible gems in gemsack."
+      echo "EGemHoarder: no eligible gems in gemsack."
       return
     end
-    echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
+    echo "EGemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
     other_loc_names = case locker_mode
                       when :strict
@@ -626,7 +626,7 @@ module GemHoarder
         }
 
         if empty_jars.empty?
-          echo "GemHoarder: no empty jars in chest for #{gem_groups.size} new gem type(s)."
+          echo "EGemHoarder: no empty jars in chest for #{gem_groups.size} new gem type(s)."
         else
           gem_groups.each do |gem_name, group|
             jar = empty_jars.shift
@@ -690,7 +690,7 @@ module GemHoarder
     end
 
     # -- Summary ---------------------------------------------------------------
-    echo "GemHoarder: deposited #{deposited} gem(s)."
+    echo "EGemHoarder: deposited #{deposited} gem(s)."
 
     leftover = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
     unless leftover.empty?
@@ -702,7 +702,7 @@ module GemHoarder
 
       unless in_other.empty?
         names = in_other.map { |g| clean_name(g.name) }.uniq
-        echo "GemHoarder: #{in_other.size} gem(s) tracked at other lockers -- left in gemsack:"
+        echo "EGemHoarder: #{in_other.size} gem(s) tracked at other lockers -- left in gemsack:"
         names.each do |n|
           other_loc = (data[:jars] || []).find { |j|
             j[:location] != location && clean_name(j[:gem]) =~ gem_regex(n)
@@ -713,7 +713,7 @@ module GemHoarder
       end
 
       unless not_jarred.empty?
-        echo "GemHoarder: #{not_jarred.size} gem(s) could not be jarred (no empty jars or unsuitable)."
+        echo "EGemHoarder: #{not_jarred.size} gem(s) could not be jarred (no empty jars or unsuitable)."
       end
     end
   end
@@ -726,7 +726,7 @@ module GemHoarder
     gem_name = args.join(' ').strip
 
     if gem_name.empty?
-      echo "GemHoarder: usage: ;egemhoarder raid <gem> [count]"
+      echo "EGemHoarder: usage: ;egemhoarder raid <gem> [count]"
       return
     end
 
@@ -738,20 +738,20 @@ module GemHoarder
     }
 
     if all_matching.empty?
-      echo "GemHoarder: no jars found for '#{gem_name}'."
+      echo "EGemHoarder: no jars found for '#{gem_name}'."
       return
     end
 
     local = all_matching.select { |j| j[:location] == location }
     unless local.any?
       other = all_matching.map { |j| j[:location] }.uniq
-      echo "GemHoarder: '#{gem_name}' not at #{location}. Found at: #{other.join(', ')}"
+      echo "EGemHoarder: '#{gem_name}' not at #{location}. Found at: #{other.join(', ')}"
       return
     end
 
     total_available = local.sum { |j| j[:count].to_i }
     if total_available < count
-      echo "GemHoarder: requested #{count} but only #{total_available} available at #{location}."
+      echo "EGemHoarder: requested #{count} but only #{total_available} available at #{location}."
       return
     end
 
@@ -768,7 +768,7 @@ module GemHoarder
 
       result = open_locker_part(slot.to_s)
       unless result
-        echo "GemHoarder: could not open #{slot}, skipping."
+        echo "EGemHoarder: could not open #{slot}, skipping."
         next
       end
       slot_id, slot_contents = result
@@ -780,14 +780,14 @@ module GemHoarder
       }
 
       unless jar
-        echo "GemHoarder: could not find jar in #{slot}, skipping."
+        echo "EGemHoarder: could not find jar in #{slot}, skipping."
         close_locker
         next
       end
 
       get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
       unless get_r =~ /^You remove/
-        echo "GemHoarder: could not retrieve jar from #{slot}, skipping."
+        echo "EGemHoarder: could not retrieve jar from #{slot}, skipping."
         close_locker
         next
       end
@@ -801,7 +801,7 @@ module GemHoarder
         break if remaining <= 0
 
         unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
-          echo "GemHoarder: lost jar from hand, stopping."
+          echo "EGemHoarder: lost jar from hand, stopping."
           remaining = 0
           break
         end
@@ -821,12 +821,12 @@ module GemHoarder
               remaining   -= 1
               gem_removed  = true
             else
-              echo "GemHoarder: could not put gem in sack, stopping."
+              echo "EGemHoarder: could not put gem in sack, stopping."
               remaining = 0
               break
             end
           else
-            echo "GemHoarder: shook jar but gem did not appear in hand, stopping."
+            echo "EGemHoarder: shook jar but gem did not appear in hand, stopping."
             remaining = 0
             break
           end
@@ -842,12 +842,12 @@ module GemHoarder
               remaining   -= 1
               gem_removed  = true
             else
-              echo "GemHoarder: could not put gem in sack, stopping."
+              echo "EGemHoarder: could not put gem in sack, stopping."
               remaining = 0
               break
             end
           else
-            echo "GemHoarder: need free hand but no gem found to stow, stopping."
+            echo "EGemHoarder: need free hand but no gem found to stow, stopping."
             remaining = 0
             break
           end
@@ -856,11 +856,11 @@ module GemHoarder
           empty_confirmed = true
           break
         when nil
-          echo "GemHoarder: shake timed out, stopping."
+          echo "EGemHoarder: shake timed out, stopping."
           remaining = 0
           break
         else
-          echo "GemHoarder: unexpected shake response '#{res}', stopping."
+          echo "EGemHoarder: unexpected shake response '#{res}', stopping."
           remaining = 0
           break
         end
@@ -872,19 +872,19 @@ module GemHoarder
         if jar_record[:count].to_i <= 0
           data[:jars].delete(jar_record)
           fput "put ##{jar.id} in chest"
-          echo "GemHoarder: jar emptied, returned to chest."
+          echo "EGemHoarder: jar emptied, returned to chest."
         else
           fput "put ##{jar.id} in bin"
         end
       else
-        echo "GemHoarder: no confirmed interaction -- returning jar unchanged."
+        echo "EGemHoarder: no confirmed interaction -- returning jar unchanged."
         fput "put ##{jar.id} in #{jar_record[:full] ? 'wardrobe' : 'bin'}"
       end
 
       close_locker
     end
 
-    echo "GemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
+    echo "EGemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
     save_data(data)
   end
 
@@ -908,7 +908,7 @@ module GemHoarder
     when "search"
       filter = Script.current.vars[2..-1].to_a.join(' ').strip
       if filter.empty?
-        echo "GemHoarder: usage: ;egemhoarder search <string>"
+        echo "EGemHoarder: usage: ;egemhoarder search <string>"
       else
         show_list(data[:jars] || [], filter: filter)
       end
@@ -919,12 +919,12 @@ module GemHoarder
         data[:jars]          = []
         data[:known_lockers] = []
         save_data(data)
-        echo "GemHoarder: all locker data cleared."
+        echo "EGemHoarder: all locker data cleared."
       else
         data[:jars].delete_if { |j| j[:location] == location }
         data[:known_lockers].delete(location)
         save_data(data)
-        echo "GemHoarder: data cleared for #{location}."
+        echo "EGemHoarder: data cleared for #{location}."
       end
 
     when "set"
@@ -944,7 +944,7 @@ module GemHoarder
       data[:jars]          ||= []
 
       unless data[:known_lockers].include?(location)
-        echo "GemHoarder: #{location} is not a registered locker. Run ;egemhoarder newlocker first."
+        echo "EGemHoarder: #{location} is not a registered locker. Run ;egemhoarder newlocker first."
         close_locker
         go_to_origin(origin_id)
         restore_hands(stowed)
@@ -964,12 +964,12 @@ module GemHoarder
       if scan_locker(data, location)
         data[:known_lockers] |= [location]
         save_data(data)
-        echo "GemHoarder: #{location} registered. Run ;egemhoarder to deposit gems."
+        echo "EGemHoarder: #{location} registered. Run ;egemhoarder to deposit gems."
       end
 
     when "", "none"
       if UserVars.gemsack.to_s.strip.empty?
-        echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+        echo "EGemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
         exit
       end
 
@@ -986,7 +986,7 @@ module GemHoarder
       data[:jars]          ||= []
 
       unless data[:known_lockers].include?(location)
-        echo "GemHoarder: #{location} is a new locker -- scanning first..."
+        echo "EGemHoarder: #{location} is a new locker -- scanning first..."
         if scan_locker(data, location)
           data[:known_lockers] |= [location]
           save_data(data)
@@ -1001,9 +1001,9 @@ module GemHoarder
       restore_hands(stowed)
 
     else
-      echo "GemHoarder: unknown command '#{cmd}'. Run ;egemhoarder help for usage."
+      echo "EGemHoarder: unknown command '#{cmd}'. Run ;egemhoarder help for usage."
     end
   end
 end
 
-GemHoarder.main
+EGemHoarder.main

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -38,7 +38,7 @@
   v1.0.1 (2024-04-04)
     - update various help text
   v1.0.0 (2024-04-03)
-    - initial releasedef self.at_locker?
+    - initial release
     - fork of gemhoarder2 with Ruby 3.x compatibility
 =end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -238,12 +238,21 @@ module GemHoarder
     display = jars.dup
     display.select! { |j| j[:location].to_s.downcase.include?(location.downcase) } if location
     if filter
-      f = Regexp.escape(filter.strip.downcase)
-                .sub(/ies\z/, '(?:y|ies)')
-                .sub(/y\z/,   '(?:y|ies)')
-                .sub(/s\z/,   's?')
-      matcher = Regexp.new(f, Regexp::IGNORECASE)
-      display.select! { |j| j[:gem].to_s.downcase =~ matcher }
+      words = filter.strip.split
+      last  = words.pop
+      last  = case last.downcase
+              when /ies\z/ then last.sub(/ies\z/i, '(?:y|ies)')
+              when /ves\z/ then last.sub(/ves\z/i, '(?:f|ves)')
+              when /es\z/  then last.sub(/es\z/i,  '(?:es)?')
+              when /s\z/   then last.sub(/s\z/i,   's?')
+              when /y\z/   then last.sub(/y\z/i,   '(?:y|ies)')
+              when /z\z/   then last + 'es?'
+              else              last + 's?'
+              end
+      pattern = (words.map { |w| Regexp.escape(w) } + [last]).join('.*')
+      matcher = Regexp.new(pattern, Regexp::IGNORECASE)
+      echo "DEBUG filter=#{filter} pattern=#{pattern} matcher=#{matcher}"
+      display.select! { |j| j[:gem].to_s =~ matcher }
     end
 
     # Group by gem+location, summing counts
@@ -626,7 +635,7 @@ module GemHoarder
     return unless sack
 
     all_matching = (data[:jars] || []).select { |j|
-      clean_name(j[:gem]) =~ gem_regex(gem_name)
+      clean_name(j[:gem]).downcase.include?(gem_name.downcase)
     }
 
     if all_matching.empty?
@@ -667,8 +676,8 @@ module GemHoarder
 
       jar = slot_contents.find { |o|
         o.noun =~ JAR_NOUNS &&
-          !o.after_name.to_s.strip.empty? &&
-          clean_name(o.after_name) =~ gem_regex(gem_name)
+        !o.after_name.to_s.strip.empty? &&
+        clean_name(o.after_name).downcase.include?(gem_name.downcase)
       }
 
       unless jar
@@ -769,7 +778,7 @@ module GemHoarder
       show_list(data[:jars] || [], location: loc)
 
     when "search"
-      filter = Script.current.vars[2].to_s.strip
+      filter = Script.current.vars[2..-1].to_a.join(' ').strip
       if filter.empty?
         echo "GemHoarder: usage: ;egemhoarder search <string>"
       else

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -152,9 +152,8 @@ module GemHoarder
   def self.current_location
     fput "location"
     result = matchfind "current location is ? or somewhere close to it."
-    # Strip common town prefixes that vary by room
     result.to_s
-          .sub(/^the (?:town|city|village|keep) of /i, '')
+          .sub(/^the (?:free port|town|city|village|keep|port) of /i, '')
           .strip
   rescue
     "Unknown"
@@ -186,8 +185,9 @@ module GemHoarder
   # ── Locker Navigation ─────────────────────────────────────────────────────────
 
   def self.at_locker?
-    result = dothistimeout "look locker", 3, /You see nothing unusual|What were you referring to|^You see/i
-    result =~ /What were you referring to/i ? false : true
+    result = dothistimeout "look locker", 3,
+      /You see nothing unusual|What were you referring to|could not find/i
+    result =~ /You see nothing unusual/i ? true : false
   end
 
   def self.go_to_locker

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -38,7 +38,9 @@
   v1.0.1 (2024-04-04)
     - update various help text
   v1.0.0 (2024-04-03)
-    - initial release
+    - initial releasedef self.at_locker?
+  (GameObj.loot || []).any? { |o| o.noun =~ /^locker$/i }
+end
     - fork of gemhoarder2 with Ruby 3.x compatibility
 =end
 
@@ -89,10 +91,10 @@ module GemHoarder
     last  = case last
             when /ies\z/i then last.sub(/ies\z/i, '(?:y|ies)')
             when /ves\z/i then last.sub(/ves\z/i, '(?:f|ves)')
-            when /es\z/i  then last.sub(/es\z/i,  '(?:es)?')
-            when /s\z/i   then last.sub(/s\z/i,   's?')
             when /y\z/i   then last.sub(/y\z/i,   '(?:y|ies)')
             when /z\z/i   then last + 'es?'
+            when /es\z/i then last.sub(/s\z/i, 's?')
+            when /s\z/i   then last.sub(/s\z/i,   's?')
             else               last + 's?'
             end
     pattern = (words + [last]).join('\s+')
@@ -183,7 +185,16 @@ module GemHoarder
 
   # ── Locker Navigation ─────────────────────────────────────────────────────────
 
+  def self.at_locker?
+    result = dothistimeout "look locker", 3, /You see nothing unusual|What were you referring to|^You see/i
+    result =~ /What were you referring to/i ? false : true
+  end
+
   def self.go_to_locker
+    if self.at_locker?
+      return true
+    end
+
     echo "GemHoarder: navigating to public lockers..."
     Script.run("go2", "publiclockers")
     pause 0.5
@@ -533,7 +544,7 @@ module GemHoarder
         next if jar_gem.empty?
 
         record = (data[:jars] || []).find { |j|
-          clean_name(j[:gem]).casecmp?(jar_gem) && j[:location] == location && !j[:full]
+          clean_name(j[:gem]) =~ gem_regex(jar_gem) && j[:location] == location && !j[:full]
         }
         next unless record
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -52,7 +52,7 @@ module GemHoarder
   SIZE_PREFIX = /\b(?:large|medium|small|tiny|some)\s+/i
   JAR_PREFIX  = /^(?:containing\s+)/i
 
-  # ── Persistence ──────────────────────────────────────────────────────────────
+  # -- Persistence --------------------------------------------------------------
 
   def self.load_data
     if File.exist?(YAML_FILE)
@@ -77,7 +77,7 @@ module GemHoarder
     echo "GemHoarder: error saving data (#{e})"
   end
 
-  # ── Name Helpers ─────────────────────────────────────────────────────────────
+  # -- Name Helpers -------------------------------------------------------------
 
   def self.clean_name(name)
     name.to_s.sub(JAR_PREFIX, '').gsub(SIZE_PREFIX, '').strip
@@ -99,7 +99,7 @@ module GemHoarder
     /^#{pattern}$/i
   end
 
-  # ── Inventory Helpers ─────────────────────────────────────────────────────────
+  # -- Inventory Helpers ---------------------------------------------------------
 
   def self.find_gemsack
     name = UserVars.gemsack.to_s.strip
@@ -145,7 +145,7 @@ module GemHoarder
     end
   end
 
-  # ── Location ──────────────────────────────────────────────────────────────────
+  # -- Location ------------------------------------------------------------------
 
   def self.current_location
     fput "location"
@@ -157,7 +157,7 @@ module GemHoarder
     "Unknown"
   end
 
-  # ── Hand Management ───────────────────────────────────────────────────────────
+  # -- Hand Management -----------------------------------------------------------
 
   def self.stow_hands
     stowed = []
@@ -180,7 +180,7 @@ module GemHoarder
     end
   end
 
-  # ── Locker Navigation ─────────────────────────────────────────────────────────
+  # -- Locker Navigation ---------------------------------------------------------
 
   def self.at_locker?
     result = dothistimeout "look locker", 3,
@@ -249,7 +249,7 @@ module GemHoarder
     pause 0.5
   end
 
-  # ── Locker Helpers ────────────────────────────────────────────────────────────
+  # -- Locker Helpers ------------------------------------------------------------
 
   def self.open_locker_part(noun)
     close_locker
@@ -276,7 +276,7 @@ module GemHoarder
     pause 0.3
   end
 
-  # ── Help ─────────────────────────────────────────────────────────────────────
+  # -- Help ---------------------------------------------------------------------
 
   def self.show_help
     respond ""
@@ -329,7 +329,7 @@ module GemHoarder
     respond ""
   end
 
-  # ── List / Search ─────────────────────────────────────────────────────────────
+  # -- List / Search -------------------------------------------------------------
   # Groups multiple jar records for the same gem+location into one display row,
   # summing counts and marking full only if ALL jars for that gem are full.
 
@@ -396,7 +396,7 @@ module GemHoarder
     respond ""
   end
 
-  # ── Manual Set ────────────────────────────────────────────────────────────────
+  # -- Manual Set ----------------------------------------------------------------
 
   def self.cmd_set(data)
     vars     = Script.current.vars
@@ -427,7 +427,7 @@ module GemHoarder
     save_data(data)
   end
 
-  # ── Scan + Sort Locker ────────────────────────────────────────────────────────
+  # -- Scan + Sort Locker --------------------------------------------------------
   # One record per physical jar. Existing records for this location are cleared
   # before scanning so we don't accumulate stale entries.
 
@@ -506,7 +506,7 @@ module GemHoarder
     true
   end
 
-  # ── Deposit Loop ──────────────────────────────────────────────────────────────
+  # -- Deposit Loop --------------------------------------------------------------
 
   def self.deposit_gems(data, location)
     sack = find_gemsack
@@ -535,7 +535,7 @@ module GemHoarder
     not_suitable = []
     deposited    = 0
 
-    # ── Phase 1: Fill partial jars from bin ──────────────────────────────────
+    # -- Phase 1: Fill partial jars from bin ----------------------------------
 
     bin_result = open_locker_part("bin")
     if bin_result
@@ -604,7 +604,7 @@ module GemHoarder
     }
     return if gems.empty?
 
-    # ── Phase 2: Start new jars from chest ───────────────────────────────────
+    # -- Phase 2: Start new jars from chest -----------------------------------
 
     gem_groups = Hash.new { |h, k| h[k] = [] }
     gems.each do |g|
@@ -689,7 +689,7 @@ module GemHoarder
       end
     end
 
-    # ── Summary ───────────────────────────────────────────────────────────────
+    # -- Summary ---------------------------------------------------------------
     echo "GemHoarder: deposited #{deposited} gem(s)."
 
     leftover = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
@@ -718,7 +718,7 @@ module GemHoarder
     end
   end
 
-  # ── Raid ──────────────────────────────────────────────────────────────────────
+  # -- Raid ----------------------------------------------------------------------
 
   def self.raid(data, location)
     args     = Script.current.vars[2..-1].to_a
@@ -888,7 +888,7 @@ module GemHoarder
     save_data(data)
   end
 
-  # ── Entry Point ───────────────────────────────────────────────────────────────
+  # -- Entry Point ---------------------------------------------------------------
 
   def self.main
     data = load_data

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -83,19 +83,22 @@ module EGemHoarder
     name.to_s.sub(JAR_PREFIX, '').gsub(SIZE_PREFIX, '').strip
   end
 
+  def self.pluralize_word(w)
+    case w
+    when /ies\z/i then w.sub(/ies\z/i, '(?:y|ies)')
+    when /ves\z/i then w.sub(/ves\z/i, '(?:f|ves)')
+    when /y\z/i   then w.sub(/y\z/i,   '(?:y|ies)')
+    when /z\z/i   then w + 'es?'
+    when /es\z/i  then w.sub(/es\z/i,  '(?:es)?')
+    when /s\z/i   then w.sub(/s\z/i,   's?')
+    else               w + 's?'
+    end
+  end
+
   def self.gem_regex(name)
-    words = clean_name(name).split
-    last  = words.pop
-    last  = case last
-            when /ies\z/i then last.sub(/ies\z/i, '(?:y|ies)')
-            when /ves\z/i then last.sub(/ves\z/i, '(?:f|ves)')
-            when /y\z/i   then last.sub(/y\z/i,   '(?:y|ies)')
-            when /z\z/i   then last + 'es?'
-            when /es\z/i then last.sub(/s\z/i, 's?')
-            when /s\z/i then last.sub(/s\z/i, 's?')
-            else last + 's?'
-            end
-    pattern = (words + [last]).join('\s+')
+    words   = clean_name(name).split
+    last    = pluralize_word(words.pop)
+    pattern = (words.map { |w| pluralize_word(w) } + [last]).join('\s+')
     /^#{pattern}$/i
   end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -265,11 +265,11 @@ module GemHoarder
         grouped[key][:jars]  += 1
       else
         grouped[key] = {
-          gem:      j[:gem].to_s,
-          count:    j[:count].to_i,
-          full:     j[:full] ? true : false,
+          gem: j[:gem].to_s,
+          count: j[:count].to_i,
+          full: j[:full] ? true : false,
           location: j[:location].to_s,
-          jars:     1,
+          jars: 1,
         }
       end
     end
@@ -419,12 +419,12 @@ module GemHoarder
     other_loc_names = case locker_mode
                       when :strict
                         (data[:jars] || [])
-                          .select { |j| j[:location] != location }
-                          .map    { |j| clean_name(j[:gem]) }
+                      .select { |j| j[:location] != location }
+                      .map    { |j| clean_name(j[:gem]) }
                       when :normal
                         (data[:jars] || [])
-                          .select { |j| j[:location] != location && !j[:full] }
-                          .map    { |j| clean_name(j[:gem]) }
+                      .select { |j| j[:location] != location && !j[:full] }
+                      .map    { |j| clean_name(j[:gem]) }
                       when :loose
                         []
                       end
@@ -510,7 +510,7 @@ module GemHoarder
       # Skip if any non-full jar record exists for this gem at this location
       next if (data[:jars] || []).any? { |j|
         j[:location] == location && !j[:full] &&
-          clean_name(j[:gem]) =~ gem_regex(cn)
+        clean_name(j[:gem]) =~ gem_regex(cn)
       }
       gem_groups[cn] << g
     end
@@ -676,8 +676,8 @@ module GemHoarder
 
       jar = slot_contents.find { |o|
         o.noun =~ JAR_NOUNS &&
-        !o.after_name.to_s.strip.empty? &&
-        clean_name(o.after_name).downcase.include?(gem_name.downcase)
+          !o.after_name.to_s.strip.empty? &&
+          clean_name(o.after_name).downcase.include?(gem_name.downcase)
       }
 
       unless jar

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -23,7 +23,7 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v3.0.0 (2026-05-08)
+  v2.0.0 (2026-05-08)
     - complete refactor
     - fixed gem_regex mangling internal spaces (pluralize last word only)
     - fixed deposit counter (^You put.*into.*jar response)

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -147,16 +147,16 @@ module GemHoarder
 
   # ── Location ──────────────────────────────────────────────────────────────────
 
-def self.current_location
-  fput "location"
-  result = matchfind "current location is ? or somewhere close to it."
-  # Strip common town prefixes that vary by room
-  result.to_s
-        .sub(/^the (?:town|city|village|keep) of /i, '')
-        .strip
-rescue
-  "Unknown"
-end
+  def self.current_location
+    fput "location"
+    result = matchfind "current location is ? or somewhere close to it."
+    # Strip common town prefixes that vary by room
+    result.to_s
+          .sub(/^the (?:town|city|village|keep) of /i, '')
+          .strip
+  rescue
+    "Unknown"
+  end
 
   # ── Hand Management ───────────────────────────────────────────────────────────
 
@@ -193,7 +193,7 @@ end
       # Try opening first, then curtain
       ["opening", "curtain"].each do |exit_name|
         result = dothistimeout "go #{exit_name}", 3,
-          /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
+                               /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
         if result =~ /^You (?:step|go|enter|pass|slip)/i
           echo "GemHoarder: entered locker room via #{exit_name}."
           return true
@@ -205,7 +205,7 @@ end
       moved = false
       ["north", "south", "east", "west"].each do |dir|
         result = dothistimeout "go #{dir}", 2,
-          /^You (?:go|head|move|walk|step)|^You can't|^A closed|^What/
+                               /^You (?:go|head|move|walk|step)|^You can't|^A closed|^What/
         if result =~ /^You (?:go|head|move|walk|step)/i
           moved = true
           break
@@ -506,17 +506,17 @@ end
     echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
     other_loc_names = case locker_mode
-    when :strict
-      (data[:jars] || [])
-        .select { |j| j[:location] != location }
-        .map { |j| clean_name(j[:gem]) }
-    when :normal
-      (data[:jars] || [])
-        .select { |j| j[:location] != location && !j[:full] }
-        .map { |j| clean_name(j[:gem]) }
-    when :loose
-      []
-    end
+                      when :strict
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location }
+                      .map { |j| clean_name(j[:gem]) }
+                      when :normal
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location && !j[:full] }
+                      .map { |j| clean_name(j[:gem]) }
+                      when :loose
+                        []
+                      end
 
     not_suitable = []
     deposited    = 0

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -813,6 +813,7 @@ module GemHoarder
               jar_record[:count] = jar_record[:count].to_i - 1
               raided    += 1
               remaining -= 1
+              true
             else
               echo "GemHoarder: could not put gem in sack, stopping."
               remaining = 0
@@ -833,6 +834,7 @@ module GemHoarder
               jar_record[:count] = jar_record[:count].to_i - 1
               raided    += 1
               remaining -= 1
+              true
             else
               echo "GemHoarder: could not put gem in sack, stopping."
               remaining = 0
@@ -846,17 +848,30 @@ module GemHoarder
         when /nothing falls out|realize that it is empty/
           jar_record[:count] = 0
           break
+        when nil
+          echo "GemHoarder: shake timed out, stopping."
+          remaining = 0
+          break
+        else
+          echo "GemHoarder: unexpected shake response '#{res}', stopping."
+          remaining = 0
+          break
         end
       end
 
-      # Route jar to correct slot
-      jar_record[:full] = false
-      if jar_record[:count].to_i <= 0
-        data[:jars].delete(jar_record)
-        fput "put ##{jar.id} in chest"
-        echo "GemHoarder: jar emptied, returned to chest."
+      # Only route jar if we actually interacted with it successfully
+      if gem_removed || empty_confirmed
+        jar_record[:full] = false
+        if jar_record[:count].to_i <= 0
+          data[:jars].delete(jar_record)
+          fput "put ##{jar.id} in chest"
+          echo "GemHoarder: jar emptied, returned to chest."
+        else
+          fput "put ##{jar.id} in bin"
+        end
       else
-        fput "put ##{jar.id} in bin"
+        echo "GemHoarder: no confirmed interaction with jar -- returning to #{jar_record[:full] ? 'wardrobe' : 'bin'} unchanged."
+        fput "put ##{jar.id} in #{jar_record[:full] ? 'wardrobe' : 'bin'}"
       end
 
       close_locker

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -17,7 +17,7 @@
   contributors: Caithris, Falicor, Yalathanil
   game: gs
   tags: gems, hoarding, locker, jars
-  version: 3.2.0
+  version: 2.0.0
 
   Version Control:
   Major_change.feature_addition.bugfix

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -50,7 +50,6 @@ silence_me
 require 'yaml'
 
 module GemHoarder
-
   YAML_FILE   = File.join(DATA_DIR, XMLData.game, XMLData.name, 'gemhoarder.yaml')
   JAR_NOUNS   = /^(?:jar|beaker|bottle)$/i
   SIZE_PREFIX = /\b(?:large|medium|small|tiny|some)\s+/i
@@ -111,8 +110,8 @@ module GemHoarder
       echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
       return nil
     end
-    sack = GameObj.inv.find { |o| o.name =~ /\b#{Regexp.escape(name)}$/i }        ||
-           GameObj.inv.find { |o| o.name =~ /#{Regexp.escape(name)}/i }            ||
+    sack = GameObj.inv.find { |o| o.name =~ /\b#{Regexp.escape(name)}$/i } ||
+           GameObj.inv.find { |o| o.name =~ /#{Regexp.escape(name)}/i } ||
            GameObj.inv.find { |o| o.noun =~ /^#{Regexp.escape(name.split.last)}$/i }
     unless sack
       echo "GemHoarder: could not find '#{name}' in inventory."
@@ -164,7 +163,7 @@ module GemHoarder
     close_locker
     status_tags
     result = dothistimeout "open locker", 6,
-      /exist="(\d+)" noun="#{Regexp.escape(noun.to_s)}"|already open/
+                           /exist="(\d+)" noun="#{Regexp.escape(noun.to_s)}"|already open/
     status_tags
     if result =~ /exist="(\d+)" noun="#{Regexp.escape(noun.to_s)}"/
       lid = $1
@@ -239,9 +238,9 @@ module GemHoarder
     display.select! { |j| j[:location].to_s.downcase.include?(location.downcase) } if location
     if filter
       f = filter.strip.downcase
-               .sub(/ies\z/, '(?:y|ies)')
-               .sub(/y\z/,   '(?:y|ies)')
-               .sub(/s\z/,   's?')
+                .sub(/ies\z/, '(?:y|ies)')
+                .sub(/y\z/,   '(?:y|ies)')
+                .sub(/s\z/,   's?')
       display.select! { |j| j[:gem].to_s.downcase =~ /#{f}/ }
     end
     display.sort_by! { |j| [-j[:count].to_i, j[:gem].to_s] }
@@ -253,9 +252,9 @@ module GemHoarder
     else
       display.each do |j|
         respond format("  %-38s %5d  %-5s  %s",
-          j[:gem].to_s, j[:count].to_i,
-          j[:full] ? "yes" : "no",
-          j[:location].to_s)
+                       j[:gem].to_s, j[:count].to_i,
+                       j[:full] ? "yes" : "no",
+                       j[:location].to_s)
       end
     end
     respond ""
@@ -324,7 +323,7 @@ module GemHoarder
         next if gem_name.empty?
 
         look = dothistimeout "look in ##{jar.id} from ##{slot_id}", 5,
-          /Inside.*?you see \d+ portion|I could not find|That is not/
+                             /Inside.*?you see \d+ portion|I could not find|That is not/
         unless look =~ /Inside.*?you see (\d+) portion/
           next
         end
@@ -376,17 +375,17 @@ module GemHoarder
     echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
     other_loc_names = case locker_mode
-    when :strict
-      (data[:jars] || [])
-        .select { |j| j[:location] != location }
-        .map    { |j| clean_name(j[:gem]) }
-    when :normal
-      (data[:jars] || [])
-        .select { |j| j[:location] != location && !j[:full] }
-        .map    { |j| clean_name(j[:gem]) }
-    when :loose
-      []
-    end
+                      when :strict
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location }
+                      .map    { |j| clean_name(j[:gem]) }
+                      when :normal
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location && !j[:full] }
+                      .map    { |j| clean_name(j[:gem]) }
+                      when :loose
+                        []
+                      end
 
     not_suitable = []
     deposited    = 0
@@ -409,7 +408,7 @@ module GemHoarder
 
         matching = gems.select { |g|
           !not_suitable.include?(g.id) &&
-          clean_name(g.name) =~ gem_regex(jar_gem)
+            clean_name(g.name) =~ gem_regex(jar_gem)
         }
         next if matching.empty?
 
@@ -426,7 +425,7 @@ module GemHoarder
         filled = false
         matching.each do |gem|
           res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
-            /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+                              /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
           case res
           when /^You add.*filling it/, /filling it/
             record[:count] = record[:count].to_i + 1
@@ -507,7 +506,7 @@ module GemHoarder
 
             group.each do |gem|
               res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
-                /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+                                  /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
               case res
               when /^You add.*filling it/, /filling it/
                 record[:gem]   = clean_name(jar.after_name) unless jar.after_name.to_s.strip.empty?
@@ -638,8 +637,8 @@ module GemHoarder
 
     jar = slot_contents.find { |o|
       o.noun =~ JAR_NOUNS &&
-      !o.after_name.to_s.strip.empty? &&
-      clean_name(o.after_name) =~ gem_regex(gem_name)
+        !o.after_name.to_s.strip.empty? &&
+        clean_name(o.after_name) =~ gem_regex(gem_name)
     }
 
     unless jar
@@ -655,8 +654,8 @@ module GemHoarder
       return
     end
 
-    raided   = 0
-    jar_noun = jar.noun
+    raided = 0
+    jar.noun
 
     count.times do
       unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
@@ -665,14 +664,13 @@ module GemHoarder
       end
 
       res = dothistimeout "shake ##{jar.id}", 4,
-        /fall into your|free hand|nothing falls out|realize that it is empty/
+                          /fall into your|free hand|nothing falls out|realize that it is empty/
       case res
       when /fall into your/
         dropped = [GameObj.right_hand, GameObj.left_hand].compact.find { |o|
           o.id != jar.id && o.type =~ /gem/i
         }
         if dropped
-          hand = GameObj.left_hand&.id == dropped.id ? "left" : "right"
           fput "put my #{dropped.noun} in my #{sack.noun}"
           jar_record[:count] = jar_record[:count].to_i - 1
           raided += 1
@@ -685,8 +683,7 @@ module GemHoarder
           o.id != jar.id && o.type =~ /gem/i
         }
         if held
-          hand = GameObj.left_hand&.id == held.id ? "left" : "right"
-          fput "put my #{hand} hand #{held.noun} in my #{sack.noun}"
+          fput "put my #{held.noun} in my #{sack.noun}"
           jar_record[:count] = jar_record[:count].to_i - 1
           raided += 1
         else
@@ -708,7 +705,7 @@ module GemHoarder
     else
       fput "put ##{jar.id} in bin"
     end
-    
+
     close_locker
 
     echo "GemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
@@ -768,7 +765,7 @@ module GemHoarder
       raid(data, location)
 
     when "newlocker"
-      location             = current_location
+      location = current_location
       data[:jars]          ||= []
       data[:known_lockers] ||= []
       data[:jars].delete_if { |j| j[:location] == location }
@@ -784,7 +781,7 @@ module GemHoarder
         exit
       end
 
-      location             = current_location
+      location = current_location
       data[:known_lockers] ||= []
       data[:jars]          ||= []
 
@@ -802,7 +799,6 @@ module GemHoarder
       echo "GemHoarder: unknown command '#{cmd}'. Run ;egemhoarder help for usage."
     end
   end
-
 end
 
 GemHoarder.main

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -237,11 +237,12 @@ module GemHoarder
     display = jars.dup
     display.select! { |j| j[:location].to_s.downcase.include?(location.downcase) } if location
     if filter
-      f = filter.strip.downcase
+      f = Regexp.escape(filter.strip.downcase)
                 .sub(/ies\z/, '(?:y|ies)')
                 .sub(/y\z/,   '(?:y|ies)')
                 .sub(/s\z/,   's?')
-      display.select! { |j| j[:gem].to_s.downcase =~ /#{f}/ }
+      matcher = Regexp.new(f, Regexp::IGNORECASE)
+      display.select! { |j| j[:gem].to_s.downcase =~ matcher }
     end
     display.sort_by! { |j| [-j[:count].to_i, j[:gem].to_s] }
     respond ""
@@ -296,13 +297,15 @@ module GemHoarder
   def self.scan_locker(data, location)
     echo "GemHoarder: scanning locker at #{location}..."
     data[:jars] ||= []
-    found = 0
-    moved = { chest: 0, bin: 0, wardrobe: 0 }
+    found  = 0
+    moved  = { chest: 0, bin: 0, wardrobe: 0 }
+    failed = []
 
     [:wardrobe, :bin, :chest].each do |slot|
       result = open_locker_part(slot.to_s)
       unless result
-        echo "GemHoarder: could not open #{slot}."
+        echo "GemHoarder: could not open #{slot} -- skipping."
+        failed << slot
         next
       end
       slot_id, slot_contents = result
@@ -323,7 +326,7 @@ module GemHoarder
         next if gem_name.empty?
 
         look = dothistimeout "look in ##{jar.id} from ##{slot_id}", 5,
-                             /Inside.*?you see \d+ portion|I could not find|That is not/
+                            /Inside.*?you see \d+ portion|I could not find|That is not/
         unless look =~ /Inside.*?you see (\d+) portion/
           next
         end
@@ -356,11 +359,16 @@ module GemHoarder
       close_locker
     end
 
+    if failed.any?
+      echo "GemHoarder: scan incomplete -- could not open: #{failed.join(', ')}."
+      echo "GemHoarder: locker data for #{location} was NOT updated to avoid overwriting good data."
+      return false
+    end
+
     echo "GemHoarder: scan complete -- #{found} jar(s) catalogued, " \
-         "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
+        "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
     true
   end
-
   # ── Deposit Loop ──────────────────────────────────────────────────────────────
 
   def self.deposit_gems(data, location)
@@ -671,7 +679,7 @@ module GemHoarder
           o.id != jar.id && o.type =~ /gem/i
         }
         if dropped
-          fput "put my #{dropped.noun} in my #{sack.noun}"
+          fput "put my #{dropped.noun} in my ##{sack.id}"
           jar_record[:count] = jar_record[:count].to_i - 1
           raided += 1
         else
@@ -683,7 +691,7 @@ module GemHoarder
           o.id != jar.id && o.type =~ /gem/i
         }
         if held
-          fput "put my #{held.noun} in my #{sack.noun}"
+          fput "put my #{held.noun} in my ##{sack.id}"
           jar_record[:count] = jar_record[:count].to_i - 1
           raided += 1
         else

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -791,6 +791,9 @@ module GemHoarder
 
       need_from_this_jar = [remaining, jar_record[:count].to_i].min
 
+      gem_removed = false
+      empty_confirmed = false
+
       need_from_this_jar.times do
         break if remaining <= 0
 
@@ -811,9 +814,9 @@ module GemHoarder
             result = dothistimeout "_drag ##{dropped.id} ##{sack.id}", 3, /^You put|could not find/
             if result =~ /^You put/
               jar_record[:count] = jar_record[:count].to_i - 1
-              raided    += 1
-              remaining -= 1
-              true
+              raided      += 1
+              remaining   -= 1
+              gem_removed  = true
             else
               echo "GemHoarder: could not put gem in sack, stopping."
               remaining = 0
@@ -832,9 +835,9 @@ module GemHoarder
             result = dothistimeout "_drag ##{held.id} ##{sack.id}", 3, /^You put|could not find/
             if result =~ /^You put/
               jar_record[:count] = jar_record[:count].to_i - 1
-              raided    += 1
-              remaining -= 1
-              true
+              raided      += 1
+              remaining   -= 1
+              gem_removed  = true
             else
               echo "GemHoarder: could not put gem in sack, stopping."
               remaining = 0
@@ -847,6 +850,7 @@ module GemHoarder
           end
         when /nothing falls out|realize that it is empty/
           jar_record[:count] = 0
+          empty_confirmed = true
           break
         when nil
           echo "GemHoarder: shake timed out, stopping."
@@ -859,7 +863,7 @@ module GemHoarder
         end
       end
 
-      # Only route jar if we actually interacted with it successfully
+      # Only route jar if we confirmed interaction
       if gem_removed || empty_confirmed
         jar_record[:full] = false
         if jar_record[:count].to_i <= 0
@@ -870,7 +874,7 @@ module GemHoarder
           fput "put ##{jar.id} in bin"
         end
       else
-        echo "GemHoarder: no confirmed interaction with jar -- returning to #{jar_record[:full] ? 'wardrobe' : 'bin'} unchanged."
+        echo "GemHoarder: no confirmed interaction -- returning jar unchanged."
         fput "put ##{jar.id} in #{jar_record[:full] ? 'wardrobe' : 'bin'}"
       end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -39,8 +39,6 @@
     - update various help text
   v1.0.0 (2024-04-03)
     - initial releasedef self.at_locker?
-  (GameObj.loot || []).any? { |o| o.noun =~ /^locker$/i }
-end
     - fork of gemhoarder2 with Ruby 3.x compatibility
 =end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -799,7 +799,8 @@ module EGemHoarder
       jar = slot_contents.find { |o|
         o.noun =~ JAR_NOUNS &&
           !o.after_name.to_s.strip.empty? &&
-          clean_name(o.after_name).downcase.include?(gem_name.downcase)
+          (clean_name(o.after_name).downcase.include?(gem_name.downcase) ||
+          clean_name(o.after_name) =~ gem_regex(gem_name))
       }
 
       unless jar

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -11,7 +11,7 @@
     - multi-locker, multi-jar support with per-jar tracking
     - auto-navigates to locker, stows hands, returns to origin after deposit/raid
     - raid pulls gems from locker back into gemsack
-    - configurable via UserVars: gemsack, egemhoarder_exclude, egemhoarder_lockermode
+    - configurable via ;egemhoarder config <key> <value>
 
   author: elanthia-online
   contributors: Caithris, Falicor, Yalathanil
@@ -30,6 +30,7 @@
     - search and raid support multi-word gem names
     - scan is atomic -- rolls back on partial failure
     - sort integrated into newlocker scan
+    - config/settings commands replace UserVars
   v1.2.0 (2025-09-09)
     - convert to yaml instead of using lich.db3
   v1.1.0 (2025-09-08)
@@ -66,7 +67,7 @@ module EGemHoarder
   end
 
   def self.default_data
-    { jars: [], known_lockers: [] }
+    { jars: [], known_lockers: [], config: { lockermode: 'strict', exclude: [], gemsack: '' } }
   end
 
   def self.save_data(data)
@@ -104,10 +105,10 @@ module EGemHoarder
 
   # -- Inventory Helpers ---------------------------------------------------------
 
-  def self.find_gemsack
-    name = UserVars.gemsack.to_s.strip
+  def self.find_gemsack(data)
+    name = data.dig(:config, :gemsack).to_s.strip
     if name.empty?
-      echo "EGemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+      echo "EGemHoarder: gemsack not set. Run: ;egemhoarder config gemsack <container name>"
       return nil
     end
     sack = GameObj.inv.find { |o| o.name =~ /\b#{Regexp.escape(name)}$/i } ||
@@ -131,17 +132,17 @@ module EGemHoarder
     (GameObj.containers[sack.id] || []).select { |o| o.type =~ /gem/i }
   end
 
-  def self.excluded_gems
-    UserVars.egemhoarder_exclude.to_s.split(',').map { |s| s.strip.downcase }
+  def self.excluded_gems(data)
+    (data.dig(:config, :exclude) || []).map(&:downcase)
   end
 
-  def self.gem_excluded?(gem_name)
+  def self.gem_excluded?(gem_name, data)
     cn = clean_name(gem_name).downcase
-    excluded_gems.any? { |ex| cn.include?(ex) }
+    excluded_gems(data).any? { |ex| cn.include?(ex) }
   end
 
-  def self.locker_mode
-    case UserVars.egemhoarder_lockermode.to_s.strip.downcase
+  def self.locker_mode(data)
+    case data.dig(:config, :lockermode).to_s.strip.downcase
     when "loose"  then :loose
     when "normal" then :normal
     else               :strict
@@ -176,7 +177,6 @@ module EGemHoarder
   def self.restore_hands(stowed)
     return if stowed.empty?
     stowed.reverse.each do |item|
-      # Check if already in hand
       next if [GameObj.right_hand, GameObj.left_hand].compact.any? { |o| o.id == item[:id] }
       fput "get ##{item[:id]}"
       pause 0.3
@@ -192,17 +192,13 @@ module EGemHoarder
   end
 
   def self.go_to_locker
-    if self.at_locker?
-      return true
-    end
+    return true if at_locker?
 
     echo "EGemHoarder: navigating to public lockers..."
     Script.run("go2", "publiclockers")
     pause 0.5
 
-    # Try to enter a locker room; if occupied try adjacent rooms
     10.times do
-      # Try opening first, then curtain
       ["opening", "curtain"].each do |exit_name|
         result = dothistimeout "go #{exit_name}", 3,
                                /^You (?:step|go|enter|pass|slip)|^There is no|^Sorry|closed|^What/
@@ -212,7 +208,6 @@ module EGemHoarder
         end
       end
 
-      # Neither worked -- locker occupied, try next room in hallway
       echo "EGemHoarder: locker occupied, trying next room..."
       moved = false
       ["north", "south", "east", "west"].each do |dir|
@@ -231,7 +226,6 @@ module EGemHoarder
 
       pause 0.5
 
-      # Check if new room has a locker entrance -- if not, wrong direction
       room_nouns = GameObj.loot.map(&:noun) + GameObj.npcs.map(&:noun)
       exits      = Room.current.exits rescue []
       unless room_nouns.any? { |n| n =~ /opening|curtain/i } ||
@@ -246,7 +240,7 @@ module EGemHoarder
   end
 
   def self.go_to_origin(origin_id)
-    return if XMLData.room_id == origin_id
+    return if Room.current.id == origin_id
     echo "EGemHoarder: returning to original location..."
     Script.run("go2", origin_id.to_s)
     pause 0.5
@@ -279,11 +273,53 @@ module EGemHoarder
     pause 0.3
   end
 
+  # -- Config --------------------------------------------------------------------
+
+  def self.set_config(data)
+    key = Script.current.vars[2].to_s.strip.downcase
+    val = Script.current.vars[3..-1].to_a.join(' ').strip
+
+    data[:config] ||= { lockermode: 'strict', exclude: [], gemsack: '' }
+
+    case key
+    when "lockermode"
+      unless %w[strict normal loose].include?(val)
+        echo "EGemHoarder: lockermode must be strict, normal, or loose."
+        return
+      end
+      data[:config][:lockermode] = val
+      echo "EGemHoarder: lockermode set to '#{val}'."
+    when "exclude"
+      data[:config][:exclude] = val.split(',').map(&:strip).reject(&:empty?)
+      echo "EGemHoarder: exclude set to: #{data[:config][:exclude].join(', ')}"
+    when "gemsack"
+      data[:config][:gemsack] = val
+      echo "EGemHoarder: gemsack set to '#{val}'."
+    when ""
+      echo "EGemHoarder: usage: ;egemhoarder config <lockermode|exclude|gemsack> <value>"
+      return
+    else
+      echo "EGemHoarder: unknown config key '#{key}'. Valid keys: lockermode, exclude, gemsack"
+      return
+    end
+    save_data(data)
+  end
+
+  def self.show_settings(data)
+    cfg = data[:config] || {}
+    respond ""
+    respond "EGemHoarder settings:"
+    respond "  gemsack    : #{cfg[:gemsack].to_s.empty? ? '(not set)' : cfg[:gemsack]}"
+    respond "  lockermode : #{cfg[:lockermode] || 'strict'}"
+    respond "  exclude    : #{(cfg[:exclude] || []).empty? ? '(none)' : cfg[:exclude].join(', ')}"
+    respond ""
+  end
+
   # -- Help ---------------------------------------------------------------------
 
   def self.show_help
     respond ""
-    respond "EGemHoarder v3.2 - Gem jar management for your locker"
+    respond "EGemHoarder v2.0 - Gem jar management for your locker"
     respond "-" * 55
     respond ""
     respond "Locker layout:"
@@ -296,6 +332,8 @@ module EGemHoarder
     respond "Commands:"
     respond "  (none)                   Deposit gems from gemsack into matching jars"
     respond "  help                     Show this help"
+    respond "  settings                 Show current configuration"
+    respond "  config <key> <value>     Set a configuration value"
     respond "  list [location]          List all known jars, optionally filtered by location"
     respond "  search <string>          Search known jars by gem name (plural-aware)"
     respond "  newlocker                Scan, sort, and register current locker"
@@ -304,13 +342,13 @@ module EGemHoarder
     respond "                           Manually set/update a jar entry; n=0 to delete"
     respond "  raid <gem> [count]       Pull gems from locker into gemsack (default: 1)"
     respond ""
-    respond "UserVars (;vars set key=value):"
-    respond "  gemsack                  Container holding loose gems (REQUIRED)"
-    respond "  egemhoarder_exclude      Comma-separated gems to never jar"
-    respond "  egemhoarder_lockermode   strict/normal/loose (default: strict)"
+    respond "Config keys (;egemhoarder config <key> <value>):"
+    respond "  gemsack <name>           Container holding loose gems (REQUIRED)"
+    respond "  lockermode <mode>        strict/normal/loose (default: strict)"
     respond "    strict = never store same gem in multiple lockers"
     respond "    normal = store here if other locker jar is full"
     respond "    loose  = always store regardless of other lockers"
+    respond "  exclude <gem1, gem2>     Comma-separated gems to never jar"
     respond ""
     respond "Notes:"
     respond "  Deposit and raid auto-navigate to public lockers via go2,"
@@ -318,10 +356,10 @@ module EGemHoarder
     respond "  newlocker must be run from inside the locker room."
     respond ""
     respond "Examples:"
-    respond "  ;vars set gemsack=canvas gem pouch"
-    respond "  ;vars set egemhoarder_exclude=doomstone,urglaes fang"
-    respond "  ;vars set egemhoarder_lockermode=normal"
-    respond "  ;egemhoarder set \"fire opals\" 12 false Solhaven"
+    respond "  ;egemhoarder config gemsack canvas gem pouch"
+    respond "  ;egemhoarder config lockermode normal"
+    respond "  ;egemhoarder config exclude uncut diamond, doomstone, urglaes fang"
+    respond "  ;egemhoarder settings"
     respond "  ;egemhoarder search ruby"
     respond "  ;egemhoarder search green amber"
     respond "  ;egemhoarder list Wehnimer's"
@@ -333,8 +371,6 @@ module EGemHoarder
   end
 
   # -- List / Search -------------------------------------------------------------
-  # Groups multiple jar records for the same gem+location into one display row,
-  # summing counts and marking full only if ALL jars for that gem are full.
 
   def self.normalize_gem(name)
     clean_name(name).downcase.gsub(/s\b/, '')
@@ -360,7 +396,6 @@ module EGemHoarder
       display.select! { |j| j[:gem].to_s =~ matcher }
     end
 
-    # Group by gem+location, summing counts
     grouped = {}
     display.each do |j|
       loc = j[:location].to_s
@@ -431,8 +466,6 @@ module EGemHoarder
   end
 
   # -- Scan + Sort Locker --------------------------------------------------------
-  # One record per physical jar. Existing records for this location are cleared
-  # before scanning so we don't accumulate stale entries.
 
   def self.scan_locker(data, location)
     echo "EGemHoarder: scanning locker at #{location}..."
@@ -440,8 +473,6 @@ module EGemHoarder
     found  = 0
     moved  = { chest: 0, bin: 0, wardrobe: 0 }
     failed = []
-
-    # Collect new records separately; only commit if all slots succeed
     new_records = []
 
     [:wardrobe, :bin, :chest].each do |slot|
@@ -478,7 +509,6 @@ module EGemHoarder
         is_full = (look =~ /It is full|filling it/) ? true : false
         correct = is_full ? :wardrobe : :bin
 
-        # One record per physical jar
         new_records << { gem: gem_name, count: count, full: is_full, location: location }
         found += 1
 
@@ -500,7 +530,6 @@ module EGemHoarder
       return false
     end
 
-    # Commit: replace all records for this location
     data[:jars].delete_if { |j| j[:location] == location }
     data[:jars].concat(new_records)
 
@@ -512,28 +541,28 @@ module EGemHoarder
   # -- Deposit Loop --------------------------------------------------------------
 
   def self.deposit_gems(data, location)
-    sack = find_gemsack
+    sack = find_gemsack(data)
     return unless sack
 
-    gems = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
+    gems = gem_contents(sack).reject { |g| gem_excluded?(g.name, data) }
     if gems.empty?
       echo "EGemHoarder: no eligible gems in gemsack."
       return
     end
     echo "EGemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
-    other_loc_names = case locker_mode
-                      when :strict
-                        (data[:jars] || [])
-                      .select { |j| j[:location] != location }
-                      .map { |j| clean_name(j[:gem]) }
-                      when :normal
-                        (data[:jars] || [])
-                      .select { |j| j[:location] != location && !j[:full] }
-                      .map { |j| clean_name(j[:gem]) }
-                      when :loose
-                        []
-                      end
+    other_loc_names = case locker_mode(data)
+    when :strict
+      (data[:jars] || [])
+        .select { |j| j[:location] != location }
+        .map { |j| clean_name(j[:gem]) }
+    when :normal
+      (data[:jars] || [])
+        .select { |j| j[:location] != location && !j[:full] }
+        .map { |j| clean_name(j[:gem]) }
+    when :loose
+      []
+    end
 
     not_suitable = []
     deposited    = 0
@@ -601,9 +630,8 @@ module EGemHoarder
       close_locker
     end
 
-    # Refresh gem list after phase 1
     gems = gem_contents(sack).reject { |g|
-      gem_excluded?(g.name) || not_suitable.include?(g.id)
+      gem_excluded?(g.name, data) || not_suitable.include?(g.id)
     }
     return if gems.empty?
 
@@ -695,7 +723,7 @@ module EGemHoarder
     # -- Summary ---------------------------------------------------------------
     echo "EGemHoarder: deposited #{deposited} gem(s)."
 
-    leftover = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
+    leftover = gem_contents(sack).reject { |g| gem_excluded?(g.name, data) }
     unless leftover.empty?
       in_other = leftover.select { |g|
         cn = clean_name(g.name)
@@ -733,7 +761,7 @@ module EGemHoarder
       return
     end
 
-    sack = find_gemsack
+    sack = find_gemsack(data)
     return unless sack
 
     all_matching = (data[:jars] || []).select { |j|
@@ -758,7 +786,6 @@ module EGemHoarder
       return
     end
 
-    # Sort: full jars first, then by descending count
     jar_records = local.sort_by { |j| [j[:full] ? 0 : 1, -j[:count].to_i] }
 
     raided    = 0
@@ -796,9 +823,8 @@ module EGemHoarder
       end
 
       need_from_this_jar = [remaining, jar_record[:count].to_i].min
-
-      gem_removed = false
-      empty_confirmed = false
+      gem_removed        = false
+      empty_confirmed    = false
 
       need_from_this_jar.times do
         break if remaining <= 0
@@ -856,7 +882,7 @@ module EGemHoarder
           end
         when /nothing falls out|realize that it is empty/
           jar_record[:count] = 0
-          empty_confirmed = true
+          empty_confirmed     = true
           break
         when nil
           echo "EGemHoarder: shake timed out, stopping."
@@ -869,7 +895,6 @@ module EGemHoarder
         end
       end
 
-      # Only route jar if we confirmed interaction
       if gem_removed || empty_confirmed
         jar_record[:full] = false
         if jar_record[:count].to_i <= 0
@@ -895,6 +920,7 @@ module EGemHoarder
 
   def self.main
     data = load_data
+    data[:config] ||= { lockermode: 'strict', exclude: [], gemsack: '' }
     before_dying { save_data(data) }
 
     cmd = Script.current.vars[1].to_s.strip.downcase
@@ -902,6 +928,12 @@ module EGemHoarder
     case cmd
     when "help", "-h", "--help", "?"
       show_help
+
+    when "settings"
+      show_settings(data)
+
+    when "config"
+      set_config(data)
 
     when "list"
       loc = Script.current.vars[2].to_s.strip
@@ -971,8 +1003,8 @@ module EGemHoarder
       end
 
     when "", "none"
-      if UserVars.gemsack.to_s.strip.empty?
-        echo "EGemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+      if data.dig(:config, :gemsack).to_s.strip.empty?
+        echo "EGemHoarder: gemsack not set. Run: ;egemhoarder config gemsack <container name>"
         exit
       end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -192,7 +192,7 @@ module EGemHoarder
     result =~ /You see nothing unusual/i ? true : false
   end
 
-def self.go_to_locker
+  def self.go_to_locker
     return true if at_locker?
 
     echo "EGemHoarder: navigating to public lockers..."
@@ -544,17 +544,17 @@ def self.go_to_locker
     echo "EGemHoarder: #{gems.size} gem(s) to deposit at #{location}."
 
     other_loc_names = case locker_mode(data)
-    when :strict
-      (data[:jars] || [])
-        .select { |j| j[:location] != location }
-        .map { |j| clean_name(j[:gem]) }
-    when :normal
-      (data[:jars] || [])
-        .select { |j| j[:location] != location && !j[:full] }
-        .map { |j| clean_name(j[:gem]) }
-    when :loose
-      []
-    end
+                      when :strict
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location }
+                      .map { |j| clean_name(j[:gem]) }
+                      when :normal
+                        (data[:jars] || [])
+                      .select { |j| j[:location] != location && !j[:full] }
+                      .map { |j| clean_name(j[:gem]) }
+                      when :loose
+                        []
+                      end
 
     not_suitable = []
     deposited    = 0
@@ -757,7 +757,8 @@ def self.go_to_locker
     return unless sack
 
     all_matching = (data[:jars] || []).select { |j|
-      clean_name(j[:gem]).downcase.include?(gem_name.downcase)
+      clean_name(j[:gem]) =~ gem_regex(gem_name) ||
+        clean_name(j[:gem]).downcase.include?(gem_name.downcase)
     }
 
     if all_matching.empty?
@@ -874,7 +875,7 @@ def self.go_to_locker
           end
         when /nothing falls out|realize that it is empty/
           jar_record[:count] = 0
-          empty_confirmed     = true
+          empty_confirmed = true
           break
         when nil
           echo "EGemHoarder: shake timed out, stopping."

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -94,8 +94,8 @@ module GemHoarder
             when /y\z/i   then last.sub(/y\z/i,   '(?:y|ies)')
             when /z\z/i   then last + 'es?'
             when /es\z/i then last.sub(/s\z/i, 's?')
-            when /s\z/i   then last.sub(/s\z/i,   's?')
-            else               last + 's?'
+            when /s\z/i then last.sub(/s\z/i, 's?')
+            else last + 's?'
             end
     pattern = (words + [last]).join('\s+')
     /^#{pattern}$/i
@@ -186,7 +186,7 @@ module GemHoarder
 
   def self.at_locker?
     result = dothistimeout "look locker", 3,
-      /You see nothing unusual|What were you referring to|could not find/i
+                           /You see nothing unusual|What were you referring to|could not find/i
     result =~ /You see nothing unusual/i ? true : false
   end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -714,10 +714,16 @@ module GemHoarder
             o.id != jar.id && o.type =~ /gem/i
           }
           if dropped
-            fput "put my #{dropped.noun} in my ##{sack.id}"
-            jar_record[:count] = jar_record[:count].to_i - 1
-            raided    += 1
-            remaining -= 1
+            result = dothistimeout "_drag ##{dropped.id} ##{sack.id}", 3, /^You put|could not find/
+            if result =~ /^You put/
+              jar_record[:count] = jar_record[:count].to_i - 1
+              raided    += 1
+              remaining -= 1
+            else
+              echo "GemHoarder: could not put gem in sack, stopping."
+              remaining = 0
+              break
+            end
           else
             echo "GemHoarder: shook jar but gem did not appear in hand, stopping."
             remaining = 0
@@ -728,10 +734,16 @@ module GemHoarder
             o.id != jar.id && o.type =~ /gem/i
           }
           if held
-            fput "put my #{held.noun} in my ##{sack.id}"
-            jar_record[:count] = jar_record[:count].to_i - 1
-            raided    += 1
-            remaining -= 1
+            result = dothistimeout "_drag ##{held.id} ##{sack.id}", 3, /^You put|could not find/
+            if result =~ /^You put/
+              jar_record[:count] = jar_record[:count].to_i - 1
+              raided    += 1
+              remaining -= 1
+            else
+              echo "GemHoarder: could not put gem in sack, stopping."
+              remaining = 0
+              break
+            end
           else
             echo "GemHoarder: need free hand but no gem found to stow, stopping."
             remaining = 0

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -86,13 +86,12 @@ module EGemHoarder
 
   def self.pluralize_word(w)
     case w
-    when /ies\z/i then w.sub(/ies\z/i, '(?:y|ies)')
-    when /ves\z/i then w.sub(/ves\z/i, '(?:f|ves)')
-    when /y\z/i   then w.sub(/y\z/i,   '(?:y|ies)')
-    when /z\z/i   then w + 'es?'
-    when /es\z/i  then w.sub(/es\z/i,  '(?:es)?')
-    when /s\z/i   then w.sub(/s\z/i,   's?')
-    else               w + 's?'
+    when /ies\z/i        then w.sub(/ies\z/i, '(?:y|ies)')
+    when /ves\z/i        then w.sub(/ves\z/i, '(?:f|ves)')
+    when /y\z/i          then w.sub(/y\z/i,   '(?:y|ies)')
+    when /z\z/i          then w + 'es?'
+    when /es\z/i, /s\z/i then w.sub(/s\z/i,   's?')
+    else                      w + 's?'
     end
   end
 

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -16,8 +16,8 @@
     - reports which locker gems are reserved for when left in gemsack
     - raid pulls a specific gem type from locker back into gemsack
 
-  author: Yalathanil
-  contributors: Caithris, Falicor, elanthia-online
+  author: elanthia-online
+  contributors: Caithris, Falicor, Yalathanil
   game: gs
   tags: gems, hoarding, locker, jars
   version: 2.0.0

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -335,6 +335,10 @@ module GemHoarder
   # Groups multiple jar records for the same gem+location into one display row,
   # summing counts and marking full only if ALL jars for that gem are full.
 
+  def self.normalize_gem(name)
+    clean_name(name).downcase.gsub(/s\b/, '')
+  end
+
   def self.show_list(jars, filter: nil, location: nil)
     display = jars.dup
     display.select! { |j| j[:location].to_s.downcase.include?(location.downcase) } if location
@@ -358,7 +362,8 @@ module GemHoarder
     # Group by gem+location, summing counts
     grouped = {}
     display.each do |j|
-      key = "#{clean_name(j[:gem])}||#{j[:location]}"
+      loc = j[:location].to_s
+      key = "#{normalize_gem(j[:gem])}||#{loc}"
       if grouped[key]
         grouped[key][:count] += j[:count].to_i
         grouped[key][:full]   = false unless j[:full]
@@ -368,7 +373,7 @@ module GemHoarder
           gem: j[:gem].to_s,
           count: j[:count].to_i,
           full: j[:full] ? true : false,
-          location: j[:location].to_s,
+          location: loc,
           jars: 1,
         }
       end

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -1,28 +1,38 @@
 =begin
-  EO fork of gemhoarder. A script to hoard gems!
+  EGemHoarder - Store gems from your inventory into labeled jars in your locker.
+
+  Locker layout:
+    Chest    = empty jars (unlabeled, ready to use)
+    Bin      = partial jars (in progress, being filled)
+    Wardrobe = full jars (complete, archived)
+
   Features:
-    - fills jars from your gemsack.
-    - takes empty jars from your chest
-    - puts full jars in your wardrobe
-    - partially filled jars go in the bin
-    - raid function
-    - manually set gem amounts
-    - multi-locker edition, premium/plat only, checks if you have gems in other lockers
-    - alphbetical list(alpha)
-    - search function (egemhoarder search "green thingy")
+    - collects gems from a configurable gem sack
+    - full jars move to wardrobe; partial jars stay in bin; empty jars stay in chest
+    - multi-locker support
+    - configurable via UserVars (gemsack, gemhoarder_exclude, gemhoarder_lockermode)
+    - commands: help, list, search, newlocker, forget, set, raid
+    - reports which locker gems are reserved for when left in gemsack
+    - raid pulls a specific gem type from locker back into gemsack
 
-  Todo:
-    - non-Premium lockers do not work
-    - script will seem to lose track of items and need to be restarted
-
-        author: elanthia-online
-  contributors: Caithris, Falicor
-          game: gs
-          tags: gems, hoarding, locker, jars
-       version: 1.2.0
+  author: Yalathanil
+  contributors: Caithris, Falicor, elanthia-online
+  game: gs
+  tags: gems, hoarding, locker, jars
+  version: 3.0.0
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v3.0.0 (2026-05-08)
+    - complete refactor
+    - fixed gem_regex mangling internal spaces (pluralize last word only)
+    - fixed deposit counter (^You put.*into.*jar response)
+    - fixed "I could not find" mid-drag handling
+    - added lockermode strict/normal/loose
+    - added list location filter
+    - added forget [all] option
+    - added location reporting for gems left in gemsack
+    - sort integrated into newlocker scan
   v1.2.0 (2025-09-09)
     - convert to yaml instead of using lich.db3
   v1.1.0 (2025-09-08)
@@ -37,753 +47,756 @@
 
 silence_me
 
-module EGemHoarder
-  @yaml_file ||= File.join(DATA_DIR, XMLData.game, XMLData.name, 'egemhoarder.yaml')
+require 'yaml'
 
-  def self.save_hoard
-    begin
-      unless @original_hoard.eql?(@egemhoarder_settings)
-        File.open(@yaml_file, 'w') { |f| f.write(@egemhoarder_settings.to_yaml) }
+module GemHoarder
+
+  YAML_FILE   = File.join(DATA_DIR, XMLData.game, XMLData.name, 'gemhoarder.yaml')
+  JAR_NOUNS   = /^(?:jar|beaker|bottle)$/i
+  SIZE_PREFIX = /\b(?:large|medium|small|tiny|some)\s+/i
+  JAR_PREFIX  = /^(?:containing\s+)/i
+
+  # ── Persistence ──────────────────────────────────────────────────────────────
+
+  def self.load_data
+    if File.exist?(YAML_FILE)
+      YAML.load_file(YAML_FILE) || default_data
+    else
+      default_data
+    end
+  rescue => e
+    echo "GemHoarder: error loading data (#{e}), starting fresh."
+    default_data
+  end
+
+  def self.default_data
+    { jars: [], known_lockers: [] }
+  end
+
+  def self.save_data(data)
+    dir = File.dirname(YAML_FILE)
+    Dir.mkdir(dir) unless Dir.exist?(dir)
+    File.open(YAML_FILE, 'w') { |f| f.write(data.to_yaml) }
+  rescue => e
+    echo "GemHoarder: error saving data (#{e})"
+  end
+
+  # ── Name Helpers ─────────────────────────────────────────────────────────────
+
+  def self.clean_name(name)
+    name.to_s.sub(JAR_PREFIX, '').gsub(SIZE_PREFIX, '').strip
+  end
+
+  # Pluralize only the last word so "uncut emerald" matches "uncut emeralds",
+  # "ruby" matches "rubies", "topaz" matches "topazes", etc.
+  def self.gem_regex(name)
+    words = clean_name(name).split
+    last  = words.pop
+    last  = case last
+            when /ies\z/i then last.sub(/ies\z/i, '(?:y|ies)')
+            when /ves\z/i then last.sub(/ves\z/i, '(?:f|ves)')
+            when /es\z/i  then last.sub(/es\z/i,  '(?:e|es)')
+            when /s\z/i   then last.sub(/s\z/i,   's?')
+            when /y\z/i   then last.sub(/y\z/i,   '(?:y|ies)')
+            when /z\z/i   then last + 'es?'
+            else               last + 's?'
+            end
+    pattern = (words + [last]).join('\s+')
+    /^#{pattern}$/i
+  end
+
+  # ── Inventory Helpers ─────────────────────────────────────────────────────────
+
+  def self.find_gemsack
+    name = UserVars.gemsack.to_s.strip
+    if name.empty?
+      echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+      return nil
+    end
+    sack = GameObj.inv.find { |o| o.name =~ /\b#{Regexp.escape(name)}$/i }        ||
+           GameObj.inv.find { |o| o.name =~ /#{Regexp.escape(name)}/i }            ||
+           GameObj.inv.find { |o| o.noun =~ /^#{Regexp.escape(name.split.last)}$/i }
+    unless sack
+      echo "GemHoarder: could not find '#{name}' in inventory."
+      echo "GemHoarder: known containers:"
+      GameObj.inv.each do |o|
+        echo "  noun=#{o.noun}  name=#{o.name}" if GameObj.containers.key?(o.id)
       end
-    rescue => e
-      echo "Error saving hoard: #{e}"
+      return nil
+    end
+    unless GameObj.containers[sack.id]
+      dothistimeout "look in ##{sack.id}", 5, /In .+? you see|is empty/
+    end
+    sack
+  end
+
+  def self.gem_contents(sack)
+    (GameObj.containers[sack.id] || []).select { |o| o.type =~ /gem/i }
+  end
+
+  def self.excluded_gems
+    UserVars.gemhoarder_exclude.to_s.split(',').map { |s| s.strip.downcase }
+  end
+
+  def self.gem_excluded?(gem_name)
+    cn = clean_name(gem_name).downcase
+    excluded_gems.any? { |ex| cn.include?(ex) }
+  end
+
+  def self.locker_mode
+    case UserVars.gemhoarder_lockermode.to_s.strip.downcase
+    when "loose"  then :loose
+    when "normal" then :normal
+    else               :strict
     end
   end
 
-  def self.load_hoard
-    @egemhoarder_settings =
-      if File.exist?(@yaml_file)
-        YAML.load_file(@yaml_file) || Hash.new
-      else
-        Hash.new
-      end
-    @original_hoard = @egemhoarder_settings.dup
+  # ── Location ──────────────────────────────────────────────────────────────────
+
+  def self.current_location
+    fput "location"
+    matchfind "current location is ? or somewhere close to it."
   rescue
-    @egemhoarder_settings = Hash.new
+    "Unknown"
   end
 
-  def self.sorted_jars
-    jars = []
-    @egemhoarder_settings[:jars].to_a.dup.each { |jar|
-      jars.push(jar.dup)
-    }
-    return jars.sort { |a, b| b[:count] <=> a[:count] }
+  # ── Locker Helpers ────────────────────────────────────────────────────────────
+
+  def self.open_locker_part(noun)
+    close_locker
+    status_tags
+    result = dothistimeout "open locker", 6,
+      /exist="(\d+)" noun="#{Regexp.escape(noun.to_s)}"|already open/
+    status_tags
+    if result =~ /exist="(\d+)" noun="#{Regexp.escape(noun.to_s)}"/
+      lid = $1
+    else
+      return nil unless result =~ /exist="(\d+)"/
+      lid = $1
+    end
+    contents = GameObj.containers[lid]
+    unless contents
+      dothistimeout "look in ##{lid}", 4, /^In the|empty/
+      contents = GameObj.containers[lid]
+    end
+    [lid, contents || []]
   end
+
+  def self.close_locker
+    dothistimeout "close locker", 2, /^You close|already closed|faint/
+    pause 0.3
+  end
+
+  # ── Help ─────────────────────────────────────────────────────────────────────
+
+  def self.show_help
+    respond ""
+    respond "EGemHoarder v3.0 - Gem jar management for your locker"
+    respond "-" * 55
+    respond ""
+    respond "Locker layout:"
+    respond "  Chest    = empty jars (unlabeled, ready to fill)"
+    respond "  Bin      = partial jars (in progress)"
+    respond "  Wardrobe = full jars (complete)"
+    respond ""
+    respond "Usage: ;egemhoarder [command] [args...]"
+    respond ""
+    respond "Commands:"
+    respond "  (none)                   Deposit gems from gemsack into matching jars"
+    respond "  help                     Show this help"
+    respond "  list [location]          List all known jars, optionally filtered by location"
+    respond "  search <string>          Search known jars by gem name (plural-aware)"
+    respond "  newlocker                Scan, sort, and register current locker"
+    respond "  forget [all]             Clear data for current locker, or all if 'all' given"
+    respond "  set <gem> <n> [full] [town]"
+    respond "                           Manually set/update a jar entry; n=0 to delete"
+    respond "  raid <gem> [count]       Pull gems from locker into gemsack (default: 1)"
+    respond ""
+    respond "UserVars (;vars set key=value):"
+    respond "  gemsack                  Container holding loose gems (REQUIRED)"
+    respond "  gemhoarder_exclude       Comma-separated gems to never jar"
+    respond "  gemhoarder_lockermode    strict/normal/loose (default: strict)"
+    respond "    strict = never store same gem in multiple lockers"
+    respond "    normal = store here if other locker jar is full"
+    respond "    loose  = always store regardless of other lockers"
+    respond ""
+    respond "Examples:"
+    respond "  ;vars set gemsack=canvas gem pouch"
+    respond "  ;vars set gemhoarder_exclude=doomstone,urglaes fang"
+    respond "  ;vars set gemhoarder_lockermode=normal"
+    respond "  ;egemhoarder set \"fire opals\" 12 false Solhaven"
+    respond "  ;egemhoarder search ruby"
+    respond "  ;egemhoarder list Wehnimer's"
+    respond "  ;egemhoarder forget"
+    respond "  ;egemhoarder forget all"
+    respond "  ;egemhoarder raid ruby 5"
+    respond "  ;egemhoarder raid \"uncut emerald\" 3"
+    respond ""
+  end
+
+  # ── List / Search ─────────────────────────────────────────────────────────────
+
+  def self.show_list(jars, filter: nil, location: nil)
+    display = jars.dup
+    display.select! { |j| j[:location].to_s.downcase.include?(location.downcase) } if location
+    if filter
+      f = filter.strip.downcase
+               .sub(/ies\z/, '(?:y|ies)')
+               .sub(/y\z/,   '(?:y|ies)')
+               .sub(/s\z/,   's?')
+      display.select! { |j| j[:gem].to_s.downcase =~ /#{f}/ }
+    end
+    display.sort_by! { |j| [-j[:count].to_i, j[:gem].to_s] }
+    respond ""
+    respond format("  %-38s %5s  %-5s  %s", "Gem", "Count", "Full?", "Location")
+    respond "  " + "-" * 65
+    if display.empty?
+      respond "  (none)"
+    else
+      display.each do |j|
+        respond format("  %-38s %5d  %-5s  %s",
+          j[:gem].to_s, j[:count].to_i,
+          j[:full] ? "yes" : "no",
+          j[:location].to_s)
+      end
+    end
+    respond ""
+  end
+
+  # ── Manual Set ────────────────────────────────────────────────────────────────
+
+  def self.cmd_set(data)
+    vars     = Script.current.vars
+    gem_name = vars[2].to_s.strip
+    if gem_name.empty?
+      echo "GemHoarder: usage: ;egemhoarder set <gem> <count> [full] [location]"
+      return
+    end
+    count = vars[3] ? vars[3].to_i : 0
+    full  = vars[4].to_s =~ /true/i ? true : false
+    loc   = vars[5].to_s.strip
+    if loc.empty?
+      loc = current_location
+      echo "GemHoarder: location not specified, using '#{loc}'"
+    end
+
+    data[:jars] ||= []
+    data[:jars].delete_if { |j|
+      clean_name(j[:gem]).casecmp?(clean_name(gem_name)) && j[:location] == loc
+    }
+
+    if count > 0
+      data[:jars] << { gem: clean_name(gem_name), count: count, full: full, location: loc }
+      echo "GemHoarder: '#{gem_name}' => count=#{count}, full=#{full}, location=#{loc}"
+    else
+      echo "GemHoarder: removed '#{gem_name}' from jar list for #{loc}."
+    end
+    save_data(data)
+  end
+
+  # ── Scan + Sort Locker ────────────────────────────────────────────────────────
+  #
+  # Scans chest, bin, and wardrobe. Catalogs every labeled jar found.
+  # Simultaneously sorts jars into correct slots:
+  #   full    -> wardrobe
+  #   partial -> bin
+  #   empty   -> chest
+
+  def self.scan_locker(data, location)
+    echo "GemHoarder: scanning locker at #{location}..."
+    data[:jars] ||= []
+    found = 0
+    moved = { chest: 0, bin: 0, wardrobe: 0 }
+
+    [:wardrobe, :bin, :chest].each do |slot|
+      result = open_locker_part(slot.to_s)
+      unless result
+        echo "GemHoarder: could not open #{slot}."
+        next
+      end
+      slot_id, slot_contents = result
+
+      slot_contents.select { |o| o.noun =~ JAR_NOUNS }.each do |jar|
+        # Empty jar -- move to chest if not already there
+        if jar.after_name.nil? || jar.after_name.strip.empty?
+          if slot != :chest
+            get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
+            if get_r =~ /^You remove/
+              fput "put ##{jar.id} in chest"
+              moved[:chest] += 1
+            end
+          end
+          next
+        end
+
+        gem_name = clean_name(jar.after_name)
+        next if gem_name.empty?
+
+        look = dothistimeout "look in ##{jar.id} from ##{slot_id}", 5,
+          /Inside.*?you see \d+ portion|I could not find|That is not/
+        unless look =~ /Inside.*?you see (\d+) portion/
+          next
+        end
+
+        count   = $1.to_i
+        is_full = (look =~ /It is full|filling it/) ? true : false
+        correct = is_full ? :wardrobe : :bin
+
+        existing = data[:jars].find { |j|
+          clean_name(j[:gem]).casecmp?(gem_name) && j[:location] == location
+        }
+        if existing
+          existing[:count] = existing[:count].to_i + count
+          existing[:full]  = is_full if is_full
+        else
+          data[:jars] << { gem: gem_name, count: count, full: is_full, location: location }
+        end
+
+        found += 1
+
+        # Move to correct slot if needed
+        if slot != correct
+          get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
+          if get_r =~ /^You remove/
+            fput "put ##{jar.id} in #{correct}"
+            moved[correct] += 1
+          end
+        end
+      end
+
+      close_locker
+    end
+
+    echo "GemHoarder: scan complete -- #{found} jar(s) catalogued, " \
+         "#{moved[:wardrobe]} -> wardrobe, #{moved[:bin]} -> bin, #{moved[:chest]} -> chest."
+    true
+  end
+
+  # ── Deposit Loop ──────────────────────────────────────────────────────────────
+
+  def self.deposit_gems(data, location)
+    sack = find_gemsack
+    return unless sack
+
+    gems = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
+    if gems.empty?
+      echo "GemHoarder: no eligible gems in gemsack."
+      return
+    end
+    echo "GemHoarder: #{gems.size} gem(s) to deposit at #{location}."
+
+    # strict -- never jar a gem tracked at any other locker
+    # normal -- jar a gem if all other locker jars for it are full
+    # loose  -- always jar regardless of other lockers
+    other_loc_names = case locker_mode
+    when :strict
+      (data[:jars] || [])
+        .select { |j| j[:location] != location }
+        .map    { |j| clean_name(j[:gem]) }
+    when :normal
+      (data[:jars] || [])
+        .select { |j| j[:location] != location && !j[:full] }
+        .map    { |j| clean_name(j[:gem]) }
+    when :loose
+      []
+    end
+
+    not_suitable = []
+    deposited    = 0
+
+    # ── Phase 1: Fill partial jars from bin ──────────────────────────────────
+
+    bin_result = open_locker_part("bin")
+    if bin_result
+      bin_id, bin_contents = bin_result
+
+      bin_contents.select { |o| o.noun =~ JAR_NOUNS }.each do |jar|
+        next if jar.after_name.nil? || jar.after_name.strip.empty?
+        jar_gem = clean_name(jar.after_name)
+        next if jar_gem.empty?
+
+        record = (data[:jars] || []).find { |j|
+          clean_name(j[:gem]).casecmp?(jar_gem) && j[:location] == location
+        }
+        next if record && record[:full]
+
+        matching = gems.select { |g|
+          !not_suitable.include?(g.id) &&
+          clean_name(g.name) =~ gem_regex(jar_gem)
+        }
+        next if matching.empty?
+
+        get_r = dothistimeout "get ##{jar.id} from ##{bin_id}", 4, /^You remove|Get what/
+        next unless get_r =~ /^You remove/
+
+        record ||= begin
+          r = { gem: jar_gem, count: 0, full: false, location: location }
+          data[:jars] ||= []
+          data[:jars] << r
+          r
+        end
+
+        filled = false
+        matching.each do |gem|
+          res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
+            /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+          case res
+          when /^You add.*filling it/, /filling it/
+            record[:count] = record[:count].to_i + 1
+            record[:full]  = true
+            filled = true
+            gems.delete(gem)
+            deposited += 1
+            break
+          when /^You add|^You put.*into.*jar/
+            record[:count] = record[:count].to_i + 1
+            gems.delete(gem)
+            deposited += 1
+            break unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
+          when /is full/
+            record[:full] = true
+            filled = true
+            fput "put ##{gem.id} in ##{sack.id}"
+            break
+          when /does not appear to be a suitable/
+            not_suitable << gem.id
+            fput "put ##{gem.id} in ##{sack.id}"
+          when /^I could not find/
+            break
+          else
+            fput "put ##{gem.id} in ##{sack.id}"
+          end
+        end
+
+        fput "put ##{jar.id} in #{filled ? 'wardrobe' : 'bin'}"
+      end
+
+      close_locker
+    end
+
+    # Refresh gem list after phase 1
+    gems = gem_contents(sack).reject { |g|
+      gem_excluded?(g.name) || not_suitable.include?(g.id)
+    }
+    return if gems.empty?
+
+    # ── Phase 2: Start new jars from chest for gem types without a partial jar ─
+
+    gem_groups = Hash.new { |h, k| h[k] = [] }
+    gems.each do |g|
+      cn = clean_name(g.name)
+      next if other_loc_names.any? { |ol| cn =~ gem_regex(ol) }
+      next if (data[:jars] || []).any? { |j|
+        j[:location] == location && !j[:full] &&
+        clean_name(j[:gem]) =~ gem_regex(cn)
+      }
+      gem_groups[cn] << g
+    end
+
+    unless gem_groups.empty?
+      chest_result = open_locker_part("chest")
+      if chest_result
+        chest_id, chest_contents = chest_result
+        empty_jars = chest_contents.select { |o|
+          o.noun =~ JAR_NOUNS && (o.after_name.nil? || o.after_name.strip.empty?)
+        }
+
+        if empty_jars.empty?
+          echo "GemHoarder: no empty jars in chest for #{gem_groups.size} new gem type(s)."
+        else
+          gem_groups.each do |gem_name, group|
+            jar = empty_jars.shift
+            break unless jar
+
+            get_r = dothistimeout "get ##{jar.id} from ##{chest_id}", 4, /^You remove|Get what/
+            next unless get_r =~ /^You remove/
+
+            data[:jars] ||= []
+            record       = { gem: gem_name, count: 0, full: false, location: location }
+            data[:jars] << record
+
+            jar_returned = false
+            filled       = false
+
+            group.each do |gem|
+              res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
+                /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+              case res
+              when /^You add.*filling it/, /filling it/
+                record[:gem]   = clean_name(jar.after_name) unless jar.after_name.to_s.strip.empty?
+                record[:count] = record[:count].to_i + 1
+                record[:full]  = true
+                filled = true
+                gems.delete(gem)
+                deposited += 1
+                break
+              when /^You add|^You put.*into.*jar/
+                record[:gem]   = clean_name(jar.after_name) unless jar.after_name.to_s.strip.empty?
+                record[:count] = record[:count].to_i + 1
+                gems.delete(gem)
+                deposited += 1
+                break unless GameObj.right_hand&.id == jar.id || GameObj.left_hand&.id == jar.id
+              when /is full/
+                record[:full] = true
+                filled = true
+                fput "put ##{gem.id} in ##{sack.id}"
+                break
+              when /does not appear to be a suitable/
+                not_suitable << gem.id
+                fput "put ##{gem.id} in ##{sack.id}"
+                data[:jars].delete(record)
+                fput "put ##{jar.id} in chest"
+                jar_returned = true
+                break
+              when /^I could not find/
+                break
+              else
+                fput "put ##{gem.id} in ##{sack.id}"
+              end
+            end
+
+            unless jar_returned
+              fput "put ##{jar.id} in #{filled ? 'wardrobe' : 'bin'}"
+            end
+          end
+        end
+
+        close_locker
+      end
+    end
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    echo "GemHoarder: deposited #{deposited} gem(s)."
+
+    leftover = gem_contents(sack).reject { |g| gem_excluded?(g.name) }
+    unless leftover.empty?
+      in_other = leftover.select { |g|
+        cn = clean_name(g.name)
+        other_loc_names.any? { |ol| cn =~ gem_regex(ol) }
+      }
+      not_jarred = leftover - in_other
+
+      unless in_other.empty?
+        names = in_other.map { |g| clean_name(g.name) }.uniq
+        echo "GemHoarder: #{in_other.size} gem(s) tracked at other lockers -- left in gemsack:"
+        names.each do |n|
+          other_loc = (data[:jars] || []).find { |j|
+            j[:location] != location && clean_name(j[:gem]) =~ gem_regex(n)
+          }
+          loc_name = other_loc ? other_loc[:location] : "unknown"
+          echo "  -> #{n} (#{loc_name})"
+        end
+      end
+
+      unless not_jarred.empty?
+        echo "GemHoarder: #{not_jarred.size} gem(s) could not be jarred (no empty jars or unsuitable)."
+      end
+    end
+  end
+
+  # ── Raid ──────────────────────────────────────────────────────────────────────
+
+  def self.raid(data, location)
+    gem_name = Script.current.vars[2].to_s.strip
+    if gem_name.empty?
+      echo "GemHoarder: usage: ;egemhoarder raid <gem> [count]"
+      return
+    end
+
+    count = Script.current.vars[3].to_i
+    count = 1 if count < 1
+
+    sack = find_gemsack
+    return unless sack
+
+    matching_records = (data[:jars] || []).select { |j|
+      clean_name(j[:gem]) =~ gem_regex(gem_name)
+    }
+
+    if matching_records.empty?
+      echo "GemHoarder: no jars found for '#{gem_name}'."
+      return
+    end
+
+    # Warn about same gem at other lockers
+    other = matching_records.select { |j| j[:location] != location }
+    unless other.empty?
+      echo "GemHoarder: '#{gem_name}' is also tracked at other lockers:"
+      other.each { |j| echo "  -> #{j[:location]} (#{j[:count]} portions, full=#{j[:full]})" }
+    end
+
+    local_records = matching_records.select { |j| j[:location] == location }
+    if local_records.empty?
+      echo "GemHoarder: no jars for '#{gem_name}' at #{location}."
+      return
+    end
+
+    total_available = local_records.sum { |j| j[:count].to_i }
+    if total_available < count
+      echo "GemHoarder: requested #{count} but only #{total_available} available at #{location}."
+      return
+    end
+
+    raided    = 0
+    remaining = count
+
+    [:wardrobe, :bin].each do |slot|
+      break if remaining <= 0
+
+      result = open_locker_part(slot.to_s)
+      unless result
+        echo "GemHoarder: could not open #{slot}."
+        next
+      end
+      slot_id, slot_contents = result
+
+      matching_jars = slot_contents.select { |o|
+        o.noun =~ JAR_NOUNS &&
+        !o.after_name.to_s.strip.empty? &&
+        clean_name(o.after_name) =~ gem_regex(gem_name)
+      }
+
+      matching_jars.each do |jar|
+        break if remaining <= 0
+
+        record = (data[:jars] || []).find { |j|
+          clean_name(j[:gem]) =~ gem_regex(gem_name) && j[:location] == location
+        }
+        next unless record
+
+        get_r = dothistimeout "get ##{jar.id} from ##{slot_id}", 4, /^You remove|Get what/
+        unless get_r =~ /^You remove/
+          echo "GemHoarder: could not retrieve jar from #{slot}."
+          next
+        end
+
+        remaining.times do
+          break if remaining <= 0
+          res = dothistimeout "shake ##{jar.id}", 4, /^You shake|nothing happens|already empty/
+          if res =~ /^You shake/
+            pause 0.25
+            dropped = GameObj.loot.find { |o|
+              o.type =~ /gem/i && clean_name(o.name) =~ gem_regex(gem_name)
+            }
+            if dropped
+              fput "get ##{dropped.id}"
+              fput "put ##{dropped.id} in ##{sack.id}"
+              record[:count] = record[:count].to_i - 1
+              raided    += 1
+              remaining -= 1
+            end
+          elsif res =~ /nothing happens|already empty/
+            record[:count] = 0
+            break
+          end
+        end
+
+        # Route jar to correct slot
+        if record[:count].to_i <= 0
+          record[:full] = false
+          data[:jars].delete(record)
+          fput "put ##{jar.id} in chest"
+        else
+          record[:full] = false
+          fput "put ##{jar.id} in bin"
+        end
+      end
+
+      close_locker
+    end
+
+    echo "GemHoarder: raided #{raided} #{gem_name}(s) into gemsack."
+    save_data(data)
+  end
+
+  # ── Entry Point ───────────────────────────────────────────────────────────────
 
   def self.main
-    load_hoard
-    before_dying {
-      save_hoard
-    }
-    unless Script.current.vars[1]
-      Script.current.vars[1] = "none"
-    end
+    data = load_data
+    before_dying { save_data(data) }
 
-    if Script.current.vars[1] =~ /raid/
-      unless Script.current.vars[2]
-        output = "Please specify a gem raid or use \"all\" to select all.\n"
-        output.concat "Usage:\n"
-        output.concat "        ;egemhoarder raid <gem|all> [amount]\n"
-        respond output
-        exit
-      end
-      unless Script.current.vars[3]
-        output = "defaulting to 1 gem to raid.\n"
-        respond output
-        Script.current.vars[3] = 1
-      end
-    end
+    cmd = Script.current.vars[1].to_s.strip.downcase
 
-    if Script.current.vars[1] =~ /help/
-      output = "Usage: ;egemhoarder [help|newlocker|list|alpha|search|forget]\n"
-      output.concat "   help:                      prints out this list.\n"
-      output.concat "   newlocker:                 add a new locker to your list.\n"
-      output.concat "   list:                      list all gems currently in jars.\n"
-      output.concat "   alpha:                     list all gems currently in jars in alphabetical order.\n"
-      output.concat "   search <string>:           list all gems currently in jars that match a search string.\n"
-      output.concat "   forget:                    forget the gem contents in all your lockers.\n"
-      output.concat "   raid <gem> <amount>:       raid <gem> where gem can be \"all\" for the specified amount.\n"
-      output.concat "   set <gem> <amount> <full>: set the selected gem to the specified amount.\n"
-      output.concat " \n"
-      output.concat "   set example: ;egemhoarder \"golden beryl gems\" 15 false\n"
-      output.concat "   another  set example: ;egemhoarder \"fire opals\" 0 false Solhaven\n"
-      output.concat " \n"
-      output.concat "   to delete a jar, please use an amount of 0\n"
-      output.concat "   to move a jar to another locker, please first delete the jar, and then use the set command with an amount, or run this script at your new locker location.\n"
+    case cmd
+    when "help", "-h", "--help", "?"
+      show_help
 
-      respond output
+    when "list"
+      loc = Script.current.vars[2].to_s.strip
+      loc = nil if loc.empty?
+      show_list(data[:jars] || [], location: loc)
 
-    elsif Script.current.vars[1] =~ /list/
-      output = "                                gem count  full  location\n"
-      output.concat "                                --- -----  ----  ------------\n"
-      sorted_jars.each do |jar|
-        if jar[:full].to_s =~ /full/
-          jar[:full] = true
-        end
-        if jar[:full].to_s =~ /false/
-          jar[:full] = false
-        end
-        output.concat "#{jar[:gem].rjust(35)} #{jar[:count].to_s.rjust(2)} #{jar[:full].to_s.rjust(8)}   #{jar[:location].to_s.ljust(30)}\n"
-      end
-      respond output
-    elsif Script.current.vars[1] =~ /alpha/
-
-      output = "                                gem count  full  location\n"
-      output.concat "                                --- -----  ----  ------------\n"
-      for jar in sorted_jars
-        if jar[:full].to_s =~ /full/
-          jar[:full] = true
-        end
-        if jar[:full].to_s =~ /false/
-          jar[:full] = false
-        end
-        output.concat "#{jar[:gem].rjust(35)} #{jar[:count].to_s.rjust(2)} #{jar[:full].to_s.rjust(8)}   #{jar[:location].to_s.ljust(30)}\n"
-      end
-      respond output
-    elsif Script.current.vars[1] =~ /search/
-      output = "                                gem count  full  location\n"
-      output.concat "                                --- -----  ----  ------------\n"
-      for jar in sorted_jars
-        if jar[:gem] =~ /#{Script.current.vars[2]}/ then
-          output.concat "#{jar[:gem].rjust(35)} #{jar[:count].to_s.rjust(2)} #{jar[:full].to_s.rjust(8)}   #{jar[:location].to_s.ljust(30)}\n"
-        end
-      end
-      respond output
-
-    elsif Script.current.vars[1] =~ /set/
-      unless Script.current.vars[2]
-        output = "Please specify which gem to modify.\n"
-        respond output
-        exit
-      end
-      unless Script.current.vars[3]
-        output = "jar amount not specified, defaulting to removal.\n"
-        respond output
-        Script.current.vars[3] = 0
-      end
-      unless Script.current.vars[4]
-        output = "jar full true/false not specified, defaulting to false.\n"
-        respond output
-        Script.current.vars[4] = false
-      end
-      if Script.current.vars[4] =~ /false/ then
-        Script.current.vars[4] = false
-      elsif Script.current.vars[4] =~ /true/ then
-        Script.current.vars[4] = true
-      end
-
-      unless Script.current.vars[5]
-        fput "location"
-        Script.current.vars[5] = matchfind "current location is ? or somewhere close to it."
-        output = "setting location to #{Script.current.vars[5]}.\n"
-        respond output
-      end
-
-      gem = Script.current.vars[2]
-      count = Script.current.vars[3].to_i
-      full = Script.current.vars[4]
-      location = Script.current.vars[5]
-      jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == gem }
-      unless jar_hash
-        jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == gem + "s" }
-      end
-
-      if count > 0
-        output = "#{gem}, #{count}, #{full}, #{location} have been added.\n"
-        respond output
-        @egemhoarder_settings[:jars].delete_if { |j| j[:gem] == gem }
-        @egemhoarder_settings[:jars].push(h = { :gem => gem, :count => count, :full => full, :location => location })
+    when "search"
+      filter = Script.current.vars[2].to_s.strip
+      if filter.empty?
+        echo "GemHoarder: usage: ;egemhoarder search <string>"
       else
-        output = "Removing #{gem} from the list.\n"
-        respond output
-        @egemhoarder_settings[:jars].delete_if { |j| j[:gem] == gem }
+        show_list(data[:jars] || [], filter: filter)
       end
 
-      exit
+    when "forget"
+      location = current_location
+      if Script.current.vars[2].to_s.strip.downcase == "all"
+        data[:jars]          = []
+        data[:known_lockers] = []
+        save_data(data)
+        echo "GemHoarder: all locker data cleared."
+      else
+        data[:jars].delete_if { |j| j[:location] == location }
+        data[:known_lockers].delete(location)
+        save_data(data)
+        echo "GemHoarder: data cleared for #{location}."
+      end
 
-    elsif Script.current.vars[1] =~ /forget/
-      @egemhoarder_settings[:jars] = nil
-      @egemhoarder_settings[:known_lockers] = nil
-      output = "Locker contents forgotten.\n"
-      respond output
-      exit
+    when "set"
+      cmd_set(data)
+
+    when "raid"
+      location = current_location
+      data[:known_lockers] ||= []
+      data[:jars]          ||= []
+      unless data[:known_lockers].include?(location)
+        echo "GemHoarder: #{location} is not a registered locker. Run ;egemhoarder newlocker first."
+        exit
+      end
+      raid(data, location)
+
+    when "newlocker"
+      location             = current_location
+      data[:jars]          ||= []
+      data[:known_lockers] ||= []
+      data[:jars].delete_if { |j| j[:location] == location }
+      if scan_locker(data, location)
+        data[:known_lockers] |= [location]
+        save_data(data)
+        echo "GemHoarder: #{location} registered. Run ;egemhoarder to deposit gems."
+      end
+
+    when "", "none"
+      if UserVars.gemsack.to_s.strip.empty?
+        echo "GemHoarder: gemsack not set. Run: ;vars set gemsack=<container name>"
+        exit
+      end
+
+      location             = current_location
+      data[:known_lockers] ||= []
+      data[:jars]          ||= []
+
+      unless data[:known_lockers].include?(location)
+        echo "GemHoarder: #{location} is a new locker -- scanning first..."
+        scan_locker(data, location)
+        data[:known_lockers] |= [location]
+        save_data(data)
+      end
+
+      deposit_gems(data, location)
+      save_data(data)
+
     else
-
-      if UserVars.gemsack.nil? or UserVars.gemsack.empty?
-        echo 'error: gemsack is not set. (;vars set gemsack=<container name>)'
-        exit
-      end
-      if UserVars.lootsack.nil? or UserVars.lootsack.empty?
-        echo 'error: lootsack is not set. (;vars set lootsack=<container name>)'
-        exit
-      end
-      unless (gemsack = (GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.gemsack.strip)}$/i } || GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.gemsack).sub(' ', ' .*')}$/i } || GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.gemsack).sub(' ', ' .*')}/i }))
-        echo 'error: failed to find your gemsack'
-        exit
-      end
-      unless (lootsack = (GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.lootsack.strip)}$/i } || GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.lootsack).sub(' ', ' .*')}$/i } || GameObj.inv.find { |obj| obj.name =~ /\b#{Regexp.escape(UserVars.lootsack).sub(' ', ' .*')}/i }))
-        echo 'error: failed to find your lootsack'
-        exit
-      end
-      close_gemsack = false
-      close_lootsack = false
-
-      open_result = dothistimeout "open ##{gemsack.id}", 5, /^You open|^You carefully|^You unfasten|^That is already open\.$/
-      if open_result =~ /^You open|^You carefully|^You unfasten/
-        close_gemsack = true
-      else
-        dothistimeout "look in ##{gemsack.id}", 5, /In .*? you see/
-        if gemsack.contents.nil?
-          echo 'error: failed to find gemsack contents'
-          exit
-        end
-      end
-
-      open_result = dothistimeout "open ##{lootsack.id}", 5, /^You open|^You carefully|^You unfasten|^That is already open\.$/
-      if open_result =~ /^You open|^You carefully|^You unfasten/
-        close_lootsack = true
-      else
-        dothistimeout "look in ##{lootsack.id}", 5, /In .*? you see/
-        if lootsack.contents.nil?
-          echo 'error: failed to find lootsack contents'
-          exit
-        end
-      end
-      empty_hands
-      dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-      if @egemhoarder_settings[:jars].nil? || Script.current.vars[1] =~ /newlocker/
-        fput "open locker"
-        jars = ["jar", "beaker", "bottle"]
-        jars.each { |jar_type|
-          echo "Moving all #{jar_type}s from your wardrobe into your chest"
-          output = "You put"
-          while output =~ /You put/ do
-            dothistimeout "get #{jar_type} from wardrobe", 3, /^You remove|Get what/
-            output = dothistimeout "put my #{jar_type} in chest", 3, /^You put|I could not find/
-          end
-        }
-        jars.each { |jar_type|
-          output = "You put"
-          echo "Moving all #{jar_type}s from your bin into your chest"
-          while output =~ /You put/ do
-            dothistimeout "get #{jar_type} from bin", 3, /^You remove|Get what/
-            output = dothistimeout "put my #{jar_type} in chest", 3, /^You put|I could not find/
-          end
-        }
-      end
-
-      dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-      status_tags
-      open_result = dothistimeout 'open locker', 5, /exist=".*?" noun="(?:locker|bin)"/
-      status_tags
-
-      if open_result =~ /exist="(\d+)" noun="(locker|chest)"/
-        fput "location"
-        location = matchfind "current location is ? or somewhere close to it."
-        locker_id = $1
-        locker_contents = GameObj.containers[locker_id]
-        unless locker_contents
-          dothistimeout "look in ##{locker_id}", 3, /^In the/
-          locker_contents = GameObj.containers[locker_id]
-        end
-        if locker_contents
-          if @egemhoarder_settings[:jars].nil?
-
-            @egemhoarder_settings[:jars] = Array.new
-            @egemhoarder_settings[:empty_jar_count] = 0
-            Script.current.vars[1] = "newlocker"
-            broken = true
-            while broken == true do
-              broken = false
-              dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-              status_tags
-              open_result = dothistimeout 'open locker', 5, /exist="(\d+)" noun="chest"/
-              locker_id = $1
-              status_tags
-              if open_result =~ /exist="(\d+)" noun="(locker|chest)"/
-                locker_id = $1
-              end
-              locker_contents = GameObj.containers[locker_id]
-              unless locker_contents
-                dothistimeout "look in ##{locker_id}", 3, /^In the/
-                locker_contents = GameObj.containers[locker_id]
-              end
-              locker_contents.find_all { |obj| obj.noun =~ /^(?:jar|bottle|beaker)$/ }.each { |jar_type|
-                unless jar_type.after_name.nil?
-                  look_result = dothistimeout "look in ##{jar_type.id} from ##{locker_id}", 3, /^Inside .*? you see [0-9]+ portion|I could not find what you were referring to/
-                  if look_result =~ /I could not find what you were referring to/ then
-                    broken = true
-                    break
-                  end
-                  if look_result =~ /^Inside .*? you see ([0-9]+) portion/
-                    count = $1.to_i
-                    gem = jar_type.after_name.gsub(/^containing |large |medium |small |tiny |some /, '')
-                    full = look_result.include?('It is full')
-                    if full
-                      output = dothistimeout "get ##{jar_type.id} from ##{locker_id}", 3, /You remove|Get what/
-                      if output =~ /Get what/
-                        broken = true
-                        break
-                      end
-                      fput "put ##{jar_type.id} in wardrobe"
-                    else
-                      output = dothistimeout "get ##{jar_type.id} from ##{locker_id}", 3, /You remove|Get what/
-                      if output =~ /Get what/
-                        broken = true
-                        break
-                      end
-                      fput "put ##{jar_type.id} in bin"
-                    end
-                    @egemhoarder_settings[:jars].push(h = { :gem => gem, :count => count, :full => full, :location => location })
-                  end
-                end
-              }
-            end
-            @egemhoarder_settings[:known_lockers] = Array.new
-            @egemhoarder_settings[:known_lockers].push(location)
-          elsif Script.current.vars[1] =~ /newlocker/
-            broken = true
-            while broken == true do
-              broken = false
-              dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-              status_tags
-              open_result = dothistimeout 'open locker', 5, /exist="(\d+)" noun="chest"/
-              if open_result =~ /exist="(\d+)" noun="(locker|chest)"/
-                locker_id = $1
-              end
-              status_tags
-              locker_contents = GameObj.containers[locker_id]
-              unless locker_contents
-                dothistimeout "look in ##{locker_id}", 3, /^In the/
-                locker_contents = GameObj.containers[locker_id]
-              end
-
-              locker_contents.find_all { |obj| obj.noun =~ /^(?:jar|bottle|beaker)$/ }.each { |jar_type|
-                unless jar_type.after_name.nil?
-                  look_result = dothistimeout "look in ##{jar_type.id} from ##{locker_id}", 3, /^Inside .*? you see [0-9]+ portion|I could not find what you were referring to/
-                  if look_result =~ /I could not find what you were referring to/ then
-                    broken = true
-                    break
-                  end
-                  if look_result =~ /^Inside .*? you see ([0-9]+) portion/
-                    count = $1.to_i
-                    gem = jar_type.after_name.gsub(/^containing |large |medium |small |tiny |some /, '')
-                    full = look_result.include?('It is full')
-                    if full
-                      fput "get ##{jar_type.id} from ##{locker_id}"
-                      fput "put ##{jar_type.id} in wardrobe"
-                    else
-                      fput "get ##{jar_type.id} from ##{locker_id}"
-                      fput "put ##{jar_type.id} in bin"
-                    end
-                    @egemhoarder_settings[:jars].push(h = { :gem => gem, :count => count, :full => full, :location => location })
-                  end
-                end
-              }
-            end
-            @egemhoarder_settings[:known_lockers].push(location)
-          end
-
-          unless @egemhoarder_settings[:known_lockers].include?(location)
-            output = "WARNING! This locker doesn't appear to have been recorded!\nIf you really want to store gems to this locker prior to recording, ;send continue.\nTo record this locker, kill egemhoarder and rerun with the newlocker option.\n"
-            respond output
-            waitfor "continue"
-          end
-
-          not_suitable = Array.new
-
-          #####
-          # RAID GOING HERE
-          ####
-          if Script.current.vars[1] =~ /raid/
-            count = Script.current.vars[3].to_i
-            gem_bin = Array.new
-            gem_wardrobe = Array.new
-            fput "location"
-            preserve = 0
-            location = matchfind "current location is ? or somewhere close to it."
-
-            @egemhoarder_settings[:jars].each { |gem_hash|
-              if gem_hash[:full].to_s =~ /full/
-                gem_hash[:full] = true
-              end
-              if gem_hash[:full].to_s =~ /false/
-                gem_hash[:full] = false
-              end
-              if gem_hash[:location] == location
-
-                if Script.current.vars[2] == "all"
-                  preserve = 1
-                  if gem_hash[:full]
-                    gem_wardrobe.push(gem_hash[:gem])
-                  elsif gem_hash[:count].to_i >= count.to_i
-                    gem_bin.push(gem_hash[:gem])
-                  end
-                else
-                  if gem_hash[:gem] == Script.current.vars[2]
-                    if gem_hash[:full]
-                      echo "pushing to gem_wardrobe"
-                      gem_wardrobe.push(gem_hash[:gem])
-                    elsif gem_hash[:count].to_i >= count.to_i
-                      echo "pushing to gem_bin"
-                      gem_bin.push(gem_hash[:gem])
-                    end
-                  elsif gem_hash[:gem] == Script.current.vars[2] + 's'
-                    if gem_hash[:full]
-                      gem_wardrobe.push(gem_hash[:gem])
-                    elsif gem_hash[:count].to_i >= count.to_i
-                      gem_bin.push(gem_hash[:gem])
-                    end
-                  elsif gem_hash[:gem] == Script.current.vars[2] + 'es'
-                    if gem_hash[:full]
-                      gem_wardrobe.push(gem_hash[:gem])
-                    elsif gem_hash[:count].to_i >= count.to_i
-                      gem_bin.push(gem_hash[:gem])
-                    end
-                  end
-
-                end
-              end
-            }
-            gem_wardrobe.each { |gem_item|
-              echo gem_item
-              gem_item.gsub!(/large |medium |small |tiny |some /, '')
-              dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-              status_tags
-              open_result = dothistimeout 'open locker', 5, /exist=".*?" noun="(wardrobe)"|already open/
-              status_tags
-              if open_result =~ /exist="(\d+)" noun="(wardrobe)"/
-                locker_id = $1
-                locker_contents = GameObj.containers[locker_id]
-
-                dothistimeout "look in ##{locker_id}", 3, /^In the/
-                locker_contents = GameObj.containers[locker_id]
-                if locker_contents
-                  if @egemhoarder_settings[:jars].any? { |char_jar| (char_jar[:gem] =~ /^#{gem_item.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/) and (char_jar[:count].to_i >= count.to_i) }
-
-                    if (jar = locker_contents.find { |locker_jar| locker_jar.after_name.gsub(/containing |large |medium |small |tiny |some /, '') =~ /^#{gem_item.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/ })
-                      jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == jar.after_name.sub(/^containing |large |medium |small |tiny |some /, '') }
-                      jar_result = dothistimeout "get ##{jar.id} from ##{locker_id}", 3, /^You remove|Get what?/
-                      if jar_result =~ /^You remove/ then
-                        count.times {
-                          dothistimeout "shake ##{jar.id}", 3, /^You .*shake/
-                          if GameObj.right_hand.id != jar.id
-                            obj = GameObj.right_hand
-                          elsif GameObj.left_hand.id != jar.id
-                            obj = GameObj.left_hand
-                          end
-                          dothistimeout "put ##{obj.id} in ##{gemsack.id}", 3, /^You put/
-                          jar_hash[:count] = jar_hash[:count] - 1
-                          jar_hash[:full] = false
-                        }
-                        if jar_hash[:count] < 1
-                          @egemhoarder_settings[:jars].delete(jar_hash)
-                          @egemhoarder_settings[:empty] = @egemhoarder_settings[:empty] + 1
-                          dothistimeout "put ##{jar.id} in chest", 3, /^You (?:put|place)/
-                        end
-                        dothistimeout "put ##{jar.id} in bin", 3, /^You (?:put|place)/
-
-                        # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                        true
-                      else
-                        echo "Sorry. Locker has refreshed. Please re-start ;egemhoarder raid."
-                        exit false
-                      end
-                    else
-                      # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                      false
-                    end
-                  else
-                    # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                    false
-                  end
-                else
-                  # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                  echo 'error: failed to find locker contents'
-                  false
-                end
-
-              else
-                dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                echo 'error: failed to find locker'
-                false
-
-              end
-            }
-
-            gem_bin.each { |gem_item|
-              gem_item.gsub!(/large |medium |small |tiny |some /, '')
-              # ###raid bin
-              dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-              status_tags
-              open_result = dothistimeout 'open locker', 5, /exist=".*?" noun="(?:locker|bin)"/
-              status_tags
-
-              if open_result =~ /exist="(\d+)" noun="(locker|bin)"/
-                locker_id = $1
-                locker_contents = GameObj.containers[locker_id]
-
-                unless locker_contents
-                  dothistimeout "look in ##{locker_id}", 3, /^In the/
-                  locker_contents = GameObj.containers[locker_id]
-                end
-
-                if locker_contents
-                  if @egemhoarder_settings[:jars].any? { |char_jar| (char_jar[:gem] =~ /^#{gem_item.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/) and (char_jar[:count] >= count.to_i + preserve.to_i) }
-                    if (jar = locker_contents.find { |locker_jar| locker_jar.after_name.gsub(/containing |large |medium |small |tiny |some /, '') =~ /^#{gem_item.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/ })
-                      jar_hash = @egemhoarder_settings[:jars].find { |char_jar| char_jar[:gem] == jar.after_name.sub(/^containing |large |medium |small |tiny |some /, '') }
-
-                      jar_result = dothistimeout "get ##{jar.id} from ##{locker_id}", 3, /^You remove|Get what?/
-                      if jar_result =~ /^You remove/ then
-                        count.to_i.times {
-                          dothistimeout "shake ##{jar.id}", 3, /^You .*shake/
-                          if GameObj.right_hand.id != jar.id
-                            obj = GameObj.right_hand
-                          elsif GameObj.left_hand.id != jar.id
-                            obj = GameObj.left_hand
-                          end
-                          dothistimeout "put ##{obj.id} in ##{gemsack.id}", 3, /^You put/
-                          jar_hash[:count] = jar_hash[:count] - 1
-                          jar_hash[:full] = false
-                        }
-                        if jar_hash[:count] < 1
-                          @egemhoarder_settings[:jars].delete(jar_hash)
-                          @egemhoarder_settings[:empty] = @egemhoarder_settings[:empty] + 1
-                          dothistimeout "put ##{jar.id} in chest", 3, /^You (?:put|place)/
-                        end
-                        dothistimeout "put ##{jar.id} in bin", 3, /^You (?:put|place)/
-
-                        # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                        true
-                      else
-                        echo "Sorry. Locker has refreshed. Please restart ;egemhoarder raid"
-                        exit
-                      end
-                    else
-                      # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                      false
-                    end
-                  else
-                    # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                    false
-                  end
-                else
-                  # dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                  echo 'error: failed to find locker contents'
-                  false
-                end
-              else
-                dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-                echo 'error: failed to find locker'
-                false
-
-              end
-            }
-
-            dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-
-          end
-
-          ########### end new section
-
-          unless (Script.current.vars[1] =~ /newlocker/ or Script.current.vars[1] =~ /raid/)
-
-            dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-            status_tags
-            open_result = dothistimeout 'open locker', 5, /exist="(\d+)" noun="bin"/
-            if open_result =~ /exist="(\d+)" noun="(locker|bin)"/
-              locker_id = $1
-            end
-            status_tags
-            locker_contents = GameObj.containers[locker_id]
-            unless locker_contents
-              dothistimeout "look in ##{locker_id}", 3, /^In the/
-              locker_contents = GameObj.containers[locker_id]
-            end
-
-            for jar in locker_contents.find_all { |obj| obj.noun =~ /^(?:jar|beaker|bottle)$/ }
-              if jar.after_name =~ /^containing /
-                gem_list = gemsack.contents.find_all { |obj| (jar.after_name.gsub(/^containing |large |medium |small |tiny |some /, '') =~ /^#{obj.name.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').sub(/x\b/, 'xe?').gsub(/\b\s/, 's? ')}s?$/) }
-                gem_list.delete_if { |obj| not_suitable.include?(obj.id) }
-                jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == jar.after_name.gsub(/^containing |large |medium |small |tiny |some /, '') }
-                unless gem_list.empty?
-                  dothistimeout "get ##{jar.id} from ##{locker_id}", 3, /^You remove/
-                  for gem in gem_list
-                    result = dothistimeout "_drag ##{gem.id} ##{jar.id}", 3, /^You add|is full|does not appear to be a suitable container for/
-
-                    if result =~ /^You add .* filling it/
-                      jar_hash[:count] = jar_hash[:count] + 1
-                      jar_hash[:full] = true
-                      fput "put ##{jar.id} in wardrobe"
-                    elsif result =~ /^You add/
-                      jar_hash[:count] = jar_hash[:count] + 1
-                    elsif result =~ /is full/
-                      jar_hash[:full] = true
-                      fput "put ##{jar.id} in wardrobe"
-                      dothistimeout "put ##{gem.id} in ##{gemsack.id}", 3, /^You put/
-                      break
-                    elsif result =~ /does not appear to be a suitable container for/
-                      dothistimeout "put ##{gem.id} in ##{lootsack.id}", 3, /^You put/
-                      not_suitable.push(gem.id)
-                    else
-                      dothistimeout "put ##{gem.id} in ##{gemsack.id}", 3, /^You put/
-                    end
-
-                  end
-                  if checkright
-                    dothistimeout "put ##{jar.id} in ##{locker_id}", 3, /^You (?:put|place)/
-                  end
-                end
-              else
-                fput "get ##{jar.id} in ##{locker_id}"
-                fput "put ##{jar.id} in chest"
-              end
-            end
-
-          end
-
-          dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-          status_tags
-          open_result = dothistimeout 'open locker', 5, /exist=".*?" noun="(?:locker|chest)"/
-          status_tags
-          if open_result =~ /exist="(\d+)" noun="(locker|chest)"/
-            locker_id = $1
-            locker_contents = GameObj.containers[locker_id]
-            unless locker_contents
-              dothistimeout "look in ##{locker_id}", 3, /^In the/
-              locker_contents = GameObj.containers[locker_id]
-            end
-            if locker_contents
-
-              not_suitable = Array.new
-              gem_hoard = Array.new
-              for jar in @egemhoarder_settings[:jars]
-                if (!jar[:full] || jar[:location] != location)
-                  gem_hoard.push(jar[:gem])
-                end
-              end
-              other_locker = Array.new
-              squelch = Array.new
-              unless Script.current.vars[1] =~ /newlocker/ or Script.current.vars[1] =~ /raid/
-                for jar in locker_contents.find_all { |obj| obj.noun =~ /^(?:jar|beaker|bottle)$/ }
-                  gem_count = Hash.new
-                  gemsack.contents.each { |obj|
-                    if (obj.type =~ /gem/) and (obj.name !~ /oblivion quartz$|doomstone|urglaes fang/) and not gem_hoard.any? { |op| op.gsub(/^containing |large |medium |small |tiny |some /, '') =~ /^#{obj.name.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/ } and not locker_contents.any? { |o| o.after_name.gsub(/^containing |large |medium |small |tiny |some /, '') =~ /^#{obj.name.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/ and not not_suitable.include?(obj.id) }
-                      gem_count[obj.name.gsub(/large |medium |small |tiny |some /, '')] = gem_count[obj.name.gsub(/large |medium |small |tiny |some /, '')].to_i + 1
-                    elsif gem_hoard.any? { |op| op.gsub(/^containing |large |medium |small |tiny |some /, '') =~ /^#{obj.name.gsub(/large |medium |small |tiny |some /, '').sub(/y\b/, '(?:y|ie)').sub(/z\b/, 'ze?').gsub(/\b\s/, 's? ')}s?$/ }
-                      other_locker.push(obj.name.gsub(/^containing |large |medium |small |tiny |some /, ''))
-                    end
-                  }
-
-                  next if gem_count.empty?
-                  gem_name = nil
-                  gem_num = 0
-                  gem_count.each_pair { |name, num|
-                    if num > gem_num
-                      gem_name = name
-                      gem_num = num
-                    end
-                  }
-                  if not squelch.include?(gem_name)
-                    dothistimeout "get ##{jar.id} from ##{locker_id}", 3, /^You remove/
-                  end
-                  jar_hash = nil
-
-                  gemsack.contents.each { |obj|
-                    if obj.name.gsub(/large |medium |small |tiny |some /, '') == gem_name and not squelch.include?(gem_name)
-                      result = dothistimeout "_drag ##{obj.id} ##{jar.id}", 3, /filling it|^You (?:add|put)|is full|does not appear to be a suitable container for|Not all drag and drop possibilities will/
-                      if result =~ /^You add .* filling it/
-                        jar_hash[:count] = jar_hash[:count] + 1
-                        jar_hash[:full] = true
-                        dothistimeout "put ##{jar.id} in wardrobe", 3, /^You put/
-                        break
-                      elsif result =~ /^You put/
-                        dothistimeout "put ##{jar.id} in ##{lootsack.id}", 3, /^You put/
-                        saveobjname = obj.name.gsub(/large |medium |small |tiny |some /, '');
-                        gem = lootsack.contents.find { |lootsack_obj| lootsack_obj.id == jar.id }.after_name.gsub(/^containing |large |medium |small |tiny |some /, '')
-                        dothistimeout "get ##{jar.id}", 3, /^You remove/
-                        if gem_hoard.include?(gem)
-                          fput "shake ##{jar.id}"
-                          fput "put ##{jar.id} in chest"
-                          fput "put left in ##{gemsack.id}"
-                          unless other_locker.include?(gem)
-                            squelch.push(saveobjname)
-                            other_locker.push(gem)
-                          end
-                          break
-                        else
-                          jar_hash = { :gem => gem, :count => 1, :full => false, :location => location }
-                          @egemhoarder_settings[:jars].push(jar_hash)
-                        end
-                      elsif result =~ /is full/
-                        dothistimeout "put ##{obj.id} in ##{gemsack.id}", 3, /^You put/
-                        jar_hash[:full] = true
-                        dothistimeout "put ##{jar.id} in wardrobe", 3, /^You put/
-                        break
-                      elsif result =~ /^You add/
-                        jar_hash[:count] = jar_hash[:count] + 1
-                      elsif result =~ /does not appear to be a suitable container for/
-                        not_suitable.push(obj.id)
-                        fput "put ##{obj.id} in ##{lootsack.id}"
-                      elsif result =~ /Not all drag and drop possibilities will/
-                        fput "put ##{obj.id} in ##{gemsack.id}"
-                        fput "put ##{jar.id} in wardrobe"
-                      end
-                    end
-                  }
-                  if checkright
-                    dothistimeout "put ##{jar.id} in bin", 3, /^You (?:put|place)/
-                  end
-
-              end
-
-              end
-            end
-            dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-            fill_hands
-          else
-            dothistimeout "close locker", 1, /^You close|That is already closed|^You hear the faint\.$/
-            echo 'error: failed to find locker contents'
-          end
-        else
-          dothistimeout "close locker", 1, /^You close|^That is already closed|^You hear the faint\.$/
-          echo 'error: failed to find locker'
-        end
-
-      end
-
-      if Script.current.vars[1] =~ /newlocker/
-        output = "New locker has been checked, sorted, and saved. Please re-run the script without arguments to deposit gems.\n"
-        output.concat "Please make sure to run \";egemhoarder newlocker\" at any other locker you are storing gems in before depositing here!\n"
-        respond output
-      end
-
-      unless other_locker.empty?
-        output = "Gems not lockered due to being already in another locker:\n"
-        output.concat "                                gem count  full  location\n"
-        output.concat "                                --- -----  ----  --------\n"
-
-        other_locker.each { |other_gem|
-          jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == other_gem }
-          unless jar_hash
-            jar_hash = @egemhoarder_settings[:jars].find { |j| j[:gem] == other_gem + "s" }
-          end
-          unless jar_hash[:full]
-            output.concat "#{jar_hash[:gem].rjust(35)} #{jar_hash[:count].to_s.rjust(2)} #{jar_hash[:full].to_s.rjust(8)}  #{jar_hash[:location].to_s.ljust(30)}\n"
-          end
-        }
-        respond output
-      end
-
+      echo "GemHoarder: unknown command '#{cmd}'. Run ;egemhoarder help for usage."
     end
-    if close_gemsack
-      fput "close ##{gemsack.id}"
-    end
-    if close_lootsack
-      fput "close ##{lootsack.id}"
-    end
-    fill_hands
   end
+
 end
 
-EGemHoarder.main
+GemHoarder.main


### PR DESCRIPTION
```
  v2.0.0 (2026-05-11)
    - complete rewrite from egemhoarder v1.x
    - auto-navigate to locker, stow hands, return to origin on deposit/raid
    - multi-jar tracking; raid spans jars; list groups by gem
    - chest=empty jars, bin=partial, wardrobe=full
    - lockermode strict/normal/loose for multi-locker gem assignment
    - search and raid support multi-word gem names
    - scan is atomic -- rolls back on partial failure
    - sort integrated into newlocker scan
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified gem-hoarder commands (help, list, search, newlocker, forget, set, raid, deposit) with per-character persistent data and automatic locker discovery.
  * Deposit/raid behavior improved: fills partial jars first, starts new jars, prefers full/larger jars when raiding, returns emptied jars to chest and removes empty records.

* **Improvements**
  * More reliable save/load with error handling; smarter locker scans (fixes misplaced jars) and clearer list/search output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->