### PR TITLE
feat(go2): v2.3.0 persist --disable-confirm and add --confirm-distance threshold

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,15 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin, Dissonance
               game: any
               tags: core, movement
-           version: 2.2.13
+           version: 2.3.0
           required: Lich >= 5.4.1
 
    changelog:
+      2.3.0 (2026-05-12)
+        Add --disable-confirm=on/off persistent flag; bare --disable-confirm retains existing one-shot behavior
+        Add --confirm-distance=<N> to configure the distance threshold (replaces hardcoded 20); minimum value 20, default 20
+        Seed CharSettings['disable_confirm']=false and CharSettings['confirm_distance']=20 on first run for back-compat
+        Show both settings in ;go2 list output and help text
       2.2.13 (2025-11-22)
         Added support for ;go2 locker taking to public locker or CHE locker as applicable, if Lich version is 5.12.2 or later
         Added support for ;go2 guild or ;go2 guild shop to automatically look for the calling character's profession and go to the appropriate guild or guild shop.
@@ -852,6 +857,8 @@ module Go2
   CharSettings['hide_room_descriptions'] = false if CharSettings['hide_room_descriptions'].nil?
   CharSettings['hide_room_titles']       = false if CharSettings['hide_room_titles'].nil?
   CharSettings['echo_input']             = true  if CharSettings['echo_input'].nil?
+  CharSettings['disable_confirm']        = false if CharSettings['disable_confirm'].nil?
+  CharSettings['confirm_distance']       = 20    if CharSettings['confirm_distance'].nil?
 
   show_help = proc {
     output = []
@@ -875,6 +882,10 @@ module Go2
     output << "     --echo_input=<on|off>                   When 'on', echos the script input from when the script was called"
     output << "     --hide_room_descriptions=<on|off>       When 'on', turns room descriptions off for traveling"
     output << "     --hide_room_titles=<on|off>             When 'on', turns room titles off for traveling"
+    output << "     --disable-confirm                       Skip the confirmation prompt for this trip only."
+    output << "     --disable-confirm=<on|off>              Persistently skip (or show) the confirmation prompt for long trips."
+    output << "     --confirm-distance=<#>                  Trips shorter than this many rooms skip the confirmation prompt."
+    output << "                                               Minimum 20; default 20."
 
     if XMLData.game =~ /^GS/
       output << "     --get-silvers=<on|off>                  Sets if #{Script.current.name} has permission to access your bank"
@@ -1046,6 +1057,8 @@ module Go2
     output << ""
     output << "                 delay: #{CharSettings['delay']}"
     output << "            echo input: #{CharSettings['echo_input'] ? 'on' : 'off'}"
+    output << "       disable confirm: #{CharSettings['disable_confirm'] ? 'on' : 'off'}"
+    output << "      confirm distance: #{CharSettings['confirm_distance']}"
     output << "hide room descriptions: #{CharSettings['hide_room_descriptions'] ? 'on' : 'off'}"
     output << "      hide room titles: #{CharSettings['hide_room_titles'] ? 'on' : 'off'}"
     if XMLData.game =~ /^GS/
@@ -1173,7 +1186,8 @@ module Go2
   target_search_array             = Array.new
   setting_typeahead               = nil
   setting_delay                   = nil
-  setting_disable_confirm         = false
+  setting_disable_confirm         = (CharSettings['disable_confirm'] == true)
+  setting_confirm_distance        = nil
   setting_use_vaalor_shortcut     = nil
   setting_ice_mode                = nil
   setting_fwi_trinket             = nil
@@ -1208,6 +1222,10 @@ module Go2
       setting_instability = $1.to_i
     elsif var =~ /^_disable_confirm_$|^--disable-confirm$/i
       setting_disable_confirm = true
+    elsif var =~ /^(?:\-\-)?disable[_\-]confirm=(on|true|yes|off|false|no)$/i
+      setting_disable_confirm = setting_value[$1.downcase]
+    elsif var =~ /^(?:\-\-)?confirm[_\-]distance=([0-9]+)$/i
+      setting_confirm_distance = $1.to_i
     elsif var =~ /^--stop-for-dead$/i
       setting_stop_for_dead = true
     elsif var =~ /^--stop-for-dead=(on|true|yes|off|false|no)/i
@@ -1299,6 +1317,15 @@ module Go2
     unless setting_echo_input.nil?
       CharSettings['echo_input'] = setting_echo_input
       echo "go2 #{(setting_echo_input ? 'will' : 'will not')} echo input when the script starts"
+    end
+    if Script.current.vars[1..-1].any? { |v| v =~ /^(?:\-\-)?disable[_\-]confirm=/i }
+      CharSettings['disable_confirm'] = setting_disable_confirm
+      echo "go2 will #{setting_disable_confirm ? 'skip the' : 'show a'} confirmation prompt for long trips by default"
+    end
+    unless setting_confirm_distance.nil?
+      setting_confirm_distance = 20 if setting_confirm_distance < 20
+      CharSettings['confirm_distance'] = setting_confirm_distance
+      echo "go2 will prompt for confirmation when the trip distance is at least #{setting_confirm_distance} rooms"
     end
 
     if XMLData.game =~ /^GSPlat|^GSF/
@@ -1863,7 +1890,7 @@ module Go2
       exit
     end
 
-    if shortest_distances[destination.id] < 20
+    if shortest_distances[destination.id] < (CharSettings['confirm_distance'] || 20)
       confirm = false
     else
       confirm = true
@@ -1998,7 +2025,7 @@ module Go2
       exit
     end
 
-    if shortest_distances[destination.id] < 20
+    if shortest_distances[destination.id] < (CharSettings['confirm_distance'] || 20)
       confirm = false
     else
       confirm = true
@@ -2026,7 +2053,7 @@ module Go2
       exit
     end
 
-    if shortest_distances[destination.id] < 20
+    if shortest_distances[destination.id] < (CharSettings['confirm_distance'] || 20)
       confirm = false
     else
       confirm = true

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -1042,7 +1042,7 @@ module Go2
       output << " - Known Nexus Rooms"
       output << "---------------------------------------------------------------"
       Map.list.find_all { |iroom| iroom.tags.include?('nexus') }
-         .each { |iroom| output << "#{iroom.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{iroom.id.to_s.rjust(5)}" }
+              .each { |iroom| output << "#{iroom.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{iroom.id.to_s.rjust(5)}" }
     end
     respond output
     exit


### PR DESCRIPTION
- Add --disable-confirm=on/off persistent flag; bare --disable-confirm retains existing one-shot behavior
- Add --confirm-distance=<N> to configure the distance threshold (replaces hardcoded 20); minimum value 20, default 20
- Seed CharSettings['disable_confirm']=false and CharSettings['confirm_distance']=20 on first run for back-compat
- Show both settings in `;go2 list` output and help text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated `go2` script to v2.3.0 with persistent trip confirmation configuration
  * Added `--disable-confirm` flag to customize trip confirmation behavior
  * Added `--confirm-distance` flag to set a custom confirmation distance threshold (minimum 20)
  * New settings are automatically initialized and persist across sessions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->