### PR TITLE
fix(bigshot.lic): v5.12.8 wandolier cmd use gameobj ID instead of nou…

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.12.7
+       version: 5.12.8
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.12.8  (2026-05-14)
+    - use gameobj id for wandolier instead of name after being found
   v5.12.7  (2026-05-07)
     - allow for wandolier command to take a noreserve option, defaults to use RESERVE system
   v5.12.6  (2026-05-02)
@@ -4907,7 +4909,12 @@ class Bigshot
 
     if (@FRESH_WAND_CONTAINER)
       fput("reserve list") if GameObj.reserve.nil?
-      until ((GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i) || GameObj.reserve.any? { |item| item.name =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i }
+      wand_obj = nil
+
+      loop do
+        wand_obj = [GameObj.right_hand, GameObj.left_hand, *GameObj.reserve.to_a].compact.find { |o| o.name.to_s =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i }
+        break if wand_obj
+
         result = dothistimeout("get #{@WAND[$bigshot_wand]} from my #{@FRESH_WAND_CONTAINER}", 3, /You (?:remove|slip|slide)|Get what/)
         if (result =~ /Get what/)
           fput("rub my #{@FRESH_WAND_CONTAINER}")
@@ -4916,12 +4923,12 @@ class Bigshot
         end
       end
 
-      if !noreserve && ((GameObj.right_hand.name.to_s + GameObj.left_hand.name.to_s) =~ /#{@WAND[$bigshot_wand].split(' ').join('.*?')}/i)
-        fput("reserve  my #{@WAND[$bigshot_wand]}")
+      if !noreserve && [GameObj.right_hand, GameObj.left_hand].compact.any? { |o| o.id == wand_obj.id }
+        fput("reserve ##{wand_obj.id}")
       end
 
       change_stance(stance)
-      result = get_res("wave my #{@WAND[$bigshot_wand]}", /d100|You hurl|is already dead|You do not see that here|You are in no condition|I could not find|What were you referring to/)
+      result = get_res("wave ##{wand_obj.id}", /d100|You hurl|is already dead|You do not see that here|You are in no condition|I could not find|What were you referring to/)
       change_stance(@HUNTING_STANCE)
 
       if (result =~ /You are in no condition/)


### PR DESCRIPTION
…n after found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wandolier wand selection and usage reliability. Wands are now identified and used by object ID instead of name-based matching for more consistent behavior.
  * Updated noreserve option behavior to align with wand identification changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2325)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->