### PR TITLE
fix(eloot.lic): v2.9.2 fix various issues

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.1
+           version: 2.9.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.2  (2026-05-17)
+    - fix shroud to skip if not currently affordable instead of waiting for mana/stamina/overexterted, mirrors glamour
+    - fix for picking up at feet slot for new Ascension codex items
   v2.9.1  (2026-05-13)
     - fix is_transmog? to also check armor, weapon, and uncommon types for safeguard future transmog possibilities
   v2.9.0  (2026-05-05)
@@ -5105,7 +5108,7 @@ module ELoot # Room looting
     def self.search(objs = GameObj.dead.to_a) # searches dead critters
       return if objs.empty?
 
-      regex_at_feet = /^<pushBold\/> \*\* A glint of light catches your eye, and you notice an? <a exist="(?<id>[\d-]+)" noun="(?<noun>[\w-]+)">(?<name>[\w\s-]+)<\/a>.*? at your feet! \*\*$/
+      regex_at_feet = /^(?:<pushBold\/> \*\* A glint of light catches your eye, and you notice|Among the remains, you find) an? <a exist="(?<id>[\d-]+)" noun="(?<noun>[\w-]+)">(?<name>[\w\s-]+)<\/a>.*?(?: at your feet! \*\*|, which falls alongside your feet\.)$/
       inhand_critters = /skayl|glacei|tumbleweed|plant|shrub|creeper|vine|bush|caedera|golem|elemental/
 
       objs.each do |thing|
@@ -6192,7 +6195,7 @@ module ELoot # Sells the loot
         glam.cast(Char.name)
       end
 
-      if shroud.known?
+      if shroud.known? && shroud.affordable?
         shroud_races = ['human',
                         'giantman',
                         'half-elf',


### PR DESCRIPTION
- fix shroud to skip if not currently affordable instead of waiting for mana/stamina/overexterted, mirrors glamour
- fix for picking up at feet slot for new Ascension codex items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes (v2.9.2)

* **Bug Fixes**
  * Fixed shroud spell behavior to only activate when both known and affordable.
  * Improved detection of loot messages to better identify items available at your feet.
  * Enhanced compatibility with new Ascension codex item pickup mechanics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->