### PR TITLE
Update bigshot.lic

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -6996,6 +6996,11 @@ class Bigshot
     @CORRECT_PERCENT_MIND = Lich::Gemstone::Experience.percent_fxp
   end
 
+  def fog_unhide
+    @followers.add_event(:FOG_UNHIDE)
+    fput('unhide') if (hidden? || invisible?)
+  end
+
   def reset_variables(moved = true)
     debug_msg(@DEBUG_SYSTEM, "reset_variables | moved: #{moved}")
 
@@ -8219,6 +8224,7 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
         bs.wait_rt
         $looting_inactive = true
       elsif (event.type == :HUNTING_SCRIPTS_STOP)
+        bs.fog_unhide
         bs.croak_scripts(bs.HUNTING_SCRIPTS)
       elsif (event.type == :RESTING_PREP_COMMANDS)
         bs.REST_PREP = false

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -6997,7 +6997,6 @@ class Bigshot
   end
 
   def fog_unhide
-    @followers.add_event(:FOG_UNHIDE)
     fput('unhide') if (hidden? || invisible?)
   end
 


### PR DESCRIPTION
Symbol of Return will leave a hidden character behind.  They need to unhide before this happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed fog-induced hiding states not being properly cleared when hunting scripts stop.
* Followers are now notified when the unhide action occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->