### PR TITLE
fix(ledger.lic): v1.4.3 change estimate_loot_cap to be Sun thru Sat

### DIFF
--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.4.2
+        version: 1.4.3
    requirements:
     - sequel gem
     - terminal-table
@@ -20,6 +20,8 @@
   Help Contribute: https://github.com/elanthia-online/scripts
   Version Control:
   Major_change.feature_addition.bugfix
+    v1.4.3 - 2026-05-24
+      - Change estimate_loot_cap weekly window from Monday-Sunday to Sunday-Saturday (EST/EDT).
     v1.4.2 - 2026-05-11
       - Track Account.name on each transaction (new 'account' column).
         On each run, backfills NULL account values for the currently-logged-in character
@@ -330,7 +332,7 @@ module Ledger
         .sum(:amount) || 0
     end
 
-    # Estimates loot cap earnings for the current week (Monday through Sunday, EST/EDT)
+    # Estimates loot cap earnings for the current week (Sunday through Saturday, EST/EDT)
     # across all characters on the current account.
     #
     # Calculates silver gained from creature kills (excluding large deposits/withdrawals)
@@ -350,17 +352,17 @@ module Ledger
     def self.estimate_loot_cap(year: Time.now.year, month: Time.now.month, account: AccountInfo.name, character: Char.name, game: XMLData.game)
       _ = year; _ = month # accepted for backward compatibility, no longer used
 
-      # Compute the start of the current week (Monday 00:00) in EST/EDT,
+      # Compute the start of the current week (Sunday 00:00) in EST/EDT,
       # then convert back to the machine's local time so it matches `created_at`,
       # which is stored as Time.now in machine-local time.
       tz                  = TZInfo::Timezone.get('America/New_York')
       now_est             = tz.utc_to_local(Time.now.utc)
       # Time#wday: Sunday=0, Monday=1 ... Saturday=6
-      days_since_monday   = (now_est.wday + 6) % 7
-      week_start_est_date = Time.utc(now_est.year, now_est.month, now_est.day) - (days_since_monday * 86_400)
-      # Build a naive EST/EDT time at midnight Monday (Time.utc avoids machine-local DST math)
-      monday_midnight_est = Time.utc(week_start_est_date.year, week_start_est_date.month, week_start_est_date.day)
-      week_start_local    = tz.local_to_utc(monday_midnight_est).getlocal
+      days_since_sunday   = now_est.wday
+      week_start_est_date = Time.utc(now_est.year, now_est.month, now_est.day) - (days_since_sunday * 86_400)
+      # Build a naive EST/EDT time at midnight Sunday (Time.utc avoids machine-local DST math)
+      sunday_midnight_est = Time.utc(week_start_est_date.year, week_start_est_date.month, week_start_est_date.day)
+      week_start_local    = tz.local_to_utc(sunday_midnight_est).getlocal
 
       identity_filter = account ? { account: account } : { character: character }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the loot cap weekly estimation window to begin on Sunday and end on Saturday (EST/EDT), replacing the previous Monday–Sunday calculation. This correction improves the accuracy of weekly loot capacity tracking and ensures proper time zone conversion for local time-based filtering, providing more reliable weekly estimates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->