### PR TITLE
Update kswole.lic for Onslaught preps

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -7,7 +7,7 @@
 
   Hunting areas currently supported:
     Atoll/Nelemar, Bonespear (partial), Bowels, Citadel, Confluence, Crawling Shore, Den of Rot,
-    Duskruin Arena, Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, OSA (partial), OTF (incl. Aqueducts),
+    Duskruin Arena, Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, Onslaughts, OSA (partial), OTF (incl. Aqueducts),
     Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), The Hive
 
     USAGE:
@@ -20,12 +20,14 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.6
+       version: 1.1.7
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.7 (2026-05-28)
+    - Added preps for Onslaughts
   v1.1.6 (2026-02-03)
     - Added preps for WL Graveyard's Shadow Valley
   v1.1.5 (2026-01-06)
@@ -185,6 +187,11 @@ class KSwole
     /^An? (?:.*)\bknight twists a skeletal hand, uttering a blasphemous chant\./,
     /^An? (?:.*)\bvampire slices a shadowy sigil in the air as (?:he|she) utters an old chant\./,
     /^An? (?:.*)\bconjurer gives a flourish of (?:his|her) spectral arms as (?:he|she) raises (?:his|her) voice in a theatrical chant\./,
+
+	  # Onslaughts
+		/^An? (?:.*)\bauramancer performs a series of intricate gestures as motes of color scintillate beneath (?:his|her) skin\./,
+		/^An? (?:.*)\bcaptain gestures one-handed, iridescent trails of energy sparkling after (?:his|her) fingers as (?:he|she) chants\./,
+		/^An? (?:.*)\bdiviner stills for a moment, (?:his|her) lips working soundlessly as half-formed images flicker in (?:his|her) eyes\./,
 
     # OSA
     /^(?:.*) snarls as (?:he|she) chants a few words of magic\./,
@@ -348,7 +355,7 @@ class KSwole
     Lich::Messaging.msg('teal', '|')
     Lich::Messaging.msg('teal', '| Hunting areas currently supported:')
     Lich::Messaging.msg('teal', '|   Atoll/Nelemar, Bonespear, Bowels, Citadel, Confluence, Crawling Shore, Den of Rot, Duskruin Arena,')
-    Lich::Messaging.msg('teal', '|   Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, OSA (partial), OTF (incl. Aqueducts),')
+    Lich::Messaging.msg('teal', '|   Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, Onslaughts, OSA (partial), OTF (incl. Aqueducts),')
     Lich::Messaging.msg('teal', '|   Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), Ta\'Vaalor (partial).')
     Lich::Messaging.msg('teal', '|')
     Lich::Messaging.msg('teal', '| Usage:')

--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -188,10 +188,10 @@ class KSwole
     /^An? (?:.*)\bvampire slices a shadowy sigil in the air as (?:he|she) utters an old chant\./,
     /^An? (?:.*)\bconjurer gives a flourish of (?:his|her) spectral arms as (?:he|she) raises (?:his|her) voice in a theatrical chant\./,
 
-	  # Onslaughts
-		/^An? (?:.*)\bauramancer performs a series of intricate gestures as motes of color scintillate beneath (?:his|her) skin\./,
-		/^An? (?:.*)\bcaptain gestures one-handed, iridescent trails of energy sparkling after (?:his|her) fingers as (?:he|she) chants\./,
-		/^An? (?:.*)\bdiviner stills for a moment, (?:his|her) lips working soundlessly as half-formed images flicker in (?:his|her) eyes\./,
+    # Onslaughts
+    /^An? (?:.*)\bauramancer performs a series of intricate gestures as motes of color scintillate beneath (?:his|her) skin\./,
+    /^An? (?:.*)\bcaptain gestures one-handed, iridescent trails of energy sparkling after (?:his|her) fingers as (?:he|she) chants\./,
+    /^An? (?:.*)\bdiviner stills for a moment, (?:his|her) lips working soundlessly as half-formed images flicker in (?:his|her) eyes\./,
 
     # OSA
     /^(?:.*) snarls as (?:he|she) chants a few words of magic\./,


### PR DESCRIPTION
Added preps for Onslaughts. I spent a few hours and only the Captain, Diviner, and Auramancer appear to cast. This code should account for the two variants of Diviner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Onslaughts so NPCs and encounters in that area are recognized and handled.
* **Documentation**
  * Updated help and hunting area lists to include Onslaughts and related guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->