### PR TITLE
refactor(autostart): remove legacy guards, require lich 5.17.2+

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.71
-      required: Lich >= 4.6.58
+       version: 0.72
+      required: Lich >= 5.17.2
 
   changelog:
+    0.72 (2026-05-27):
+      remove legacy DR dependency path and respond_to? guards (lich 5.17.2+ provides all)
     0.71 (2026-05-07):
       Force population of Account.subscription for newer Lich5 when using non-Lich authentication
     0.70 (2026-05-07):
@@ -150,79 +152,41 @@ if script.vars.empty?
   end
 
   # Check for Lich5 updates and announce if available
-  if Gem::Version.new(LICH_VERSION) > Gem::Version.new('5.6.2')
-    Lich::Util::Update.request("--announce")
-  end
+  Lich::Util::Update.request("--announce")
 
-  # DR: load dependency before other scripts.
-  # dependency.lic defines the parse_args() bridge that DR scripts need.
+  # DR: load dependency for its runtime helpers (bankbot, slackbot, hometown).
+  # Core lich 5.17.2+ provides parse_args, get_settings, map overrides natively.
   if XMLData.game =~ /^DR/
-    if respond_to?(:start_scripts_if_available, true)
-      Script.run('dependency') if Script.exists?('dependency') && !Script.running?('dependency')
-      did_something = true
-    else
-      # Legacy path: dependency.lic handles everything (script sync, autostarts, map edits)
-      begin
-        did_dependency_install = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_dependency_install';")
-      rescue SQLite3::BusyException
-        sleep 0.1
-        retry
-      end
-      if did_dependency_install.nil?
-        unless File.exist?("#{SCRIPT_DIR}/dependency.lic")
-          _respond Lich::Messaging.monsterbold("DR First run detected. Downloading dependency.")
-          Script.run('repository', 'download dependency')
-          sleep 1
-        end
-        unless File.exist?("#{SCRIPT_DIR}/hunting-buddy.lic") && File.exist?("#{SCRIPT_DIR}/combat-trainer.lic") && File.exist?("#{SCRIPT_DIR}/get2.lic") && File.exist?("#{SCRIPT_DIR}/dependency.lic")
-          _respond Lich::Messaging.monsterbold("DR First run detected. Performing dependency install. - Please wait until the process finishes completely before proceeding.")
-          sleep 0.5
-          Script.run('dependency', 'install')
-        end
-        begin
-          Lich.db.execute("INSERT INTO lich_settings(name,value) VALUES('did_dependency_install', 'yes');")
-        rescue SQLite3::BusyException
-          sleep 0.1
-          retry
-        end
-      else
-        Script.start('dependency') unless Script.running?('dependency')
-        sleep 1
-      end
-    end
+    Script.run('dependency') if Script.exists?('dependency') && !Script.running?('dependency')
+    did_something = true
   end
 
   # YAML-based autostarts, UserVars autostarts, and wayto overrides.
-  # Game-agnostic -- requires modern Lich with get_settings support.
-  if respond_to?(:get_settings, true)
-    UserVars.autostart_scripts ||= []
-    all_autostarts = (UserVars.autostart_scripts.to_a +
-                      get_settings.autostarts.to_a).uniq
+  UserVars.autostart_scripts ||= []
+  all_autostarts = (UserVars.autostart_scripts.to_a +
+                    get_settings.autostarts.to_a).uniq
 
-    Map.apply_wayto_overrides if Map.respond_to?(:apply_wayto_overrides)
+  Map.apply_wayto_overrides
 
-    all_autostarts.each do |script_name|
-      next if script_name == 'dependency'
-      next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
-      next if Script.running?(script_name)
+  all_autostarts.each do |script_name|
+    next if script_name == 'dependency'
+    next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
+    next if Script.running?(script_name)
 
-      unless Script.exists?(script_name)
-        respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
-        next
-      end
-
-      start_script(script_name)
+    unless Script.exists?(script_name)
+      respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
+      next
     end
-    did_something = true unless all_autostarts.empty?
+
+    start_script(script_name)
   end
+  did_something = true unless all_autostarts.empty?
 
   for script_list in [Settings['scripts'], CharSettings['scripts']]
     if script_list.is_a?(Array)
       # Loop through list
       for script_info in script_list
-        if ['infomon', 'repository', 'dependency'].include?(script_info[:name])
-          next
-        elsif script_info[:name] == 'lich5-update' && Gem::Version.new(LICH_VERSION) > Gem::Version.new('5.6.2')
+        if ['infomon', 'repository', 'dependency', 'lich5-update'].include?(script_info[:name])
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
           respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with '#{$clean_lich_char}autostart remove --global dependency'"

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -10,11 +10,12 @@
           game: any
           tags: core
        version: 0.72
-      required: Lich >= 5.17.2
+      required: Lich >= 4.6.58
 
   changelog:
     0.72 (2026-05-27):
-      remove legacy DR dependency path and respond_to? guards (lich 5.17.2+ provides all)
+      remove legacy DR dependency path (dependency.lic enforces 5.17.2 for DR)
+      keep respond_to? guards for GS backward compatibility on older lich
     0.71 (2026-05-07):
       Force population of Account.subscription for newer Lich5 when using non-Lich authentication
     0.70 (2026-05-07):
@@ -152,7 +153,9 @@ if script.vars.empty?
   end
 
   # Check for Lich5 updates and announce if available
-  Lich::Util::Update.request("--announce")
+  if defined?(Lich::Util::Update)
+    Lich::Util::Update.request("--announce")
+  end
 
   # DR: load dependency for its runtime helpers (bankbot, slackbot, hometown).
   # Core lich 5.17.2+ provides parse_args, get_settings, map overrides natively.
@@ -162,31 +165,36 @@ if script.vars.empty?
   end
 
   # YAML-based autostarts, UserVars autostarts, and wayto overrides.
-  UserVars.autostart_scripts ||= []
-  all_autostarts = (UserVars.autostart_scripts.to_a +
-                    get_settings.autostarts.to_a).uniq
+  # Guarded for GS backward compatibility on lich < 5.17.
+  if respond_to?(:get_settings, true)
+    UserVars.autostart_scripts ||= []
+    all_autostarts = (UserVars.autostart_scripts.to_a +
+                      get_settings.autostarts.to_a).uniq
 
-  Map.apply_wayto_overrides
+    Map.apply_wayto_overrides if Map.respond_to?(:apply_wayto_overrides)
 
-  all_autostarts.each do |script_name|
-    next if script_name == 'dependency'
-    next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
-    next if Script.running?(script_name)
+    all_autostarts.each do |script_name|
+      next if script_name == 'dependency'
+      next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
+      next if Script.running?(script_name)
 
-    unless Script.exists?(script_name)
-      respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
-      next
+      unless Script.exists?(script_name)
+        respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
+        next
+      end
+
+      start_script(script_name)
     end
-
-    start_script(script_name)
+    did_something = true unless all_autostarts.empty?
   end
-  did_something = true unless all_autostarts.empty?
 
   for script_list in [Settings['scripts'], CharSettings['scripts']]
     if script_list.is_a?(Array)
       # Loop through list
       for script_info in script_list
-        if ['infomon', 'repository', 'dependency', 'lich5-update'].include?(script_info[:name])
+        if ['infomon', 'repository', 'dependency'].include?(script_info[:name])
+          next
+        elsif script_info[:name] == 'lich5-update' && defined?(Lich::Util::Update)
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
           respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with '#{$clean_lich_char}autostart remove --global dependency'"

--- a/spec/autostart/autostart_spec.rb
+++ b/spec/autostart/autostart_spec.rb
@@ -123,28 +123,24 @@ end
 
 # -- Helper that mirrors the game-agnostic YAML autostart loop ------------
 
-# Replicates lines 137-158 of autostart.lic.
+# Replicates the YAML autostart loop of autostart.lic.
 #
 # @param script_mod [Module] mock for Script (running?, exists?, start)
 # @param map_mod [Module] mock for Map (apply_wayto_overrides)
 # @param user_vars_mod [Module] mock for UserVars (autostart_scripts)
 # @param yaml_autostarts [Array<String>, nil] simulated get_settings.autostarts
-# @param has_get_settings [Boolean] whether get_settings is available
 # @param respond_output [Array<String>] collects warning messages
-# @return [Array<String>, nil] list of started script names, or nil if skipped
+# @return [Array<String>] list of started script names
 def run_yaml_autostart_loop(script_mod: MockScript,
                             map_mod: MockMap,
                             user_vars_mod: MockUserVars,
                             yaml_autostarts: [],
-                            has_get_settings: true,
                             respond_output: [])
-  return unless has_get_settings
-
   user_vars_mod.autostart_scripts ||= []
   all_autostarts = (user_vars_mod.autostart_scripts.to_a +
                     yaml_autostarts.to_a).uniq
 
-  map_mod.apply_wayto_overrides if map_mod.respond_to?(:apply_wayto_overrides)
+  map_mod.apply_wayto_overrides
 
   started = []
   all_autostarts.each do |script_name|
@@ -177,12 +173,11 @@ def run_generic_autostart_loop(settings_mod: MockSettings,
                                char_settings_mod: MockCharSettings,
                                script_mod: MockScript,
                                xml_data_mod: MockXMLData,
-                               lich_version: "5.7.0",
                                respond_output: [])
   for script_list in [settings_mod['scripts'], char_settings_mod['scripts']]
     if script_list.is_a?(Array)
       for script_info in script_list
-        if ['infomon', 'repository', 'dependency'].include?(script_info[:name])
+        if ['infomon', 'repository', 'dependency', 'lich5-update'].include?(script_info[:name])
           # dependency removal for DR
           if script_info[:name] == 'dependency' && xml_data_mod.game =~ /^DR/
             respond_output << "dependency removed"
@@ -199,9 +194,6 @@ def run_generic_autostart_loop(settings_mod: MockSettings,
               char_settings_mod['scripts'] = temp_script_list
             end
           end
-          next
-        elsif script_info[:name] == 'lich5-update' &&
-              Gem::Version.new(lich_version) > Gem::Version.new('5.6.2')
           next
         else
           next if script_mod.running?(script_info[:name])
@@ -326,10 +318,10 @@ RSpec.describe "Generic autostart loop" do
       expect(MockScript.started).to be_empty
     end
 
-    it "skips lich5-update when LICH_VERSION > 5.6.2" do
+    it "skips lich5-update" do
       MockSettings['scripts'] = [{ name: 'lich5-update', args: [] }]
 
-      run_generic_autostart_loop(lich_version: "5.7.0")
+      run_generic_autostart_loop
       expect(MockScript.started).to be_empty
     end
   end
@@ -394,11 +386,6 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
     it "starts scripts from YAML autostarts list" do
       started = run_yaml_autostart_loop(yaml_autostarts: ['esp', 'afk'])
       expect(started).to eq(['esp', 'afk'])
-    end
-
-    it "does nothing when get_settings is not available" do
-      started = run_yaml_autostart_loop(yaml_autostarts: ['esp'], has_get_settings: false)
-      expect(started).to be_nil
     end
 
     it "handles empty YAML autostarts" do

--- a/spec/autostart/autostart_spec.rb
+++ b/spec/autostart/autostart_spec.rb
@@ -129,18 +129,22 @@ end
 # @param map_mod [Module] mock for Map (apply_wayto_overrides)
 # @param user_vars_mod [Module] mock for UserVars (autostart_scripts)
 # @param yaml_autostarts [Array<String>, nil] simulated get_settings.autostarts
+# @param has_get_settings [Boolean] whether get_settings is available (false on old GS lich)
 # @param respond_output [Array<String>] collects warning messages
-# @return [Array<String>] list of started script names
+# @return [Array<String>, nil] list of started script names, or nil if skipped
 def run_yaml_autostart_loop(script_mod: MockScript,
                             map_mod: MockMap,
                             user_vars_mod: MockUserVars,
                             yaml_autostarts: [],
+                            has_get_settings: true,
                             respond_output: [])
+  return unless has_get_settings
+
   user_vars_mod.autostart_scripts ||= []
   all_autostarts = (user_vars_mod.autostart_scripts.to_a +
                     yaml_autostarts.to_a).uniq
 
-  map_mod.apply_wayto_overrides
+  map_mod.apply_wayto_overrides if map_mod.respond_to?(:apply_wayto_overrides)
 
   started = []
   all_autostarts.each do |script_name|
@@ -173,11 +177,12 @@ def run_generic_autostart_loop(settings_mod: MockSettings,
                                char_settings_mod: MockCharSettings,
                                script_mod: MockScript,
                                xml_data_mod: MockXMLData,
+                               has_lich_update: true,
                                respond_output: [])
   for script_list in [settings_mod['scripts'], char_settings_mod['scripts']]
     if script_list.is_a?(Array)
       for script_info in script_list
-        if ['infomon', 'repository', 'dependency', 'lich5-update'].include?(script_info[:name])
+        if ['infomon', 'repository', 'dependency'].include?(script_info[:name])
           # dependency removal for DR
           if script_info[:name] == 'dependency' && xml_data_mod.game =~ /^DR/
             respond_output << "dependency removed"
@@ -194,6 +199,8 @@ def run_generic_autostart_loop(settings_mod: MockSettings,
               char_settings_mod['scripts'] = temp_script_list
             end
           end
+          next
+        elsif script_info[:name] == 'lich5-update' && has_lich_update
           next
         else
           next if script_mod.running?(script_info[:name])
@@ -318,11 +325,18 @@ RSpec.describe "Generic autostart loop" do
       expect(MockScript.started).to be_empty
     end
 
-    it "skips lich5-update" do
+    it "skips lich5-update when Lich::Util::Update is available" do
       MockSettings['scripts'] = [{ name: 'lich5-update', args: [] }]
 
-      run_generic_autostart_loop
+      run_generic_autostart_loop(has_lich_update: true)
       expect(MockScript.started).to be_empty
+    end
+
+    it "does not skip lich5-update on old lich without Lich::Util::Update" do
+      MockSettings['scripts'] = [{ name: 'lich5-update', args: [] }]
+
+      run_generic_autostart_loop(has_lich_update: false)
+      expect(MockScript.started).to eq([{ name: 'lich5-update', args: [] }])
     end
   end
 
@@ -386,6 +400,11 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
     it "starts scripts from YAML autostarts list" do
       started = run_yaml_autostart_loop(yaml_autostarts: ['esp', 'afk'])
       expect(started).to eq(['esp', 'afk'])
+    end
+
+    it "does nothing when get_settings is not available (old GS lich)" do
+      started = run_yaml_autostart_loop(yaml_autostarts: ['esp'], has_get_settings: false)
+      expect(started).to be_nil
     end
 
     it "handles empty YAML autostarts" do


### PR DESCRIPTION
## Summary

- Remove legacy DR dependency install path (first-run detection, old lich fallback)
- Remove `respond_to?(:get_settings)` and `Map.respond_to?(:apply_wayto_overrides)` guards -- always true on 5.17.2+
- Remove `Gem::Version` lich5-update version check -- always true on 5.17.2+
- Consolidate `lich5-update` into the static skip list
- Update comment: dependency loads for runtime helpers, not the parse_args bridge
- Bump version to 0.72, require Lich >= 5.17.2
- Update spec helpers to match simplified code

**Net: -79 lines (+30 / -109)**

### Companion PR

dependency.lic strip (dr-scripts): [elanthia-online/dr-scripts#7407](https://github.com/elanthia-online/dr-scripts/pull/7407) -- removes all gated dead code, bumps to v4.0.0.

## Test plan

- [x] `bundle exec rspec spec/autostart/autostart_spec.rb` -- 49 examples, 0 failures
- [ ] Verify autostart runs dependency and starts DR scripts in-game
- [ ] Verify GS autostart loop still works (YAML + Settings/CharSettings)
- [ ] Verify map wayto overrides apply on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped script version to 0.72.
  * Simplified dependency bootstrap process for improved reliability.
  * Streamlined autostart execution flow and update detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/scripts/pull/2342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->