### PR TITLE
fix(eloot.lic): v2.9.3 update regex_at_feet & prevent selling jewelry at the pawnshop

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -20,7 +20,7 @@
   Major_change.feature_addition.bugfix
   v2.9.3  (2026-06-05)
     - fix jewelry being inappropriately appraised and sold at the pawnshop
-	- improved loot detection for items at your feet
+    - improved loot detection for items at your feet
   v2.9.2  (2026-05-17)
     - fix shroud to skip if not currently affordable instead of waiting for mana/stamina/overexterted, mirrors glamour
     - fix for picking up at feet slot for new Ascension codex items
@@ -5335,7 +5335,7 @@ module ELoot # Sells the loot
         raw = $1
         amount = $1.delete(",").to_i
       end
-	 
+
       if amount > limit.to_i || lines.any? { |l| l =~ /not buying anything this valuable today/ }
         message = amount > limit.to_i ? " The #{item} appraises for #{raw}. That's above your settings." : " The #{item} appraises as too valuable to sell."
         ELoot.msg(type: "info", text: message)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5108,7 +5108,7 @@ module ELoot # Room looting
     def self.search(objs = GameObj.dead.to_a) # searches dead critters
       return if objs.empty?
 
-      regex_at_feet = /^(?:<pushBold\/> \*\* A glint of light catches your eye, and you notice|Among the remains, you find) an? <a exist="(?<id>[\d-]+)" noun="(?<noun>[\w-]+)">(?<name>[\w\s-]+)<\/a>.*?(?: at your feet! \*\*|, which falls alongside your feet\.)$/
+      regex_at_feet = /^(?:<pushBold\/> \*\* (?:A glint of light catches your eye, and you notice|Among the remains, you find|Among the spoils, you find)|Among the remains, you find) an? <a exist="(?<id>[\d-]+)" noun="(?<noun>[\w-]+)">(?<name>[\w\s-]+)<\/a>.*?(?: at your feet! \*\*|! \*\*|, which falls alongside your feet\.)$/
       inhand_critters = /skayl|glacei|tumbleweed|plant|shrub|creeper|vine|bush|caedera|golem|elemental/
 
       objs.each do |thing|
@@ -5319,7 +5319,7 @@ end
 module ELoot # Sells the loot
   module Sell
     def self.appraise(item, location, _data = nil)
-      return if item.type =~ /jewelry/ && location == "pawnshop"
+      return if item.type =~ /jewelry/ && location == "Pawnshop"
 
       amount = 0
       raw = nil
@@ -5332,7 +5332,7 @@ module ELoot # Sells the loot
         raw = $1
         amount = $1.delete(",").to_i
       end
-
+	 
       if amount > limit.to_i || lines.any? { |l| l =~ /not buying anything this valuable today/ }
         message = amount > limit.to_i ? " The #{item} appraises for #{raw}. That's above your settings." : " The #{item} appraises as too valuable to sell."
         ELoot.msg(type: "info", text: message)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.2
+           version: 2.9.3
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.3  (2026-06-05)
+    - fix jewelry being inappropriately appraised and sold at the pawnshop
+	- improved loot detection for items at your feet
   v2.9.2  (2026-05-17)
     - fix shroud to skip if not currently affordable instead of waiting for mana/stamina/overexterted, mirrors glamour
     - fix for picking up at feet slot for new Ascension codex items


### PR DESCRIPTION
If you saw the scripting channel in the Discord, you will know that I made a huge stink about my alt selling an armband worth more at the gemshop than at the pawnshop.

Turns out after some investigation, this was not intentional behavior and there were two things designed to stop it: selling hybrid clothing/jewelry at the gemshop first, and preventing the appraisal of jewelry at the pawnshop.

The latter did not work because the matcher was not capitalized. Now it is.

This pull request also includes Tysong's improvements to regex_at_feet, added at his request for his convenience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved loot detection to recognize additional message variants when identifying items at your feet.

* **Bug Fixes**
  * Fixed pawnshop jewelry appraisal to handle location names properly regardless of capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->