### PR TITLE
fix(gameobj-data.xml): add rough crystalline geode gem/gemshop exclusion

### DIFF
--- a/type_data/migrations/71_onslaughts.rb
+++ b/type_data/migrations/71_onslaughts.rb
@@ -10,6 +10,10 @@ migrate "ascension:jewel" do
   insert(:name, %[rough crystalline geode])
 end
 
+migrate :gem, :gemshop do
+  insert(:exclude, %{rough crystalline geode})
+end
+
 migrate "ascension:misc" do
   insert(:name, %{viscous vial of violet vodka})
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The rough crystalline geode is now properly excluded from gem shop operations and related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->