### PR TITLE
feat(ebounty.lic): v1.11.0 cap bandit crawl area at 100 rooms with au…

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,14 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.10.1
+       version: 1.11.0
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.11.0 (2026-06-07)
+    - cap bandit/location crawl area at 100 rooms (Task::MAX_CRAWL_ROOMS)
+    - add Task.limit_crawl_area BFS to select a contiguous region from the nearest room
+    - excluded location rooms beyond the cap are added to location_boundaries automatically
   v1.10.1 (2026-05-25)
     - fix for forage_find to use distance calc of 90 for nearest only
     - fix for no forageable item found when foraging in rift due to inside/outside rooms changing
@@ -2288,6 +2292,12 @@ module EBounty
   end
 
   module Task
+    # Maximum number of rooms the crawler will hunt within a single location.
+    # Larger locations are capped to a contiguous region of this size, seeded
+    # from the room nearest the character; location rooms beyond the cap are
+    # treated as boundaries so the crawler does not wander past them.
+    MAX_CRAWL_ROOMS = 100 unless defined?(MAX_CRAWL_ROOMS)
+
     def self.bounty_check(repeat: false)
       EBounty.msg("debug", " #{__method__} | caller: #{caller[0]} | checkbounty: #{checkbounty}")
 
@@ -2735,6 +2745,13 @@ module EBounty
         EBounty.exit_script
       end
 
+      location_start = Room.current.find_nearest(location_list)
+
+      if location_list.size > MAX_CRAWL_ROOMS
+        EBounty.msg("debug", " find_location: capping #{location_list.size} location rooms to #{MAX_CRAWL_ROOMS}")
+        location_list = limit_crawl_area(location_start, location_list)
+      end
+
       EBounty.msg("debug", " find_location: location_list - #{location_list}")
       location_list.each { |id|
         Room[id].wayto.keys.each { |room|
@@ -2744,8 +2761,36 @@ module EBounty
         }
       }
       EBounty.msg("debug", "Bandits: boundary_list - #{boundary_list}")
-      EBounty.data.location_start = Room.current.find_nearest(location_list).to_s
+      EBounty.data.location_start = location_start.to_s
       EBounty.data.location_boundaries = boundary_list.join(",")
+    end
+
+    # Breadth-first crawl from +start_id+, restricted to rooms in +location_list+,
+    # returning a contiguous subset of at most +max_rooms+ room ids. Used to cap
+    # large hunting locations to a manageable, connected region around the start.
+    # @param start_id [Integer, String] seed room id (nearest location room)
+    # @param location_list [Array<Integer>] full set of room ids within the location
+    # @param max_rooms [Integer] hard cap on the number of rooms returned
+    # @return [Array<Integer>] contiguous subset of +location_list+, size <= max_rooms
+    def self.limit_crawl_area(start_id, location_list, max_rooms = MAX_CRAWL_ROOMS)
+      selected = []
+      queued = [start_id.to_i]
+
+      until queued.empty? || selected.size >= max_rooms
+        current = queued.shift
+        next if selected.include?(current)
+
+        selected.push(current)
+        Room[current].wayto.keys.each { |room|
+          neighbor = room.to_i
+          next if selected.include?(neighbor) || queued.include?(neighbor)
+          next unless location_list.include?(neighbor)
+
+          queued.push(neighbor)
+        }
+      end
+
+      selected
     end
 
     def self.bandit_bounty(location)


### PR DESCRIPTION
…to-boundaries

## Summary
Caps the auto-detected hunting area for bandit/location bounties at a maximum of 100 rooms. Large locations are reduced to a contiguous region seeded from the room nearest the character; any location rooms left outside that region are automatically added to the existing boundary set so the crawler does not wander past them.

## Motivation
`Task.find_location` previously selected *every* room whose `.location` matched, which on large areas produced an unbounded crawl region. This caps the region to a manageable, connected size while still respecting the existing in-location constraint.

## Changes
- Add guarded constant `EBounty::Task::MAX_CRAWL_ROOMS = 100`.
- Add `EBounty::Task.limit_crawl_area(start_id, location_list, max_rooms)` — a BFS from the nearest location room, restricted to in-location rooms, returning at most `max_rooms` contiguous room ids.
- In `find_location`, compute `location_start` once, then cap `location_list` via `limit_crawl_area` only when it exceeds `MAX_CRAWL_ROOMS`. The existing boundary loop is unchanged and now naturally walls off excluded location rooms.

## Behavior / regression
- Locations of 100 rooms or fewer are **unaffected** — the cap branch never fires and `location_start` / `location_boundaries` are produced identically to before.
- Only oversized locations take the new path.
- Existing boundary de-duplication behavior is preserved as-is (not changed).

## Notes for reviewers
- "Which 100 rooms" is the one design choice: I used **nearest-by-graph-hops** (BFS from the start room) to keep the region connected and centered on entry. If a configurable cap (per-profile) is preferred over a hardcoded constant, that's a small follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent area limiting for location crawling to prevent timeout issues in large areas.
  * When exploring bandit locations exceeding a size threshold, the script now restricts crawling to a contiguous subset of nearby connected rooms instead of attempting to explore all rooms.

* **Documentation**
  * Updated version to v1.11.0 (2026-06-07).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->