### PR TITLE
fix(eloot.lic): v2.9.4 more exact matching for frozen bramble mobs

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5117,7 +5117,7 @@ module ELoot # Room looting
       frozen_bramble_critters = ['tumbleweed', 'plant', 'shrub', 'creeper', 'vine', 'bush']
       inhand_critters = ['skayl', 'glacei', 'caedera', 'golem', 'elemental']
       inhand_critters_all_reg = /\b#{Regexp.union(frozen_bramble_critters + inhand_critters)}\b/
-      
+
       objs.each do |thing|
         next if (ELoot.data.settings[:critter_exclude].length.positive? && thing.name =~ Regexp.union(ELoot.data.settings[:critter_exclude]))
         next if thing.name =~ /child/

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.3
+           version: 2.9.4
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.4  (2026-06-10)
+    - more exact check for frozen bramble mob special logic
   v2.9.3  (2026-06-05)
     - fix jewelry being inappropriately appraised and sold at the pawnshop
     - improved loot detection for items at your feet
@@ -5112,8 +5114,10 @@ module ELoot # Room looting
       return if objs.empty?
 
       regex_at_feet = /^(?:<pushBold\/> \*\* (?:A glint of light catches your eye, and you notice|Among the remains, you find|Among the spoils, you find)|Among the remains, you find) an? <a exist="(?<id>[\d-]+)" noun="(?<noun>[\w-]+)">(?<name>[\w\s-]+)<\/a>.*?(?: at your feet! \*\*|! \*\*|, which falls alongside your feet\.)$/
-      inhand_critters = /skayl|glacei|tumbleweed|plant|shrub|creeper|vine|bush|caedera|golem|elemental/
-
+      frozen_bramble_critters = ['tumbleweed', 'plant', 'shrub', 'creeper', 'vine', 'bush']
+      inhand_critters = ['skayl', 'glacei', 'caedera', 'golem', 'elemental']
+      inhand_critters_all_reg = /\b#{Regexp.union(frozen_bramble_critters + inhand_critters)}\b/
+      
       objs.each do |thing|
         next if (ELoot.data.settings[:critter_exclude].length.positive? && thing.name =~ Regexp.union(ELoot.data.settings[:critter_exclude]))
         next if thing.name =~ /child/
@@ -5125,8 +5129,8 @@ module ELoot # Room looting
           fput "raise ##{ELoot.data.blood_band.id} at ##{thing.id}"
         end
 
-        if thing.name =~ inhand_critters
-          (thing.name =~ /tumbleweed|plant|shrub|creeper|vine|bush/) ? Inventory.free_hands(left: true) : Inventory.free_hand
+        if thing.name =~ inhand_critters_all_reg
+          frozen_bramble_critters.any?(thing.name) ? Inventory.free_hands(left: true) : Inventory.free_hand
           if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
             free_hand = "left"
           else
@@ -5163,7 +5167,7 @@ module ELoot # Room looting
         end
 
         # Some creatures put an item directly in your hand
-        if thing.name =~ inhand_critters
+        if thing.name =~ inhand_critters_all_reg
           check_hand = (free_hand == "right") ? GameObj.right_hand : GameObj.left_hand
           Inventory.single_drag(check_hand) unless check_hand.name == "Empty"
         end

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5130,7 +5130,7 @@ module ELoot # Room looting
         end
 
         if thing.name =~ inhand_critters_all_reg
-          frozen_bramble_critters.any?(thing.name) ? Inventory.free_hands(left: true) : Inventory.free_hand
+          frozen_bramble_critters.any?(thing.noun) ? Inventory.free_hands(left: true) : Inventory.free_hand
           if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
             free_hand = "left"
           else


### PR DESCRIPTION
goliath di----**vine**----rs were making people empty a left hand erroneously. Anchor a regex for the more general inhand check to avoid something like this in the future and do a more exact noun check for a string for the special frozen bramble check instead of a name + regex eval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.9.4

* **Bug Fixes**
  * Improved detection accuracy for frozen bramble mob special abilities during looting
  * Refined hand management behavior to better handle different mob types when searching dead creatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->