### PR TITLE
fix(eloot) v2.9.5 bugfix for trying to open locker in wrong town

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.4
+           version: 2.9.5
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.5  (2026-06-13)
+    - bugfix for opening locker when not in correct town.
   v2.9.4  (2026-06-10)
     - more exact check for frozen bramble mob special logic
   v2.9.3  (2026-06-05)
@@ -4056,6 +4058,7 @@ module ELoot # Gem and Reagent hoarding
         index = (index + 1) % lockers.length # Increment index, wrapping around if it exceeds the array length
       end
       ELoot.wait_rt
+      Hoard.open_locker
     end
 
     def self.open_locker(reset: false)
@@ -4282,9 +4285,6 @@ module ELoot # Gem and Reagent hoarding
         is_locksmith_room = Room.current.tags.include?('locksmith')
 
         Hoard.go2_locker if is_locksmith_room || locker_item.nil?
-
-        Hoard.open_locker
-        # ELoot.data.stash variable set when opening locker
       else
         ELoot.data.stash = GameObj.inv.find { |i| i.name =~ /#{ELoot.data.cache}\b/ }
         Inventory.open_single_container(ELoot.data.stash)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the hoarding locker could not be opened when not in the correct town. The locker opening logic has been repositioned earlier in the hoarding workflow to prevent this problem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->