### PR TITLE
fix(eloot):v2.9.6 bugfix to check Bounty.task.done? when selling gems.

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -4486,9 +4486,9 @@ module ELoot # Gem and Reagent hoarding
         ELoot.data.items_to_hoard.concat(container.contents.to_a)
       end
 
-      return ELoot.data.items_to_hoard.select { |item| item.name =~ /#{single}/ && item.type =~ /#{obj_type}/ } if single
+      return ELoot.data.items_to_hoard.select { |item| item.name =~ /#{single}/ && item.type =~ /#{obj_type}/ && !$sell_ignore.include?(item.id)} if single
 
-      ELoot.data.items_to_hoard.reject! { |item| item.type !~ /#{obj_type}/ }
+      ELoot.data.items_to_hoard.reject! { |item| item.type !~ /#{obj_type}/ || $sell_ignore.include?(item.id)}
 
       if ELoot.data.everything_list && ELoot.data.everything.any?
         ELoot.data.items_to_hoard.reject! { |item| item.name =~ Regexp.union(ELoot.data.everything) }
@@ -4615,7 +4615,8 @@ module ELoot # Gem and Reagent hoarding
           case result
           when /does not appear to be a suitable/
             ELoot.msg(text: "Something went wrong. Not able to jar #{thing.name}.", space: true)
-            Inventory.store_item(StowList.stow_list[:default], thing)
+            $sell_ignore.push(thing.id)
+            Inventory.single_drag(thing)
             ELoot.wait_rt
             next
           when /into your empty (?:jar|bottle|beaker)/

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -4605,6 +4605,7 @@ module ELoot # Gem and Reagent hoarding
           next
         end
 
+        thing_name = nil
         items_to_hoard.each do |thing|
           thing_name = Hoard.normalize_name(thing.name)
 

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.5
+           version: 2.9.6
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.6  (2026-06-13)
+    - bugfix to check Bounty.task.done? when selling gems.
   v2.9.5  (2026-06-13)
     - bugfix for opening locker when not in correct town.
   v2.9.4  (2026-06-10)
@@ -5642,6 +5644,7 @@ module ELoot # Sells the loot
           Inventory.free_hands(both: true)
         else
           sack.contents.each do |item|
+            break if Bounty.task.done?
             next unless item.name =~ /#{gem}/
 
             Inventory.drag(item)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -4486,9 +4486,9 @@ module ELoot # Gem and Reagent hoarding
         ELoot.data.items_to_hoard.concat(container.contents.to_a)
       end
 
-      return ELoot.data.items_to_hoard.select { |item| item.name =~ /#{single}/ && item.type =~ /#{obj_type}/ && !$sell_ignore.include?(item.id)} if single
+      return ELoot.data.items_to_hoard.select { |item| item.name =~ /#{single}/ && item.type =~ /#{obj_type}/ && !$sell_ignore.include?(item.id) } if single
 
-      ELoot.data.items_to_hoard.reject! { |item| item.type !~ /#{obj_type}/ || $sell_ignore.include?(item.id)}
+      ELoot.data.items_to_hoard.reject! { |item| item.type !~ /#{obj_type}/ || $sell_ignore.include?(item.id) }
 
       if ELoot.data.everything_list && ELoot.data.everything.any?
         ELoot.data.items_to_hoard.reject! { |item| item.name =~ Regexp.union(ELoot.data.everything) }

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -20,6 +20,7 @@
   Major_change.feature_addition.bugfix
   v2.9.6  (2026-06-13)
     - bugfix to check Bounty.task.done? when selling gems.
+    - bugfix when failing to jar a gem
   v2.9.5  (2026-06-13)
     - bugfix for opening locker when not in correct town.
   v2.9.4  (2026-06-10)
@@ -4604,15 +4605,19 @@ module ELoot # Gem and Reagent hoarding
           next
         end
 
-        thing_name = nil
         items_to_hoard.each do |thing|
           thing_name = Hoard.normalize_name(thing.name)
 
           Inventory.drag(thing, 'right')
 
-          result = ELoot.get_res("_drag ##{thing.id} ##{jar.id}", /You (add|put)|The.*?is full/)
+          result = ELoot.get_res("_drag ##{thing.id} ##{jar.id}", /You (add|put)|The.*?is full|does not appear to be a suitable/)
 
           case result
+          when /does not appear to be a suitable/
+            ELoot.msg(text: "Something went wrong. Not able to jar #{thing.name}.", space: true)
+            Inventory.store_item(StowList.stow_list[:default], thing)
+            ELoot.wait_rt
+            next
           when /into your empty (?:jar|bottle|beaker)/
             ELoot.data.inventory << { item: thing_name, count: 1, full: false }
             ELoot.data.inventory.uniq!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release to 2.9.6 with bugfix notes.
  * Improved hoarding inventory filtering to respect the ignore list and correctly limit results when a single-item query is used.
  * Enhanced jar/deposit processing to mark unsuitable items, return them to inventory, wait briefly, and continue processing.
  * Gem-selling loop now stops immediately when the related bounty task completes, avoiding extra processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->