### PR TITLE
fix(eloot): v2.9.7 add word boundaries to looting/selling exemption r…

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.6
+           version: 2.9.7
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.7  (2026-06-14)
+    - add word boundaries to looting/selling exemption regex.
   v2.9.6  (2026-06-13)
     - bugfix to check Bounty.task.done? when selling gems.
     - bugfix when failing to jar a gem
@@ -269,13 +271,13 @@ module ELoot # Data
   class Data
     attr_accessor :disk, :disk_full, :sacks_full, :ready_method, :settings, :skinners, :skinsheath, :silent_open, :checked_bags,
                   :close_regex, :look_regex, :sacks_closed, :all_loot_categories, :regex_gold_rings, :right_hand, :left_hand, :skin_edged, :skin_blunt,
-                  :coin_hand, :coin_container, :silver_breakdown, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables, :exclude,
+                  :coin_hand, :coin_container, :silver_breakdown, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables,
                   :charm, :gauntlet, :coin_bag, :account_type, :locker, :container_settings, :everything_list, :everything,
                   :only_list, :only, :inventory, :gem_inventory, :alchemy_inventory, :hoard_type, :cache, :locker_city, :use_hoarding, :stash,
                   :items_to_hoard, :hoard_deposit, :inv_save, :deposit_regex, :withdraw_regex, :disk_nouns_regex, :sigil_determination_on_fail, :start_room, :last_called,
                   :urchin_msg, :gemshop_first, :reject_loot_names, :reject_loot_nouns, :version, :debug_logger, :details_check, :coin_bag_full,
                   :use_house_locker, :che_rooms, :che_entry, :che_exit, :towns, :gambling_kit, :gambling_kit_full, :ready_lines, :weapon_inv, :original_readylist, :blood_band,
-                  :transmog_cache
+                  :transmog_cache, :loot_exclude_regex, :critter_exclude_regex, :loot_keep_regex, :allowed_special_types, :sell_exclude_regex, :no_vib_regex, :vib_scrolls_regex
 
     def initialize(settings)
       @settings = settings
@@ -396,7 +398,20 @@ module ELoot # Data
 
       @settings[:unskinnable]&.uniq!
 
-      @exclude = @settings[:loot_exclude].map { |r| r.is_a?(String) ? Regexp.new(r) : r }
+      # Word Boundaries for the various loot exceptions
+      @loot_exclude_regex = build_word_boundary_regexes(@settings[:loot_exclude])
+      @critter_exclude_regex = build_word_boundary_regexes(@settings[:critter_exclude])
+      @loot_keep_regex = build_word_boundary_regexes(@settings[:loot_keep])
+
+      # Word Boundaries for sell exceptions
+      @sell_exclude_regex = build_word_boundary_regexes(@settings[:sell_exclude])
+
+      # Scroll regex
+      no_vib = @settings[:sell_keep_scrolls].reject { |item| item.to_s =~ /v/i }
+      @no_vib_regex = /\((?:#{no_vib.join("|")})\)(?!.*vibrant)/i
+
+      vib_scrolls = @settings[:sell_keep_scrolls].select { |item| item.to_s =~ /v/i }.map { |item| item.to_s[/\d+/] }
+      @vib_scrolls_regex = /\((?:#{vib_scrolls.join("|")})\).*vibrant/i
 
       @deposit_regex = Regexp.union(
         /You deposit (?<silver>[\d,]+) silvers? into your account/,
@@ -572,6 +587,17 @@ module ELoot # Data
       ]
 
       @all_loot_categories = ["alchemy", "armor", "box", "clothing", "collectible", "cursed", "food", "gem", "herb", "jewelry", "junk", "lockpick", "lm trap", "magic", "reagent", "scroll", "skin", "uncommon", "valuable", "wand", "weapon"]
+
+      special_types = ["box", "clothing", "collectible", "cursed", "jewelry", "food", "breakable", "lm trap"]
+      @allowed_special_types = Set.new(special_types) & Set.new(@settings[:loot_types].to_a)
+    end
+
+    def build_word_boundary_regexes(list)
+      Regexp.union(
+        Array(list).map do |r|
+          r.is_a?(String) ? /\b#{Regexp.escape(r)}\b/ : r
+        end
+      )
     end
   end
 end
@@ -4997,12 +5023,6 @@ module ELoot # Room looting
       # Open sacks for looting the room
       Inventory.open_loot_containers(objs)
 
-      types = ["box", "clothing", "collectible", "cursed", "jewelry", "food", "breakable", "lm trap"]
-      types_regex = Regexp.union(types)
-
-      loot_types_regex = Regexp.union(ELoot.data.settings[:loot_types])
-      loot_keep_regex = Regexp.union(ELoot.data.settings[:loot_keep].to_a)
-
       # Uncommon items in HW that loot room doesn't work on
       uncommon_loot = ["stygian valravn quill", "nacreous disir feather", "silver-veined black draconic idol"]
       loot_uncommon_regex = Regexp.union(uncommon_loot)
@@ -5011,14 +5031,14 @@ module ELoot # Room looting
         result = Loot.bag_loot(thing) if thing.type =~ /clothing/
 
         next true if result == "crumbly"
-        next false if ELoot.data.exclude && thing.name.match(Regexp.union(ELoot.data.exclude))
+        next false if thing.name.match?(ELoot.data.loot_exclude_regex)
         next false if (thing.name.eql?("shard of oblivion quartz") and Stats.level.eql?(100) && ELoot.data.settings[:loot_types].include?("gem"))
-        next false if (thing.name =~ /doomstone|urglaes fang/ && !ELoot.data.settings[:loot_types].include?("cursed"))
+        next false if (thing.type =~ /cursed/ && !ELoot.data.settings[:loot_types].include?("cursed"))
 
         next false unless (
-          (thing.type =~ loot_types_regex && thing.type =~ types_regex) ||
+          (thing.type.split(",").any? { |t| @allowed_special_types.include?(t.strip) }) ||
           (thing.type =~ /lockandkey/i) ||
-          (ELoot.data.settings[:loot_keep].length.positive? && thing.name =~ loot_keep_regex) ||
+          (thing.name.match?(ELoot.data.loot_keep_regex)) ||
           (thing.type =~ /cursed/i && ELoot.data.settings[:loot_types].include?("cursed")) ||
           (thing.type =~ /weapon/i && thing.type =~ /uncommon/ && ELoot.data.settings[:loot_types].include?("weapon")) ||
           (thing.type =~ /armor/i && thing.type =~ /uncommon/ && ELoot.data.settings[:loot_types].include?("armor")) ||
@@ -5076,10 +5096,10 @@ module ELoot # Room looting
 
     def self.should_grab_item?(thing)
       # If its on the exclude list return
-      return false if ELoot.data.exclude && thing.name.match(Regexp.union(ELoot.data.exclude))
+      return false if thing.name.match?(ELoot.data.loot_exclude_regex)
 
       # oblivion quartz isn't cursed if you are level 100
-      return true  if thing.name.eql?("shard of oblivion quartz") and Stats.level.eql?(100) && ELoot.data.settings[:loot_types].include?("gem")
+      return true if thing.name.eql?("shard of oblivion quartz") and Stats.level.eql?(100) && ELoot.data.settings[:loot_types].include?("gem")
 
       # Cursed items need to be handled separate due to gems
       return false if thing.type =~ /cursed/i && !ELoot.data.settings[:loot_types].include?("cursed")
@@ -5128,7 +5148,7 @@ module ELoot # Room looting
       inhand_critters_all_reg = /\b#{Regexp.union(frozen_bramble_critters + inhand_critters)}\b/
 
       objs.each do |thing|
-        next if (ELoot.data.settings[:critter_exclude].length.positive? && thing.name =~ Regexp.union(ELoot.data.settings[:critter_exclude]))
+        next if thing.name.match?(ELoot.data.critter_exclude_regex)
         next if thing.name =~ /child/
         next if thing.status =~ /gone/
 
@@ -5305,7 +5325,7 @@ module ELoot # Room looting
           obj.type =~ /bandit/ ||
           obj.name =~ /(?:ethereal|ghostly|unwordly|Grimswarm|child)/ ||
           ELoot.data.settings[:skin_exclude].length.positive? && obj.name =~ Regexp.union(ELoot.data.settings[:skin_exclude]) ||
-          ELoot.data.settings[:critter_exclude].length.positive? && obj.name =~ Regexp.union(ELoot.data.settings[:critter_exclude])
+          obj.name.match?(ELoot.data.critter_exclude_regex)
       end
 
       if ELoot.data.settings[:skin_bounty_only]
@@ -5531,10 +5551,9 @@ module ELoot # Sells the loot
 
         bulk_sell = true
         bulk_sell = false if sack.contents.any? { |obj| obj.name =~ /bundle of/ }
-        unless ELoot.data.settings[:sell_exclude].empty?
-          if sack.contents.any? { |obj| obj.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/ && obj.sellable =~ /furrier/ }
-            bulk_sell = false
-          end
+
+        if sack.contents.any? { |obj| obj.name.match?(ELoot.data.sell_exclude_regex) && obj.sellable =~ /furrier/ }
+          bulk_sell = false
         end
 
         bulk_sell = false if sack.contents.any? { |obj| obj.name !~ /#{skin}/ && obj.sellable =~ /furrier/ }
@@ -5558,7 +5577,7 @@ module ELoot # Sells the loot
           sack.contents.each do |item|
             next if $sell_ignore.include?(item.id)
             next unless item.sellable =~ /furrier/
-            next if !ELoot.data.settings[:sell_exclude].empty? && item.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+            next if item.name.match?(ELoot.data.sell_exclude_regex)
             next unless item.name =~ /#{skin}|#{bundled_skins}/i
 
             $sell_ignore.push(item.id)
@@ -5630,11 +5649,11 @@ module ELoot # Sells the loot
 
         bulk_sell = true
         bulk_sell = false if sack.contents.any? { |obj| obj.name !~ /#{gem}/ && obj.type =~ /gem/ }
-        unless ELoot.data.settings[:sell_exclude].empty?
-          if sack.contents.any? { |obj| obj.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/ && obj.sellable =~ /gemshop/ }
-            bulk_sell = false
-          end
+
+        if sack.contents.any? { |obj| obj.name.match?(ELoot.data.sell_exclude_regex) && obj.sellable =~ /gemshop/ }
+          bulk_sell = false
         end
+
         # Bulk sell sack if it has gems and no exclusions
         if bulk_sell
           Inventory.drag(sack) if [checkleft, checkright].index(sack.noun).nil?
@@ -5678,7 +5697,7 @@ module ELoot # Sells the loot
       all_contents.each { |thing|
         next if $sell_ignore.include?(thing.id)
         next if ReadyList.ready_list.find { |_k, v| v.id == thing.id }
-        next if !ELoot.data.settings[:sell_exclude].empty? && thing.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+        next if thing.name.match?(ELoot.data.sell_exclude_regex)
         next if thing.name =~ /\bbound\b|^shimmering \w+ orb$/
         next if selling.include?(thing.type) && !thing.type.nil?
         if !specific.nil?
@@ -5769,7 +5788,7 @@ module ELoot # Sells the loot
           next if $sell_ignore.include?(thing.id)
           next unless thing.type == "collectible"
           next if ReadyList.ready_list.find { |_k, v| v.id == thing.id }
-          next if (thing.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/ && !ELoot.data.settings[:sell_exclude].empty?)
+          next if thing.name.match?(ELoot.data.sell_exclude_regex)
           next if thing.name =~ /bound/
 
           $sell_ignore.push(thing.id)
@@ -5808,7 +5827,7 @@ module ELoot # Sells the loot
           next unless thing.sellable.include?("consignment")
           next unless thing.type.split(',').any? { |type| type =~ /^#{ELoot.data.settings[:sell_loot_types].join('|')}$/ }
           next if ReadyList.ready_list.find { |_k, v| v.id == thing.id }
-          next if !ELoot.data.settings[:sell_exclude].empty? && thing.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+          next if thing.name.match?(ELoot.data.sell_exclude_regex)
           next if thing.name =~ /bound/
 
           if ELoot.data.alchemy_mode
@@ -5991,7 +6010,7 @@ module ELoot # Sells the loot
       dump_items = ELoot.set_selling_containers.flat_map(&:contents).select do |item|
         next false unless dump_stuff.any? { |type| item.type =~ /#{type}/ } || (ELoot.data.alchemy_mode && item.name =~ alchemy_regex)
         next false if ELoot.data.alchemy_mode && Vars.needed_reagents.any? { |r| item.name =~ /#{r}/ }
-        next false if !ELoot.data.settings[:sell_exclude].empty? && item.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+        next false if item.name.match?(ELoot.data.sell_exclude_regex)
         next false if ELoot.data.settings[:keep_transmogs] && Inventory.is_transmog?(item)
         true
       end
@@ -6053,10 +6072,9 @@ module ELoot # Sells the loot
         bulk_sell = true
         bulk_sell = false if bounty? =~ skin_match && sack.contents.find_all { |obj| obj.name =~ /bundle/ }.length.positive?
         bulk_sell = false if ELoot.data.alchemy_mode
-        unless ELoot.data.settings[:sell_exclude].empty?
-          if sack.contents.find_all { |obj| obj.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/ && obj.sellable =~ /furrier/ }.length.positive?
-            bulk_sell = false
-          end
+
+        if sack.contents.any? { |obj| obj.name.match?(ELoot.data.sell_exclude_regex) && obj.sellable =~ /furrier/ }
+          bulk_sell = false
         end
 
         if bulk_sell
@@ -6082,7 +6100,7 @@ module ELoot # Sells the loot
         sack.contents.each do |item|
           next if $sell_ignore.include?(item.id)
           next unless item.sellable =~ /furrier/
-          next if !ELoot.data.settings[:sell_exclude].empty? && item.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+          next if item.name.match?(ELoot.data.sell_exclude_regex)
 
           if ELoot.data.alchemy_mode
             next if item.name =~ /#{Vars.needed_reagents}/ && Vars.needed_reagents.length.to_i > 0
@@ -6136,13 +6154,13 @@ module ELoot # Sells the loot
         Inventory.check_auto_closer
       end
 
-      gem_sacks.each { |sack|
+      gem_sacks.each do |sack|
         next if sack.nil?
-        next if sack.contents.find_all { |obj| obj.sellable.include?("gemshop") }.empty?
+        next unless sack.contents.any? { |obj| obj.sellable.include?("gemshop") }
 
         # Bulk sell sack if it has gems and no exclusions
-        if (ELoot.data.settings[:sell_exclude].empty? || (sack.contents.find_all { |obj| obj.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/ && obj.type =~ /gem/ }).empty?) && sack.contents.find_all { |obj| obj.type =~ /gem/ }.length.positive? && ELoot.data.settings[:sell_loot_types].include?("gem") && !ELoot.data.alchemy_mode
-          if type.nil? || !type.nil? && type.include?('gem')
+        if sack.contents.any? { |obj| obj.type =~ /gem/ && !obj.name.match?(ELoot.data.sell_exclude_regex) } && ELoot.data.settings[:sell_loot_types].include?("gem") && !ELoot.data.alchemy_mode
+          if type.nil? || type.include?('gem')
             Inventory.drag(sack) if [checkleft, checkright].index(sack.noun).nil?
 
             dothistimeout("sell ##{sack.id}", 3, /inspects the contents carefully/)
@@ -6165,7 +6183,8 @@ module ELoot # Sells the loot
           next if $sell_ignore.include?(item.id)
           next unless item.sellable.include?("gemshop") || item.noun =~ /thorn|berry/ || item.type =~ /scarab/
           next unless item.type.split(',').any? { |obj| obj =~ /^#{ELoot.data.settings[:sell_loot_types].join('|')}$/ }
-          next if !ELoot.data.settings[:sell_exclude].empty? && item.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+          next if item.name.match?(ELoot.data.sell_exclude_regex)
+
           next if ELoot.data.settings[:sell_gold_rings] && item.name =~ ELoot.data.regex_gold_rings
           next if item.name =~ /\bbound\b|^shimmering \w+ orb$/
           if !type.nil?
@@ -6198,7 +6217,7 @@ module ELoot # Sells the loot
 
           Inventory.free_hands(both: true)
         end
-      }
+      end
 
       ELoot.data.silver_breakdown["Gemshop"] += (ELoot.silver_check - start_silvers)
     end
@@ -6679,7 +6698,7 @@ module ELoot # Sells the loot
         next if $sell_ignore.include?(thing.id)
         next unless (thing.sellable.include?("pawnshop") && !thing.sellable.include?("gemshop")) || thing.type == "box" || thing.type =~ /clothing/
         next if ReadyList.ready_list.find { |_k, v| v.id == thing.id }
-        next if !ELoot.data.settings[:sell_exclude].empty? && thing.name =~ /#{ELoot.data.settings[:sell_exclude].join('|')}/
+        next if thing.name.match?(ELoot.data.sell_exclude_regex)
         next unless thing.type.split(',').any? { |obj| obj =~ /^#{ELoot.data.settings[:sell_loot_types].join('|')}$/ }
         next if thing.name =~ /\bbound\b|^shimmering \w+ orb$/
         next if ELoot.data.settings[:sell_gold_rings] && thing.name =~ ELoot.data.regex_gold_rings
@@ -6688,17 +6707,11 @@ module ELoot # Sells the loot
         end
 
         $sell_ignore.push(thing.id)
-        if thing.type =~ /scroll/ && ELoot.data.settings[:sell_keep_scrolls].length.positive?
-          no_vib = ELoot.data.settings[:sell_keep_scrolls].reject { |item| item.to_s =~ /v/i }
-          no_vib_regex = /\((?:#{no_vib.join("|")})\)(?!.*vibrant)/i
-
-          vib_scrolls = ELoot.data.settings[:sell_keep_scrolls].select { |item| item.to_s =~ /v/i }.map { |item| item.to_s[/\d+/] }
-          vib_scrolls_regex = /\((?:#{vib_scrolls.join("|")})\).*vibrant/i
-
+        if thing.type =~ /scroll/ && ELoot.data.settings[:sell_keep_scrolls].any?
           lines = ELoot.get_command("read ##{thing.id}", /It takes you a moment|There is nothing there to read|You can't do that/, silent: true, quiet: true)
 
-          next if lines.any? { |line| line =~ no_vib_regex }
-          next if lines.any? { |line| line =~ vib_scrolls_regex }
+          next if lines.any? { |line| line =~ ELoot.data.no_vib_regex }
+          next if lines.any? { |line| line =~ ELoot.data.vib_scrolls_regex }
         end
 
         if thing.type =~ /cursed/ && !ELoot.data.settings[:sell_loot_types].include?("cursed")

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -173,6 +173,7 @@ end
 
 require 'yaml'
 require 'terminal-table'
+require 'set'
 
 module ELoot # Writes debug output to a file
   class DebugLogger
@@ -398,13 +399,8 @@ module ELoot # Data
 
       @settings[:unskinnable]&.uniq!
 
-      # Word Boundaries for the various loot exceptions
-      @loot_exclude_regex = build_word_boundary_regexes(@settings[:loot_exclude])
-      @critter_exclude_regex = build_word_boundary_regexes(@settings[:critter_exclude])
-      @loot_keep_regex = build_word_boundary_regexes(@settings[:loot_keep])
-
-      # Word Boundaries for sell exceptions
-      @sell_exclude_regex = build_word_boundary_regexes(@settings[:sell_exclude])
+      # This pre-builds the loot/selling regexes
+      build_compiled_filters
 
       # Scroll regex
       no_vib = @settings[:sell_keep_scrolls].reject { |item| item.to_s =~ /v/i }
@@ -595,9 +591,20 @@ module ELoot # Data
     def build_word_boundary_regexes(list)
       Regexp.union(
         Array(list).map do |r|
-          r.is_a?(String) ? /\b#{Regexp.escape(r)}\b/ : r
+          source = r.is_a?(Regexp) ? r.source : r.to_s
+          /\b(?:#{source})\b/
         end
       )
+    end
+
+    def build_compiled_filters
+      # Word Boundaries for the various loot exceptions
+      @loot_exclude_regex = build_word_boundary_regexes(@settings[:loot_exclude])
+      @critter_exclude_regex = build_word_boundary_regexes(@settings[:critter_exclude])
+      @loot_keep_regex = build_word_boundary_regexes(@settings[:loot_keep])
+
+      # Word Boundaries for sell exceptions
+      @sell_exclude_regex = build_word_boundary_regexes(@settings[:sell_exclude])
     end
   end
 end
@@ -5036,7 +5043,7 @@ module ELoot # Room looting
         next false if (thing.type =~ /cursed/ && !ELoot.data.settings[:loot_types].include?("cursed"))
 
         next false unless (
-          (thing.type.split(",").any? { |t| @allowed_special_types.include?(t.strip) }) ||
+          (thing.type.split(",").any? { |t| ELoot.data.allowed_special_types.include?(t.strip) }) ||
           (thing.type =~ /lockandkey/i) ||
           (thing.name.match?(ELoot.data.loot_keep_regex)) ||
           (thing.type =~ /cursed/i && ELoot.data.settings[:loot_types].include?("cursed")) ||
@@ -7109,6 +7116,7 @@ module ELoot # Starts the script
   when /settings|setup/i
     if Script.current.vars[2]
       ELoot.update_setting(Script.current.vars[2..-1])
+      ELoot.data.build_compiled_filters if ELoot.data.respond_to?(:build_compiled_filters)
     elsif defined?(Gtk)
       ELoot.launch_settings_ui
     else

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -173,7 +173,6 @@ end
 
 require 'yaml'
 require 'terminal-table'
-require 'set'
 
 module ELoot # Writes debug output to a file
   class DebugLogger

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -20,6 +20,7 @@
   Major_change.feature_addition.bugfix
   v2.9.7  (2026-06-14)
     - add word boundaries to looting/selling exemption regex.
+    - bugfix for open box at town locksmith
   v2.9.6  (2026-06-13)
     - bugfix to check Bounty.task.done? when selling gems.
     - bugfix when failing to jar a gem
@@ -6462,33 +6463,34 @@ module ELoot # Sells the loot
 
     def self.locksmith_open(box, activator)
       lines = ELoot.get_command("look in ##{box.id}", /<container|That is closed|You see the shifting form/, silent: true, quiet: true)
-      return unless lines.any? { |line| line =~ /That is closed|You see the shifting form/i }
 
-      Inventory.drag(box) unless ELoot.in_hand?(box)
-      box = ELoot.box_unphase(box)
+      if lines.any? { |line| line =~ /That is closed|You see the shifting form/i }
+        Inventory.drag(box) unless ELoot.in_hand?(box)
+        box = ELoot.box_unphase(box)
 
-      lines = ELoot.get_command("open ##{box.id}", /That is already open|You open|You throw back|It appears to be locked/, silent: true, quiet: true)
+        lines = ELoot.get_command("open ##{box.id}", /That is already open|You open|You throw back|It appears to be locked/, silent: true, quiet: true)
 
-      if lines.any?(/locked/)
-        res = dothistimeout(activator, 2, /Gimme ([\d,]+) silvers/)
-        if res =~ /Gimme ([\d,]+) silvers/
-          ELoot.data.silver_breakdown["Town Locksmith"] += -1 * $1.delete(",").to_i
-          ELoot.data.silver_breakdown["Town Open"] += 1
-        end
+        if lines.any?(/locked/)
+          res = dothistimeout(activator, 2, /Gimme ([\d,]+) silvers/)
+          if res =~ /Gimme ([\d,]+) silvers/
+            ELoot.data.silver_breakdown["Town Locksmith"] += -1 * $1.delete(",").to_i
+            ELoot.data.silver_breakdown["Town Open"] += 1
+          end
 
-        unless res
-          ELoot.msg(type: "error", text: ' Unknown locksmith response.')
-          Inventory.single_drag(box, false)
-          return
-        end
+          unless res
+            ELoot.msg(type: "error", text: ' Unknown locksmith response.')
+            Inventory.single_drag(box, false)
+            return
+          end
 
-        result = dothistimeout('pay', 2, /accepts|have enough/)
-        if result =~ /have enough/
-          Inventory.single_drag(box, false)
-          ELoot.silver_withdraw(ELoot.data.settings[:locksmith_withdraw_amount])
-          ELoot.go2('locksmith')
+          result = dothistimeout('pay', 2, /accepts|have enough/)
+          if result =~ /have enough/
+            Inventory.single_drag(box, false)
+            ELoot.silver_withdraw(ELoot.data.settings[:locksmith_withdraw_amount])
+            ELoot.go2('locksmith')
 
-          return Sell.locksmith_open(box, activator)
+            return Sell.locksmith_open(box, activator)
+          end
         end
       end
       Loot.box_loot(box, "Town Locksmith", ELoot.data.silver_breakdown)


### PR DESCRIPTION
…egex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced loot and sell exemption matching with word-boundary support for more precise filtering
  * Improved performance and consistency by using precompiled exemption patterns across loot and selling workflows
  * Refined creature exclusion and loot keep behavior for more accurate results
  * Updated pawnshop scroll selection to use vibrancy-aware keep/exclude rules
* **Fixes**
  * Addressed an issue related to opening a box at a town locksmith
<!-- end of auto-generated comment: release notes by coderabbit.ai -->