### PR TITLE
fix(bigshot.lic): v5.13.1 resonance npc

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.13.0
+       version: 5.13.1
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.13.1  (2026-06-14)
+    - bugfix in resonance cmd
   v5.13.0  (2026-05-17)
     - add new resonance command for casting bolts
     - add new UNHIDE event to allow for unhiding before fogging
@@ -3370,7 +3372,7 @@ class Bigshot
     if (command =~ /^(incant)?\s?(\d+)\s?((?:open|closed)?\s?(?:cast|channel|evoke)?\s?(?:cast|channel|evoke)?\s?(?:open|closed)?\s?(?:acid|air|cold|earth|fire|lightning|steam|water)?)?.*$/i)
       cmd_spell(incant: $1, id: $2.to_i, extra: $3, target: npc)
     elsif (command =~ /^resonance\s+([\d\s]+)/i)
-      cmd_resonance_bolt($1)
+      cmd_resonance_bolt($1, npc)
     elsif (command =~ /^barrage|^flurry|^fury|^gthrusts|^pummel|^thrash/i)
       cmd_assault(npc, command)
     elsif (command =~ /^pindown|^cripple|^charge|^twinhammer|^dizzyingswing|^clash|^volley|^pulverize|^cyclone|^whirlwind|^wblade/i)
@@ -4866,7 +4868,7 @@ class Bigshot
     end
   end
 
-  def cmd_resonance_bolt(ids)
+  def cmd_resonance_bolt(ids, npc)
     @last ||= nil
     debug_msg(@DEBUG_COMMANDS, "cmd_resonance_bolt | ids: #{ids} | last: #{@last}")
 
@@ -4875,7 +4877,7 @@ class Bigshot
     selected_spell = spell_options.sample
     return if selected_spell.nil?
 
-    cmd_spell(incant: true, id: selected_spell)
+    cmd_spell(incant: true, id: selected_spell, target: npc)
 
     @last = selected_spell
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resonance command casting behavior to properly target the intended NPC character during spell execution.

* **Chores**
  * Updated version to 5.13.1 with changelog entry documenting bugfix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->