### PR TITLE
fix(bigshot.lic): v5.13.2 box_in_hand & run_script only activate if h…

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.13.1
+       version: 5.13.2
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.13.2  (2026-06-15)
+    - bugfix in run_script to only do box_in_hand if hunting
   v5.13.1  (2026-06-14)
     - bugfix in resonance cmd
   v5.13.0  (2026-05-17)
@@ -5771,7 +5773,7 @@ class Bigshot
     return if script_ran.nil?
     return unless script_ran.name.is_a?(String) && !script_ran.name.empty?
     if pause_bigshot
-      if name == @LOOT_SCRIPT && @BOX_IN_HAND
+      if name == @LOOT_SCRIPT && @BOX_IN_HAND && $bigshot_status.eql?(:hunting)
         looting_watch(script_ran)
       else
         wait_until { !Script.running?(script_ran.name) }


### PR DESCRIPTION
…unting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loot script behavior to properly restrict box handling to active hunting sessions, preventing unintended actions when not actively hunting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->