### PR TITLE
fix(ewaggle) v2.1.6 bugfix to cast 1612 first

### DIFF
--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -1496,7 +1496,7 @@ module Ewaggle
     end
 
     def self.cast_stackable(target, info)
-      Ewaggle.data.cast_list = Ewaggle.data.cast_list.sort_by { |n| [625,1612].include?(n) ? 0 : n }
+      Ewaggle.data.cast_list = Ewaggle.data.cast_list.sort_by { |n| [625, 1612].include?(n) ? 0 : n }
       Ewaggle.data.cast_list.each do |spell|
         spell = Ewaggle.fix_spell(spell)
 

--- a/scripts/ewaggle.lic
+++ b/scripts/ewaggle.lic
@@ -8,10 +8,12 @@
           game: gs
           tags: magic, utility, spell
       required: Lich >= 5.9.0
-       version: 2.1.5
+       version: 2.1.6
 
   Version Control:
     Major_change.feature_addition.bugfix
+  2.1.6 (2026-06-16)
+    - bugfix to cast 1612 first if in the cast list
   2.1.5 (2025-11-25)
     - add disk casting support
   2.1.4 (2025-10-16)
@@ -1494,7 +1496,7 @@ module Ewaggle
     end
 
     def self.cast_stackable(target, info)
-      Ewaggle.data.cast_list = Ewaggle.data.cast_list.sort_by { |n| n == 625 ? 0 : n }
+      Ewaggle.data.cast_list = Ewaggle.data.cast_list.sort_by { |n| [625,1612].include?(n) ? 0 : n }
       Ewaggle.data.cast_list.each do |spell|
         spell = Ewaggle.fix_spell(spell)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Version 2.1.6** — Released 2026-06-16

* **Bug Fixes**
  * Corrected spell prioritization in the casting order to ensure proper execution sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->