### PR TITLE
fix(eloot) v2.9.8 empty hand if selling box-in-hand

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.7
+           version: 2.9.8
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.8  (2026-06-17)
+    - try to empty the other hand when starting with a box in hand
   v2.9.7  (2026-06-14)
     - add word boundaries to looting/selling exemption regex.
     - bugfix for open box at town locksmith
@@ -5398,6 +5400,10 @@ module ELoot # Sells the loot
     def self.box_in_hand(deposit = true)
       return unless [GameObj.left_hand.type, GameObj.right_hand.type].include?("box")
 
+      # try to free up the other hand
+      ELoot::Inventory.free_hands(right: true) if GameObj.right_hand.type != "box"
+      ELoot::Inventory.free_hands(left:  true) if GameObj.left_hand.type  != "box"
+
       if [GameObj.left_hand.noun, GameObj.right_hand.noun].include?("reliquary")
         ELoot.msg(text: " Looks like you have a reliquary", space: true)
         exit
@@ -6463,7 +6469,6 @@ module ELoot # Sells the loot
 
     def self.locksmith_open(box, activator)
       lines = ELoot.get_command("look in ##{box.id}", /<container|That is closed|You see the shifting form/, silent: true, quiet: true)
-
       if lines.any? { |line| line =~ /That is closed|You see the shifting form/i }
         Inventory.drag(box) unless ELoot.in_hand?(box)
         box = ELoot.box_unphase(box)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ELoot could get stuck with an occupied hand during selling when starting with a box in hand. The script now properly manages hand availability to prevent this blockage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->