### PR TITLE
fix(bigshot): remove greedy PRONE check for bullrush

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.14.0
+       version: 5.14.1
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,7 +17,7 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
-  v5.14.1  (2026-06-17)
+  v5.14.1  (2026-06-18)
     - remove greedy prone check for bullrush
   v5.14.0  (2026-06-17)
     - add new sacrifice command
@@ -3857,7 +3857,14 @@ class Bigshot
     cmd_clean = cmd.split(' ').first
     return if !Weapon.available?(commands[cmd_clean])
     return unless Weapon.affordable?(commands[cmd_clean])
-    return if npc.status =~ PRONE && commands[cmd] =~ /Charge|Twin Hammerfists/
+    # removing explicit skip of these from PRONE state
+    # was likely put here because cannot be executed on targets that 
+    # are true prone (laying down), but this failure is handled by
+    # the "awkward position" result check
+    # user may still want to use if the target is only stunned or any of the other
+    # stauses rolled up in the PRONE check. Can remove entirely for more explicit
+    # true prone check once we include the pending crtrStatus XML updates
+    # return if npc.status =~ PRONE && commands[cmd] =~ /Charge|Twin Hammerfists/
 
     waitrt?
     waitcastrt?
@@ -4127,6 +4134,14 @@ class Bigshot
     cmd_clean = cmd.split(' ').first
     return if !CMan.available?(commands[cmd_clean])
     return unless CMan.affordable?(commands[cmd_clean])
+    # removing explicit skip of these from PRONE state
+    # was likely put here because cannot be executed on targets that 
+    # are true prone (laying down), but this failure is handled by
+    # the "awkward position" result check
+    # user may still want to use if the target is only stunned or any of the other
+    # stauses rolled up in the PRONE check. Can remove entirely for more explicit
+    # true prone check once we include the pending crtrStatus XML updates
+    # return if npc.status =~ PRONE && cmd =~ /^bullrush/i
     return if Effects::Cooldowns.active?("Spell Cleave") && cmd =~ /^scleave/i
     return if Effects::Cooldowns.active?("Spell Thieve") && cmd =~ /^sthieve/i
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -3858,7 +3858,7 @@ class Bigshot
     return if !Weapon.available?(commands[cmd_clean])
     return unless Weapon.affordable?(commands[cmd_clean])
     # removing explicit skip of these from PRONE state
-    # was likely put here because cannot be executed on targets that 
+    # was likely put here because cannot be executed on targets that
     # are true prone (laying down), but this failure is handled by
     # the "awkward position" result check
     # user may still want to use if the target is only stunned or any of the other
@@ -4135,7 +4135,7 @@ class Bigshot
     return if !CMan.available?(commands[cmd_clean])
     return unless CMan.affordable?(commands[cmd_clean])
     # removing explicit skip of these from PRONE state
-    # was likely put here because cannot be executed on targets that 
+    # was likely put here because cannot be executed on targets that
     # are true prone (laying down), but this failure is handled by
     # the "awkward position" result check
     # user may still want to use if the target is only stunned or any of the other

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.14.1  (2026-06-17)
+    - remove greedy prone check for bullrush
   v5.14.0  (2026-06-17)
     - add new sacrifice command
     - bugfix for creature escape result regex check
@@ -4125,7 +4127,6 @@ class Bigshot
     cmd_clean = cmd.split(' ').first
     return if !CMan.available?(commands[cmd_clean])
     return unless CMan.affordable?(commands[cmd_clean])
-    return if npc.status =~ PRONE && cmd =~ /^bullrush/i
     return if Effects::Cooldowns.active?("Spell Cleave") && cmd =~ /^scleave/i
     return if Effects::Cooldowns.active?("Spell Thieve") && cmd =~ /^sthieve/i
 


### PR DESCRIPTION
This should already have the possible error of "awkward position" if they are knocked down accounted for in the general response handling for the command, I don't know why else it would have this explicit check here. Users may want to do a bullrush in an AOE situation / to give vulnerable status on top of stunned or similar. If someone doesn't want to bullrush a target that is already disabled they can use the prone check in the command. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where bullrush could not be used against prone enemies.
  * Prone targets are now properly eligible for other affected maneuvers (including Charge and Twin Hammerfists), while existing cooldown logic is still respected.
* **Chores**
  * Updated the Bigshot changelog to v5.14.1 with the corresponding note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->