### PR TITLE
fix(eloot.lic): v2.9.9 match gems to jars when descriptor is multi-wo…

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.8
+           version: 2.9.9
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.9  (2026-06-18)
+    - bugfix for hoarding gems whose jar after_name uses a multi-word, pluralized descriptor (e.g. "raw chunks of ...") that prevented matching loose gems to their existing jar
   v2.9.8  (2026-06-17)
     - try to empty the other hand when starting with a box in hand
   v2.9.7  (2026-06-14)
@@ -4000,7 +4002,7 @@ module ELoot # Gem and Reagent hoarding
 
       sizes = "tiny|small|medium|large|blue-violet|pyrite-capped vibrant"
       articles = "some|an? |the"
-      descriptors = "\\w+s? of(?: polished)?|polished"
+      descriptors = "(?:\\w+ )*?\\w+s? of(?: polished)?|polished"
 
       pattern = /^\s*(?:containing )?(?:#{articles})?\s*(?:#{sizes})?\s*(?:#{descriptors})?\s*(?:#{sizes})?\s*(.*?)\s*$/
 


### PR DESCRIPTION
…rd and pluralized

## Summary

Loose gems with a multi-word descriptor (e.g. "raw chunk of titian orange sunstone", "craggy orb of coppery blue azurite") were never matched to their existing jar, producing "No empty jars found to store ..." even when a correct jar was present in the stash.

## Root cause

`Hoard.normalize_name` strips a leading descriptor via:

    descriptors = "\w+s? of(?: polished)?|polished"

`\w+s? of` matches only a single word before "of". A two-word descriptor like "raw chunk of" / "craggy orb of" fails to match, so the descriptor is left in place. The jar matcher in `store_items` then compares:

    normalize_name(gem.name)        # "raw chunk of titian orange sunstone"
    normalize_name(jar.after_name)  # "raw chunks of titian orange sunstone"

These differ only by the descriptor's plural ("chunk" vs "chunks"), the `=~ /^...$/` comparison fails, no jar is selected, and the deposit is skipped.

The plural is incidental: single-word descriptors already work because the descriptor (and its plural "s") is stripped entirely ("chunk of bloodstone" and "containing chunks of bloodstone" both normalize to "bloodstone"). The bug only surfaces for multi-word descriptors.

## Fix

Allow optional leading adjective words before the shape noun:

    descriptors = "(?:\w+ )*?\w+s? of(?: polished)?|polished"

This generalizes existing behavior rather than adding a new code path. Every `normalize_name` call site compares normalized-to-normalized and already treats the gem *material* as the identity, so collapsing the full shape descriptor is the established intent.

## Behavior preservation

Verified against existing single-word and no-descriptor inputs: "bloodstone", "uncut diamond", "lustrous black pearl", "amber", "ruby", "emerald", "deep blue sapphire talon", and "essence" are all unchanged. Only the previously-broken multi-word cases change, and they now normalize to the correct material identity:

    "raw chunk of titian orange sunstone"           -> "titian orange sunstone"
    "containing raw chunks of titian orange sunstone" -> "titian orange sunstone"
    "craggy orb of coppery blue azurite"            -> "coppery blue azurite"
    "containing craggy orbs of coppery blue azurite"  -> "coppery blue azurite"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.9.9

* **Bug Fixes**
  * Fixed an issue in hoarding operations where loose gems would not match existing jars when jar names included multi-word pluralized descriptors. The name-matching logic has been enhanced to correctly recognize and match gems with more complex jar naming patterns, ensuring proper gem grouping during hoarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->