### PR TITLE
fix(eloot.lic): v2.9.10 gemshop bulk sell no longer sells excluded ge…

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -19,7 +19,7 @@
   Improvements:
   Major_change.feature_addition.bugfix
   v2.9.10 (2026-06-18)
-    - bugfix for gemshop bulk sell selling an entire gem sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
+    - bugfix for gemshop/furrier bulk sell selling an entire sack when only some items were sell-excluded; now bulk sells only when the sack has items and none are excluded
   v2.9.9  (2026-06-18)
     - bugfix for hoarding gems whose jar after_name uses a multi-word, pluralized descriptor (e.g. "raw chunks of ...") that prevented matching loose gems to their existing jar
   v2.9.8  (2026-06-17)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -6090,7 +6090,8 @@ module ELoot # Sells the loot
         bulk_sell = false if bounty? =~ skin_match && sack.contents.find_all { |obj| obj.name =~ /bundle/ }.length.positive?
         bulk_sell = false if ELoot.data.alchemy_mode
 
-        if sack.contents.any? { |obj| obj.name.match?(ELoot.data.sell_exclude_regex) && obj.sellable =~ /furrier/ }
+        if sack.contents.any? { |obj| obj.sellable =~ /furrier } && 
+           sack.contents.none? { |obj| obj.sellable =~ /furrier && obj.name.match?(ELoot.data.sell_exclude_regex) }
           bulk_sell = false
         end
 

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.9
+           version: 2.9.10
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.10 (2026-06-18)
+    - bugfix for gemshop bulk sell selling an entire gem sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
   v2.9.9  (2026-06-18)
     - bugfix for hoarding gems whose jar after_name uses a multi-word, pluralized descriptor (e.g. "raw chunks of ...") that prevented matching loose gems to their existing jar
   v2.9.8  (2026-06-17)
@@ -6174,7 +6176,9 @@ module ELoot # Sells the loot
         next unless sack.contents.any? { |obj| obj.sellable.include?("gemshop") }
 
         # Bulk sell sack if it has gems and no exclusions
-        if sack.contents.any? { |obj| obj.type =~ /gem/ && !obj.name.match?(ELoot.data.sell_exclude_regex) } && ELoot.data.settings[:sell_loot_types].include?("gem") && !ELoot.data.alchemy_mode
+        if sack.contents.any? { |obj| obj.type =~ /gem/ } &&
+           sack.contents.none? { |obj| obj.type =~ /gem/ && obj.name.match?(ELoot.data.sell_exclude_regex) } &&
+           ELoot.data.settings[:sell_loot_types].include?("gem") && !ELoot.data.alchemy_mode
           if type.nil? || type.include?('gem')
             Inventory.drag(sack) if [checkleft, checkright].index(sack.noun).nil?
 

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -19,7 +19,7 @@
   Improvements:
   Major_change.feature_addition.bugfix
   v2.9.10 (2026-06-18)
-    - bugfix for gemshop/furrier bulk sell selling an entire sack when only some items were sell-excluded; now bulk sells only when the sack has items and none are excluded
+    - bugfix for gemshop bulk sell selling an entire sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
   v2.9.9  (2026-06-18)
     - bugfix for hoarding gems whose jar after_name uses a multi-word, pluralized descriptor (e.g. "raw chunks of ...") that prevented matching loose gems to their existing jar
   v2.9.8  (2026-06-17)
@@ -6090,8 +6090,7 @@ module ELoot # Sells the loot
         bulk_sell = false if bounty? =~ skin_match && sack.contents.find_all { |obj| obj.name =~ /bundle/ }.length.positive?
         bulk_sell = false if ELoot.data.alchemy_mode
 
-        if sack.contents.any? { |obj| obj.sellable =~ /furrier } && 
-           sack.contents.none? { |obj| obj.sellable =~ /furrier && obj.name.match?(ELoot.data.sell_exclude_regex) }
+        if sack.contents.any? { |obj| obj.sellable =~ /furrier && obj.name.match?(ELoot.data.sell_exclude_regex) }
           bulk_sell = false
         end
 

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -6090,7 +6090,7 @@ module ELoot # Sells the loot
         bulk_sell = false if bounty? =~ skin_match && sack.contents.find_all { |obj| obj.name =~ /bundle/ }.length.positive?
         bulk_sell = false if ELoot.data.alchemy_mode
 
-        if sack.contents.any? { |obj| obj.sellable =~ /furrier && obj.name.match?(ELoot.data.sell_exclude_regex) }
+        if sack.contents.any? { |obj| obj.sellable =~ /furrier/ && obj.name.match?(ELoot.data.sell_exclude_regex) }
           bulk_sell = false
         end
 


### PR DESCRIPTION
…ms from a mixed sack

## Summary

In `gemshop(type = nil)`, a gem sack was bulk-sold (`sell #<sack.id>`, "inspects the contents carefully") whenever it contained *any* gem not matching `sell_exclude_regex`. Because bulk sell disposes of the entire sack at once, any sell-excluded gems sharing that sack were sold too.

## Root cause

    if sack.contents.any? { |obj| obj.type =~ /gem/ && !obj.name.match?(ELoot.data.sell_exclude_regex) } && ...

`any? { gem && !excluded }` is true as soon as one non-excluded gem exists, so a sack with a mix of excluded and non-excluded gems still triggers the bulk sell. The per-item loop below correctly honors the exclusion, but the bulk path runs first and never reaches it.

## Fix

Bulk sell only when the sack has at least one gem AND no gem is excluded, matching the existing comment ("has gems and no exclusions"):

    if sack.contents.any? { |obj| obj.type =~ /gem/ } &&
       sack.contents.none? { |obj| obj.type =~ /gem/ && obj.name.match?(ELoot.data.sell_exclude_regex) } && ...

When an exclusion is present, the sack falls through to the per-item loop, which already skips excluded gems via `next if item.name.match?(...)`.

## Behavior preservation

- Sack with gems, none excluded: bulk sells (unchanged).
- Sack with all gems excluded: skips bulk (unchanged).
- Sack with no gems: skips bulk (unchanged; the dual check keeps the "has a gem" guard rather than vacuously bulk-selling a gemless sack).
- Sack with a mix: now skips bulk and sells per-item, respecting exclusions (the fixed case).

`check_bounty_gems` already disables bulk sell on exclusions and is not modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gemshop bulk selling to properly respect configured gem exclusions. Sacks containing excluded gems will no longer be bulk-sold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->