### PR TITLE
feat(eloot.lic): v2.10.0 report unsold over-limit items + pawnshop recheck

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,16 +15,14 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.1
+           version: 2.10.0
   Improvements:
   Major_change.feature_addition.bugfix
-  v2.11.1 (2026-07-16)
-    - run the pawnshop recheck for the custom sell flows too (;eloot sell/sellable/type), not just a full sell; all sell flows now finish through Sell.finish_sell_run
-    - fix a breakdown crash when over-max items exist but nothing was hoarded (hoard_deposit was still nil); the breakdown now uses nil-safe locals throughout
-  v2.11.0 (2026-06-24)
-    - add a Selling option "Recheck gemshop-refused items at the pawnshop": when the gemshop won't quote a price ("not buying anything this valuable today"), eloot makes a trip to the pawnshop and appraises the item there (appraise only, never sells) so its real value shows up in the breakdown. These items are grouped under a "Gemshop refused, pawn appraisals:" subheading within the Over Max Value list
   v2.10.0 (2026-06-24)
     - add "Over Max Value (not sold)" section to the eloot breakdown: lists items that appraised above your gemshop/pawnshop limit, with their appraised values, so you know what to put in your locker or investigate more deeply
+    - add a Selling option "Recheck gemshop-refused items at the pawnshop": when the gemshop won't quote a price ("not buying anything this valuable today"), eloot makes a trip to the pawnshop and appraises the item there (appraise only, never sells) so its real value shows up in the breakdown. These items are grouped under a "Gemshop refused, pawn appraisals:" subheading within the Over Max Value list
+    - run the pawnshop recheck for the custom sell flows too (;eloot sell/sellable/type), not just a full sell; all sell flows now finish through Sell.finish_sell_run
+    - fix a breakdown crash when over-max items exist but nothing was hoarded (hoard_deposit was still nil); the breakdown now uses nil-safe locals throughout
   v2.9.10 (2026-06-18)
     - bugfix for gemshop bulk sell selling an entire sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
   v2.9.9  (2026-06-18)

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,13 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.10
+           version: 2.11.0
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.0 (2026-06-24)
+    - add a Selling option "Recheck gemshop-refused items at the pawnshop": when the gemshop won't quote a price ("not buying anything this valuable today"), eloot makes a trip to the pawnshop and appraises the item there (appraise only, never sells) so its real value shows up in the breakdown. These items are grouped under a "Gemshop refused, pawn appraisals:" subheading within the Over Max Value list
+  v2.10.0 (2026-06-24)
+    - add "Over Max Value (not sold)" section to the eloot breakdown: lists items that appraised above your gemshop/pawnshop limit, with their appraised values, so you know what to put in your locker or investigate more deeply
   v2.9.10 (2026-06-18)
     - bugfix for gemshop bulk sell selling an entire sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
   v2.9.9  (2026-06-18)
@@ -278,7 +282,7 @@ module ELoot # Data
   class Data
     attr_accessor :disk, :disk_full, :sacks_full, :ready_method, :settings, :skinners, :skinsheath, :silent_open, :checked_bags,
                   :close_regex, :look_regex, :sacks_closed, :all_loot_categories, :regex_gold_rings, :right_hand, :left_hand, :skin_edged, :skin_blunt,
-                  :coin_hand, :coin_container, :silver_breakdown, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables,
+                  :coin_hand, :coin_container, :silver_breakdown, :over_max, :pawn_recheck, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables,
                   :charm, :gauntlet, :coin_bag, :account_type, :locker, :container_settings, :everything_list, :everything,
                   :only_list, :only, :inventory, :gem_inventory, :alchemy_inventory, :hoard_type, :cache, :locker_city, :use_hoarding, :stash,
                   :items_to_hoard, :hoard_deposit, :inv_save, :deposit_regex, :withdraw_regex, :disk_nouns_regex, :sigil_determination_on_fail, :start_room, :last_called,
@@ -360,6 +364,8 @@ module ELoot # Data
       # Misc
       @account_type = nil
       @silver_breakdown = Hash.new(0)
+      @over_max = []
+      @pawn_recheck = []
       @inv_save = true
 
       $sell_ignore = []
@@ -818,6 +824,7 @@ module ELoot # UI Setup
           sell_appraise_gemshop: { default: 14_999 },
           sell_appraise_pawnshop: { default: 34_999 },
           appraisal_container: { default: '' },
+          sell_pawn_recheck: { default: false },
 
           sell_collectibles: { default: true },
           sell_gold_rings: { default: false },
@@ -1138,7 +1145,7 @@ module ELoot # UI Setup
         </object><packing><property name="left-attach">3</property><property name="top-attach">0</property></packing></child><child><object class="GtkCheckButton" id="sell_appraise_types:jewelry"><property name="label" translatable="yes">Jewelry</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-top">5</property><property name="draw-indicator">True</property>
         </object><packing><property name="left-attach">2</property><property name="top-attach">0</property></packing></child><child><object class="GtkLabel"><property name="visible">True</property><property name="can-focus">False</property><property name="margin-start">75</property><property name="margin-end">10</property><property name="margin-top">5</property><property name="label" translatable="yes">Container to store items exceeding appraisal limit</property></object><packing><property name="left-attach">4</property><property name="top-attach">0</property>
         </packing></child><child><object class="GtkEntry" id="appraisal_container"><property name="visible">True</property><property name="can-focus">True</property><property name="valign">start</property><property name="margin-start">75</property><property name="margin-top">5</property><property name="placeholder-text" translatable="yes">If blank will return items to original container</property></object><packing><property name="left-attach">4</property><property name="top-attach">1</property><property name="height">2</property>
-        </packing></child></object></child><child type="label"><object class="GtkLabel"><property name="visible">True</property><property name="can-focus">False</property><property name="label" translatable="yes">Appraisals</property></object></child></object><packing><property name="left-attach">0</property><property name="top-attach">0</property><property name="width">2</property></packing></child></object><packing><property name="expand">False</property><property name="fill">True</property><property name="position">2</property>
+        </packing></child><child><object class="GtkCheckButton" id="sell_pawn_recheck"><property name="label" translatable="yes">Recheck gemshop-refused items at the pawnshop (appraise only, never sells)</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">10</property><property name="margin-top">5</property><property name="margin-bottom">5</property><property name="draw-indicator">True</property></object><packing><property name="left-attach">0</property><property name="top-attach">3</property><property name="width">5</property></packing></child></object></child><child type="label"><object class="GtkLabel"><property name="visible">True</property><property name="can-focus">False</property><property name="label" translatable="yes">Appraisals</property></object></child></object><packing><property name="left-attach">0</property><property name="top-attach">0</property><property name="width">2</property></packing></child></object><packing><property name="expand">False</property><property name="fill">True</property><property name="position">2</property>
         </packing></child><child><!-- n-columns=2 n-rows=1 --><object class="GtkGrid"><property name="visible">True</property><property name="can-focus">False</property><property name="column-homogeneous">True</property><child><object class="GtkFrame"><property name="visible">True</property><property name="can-focus">False</property><property name="border-width">5</property><property name="label-xalign">0</property><child><!-- n-columns=4 n-rows=3 --><object class="GtkGrid"><property name="visible">True</property><property name="can-focus">False</property><property name="margin-top">5</property><property name="margin-bottom">5</property><property name="hexpand">True</property><property name="row-spacing">2</property><property name="column-spacing">5</property><child><object class="GtkCheckButton" id="sell_collectibles"><property name="label" translatable="yes">Deposit Collectibles</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">5</property><property name="draw-indicator">True</property>
         </object><packing><property name="left-attach">0</property><property name="top-attach">0</property></packing></child><child><object class="GtkCheckButton" id="sell_fwi"><property name="label" translatable="yes">Sell in FWI</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">5</property><property name="draw-indicator">True</property></object><packing><property name="left-attach">0</property><property name="top-attach">1</property>
         </packing></child><child><object class="GtkCheckButton" id="sell_gold_rings"><property name="label" translatable="yes">Gold Rings to Chrono.</property><property name="visible">True</property><property name="can-focus">True</property><property name="receives-default">False</property><property name="halign">start</property><property name="margin-start">5</property><property name="draw-indicator">True</property></object><packing><property name="left-attach">0</property><property name="top-attach">2</property>
@@ -1924,6 +1931,7 @@ module ELoot # Profile loading/saving and settings
       :sell_appraise_types             => ["jewelry", "magic", "uncommon", "valuable"],
       :sell_appraise_gemshop           => 14999,
       :sell_appraise_pawnshop          => 34999,
+      :sell_pawn_recheck               => false,
       :sell_collectibles               => true,
       :sell_gold_rings                 => false,
       :sell_locksmith                  => false,
@@ -5367,6 +5375,19 @@ end
 
 module ELoot # Sells the loot
   module Sell
+    # Pure: pull the appraised value out of the merchant's lines. Reads the
+    # "worth approximately X silvers" / "give you X" value and ignores any
+    # lowball follow-up offer ("out of my price range, I will offer you Y").
+    # Returns { raw: "356,400", amount: 356400 } or nil when no value is given.
+    def self.parse_appraisal(lines)
+      rx = /([,0-9]+) (?:silver|for it if you want to sell|for this if you'd like)/
+      line = Array(lines).find { |l| l =~ rx }
+      return nil unless line && line =~ rx
+
+      raw = Regexp.last_match(1)
+      { raw: raw, amount: raw.delete(',').to_i }
+    end
+
     def self.appraise(item, location, _data = nil)
       return if item.type =~ /jewelry/ && location == "Pawnshop"
 
@@ -5377,10 +5398,12 @@ module ELoot # Sells the loot
 
       lines = ELoot.get_command("appraise ##{item.id}", /^You ask .*to appraise/)
 
-      if lines.any? { |l| l =~ /([,0-9]+) (?:silver|for it if you want to sell|for this if you'd like)/ }
-        raw = $1
-        amount = $1.delete(",").to_i
+      if (parsed = Sell.parse_appraisal(lines))
+        raw = parsed[:raw]
+        amount = parsed[:amount]
       end
+
+      gemshop_refused = location =~ /gemshop/i && lines.any? { |l| l =~ /not buying anything this valuable today/ }
 
       if amount > limit.to_i || lines.any? { |l| l =~ /not buying anything this valuable today/ }
         message = amount > limit.to_i ? " The #{item} appraises for #{raw}. That's above your settings." : " The #{item} appraises as too valuable to sell."
@@ -5389,16 +5412,90 @@ module ELoot # Sells the loot
         # Reset the appraisal container if the StowList got updated
         ELoot.ensure_items(key: 'appraisal_container', list: StowList.stow_list)
 
-        if StowList.stow_list[:appraisal_container].to_s.empty?
+        container = StowList.stow_list[:appraisal_container]
+
+        # Record items that beat the user's configured limit so the breakdown can
+        # list them (with values) as candidates for the locker / further review.
+        if amount > limit.to_i
+          (ELoot.data.over_max ||= []) << {
+            item:   item.name,
+            value:  amount,
+            raw:    raw,
+            shop:   location,
+            stowed: (container.to_s.empty? ? nil : container)
+          }
+        end
+
+        # The gemshop wouldn't even quote a price ("not buying anything this
+        # valuable today"). If enabled, flag the item to be re-appraised at the
+        # pawnshop later so we can learn (and report) its real value.
+        if gemshop_refused && ELoot.data.settings[:sell_pawn_recheck]
+          (ELoot.data.pawn_recheck ||= []) << item
+        end
+
+        if container.to_s.empty?
           Inventory.single_drag(item)
         else
-          Inventory.store_item(StowList.stow_list[:appraisal_container], item)
+          Inventory.store_item(container, item)
         end
       elsif amount.positive? && amount <= limit.to_i
         Sell.sell_item(item, location, ELoot.data.silver_breakdown)
       else
         Inventory.single_drag(item)
       end
+    end
+
+    # Items the gemshop refused as too valuable get a second-opinion appraisal at
+    # the pawnshop (when the "sell_pawn_recheck" option is on). This only learns
+    # and reports the value -- it never sells -- so you can decide what to locker
+    # or look into. Results land in the over_max breakdown with a note.
+    def self.recheck_refused_at_pawnshop
+      return unless ELoot.data.settings[:sell_pawn_recheck]
+
+      items = Array(ELoot.data.pawn_recheck).compact
+      return if items.empty?
+
+      ELoot.msg(type: "info", text: " Rechecking #{items.length} gemshop-refused item(s) at the pawnshop...", space: true)
+
+      pawn = Room.current.find_nearest_by_tag("pawnshop")
+      if pawn.nil?
+        ELoot.msg(type: "info", text: " No pawnshop found nearby; leaving the refused items with your loot.")
+        return
+      end
+      ELoot.go2("pawnshop")
+
+      items.each do |item|
+        next if item.nil?
+
+        # Bring it back to hand (drag reopens containers and refinds by id).
+        Inventory.drag(item)
+        obj = [GameObj.right_hand, GameObj.left_hand].find { |h| h && !h.id.nil? && h.id == item.id }
+        next if obj.nil?
+
+        lines = ELoot.get_command("appraise ##{obj.id}", /^You ask .*to appraise/)
+        parsed = Sell.parse_appraisal(lines)
+
+        if parsed && parsed[:amount].positive?
+          container = StowList.stow_list[:appraisal_container]
+          (ELoot.data.over_max ||= []) << {
+            item:   obj.name,
+            value:  parsed[:amount],
+            raw:    parsed[:raw],
+            shop:   "Pawnshop",
+            stowed: (container.to_s.empty? ? nil : container),
+            note:   "gemshop refused, pawn appraisal"
+          }
+        end
+
+        # Put it back the same way appraise would (we never sell it here).
+        if (c = StowList.stow_list[:appraisal_container]).to_s.empty?
+          Inventory.single_drag(obj)
+        else
+          Inventory.store_item(c, obj)
+        end
+      end
+
+      ELoot.data.pawn_recheck = []
     end
 
     def self.box_in_hand(deposit = true)
@@ -5433,8 +5530,48 @@ module ELoot # Sells the loot
       end
     end
 
+    # Build Terminal::Table rows for items that appraised above the user's
+    # gemshop/pawnshop limit (captured during Sell.appraise). Pure and testable:
+    # takes the over_max record array, returns rows (arrays / :separator / header
+    # hashes), most valuable first. Items the gemshop refused (re-appraised at the
+    # pawnshop, flagged with :note) are grouped under their own subheading.
+    def self.over_max_rows(records)
+      return [] if records.nil? || records.empty?
+
+      refused = records.select { |r| r[:note] }
+      normal  = records - refused
+      by_value = ->(list) { list.sort_by { |r| -r[:value].to_i } }
+      item_row = ->(r) { [ELoot.capitalize_words(r[:item].to_s), "   " + (r[:raw] || ELoot.format_number(r[:value])).to_s] }
+
+      rows = []
+      rows << :separator
+      rows << [{ value: 'Over Max Value (not sold)', colspan: 2, alignment: :center }]
+      rows << :separator
+
+      # Disposition note only when every item shares one appraisal container.
+      containers = records.map { |r| r[:stowed] }.uniq
+      if containers.length == 1 && containers.first
+        rows << [{ value: "(stowed in your #{containers.first})", colspan: 2, alignment: :left }]
+        rows << :separator
+      end
+
+      by_value.call(normal).each { |r| rows << item_row.call(r) }
+
+      if refused.any?
+        rows << :separator if normal.any?
+        # Two-cell (not colspan) so the column separator pipe still renders.
+        rows << ['Gemshop refused, pawn appraisals:', '']
+        by_value.call(refused).each { |r| rows << item_row.call(r) }
+      end
+
+      rows
+    end
+
     def self.breakdown
-      return if ELoot.data.silver_breakdown.empty? && (ELoot.data.hoard_deposit.empty? || ELoot.data.hoard_deposit.nil?)
+      sb_empty = ELoot.data.silver_breakdown.nil? || ELoot.data.silver_breakdown.empty?
+      hd_empty = ELoot.data.hoard_deposit.nil? || ELoot.data.hoard_deposit.empty?
+      om_empty = ELoot.data.over_max.nil? || ELoot.data.over_max.empty?
+      return if sb_empty && hd_empty && om_empty
       return unless defined?(Terminal)
       rows = []
 
@@ -5499,6 +5636,8 @@ module ELoot # Sells the loot
           }
         end
       end
+
+      rows.concat(Sell.over_max_rows(ELoot.data.over_max))
 
       table = Terminal::Table.new :title => "Eloot Breakdown", :rows => rows # , :style => {:all_separators => true}
       table.align_column(1, :right)
@@ -6922,6 +7061,9 @@ module ELoot # Sells the loot
 
       Sell.go_sell(Sell.check_items)
 
+      # Second-opinion pawnshop appraisal for anything the gemshop refused.
+      Sell.recheck_refused_at_pawnshop
+
       ELoot.silver_deposit(true)
 
       # If herb or junk is checked for selling we dump it. Only default and overflow
@@ -7037,6 +7179,8 @@ module ELoot # Starts the script
 
   $sell_ignore ||= Array.new
   ELoot.data.silver_breakdown = Hash.new(0)
+  ELoot.data.over_max = []
+  ELoot.data.pawn_recheck = []
 
   case Script.current.vars[0]
   when /debug/

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.0
+           version: 2.11.1
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.1 (2026-07-16)
+    - run the pawnshop recheck for the custom sell flows too (;eloot sell/sellable/type), not just a full sell; all sell flows now finish through Sell.finish_sell_run
+    - fix a breakdown crash when over-max items exist but nothing was hoarded (hoard_deposit was still nil); the breakdown now uses nil-safe locals throughout
   v2.11.0 (2026-06-24)
     - add a Selling option "Recheck gemshop-refused items at the pawnshop": when the gemshop won't quote a price ("not buying anything this valuable today"), eloot makes a trip to the pawnshop and appraises the item there (appraise only, never sells) so its real value shows up in the breakdown. These items are grouped under a "Gemshop refused, pawn appraisals:" subheading within the Over Max Value list
   v2.10.0 (2026-06-24)
@@ -5498,6 +5501,14 @@ module ELoot # Sells the loot
       ELoot.data.pawn_recheck = []
     end
 
+    # Shared tail for every sell flow: drain any gemshop-refused items to the
+    # pawnshop (no-op unless sell_pawn_recheck is on and something was queued),
+    # then deposit. Keeps the custom entrypoints in step with the main flow.
+    def self.finish_sell_run
+      Sell.recheck_refused_at_pawnshop
+      ELoot.silver_deposit(true)
+    end
+
     def self.box_in_hand(deposit = true)
       return unless [GameObj.left_hand.type, GameObj.right_hand.type].include?("box")
 
@@ -5568,17 +5579,20 @@ module ELoot # Sells the loot
     end
 
     def self.breakdown
-      sb_empty = ELoot.data.silver_breakdown.nil? || ELoot.data.silver_breakdown.empty?
-      hd_empty = ELoot.data.hoard_deposit.nil? || ELoot.data.hoard_deposit.empty?
-      om_empty = ELoot.data.over_max.nil? || ELoot.data.over_max.empty?
-      return if sb_empty && hd_empty && om_empty
+      # nil-safe locals so the body never re-reads a field that may still be nil
+      # (e.g. hoard_deposit stays nil until Hoard.hoard_items runs, but over_max
+      # can be populated on its own -- see recheck_refused_at_pawnshop).
+      silver_breakdown = ELoot.data.silver_breakdown || Hash.new(0)
+      hoard_deposit = ELoot.data.hoard_deposit || []
+      over_max = ELoot.data.over_max || []
+      return if silver_breakdown.empty? && hoard_deposit.empty? && over_max.empty?
       return unless defined?(Terminal)
       rows = []
 
-      unless ELoot.data.silver_breakdown.empty?
+      unless silver_breakdown.empty?
         total_silver = 0
 
-        ELoot.data.silver_breakdown.each_with_index do |(location, amount), index|
+        silver_breakdown.each_with_index do |(location, amount), index|
           unless location =~ /(Pool|Town) (Dropoff|Depth|Open)/
             begin
               total_silver += amount
@@ -5599,7 +5613,7 @@ module ELoot # Sells the loot
           rows << [location, "   " + ELoot.format_number(amount)]
 
           # Only add a separator if the location matches the pattern and is not the last one
-          if location =~ /Pool Depth|Town Open/ && index < ELoot.data.silver_breakdown.size - 1
+          if location =~ /Pool Depth|Town Open/ && index < silver_breakdown.size - 1
             rows << :separator
           end
         end
@@ -5608,8 +5622,8 @@ module ELoot # Sells the loot
         rows << ["Total", ELoot.format_number(total_silver)]
       end
 
-      if ELoot.data.hoard_deposit.length.to_i.positive?
-        all_gems = ELoot.data.hoard_deposit.find_all { |item| item[:type] == 'gem' }
+      if hoard_deposit.length.to_i.positive?
+        all_gems = hoard_deposit.find_all { |item| item[:type] == 'gem' }
 
         unless all_gems.length.to_i.zero?
           unique_gems = all_gems.uniq { |item| item[:item] }
@@ -5618,12 +5632,12 @@ module ELoot # Sells the loot
           rows << :separator
 
           unique_gems.each { |obj|
-            count = ELoot.data.hoard_deposit.find_all { |item| item[:item] == obj[:item] }.length.to_i
+            count = hoard_deposit.find_all { |item| item[:item] == obj[:item] }.length.to_i
             rows << [ELoot.capitalize_words(obj[:item]), "   " + count.to_s]
           }
         end
 
-        all_reagents = ELoot.data.hoard_deposit.find_all { |item| item[:type] == 'reagent' }
+        all_reagents = hoard_deposit.find_all { |item| item[:type] == 'reagent' }
 
         unless all_reagents.length.to_i.zero?
           unique_reagents = all_reagents.uniq { |item| item[:item] }
@@ -5631,13 +5645,13 @@ module ELoot # Sells the loot
           rows << [{ value: 'Reagents Hoarded', colspan: 2, alignment: :center }]
           rows << :separator
           unique_reagents.uniq!.each { |obj|
-            count = ELoot.data.hoard_deposit.find_all { |item| item[:item] == obj[:item] }.length.to_i
+            count = hoard_deposit.find_all { |item| item[:item] == obj[:item] }.length.to_i
             rows << [ELoot.capitalize_words(obj[:item]), "   " + count.to_s]
           }
         end
       end
 
-      rows.concat(Sell.over_max_rows(ELoot.data.over_max))
+      rows.concat(Sell.over_max_rows(over_max))
 
       table = Terminal::Table.new :title => "Eloot Breakdown", :rows => rows # , :style => {:all_separators => true}
       table.align_column(1, :right)
@@ -6042,7 +6056,7 @@ module ELoot # Sells the loot
         end
       end
 
-      ELoot.silver_deposit(true)
+      Sell.finish_sell_run
       Inventory.return_hands
     end
 
@@ -6086,7 +6100,7 @@ module ELoot # Sells the loot
 
       Sell.go_sell(remaining_sellable)
 
-      ELoot.silver_deposit(true)
+      Sell.finish_sell_run
       Inventory.return_hands
     end
 
@@ -6153,7 +6167,7 @@ module ELoot # Sells the loot
       Sell.pawnshop(sell_types) if locations.include?("pawnshop")
       Sell.collectibles if locations.include?("collectibles")
 
-      ELoot.silver_deposit(true)
+      Sell.finish_sell_run
       Inventory.return_hands
     end
 
@@ -7061,10 +7075,8 @@ module ELoot # Sells the loot
 
       Sell.go_sell(Sell.check_items)
 
-      # Second-opinion pawnshop appraisal for anything the gemshop refused.
-      Sell.recheck_refused_at_pawnshop
-
-      ELoot.silver_deposit(true)
+      # Second-opinion pawnshop appraisal for anything the gemshop refused, then deposit.
+      Sell.finish_sell_run
 
       # If herb or junk is checked for selling we dump it. Only default and overflow
       Sell.dump_herbs_junk

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5421,10 +5421,10 @@ module ELoot # Sells the loot
         # list them (with values) as candidates for the locker / further review.
         if amount > limit.to_i
           (ELoot.data.over_max ||= []) << {
-            item:   item.name,
-            value:  amount,
-            raw:    raw,
-            shop:   location,
+            item: item.name,
+            value: amount,
+            raw: raw,
+            shop: location,
             stowed: (container.to_s.empty? ? nil : container)
           }
         end
@@ -5481,12 +5481,12 @@ module ELoot # Sells the loot
         if parsed && parsed[:amount].positive?
           container = StowList.stow_list[:appraisal_container]
           (ELoot.data.over_max ||= []) << {
-            item:   obj.name,
-            value:  parsed[:amount],
-            raw:    parsed[:raw],
-            shop:   "Pawnshop",
+            item: obj.name,
+            value: parsed[:amount],
+            raw: parsed[:raw],
+            shop: "Pawnshop",
             stowed: (container.to_s.empty? ? nil : container),
-            note:   "gemshop refused, pawn appraisal"
+            note: "gemshop refused, pawn appraisal"
           }
         end
 


### PR DESCRIPTION
## What

Two additions to the `;eloot` breakdown around items that don't sell. **Default behavior is unchanged** — the new section only appears when relevant, and the pawnshop recheck is off unless you enable it.

### v2.10.0 
#### "Over Max Value (not sold)" breakdown section
Items that appraise above your gemshop/pawnshop limit are stowed and the run moves on with no record of what they were or what they're worth. This adds a section to the end-of-run breakdown listing those items with their appraised values (highest first), so you know what to put in your locker or look into.

#### "Recheck gemshop-refused items at the pawnshop" (new Selling option, default off)
The gemshop sometimes refuses an item outright ("Sorry, I'm not buying anything this valuable today") and gives no value, while the pawnshop will still appraise it. With this checkbox enabled, after the normal sell route eloot makes a trip to the nearest pawnshop and appraises those items there. It only **learns and reports** the value — it never sells on this path — and groups the results under a subheading in the same Over Max Value list.

Example breakdown:

```
+-----------------------------------+------------+
|           Over Max Value (not sold)            |
+------------------------------------------------+
+-----------------------------------+------------+
| Crystal Amulet                    |     16,100 |
+-----------------------------------+------------+
| Gemshop refused, pawn appraisals: |            |
| Amethyst Studded Bronze Torc      |    356,400 |
| Jade Pendant                      |     90,000 |
+-----------------------------------+------------+
```

## How

- New per-run collections `Data#over_max` / `Data#pawn_recheck` (reset alongside `silver_breakdown`).
- `Sell.appraise` records over-limit items into `over_max`, and (when the option is on) flags gemshop-refused items for recheck.
- `Sell.recheck_refused_at_pawnshop` (called from `Sell.sell` after `go_sell`) travels to the pawnshop, appraises each flagged item, records the value, and re-stows it — no selling.
- Pure helpers `Sell.parse_appraisal` (reads "worth approximately X", ignores the lowball "I'll offer you Y") and `Sell.over_max_rows` (builds the table rows). `parse_appraisal` is now also used by `Sell.appraise`.
- New setting `sell_pawn_recheck` (default `false`) with a checkbox in the Selling tab's Appraisals frame.
- `breakdown`'s early-return guard is made nil-safe and now also fires when only over-max items exist.

## Testing

- The pure helpers (`parse_appraisal`, `over_max_rows`) are covered by an offline unit harness (value parsing incl. the lowball case, grouping/ordering, edge cases) — all green.
- In-game on GSIV: verified the Over Max Value section, the pawnshop recheck trip (appraise-only), the grouped subheading, and the default-off behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `sell_pawn_recheck` option to re-appraise gem-shop–refused items at the pawn shop (when enabled).
  * Selling reports now show an **“Over Max Value (not sold)”** section, and refused items are grouped when applicable.

* **Bug Fixes**
  * Prevented breakdown crashes when over-max items exist without matching hoard/silver sections.
  * Improved tracking of over-max items and ensured pawn-shop recheck + final deposit works consistently across standard and custom sell flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->