### PR TITLE
fix(alias): update alias-service hook registration with persistence

### DIFF
--- a/scripts/alias.lic
+++ b/scripts/alias.lic
@@ -506,5 +506,9 @@ hook_proc = proc { |client_string|
   end
 }
 
-UpstreamHook.add('alias-service', hook_proc)
+# v5.19.0 introduces a shared hook registry. Hooks are either
+# removed when their owning script exits, or explicitly marked
+# to persist and are cleaned up separately.
+kw = UpstreamHook.method(:add).parameters.any? { |_t, n| n == :persist } ? { persist: true } : {}
+UpstreamHook.add('alias-service', hook_proc, **kw)
 respond "--- Lich: alias service started"

--- a/scripts/alias.lic
+++ b/scripts/alias.lic
@@ -509,6 +509,9 @@ hook_proc = proc { |client_string|
 # v5.19.0 introduces a shared hook registry. Hooks are either
 # removed when their owning script exits, or explicitly marked
 # to persist and are cleaned up separately.
-kw = UpstreamHook.method(:add).parameters.any? { |_t, n| n == :persist } ? { persist: true } : {}
-UpstreamHook.add('alias-service', hook_proc, **kw)
+if UpstreamHook.method(:add).parameters.any? { |_t, n| n == :persist }
+  UpstreamHook.add('alias-service', hook_proc, persist: true)
+else
+  UpstreamHook.add('alias-service', hook_proc)
+end
 respond "--- Lich: alias service started"

--- a/scripts/alias.lic
+++ b/scripts/alias.lic
@@ -9,11 +9,13 @@
    game: Gemstone
    tags: core, alias
    required: Lich > 5.0.1
-   version: 1.0.4
+   version: 1.0.5
 
   Help Contribute: https://github.com/elanthia-online/scripts
 
    changelog:
+      1.0.5 (2026-06-30)
+         Updated for 5.19.0 Lich to include new hook registry semantics
       1.0.4 (2025-01-31)
         Bugfix in .include? syntax for stopping upstreamhook
       1.0.3 (2024-05-08)


### PR DESCRIPTION
Lich v5.19.0 introduces a shared hook registry. Hooks are either removed when their owning script exits, or explicitly marked to persist and are cleaned up separately.  Declare whether hooks should be removed when their owning script exits, or persist for separate cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alias service compatibility with newer hook handling, helping it register more reliably across environments.
  * Added fallback behavior so the service continues to work with older hook implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->