### PR TITLE
autostart: v0.74 per-script args + retire UserVars.autostart_scripts

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,18 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.73
+       version: 0.74
       required: Lich >= 4.6.58
 
   changelog:
+    0.74 (2026-07-03):
+      YAML autostarts (get_settings.autostarts) accept optional per-script args:
+        bare "name", "name arg1 arg2", or { name:, args: } hash forms
+      on duplicate names an args-carrying entry wins over a bare duplicate
+      retire the legacy UserVars.autostart_scripts store (superseded by YAML autostarts);
+        one-time login check clears it, quietly if every entry is already in YAML/DB,
+        or with a loud notice naming any gap and how to re-add it (never auto-migrates)
+      extract normalize_autostart_entry / yaml_autostart_entries / launch_autostart
     0.73 (2026-07-02):
       force ACCOUNT command population if subscription is not free/premium/normal
     0.72 (2026-05-27):
@@ -93,6 +101,140 @@ def gtk_version
   end
 end
 
+# Normalizes a single YAML autostart entry into a [name, args] pair.
+#
+# Autostart entries may take three forms:
+#   - a bare script name:   "lichbot"          -> ["lichbot", []]
+#   - a name with args:     "lichbot start"    -> ["lichbot", ["start"]]
+#   - a { name:, args: } hash                  -> ["lichbot", ["start"]]
+# Hash keys may be Symbols (:name / :args) or Strings ('name' / 'args'), since
+# YAML parses inline hash keys as Strings. Both forms are accepted.
+#
+# This is the single source of truth for autostart entry formats; adding a
+# future format is a localized change here.
+#
+# @param entry [String, Hash, nil] a YAML autostart entry.
+# @return [Array(String, Array<String>)] the script name and its argument list.
+#   The name is "" when the entry carries no usable name (callers guard on this).
+# @example Bare name
+#   normalize_autostart_entry('lichbot')                 # => ['lichbot', []]
+# @example Name with whitespace-separated args
+#   normalize_autostart_entry('lichbot start')           # => ['lichbot', ['start']]
+# @example Symbol-keyed hash
+#   normalize_autostart_entry(:name => 'lichbot', :args => ['start']) # => ['lichbot', ['start']]
+# @example String-keyed hash (as produced by YAML)
+#   normalize_autostart_entry('name' => 'lichbot', 'args' => ['start']) # => ['lichbot', ['start']]
+def normalize_autostart_entry(entry)
+  if entry.is_a?(Hash)
+    name = (entry[:name] || entry['name']).to_s.strip
+    args = Array(entry[:args] || entry['args']).map(&:to_s)
+    [name, args]
+  else
+    parts = entry.to_s.split
+    [parts.first.to_s, parts[1..].to_a]
+  end
+end
+
+# Collects, normalizes, and de-dups the profile's YAML autostart entries.
+#
+# Reads get_settings.autostarts, normalizes every entry to a [name, args] pair
+# via {#normalize_autostart_entry}, drops entries with a blank name, and de-dups
+# by name. On a name collision an entry that carries args wins over a bare
+# (arg-less) duplicate; if several carry args, the first wins (so a duplicate
+# bare "lichbot" won't strip the args off a "lichbot start" entry). Start order
+# follows first occurrence of a name.
+#
+# @return [Array<Array(String, Array<String>)>] normalized [name, args] pairs.
+def yaml_autostart_entries
+  get_settings.autostarts.to_a
+              .map { |entry| normalize_autostart_entry(entry) }
+              .reject { |name, _args| name.nil? || name.empty? }
+              .group_by { |name, _args| name }
+              .map { |_name, group| group.find { |_n, args| !args.empty? } || group.first }
+end
+
+# The set of script names already covered by the autostart configuration.
+#
+# Combines the profile YAML `autostarts:` list (when get_settings is available)
+# with the global and per-character DB autostart lists (Settings['scripts'] and
+# CharSettings['scripts']). Used to decide whether a legacy UserVars entry would
+# actually be lost if it were dropped.
+#
+# @return [Array<String>] unique, non-blank script names already autostarted.
+def autostart_covered_names
+  names = []
+  names.concat(get_settings.autostarts.to_a.map { |entry| normalize_autostart_entry(entry).first }) if respond_to?(:get_settings, true)
+  [Settings['scripts'], CharSettings['scripts']].each do |list|
+    names.concat(list.map { |info| info[:name] }) if list.is_a?(Array)
+  end
+  names.compact.map(&:to_s).reject(&:empty?).uniq
+end
+
+# Reads, reports on, and clears any legacy UserVars.autostart_scripts.
+#
+# UserVars.autostart_scripts was the old (now-removed) DR autostart store and is
+# no longer read as a launch source. This retires it read-only: it compares the
+# stale names against what is already covered by the YAML `autostarts:` list and
+# the ;autostart DB lists ({#autostart_covered_names}), then clears the UserVar.
+#
+# - If every stale entry is already covered, it just prints a brief note that the
+#   unused UserVar is being cleared (no action needed).
+# - If any stale entry is NOT in the YAML list or the DB, that script would stop
+#   autostarting, so it prints a loud notice naming the gap and the two ways to
+#   re-add it (profile YAML `autostarts:` list, or ;autostart add for the DB).
+#
+# Nothing is ever re-added automatically -- the user chooses where each script
+# should live. The UserVar is always cleared so the check runs only once.
+#
+# @return [void]
+def migrate_legacy_uservars_autostarts
+  legacy = UserVars.autostart_scripts.to_a
+  return if legacy.empty?
+
+  covered = autostart_covered_names
+  gaps = legacy.map { |entry| normalize_autostart_entry(entry).first }
+               .reject { |name| name.nil? || name.empty? }
+               .uniq
+               .reject { |name| covered.include?(name) }
+
+  if gaps.empty?
+    respond "\n--- autostart: clearing the legacy UserVars.autostart_scripts store -- it is no longer used and every entry is already in your YAML 'autostarts:' list or your ;autostart DB list. No action needed.\n\n"
+  else
+    plural = gaps.size == 1 ? 'script is' : 'scripts are'
+    respond "\n*** autostart: ACTION NEEDED ***"
+    respond "    The legacy UserVars.autostart_scripts store is being retired, but the following #{plural}"
+    respond "    NOT in your profile YAML 'autostarts:' list or your ;autostart DB list, so #{gaps.size == 1 ? 'it' : 'they'} will stop autostarting:"
+    respond "      #{gaps.join(', ')}"
+    respond "    To keep #{gaps.size == 1 ? 'it' : 'them'} starting at login, add each to EITHER:"
+    respond "      - your profile YAML 'autostarts:' list (args supported, e.g.  - lichbot start), or"
+    respond "      - the autostart database:  #{$clean_lich_char}autostart add <script> [args]   (or --global <script> [args])"
+    respond "    Clearing UserVars.autostart_scripts now.\n\n"
+  end
+
+  UserVars.autostart_scripts = nil
+end
+
+# Starts a single normalized YAML autostart entry, applying the shared
+# skip-guards: 'dependency', obsolete DR scripts, already-running, and
+# missing-on-disk (which emits the "not found, skipping" notice).
+#
+# @param name [String] the normalized script name to start.
+# @param args [Array<String>] arguments to pass to the script.
+# @return [Boolean] true if the script was started, false if a guard skipped it.
+def launch_autostart(name, args)
+  return false if name == 'dependency'
+  return false if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(name)
+  return false if Script.running?(name)
+
+  unless Script.exists?(name)
+    respond "\n--- autostart: '#{name}' not found, skipping\n\n"
+    return false
+  end
+
+  start_script(name, args)
+  true
+end
+
 if defined?(Lich::Common::Account) && (Lich::Common::Account.subscription.nil? || (Lich::Common::Account.subscription.is_a?(String) && Lich::Common::Account.subscription !~ /free|normal|premium/i))
   respond "Retrieving Account subscription information due to currently undetected!"
   waitrt?
@@ -166,28 +308,34 @@ if script.vars.empty?
     did_something = true
   end
 
-  # YAML-based autostarts, UserVars autostarts, and wayto overrides.
+  # One-time migration: warn about and clear the legacy UserVars.autostart_scripts
+  # store (superseded by the profile YAML `autostarts:` list and the ;autostart DB).
+  migrate_legacy_uservars_autostarts
+
+  # YAML-based autostarts (get_settings.autostarts) and wayto overrides.
   # Guarded for GS backward compatibility on lich < 5.17.
+  #
+  # Each entry in the profile's `autostarts:` list may take one of three forms:
+  #   - a bare script name          - "lichbot"
+  #   - a name with arguments       - "lichbot start"
+  #   - a { name:, args: } hash     - { name: lichbot, args: [start] }
+  # Entries are normalized to [name, args] and de-duped by name; on a name
+  # collision an entry that carries args wins over a bare duplicate (so a
+  # duplicate bare "lichbot" won't strip the args off a "lichbot start" entry).
+  # See normalize_autostart_entry / yaml_autostart_entries / launch_autostart.
+  #
+  # NOTE: the normalizer is intentionally scoped to this YAML path and not
+  # shared with the Settings/CharSettings DB loop below. That loop already
+  # stores normalized { :name, :args } hashes and carries a distinct guard set
+  # (infomon/repository skips, lich5-update skip, DR dependency removal), so
+  # reusing the normalizer there would add coupling without removing duplication.
   if respond_to?(:get_settings, true)
-    UserVars.autostart_scripts ||= []
-    all_autostarts = (UserVars.autostart_scripts.to_a +
-                      get_settings.autostarts.to_a).uniq
+    entries = yaml_autostart_entries
 
     Map.apply_wayto_overrides if Map.respond_to?(:apply_wayto_overrides)
 
-    all_autostarts.each do |script_name|
-      next if script_name == 'dependency'
-      next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
-      next if Script.running?(script_name)
-
-      unless Script.exists?(script_name)
-        respond "\n--- autostart: '#{script_name}' not found, skipping\n\n"
-        next
-      end
-
-      start_script(script_name)
-    end
-    did_something = true unless all_autostarts.empty?
+    entries.each { |name, args| launch_autostart(name, args) }
+    did_something = true unless entries.empty?
   end
 
   for script_list in [Settings['scripts'], CharSettings['scripts']]

--- a/scripts/version.lic
+++ b/scripts/version.lic
@@ -5,10 +5,14 @@
   contributors: LostRanger, Doug, Tysong
           game: gs
           tags: utility, version
-       version: 1.3.1
+       version: 1.3.2
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.3.2 (2026-07-03)
+    - drop "DR autostarts" report; UserVars.autostart_scripts is retired by autostart.lic
+    - report YAML profile autostarts ("Autostart profile (YAML)") and label the DB
+      lists "(DB)" so each autostart source is distinguishable
   v1.3.1 (2026-06-09)
     - correct fe output to wrayth where appropriate
     - report Account.type instead of Account.subscription
@@ -472,7 +476,7 @@ module VersionScript
             scripts.push("#{hash[:name]}(args: #{hash[:args].join(' ')})")
           end
         }
-        report["Autostart global"] = scripts.join(', ')
+        report["Autostart global (DB)"] = scripts.join(', ')
       end
       if (scripts_hashes = load_autostart_scripts("#{XMLData.game}:#{XMLData.name}"))
         scripts = []
@@ -483,9 +487,22 @@ module VersionScript
             scripts.push("#{hash[:name]}(args: #{hash[:args].join(' ')})")
           end
         }
-        report["Autostart #{Char.name}"] = scripts.join(', ')
+        report["Autostart #{Char.name} (DB)"] = scripts.join(', ')
       end
-      report["DR autostarts"]          = UserVars.autostart_scripts.to_a.join(', ') if XMLData.game =~ /^DR/
+      if respond_to?(:get_settings, true) && !(yaml_autostarts = get_settings.autostarts.to_a).empty?
+        scripts = yaml_autostarts.map { |entry|
+          if entry.is_a?(Hash)
+            name = (entry[:name] || entry['name']).to_s.strip
+            args = Array(entry[:args] || entry['args']).map(&:to_s)
+          else
+            parts = entry.to_s.split
+            name = parts.first.to_s
+            args = parts[1..].to_a
+          end
+          args.empty? ? name : "#{name}(args: #{args.join(' ')})"
+        }
+        report["Autostart profile (YAML)"] = scripts.join(', ')
+      end
       report["Running scripts"]        = Script.list.map { |x| x.name }.join(', ')
       report["Downstream hooks"]       = (defined?(DownstreamHook.hook_sources) ? DownstreamHook.hook_sources.map { |k, v| "#{v}(#{k})" }.join(', ') : DownstreamHook.list.join(', '))
       report["Upstream hooks"]         = (defined?(UpstreamHook.hook_sources) ? UpstreamHook.hook_sources.map { |k, v| "#{v}(#{k})" }.join(', ') : UpstreamHook.list.join(', '))

--- a/spec/autostart/autostart_spec.rb
+++ b/spec/autostart/autostart_spec.rb
@@ -121,33 +121,104 @@ module MockUserVars
   end
 end
 
-# -- Helper that mirrors the game-agnostic YAML autostart loop ------------
+# -- Helpers that mirror the game-agnostic YAML autostart path -----------
+#
+# The helpers below are verbatim mirrors of the same-named methods in
+# scripts/autostart.lic. As documented at the top of this file, we cannot load
+# the .lic (it runs heavy startup side effects), so the pure logic is duplicated
+# here and exercised directly. Keep these in sync with the production methods.
+
+# Mirror of autostart.lic#normalize_autostart_entry.
+#
+# @param entry [String, Hash, nil] a YAML autostart entry.
+# @return [Array(String, Array<String>)] the script name and its argument list.
+def normalize_autostart_entry(entry)
+  if entry.is_a?(Hash)
+    name = (entry[:name] || entry['name']).to_s.strip
+    args = Array(entry[:args] || entry['args']).map(&:to_s)
+    [name, args]
+  else
+    parts = entry.to_s.split
+    [parts.first.to_s, parts[1..].to_a]
+  end
+end
+
+# Mirror of autostart.lic#yaml_autostart_entries (with injectable source).
+#
+# @param yaml_autostarts [Array, nil] simulated get_settings.autostarts
+# @return [Array<Array(String, Array<String>)>] normalized [name, args] pairs
+def build_yaml_autostart_entries(yaml_autostarts: [])
+  yaml_autostarts.to_a
+                 .map { |entry| normalize_autostart_entry(entry) }
+                 .reject { |name, _args| name.nil? || name.empty? }
+                 .group_by { |name, _args| name }
+                 .map { |_name, group| group.find { |_n, args| !args.empty? } || group.first }
+end
+
+# Mirror of autostart.lic#autostart_covered_names (with injectable sources).
+#
+# @param yaml_autostarts [Array, nil] simulated get_settings.autostarts
+# @param settings_scripts [Array, nil] simulated Settings['scripts']
+# @param char_scripts [Array, nil] simulated CharSettings['scripts']
+# @return [Array<String>] unique, non-blank names already autostarted
+def build_autostart_covered_names(yaml_autostarts: [], settings_scripts: nil, char_scripts: nil)
+  names = yaml_autostarts.to_a.map { |entry| normalize_autostart_entry(entry).first }
+  [settings_scripts, char_scripts].each do |list|
+    names.concat(list.map { |info| info[:name] }) if list.is_a?(Array)
+  end
+  names.compact.map(&:to_s).reject(&:empty?).uniq
+end
+
+# Mirror of autostart.lic#migrate_legacy_uservars_autostarts.
+#
+# Compares the stale UserVars names against the covered set; pushes a quiet
+# "clearing" note when all are covered or a loud "ACTION NEEDED" notice naming
+# the gap otherwise, then clears the UserVar so the check runs only once. Never
+# re-adds or starts anything.
+#
+# @param user_vars_mod [Module] mock for UserVars (autostart_scripts)
+# @param covered [Array<String>] names already covered by YAML/DB autostarts
+# @param respond_output [Array<String>] collects notice lines
+# @return [void]
+def run_legacy_uservars_migration(user_vars_mod: MockUserVars, covered: [], respond_output: [])
+  legacy = user_vars_mod.autostart_scripts.to_a
+  return if legacy.empty?
+
+  gaps = legacy.map { |entry| normalize_autostart_entry(entry).first }
+               .reject { |name| name.nil? || name.empty? }
+               .uniq
+               .reject { |name| covered.include?(name) }
+
+  if gaps.empty?
+    respond_output << "clearing legacy UserVars.autostart_scripts (no longer used; all entries already in YAML/DB)"
+  else
+    respond_output << "ACTION NEEDED: not in YAML 'autostarts:' or ;autostart DB: #{gaps.join(', ')}"
+    respond_output << "add to the profile 'autostarts:' list or via ;autostart add <script> [args]"
+  end
+  user_vars_mod.autostart_scripts = nil
+end
 
 # Replicates the YAML autostart loop of autostart.lic.
 #
 # @param script_mod [Module] mock for Script (running?, exists?, start)
 # @param map_mod [Module] mock for Map (apply_wayto_overrides)
-# @param user_vars_mod [Module] mock for UserVars (autostart_scripts)
-# @param yaml_autostarts [Array<String>, nil] simulated get_settings.autostarts
+# @param yaml_autostarts [Array, nil] simulated get_settings.autostarts
 # @param has_get_settings [Boolean] whether get_settings is available (false on old GS lich)
 # @param respond_output [Array<String>] collects warning messages
 # @return [Array<String>, nil] list of started script names, or nil if skipped
 def run_yaml_autostart_loop(script_mod: MockScript,
                             map_mod: MockMap,
-                            user_vars_mod: MockUserVars,
                             yaml_autostarts: [],
                             has_get_settings: true,
                             respond_output: [])
   return unless has_get_settings
 
-  user_vars_mod.autostart_scripts ||= []
-  all_autostarts = (user_vars_mod.autostart_scripts.to_a +
-                    yaml_autostarts.to_a).uniq
+  entries = build_yaml_autostart_entries(yaml_autostarts: yaml_autostarts)
 
   map_mod.apply_wayto_overrides if map_mod.respond_to?(:apply_wayto_overrides)
 
   started = []
-  all_autostarts.each do |script_name|
+  entries.each do |script_name, args|
     next if script_name == 'dependency'
     next if defined?(DR_OBSOLETE_SCRIPTS) && DR_OBSOLETE_SCRIPTS.include?(script_name)
     next if script_mod.running?(script_name)
@@ -158,7 +229,7 @@ def run_yaml_autostart_loop(script_mod: MockScript,
     end
 
     started << script_name
-    script_mod.start(script_name)
+    script_mod.start(script_name, args: args)
   end
   started
 end
@@ -418,28 +489,6 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
     end
   end
 
-  describe "UserVars autostarts" do
-    it "starts scripts from UserVars.autostart_scripts" do
-      MockUserVars.autostart_scripts = ['my-script']
-      started = run_yaml_autostart_loop(yaml_autostarts: [])
-      expect(started).to eq(['my-script'])
-    end
-
-    it "initializes UserVars.autostart_scripts to empty array when nil" do
-      MockUserVars.autostart_scripts = nil
-      run_yaml_autostart_loop(yaml_autostarts: [])
-      expect(MockUserVars.autostart_scripts).to eq([])
-    end
-  end
-
-  describe "merging UserVars and YAML" do
-    it "combines and deduplicates UserVars and YAML autostarts" do
-      MockUserVars.autostart_scripts = ['shared', 'uvar-only']
-      started = run_yaml_autostart_loop(yaml_autostarts: ['shared', 'yaml-only'])
-      expect(started).to contain_exactly('shared', 'uvar-only', 'yaml-only')
-    end
-  end
-
   describe "wayto overrides" do
     it "applies Map.apply_wayto_overrides" do
       run_yaml_autostart_loop(yaml_autostarts: [])
@@ -485,14 +534,11 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
 
   describe "GS character with no YAML profiles" do
     it "handles nil autostarts from missing base.yaml and no character profile" do
-      MockUserVars.autostart_scripts = nil
       started = run_yaml_autostart_loop(yaml_autostarts: nil)
       expect(started).to eq([])
-      expect(MockUserVars.autostart_scripts).to eq([])
     end
 
     it "still applies wayto overrides even with no autostarts" do
-      MockUserVars.autostart_scripts = nil
       run_yaml_autostart_loop(yaml_autostarts: nil)
       expect(MockMap.applied).to be true
     end
@@ -504,16 +550,6 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
   end
 
   describe "adversarial inputs" do
-    it "handles nil entries in UserVars.autostart_scripts" do
-      MockUserVars.autostart_scripts = [nil, 'esp', nil]
-      allow(MockScript).to receive(:running?).and_call_original
-      allow(MockScript).to receive(:exists?).and_call_original
-      allow(MockScript).to receive(:running?).with(nil).and_return(false)
-      allow(MockScript).to receive(:exists?).with(nil).and_return(false)
-      started = run_yaml_autostart_loop(yaml_autostarts: [])
-      expect(started).to eq(['esp'])
-    end
-
     it "handles nil entries in YAML autostarts" do
       allow(MockScript).to receive(:running?).and_call_original
       allow(MockScript).to receive(:exists?).and_call_original
@@ -530,25 +566,12 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
       expect(started).to eq(['esp'])
     end
 
-    it "deduplicates across UserVars and YAML when both contain the same script" do
-      MockUserVars.autostart_scripts = ['esp', 'afk']
-      started = run_yaml_autostart_loop(yaml_autostarts: ['afk', 'esp'])
-      expect(started).to eq(['esp', 'afk'])
-    end
-
-    it "deduplicates within UserVars itself" do
-      MockUserVars.autostart_scripts = ['esp', 'esp', 'esp']
-      started = run_yaml_autostart_loop(yaml_autostarts: [])
-      expect(started).to eq(['esp'])
-    end
-
-    it "deduplicates within YAML autostarts itself" do
+    it "deduplicates within the YAML autostarts list itself" do
       started = run_yaml_autostart_loop(yaml_autostarts: ['afk', 'afk', 'afk'])
       expect(started).to eq(['afk'])
     end
 
-    it "handles both UserVars and YAML being nil simultaneously" do
-      MockUserVars.autostart_scripts = nil
+    it "handles nil YAML autostarts" do
       started = run_yaml_autostart_loop(yaml_autostarts: nil)
       expect(started).to eq([])
     end
@@ -568,9 +591,8 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
       expect(output.size).to eq(2)
     end
 
-    it "skips dependency even when it appears in both UserVars and YAML" do
-      MockUserVars.autostart_scripts = ['dependency']
-      started = run_yaml_autostart_loop(yaml_autostarts: ['dependency', 'esp'])
+    it "skips dependency even when it appears twice in the YAML list" do
+      started = run_yaml_autostart_loop(yaml_autostarts: ['dependency', 'dependency', 'esp'])
       expect(started).to eq(['esp'])
     end
   end
@@ -583,16 +605,6 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
       started = run_yaml_autostart_loop(yaml_autostarts: ['typo-script'], respond_output: output)
       expect(started).to eq([])
       expect(output).to include(a_string_matching(/typo-script.*not found/))
-    end
-
-    it "warns when a UserVars autostart script does not exist" do
-      MockUserVars.autostart_scripts = ['gone-script']
-      allow(MockScript).to receive(:exists?).and_call_original
-      allow(MockScript).to receive(:exists?).with('gone-script').and_return(false)
-      output = []
-      started = run_yaml_autostart_loop(yaml_autostarts: [], respond_output: output)
-      expect(started).to eq([])
-      expect(output).to include(a_string_matching(/gone-script.*not found/))
     end
 
     it "warns for each missing script individually" do
@@ -634,5 +646,225 @@ RSpec.describe "YAML autostart loop (game-agnostic)" do
       expect(output.size).to eq(1)
       expect(output.first).to match(/missing.*not found/)
     end
+  end
+end
+
+RSpec.describe "normalize_autostart_entry" do
+  it "normalizes a bare script name to [name, []]" do
+    expect(normalize_autostart_entry('lichbot')).to eq(['lichbot', []])
+  end
+
+  it "splits a name-with-args string on whitespace" do
+    expect(normalize_autostart_entry('lichbot start')).to eq(['lichbot', ['start']])
+  end
+
+  it "handles multiple args and collapses extra whitespace" do
+    expect(normalize_autostart_entry('  foo  a   b ')).to eq(['foo', ['a', 'b']])
+  end
+
+  it "normalizes a symbol-keyed hash" do
+    expect(normalize_autostart_entry(name: 'lichbot', args: ['start']))
+      .to eq(['lichbot', ['start']])
+  end
+
+  it "normalizes a string-keyed hash (as produced by YAML)" do
+    expect(normalize_autostart_entry('name' => 'lichbot', 'args' => ['start']))
+      .to eq(['lichbot', ['start']])
+  end
+
+  it "prefers symbol keys but falls back to string keys" do
+    expect(normalize_autostart_entry('name' => 'foo', 'args' => %w[a b]))
+      .to eq(['foo', %w[a b]])
+  end
+
+  it "coerces non-string hash args to strings" do
+    expect(normalize_autostart_entry(name: 'foo', args: [1, :two]))
+      .to eq(['foo', ['1', 'two']])
+  end
+
+  it "wraps a scalar (non-array) hash args value" do
+    expect(normalize_autostart_entry(name: 'foo', args: 'start'))
+      .to eq(['foo', ['start']])
+  end
+
+  it "returns empty args when a hash omits args" do
+    expect(normalize_autostart_entry(name: 'foo')).to eq(['foo', []])
+  end
+
+  it "yields a blank name for a nil entry (caller rejects it)" do
+    expect(normalize_autostart_entry(nil)).to eq(['', []])
+  end
+
+  it "yields a blank name for an empty string" do
+    expect(normalize_autostart_entry('')).to eq(['', []])
+  end
+
+  it "yields a blank name for a whitespace-only string" do
+    expect(normalize_autostart_entry('   ')).to eq(['', []])
+  end
+
+  it "yields a blank name for a hash with no name" do
+    expect(normalize_autostart_entry(args: ['start'])).to eq(['', ['start']])
+  end
+end
+
+RSpec.describe "YAML autostart args support" do
+  before do
+    MockScript.reset!
+    MockMap.reset!
+    MockUserVars.reset!
+  end
+
+  it "passes args from a name-with-args string to Script.start" do
+    run_yaml_autostart_loop(yaml_autostarts: ['lichbot start'])
+    expect(MockScript.started).to eq([{ name: 'lichbot', args: ['start'] }])
+  end
+
+  it "passes args from a symbol-keyed hash entry" do
+    run_yaml_autostart_loop(yaml_autostarts: [{ name: 'lichbot', args: ['start'] }])
+    expect(MockScript.started).to eq([{ name: 'lichbot', args: ['start'] }])
+  end
+
+  it "passes args from a string-keyed hash entry" do
+    run_yaml_autostart_loop(yaml_autostarts: [{ 'name' => 'lichbot', 'args' => ['start'] }])
+    expect(MockScript.started).to eq([{ name: 'lichbot', args: ['start'] }])
+  end
+
+  it "starts a bare-name entry with empty args (backward compatible)" do
+    run_yaml_autostart_loop(yaml_autostarts: ['esp'])
+    expect(MockScript.started).to eq([{ name: 'esp', args: [] }])
+  end
+
+  it "rejects nil-name and empty-name entries before starting" do
+    started = run_yaml_autostart_loop(yaml_autostarts: [nil, '', '   ', 'esp'])
+    expect(started).to eq(['esp'])
+    expect(MockScript.started).to eq([{ name: 'esp', args: [] }])
+  end
+
+  it "de-dups duplicate names in the list; when both carry args the first wins" do
+    started = run_yaml_autostart_loop(
+      yaml_autostarts: ['lichbot start', { name: 'lichbot', args: ['stop'] }]
+    )
+    expect(started).to eq(['lichbot'])
+    # Both carry args, so first occurrence ('start') wins over 'stop'.
+    expect(MockScript.started).to eq([{ name: 'lichbot', args: ['start'] }])
+  end
+
+  it "lets an args entry win over a bare duplicate regardless of order" do
+    # A bare 'lichbot' listed before 'lichbot start' must not strip the args.
+    started = run_yaml_autostart_loop(yaml_autostarts: ['lichbot', 'lnet', 'lichbot start'])
+    expect(started).to eq(['lichbot', 'lnet'])
+    expect(MockScript.started).to eq([
+                                       { name: 'lichbot', args: ['start'] },
+                                       { name: 'lnet', args: [] }
+                                     ])
+  end
+
+  it "lets an args entry win even when the bare duplicate comes later" do
+    started = run_yaml_autostart_loop(yaml_autostarts: ['lichbot start', 'lichbot'])
+    expect(started).to eq(['lichbot'])
+    expect(MockScript.started).to eq([{ name: 'lichbot', args: ['start'] }])
+  end
+
+  it "applies the dependency skip-guard to normalized entries" do
+    started = run_yaml_autostart_loop(yaml_autostarts: ['dependency start', 'esp'])
+    expect(started).to eq(['esp'])
+  end
+end
+
+RSpec.describe "autostart_covered_names" do
+  it "collects names from the YAML autostarts list" do
+    covered = build_autostart_covered_names(yaml_autostarts: ['lichbot start', 'lnet'])
+    expect(covered).to contain_exactly('lichbot', 'lnet')
+  end
+
+  it "collects names from the global and per-character DB lists" do
+    covered = build_autostart_covered_names(
+      settings_scripts: [{ name: 'alias', args: [] }],
+      char_scripts: [{ name: 'go2', args: [] }]
+    )
+    expect(covered).to contain_exactly('alias', 'go2')
+  end
+
+  it "unions and de-dups across YAML and DB, ignoring blanks" do
+    covered = build_autostart_covered_names(
+      yaml_autostarts: ['lichbot start', '', nil],
+      settings_scripts: [{ name: 'lichbot', args: [] }, { name: 'alias', args: [] }]
+    )
+    expect(covered).to contain_exactly('lichbot', 'alias')
+  end
+
+  it "tolerates non-array DB lists" do
+    covered = build_autostart_covered_names(yaml_autostarts: ['lnet'], settings_scripts: 'nope')
+    expect(covered).to eq(['lnet'])
+  end
+end
+
+RSpec.describe "legacy UserVars.autostart_scripts migration" do
+  before do
+    MockUserVars.reset!
+  end
+
+  it "does nothing when UserVars.autostart_scripts is nil" do
+    MockUserVars.autostart_scripts = nil
+    output = []
+    run_legacy_uservars_migration(respond_output: output)
+    expect(output).to be_empty
+    expect(MockUserVars.autostart_scripts).to be_nil
+  end
+
+  it "does nothing when UserVars.autostart_scripts is empty" do
+    MockUserVars.autostart_scripts = []
+    output = []
+    run_legacy_uservars_migration(respond_output: output)
+    expect(output).to be_empty
+  end
+
+  it "quietly clears when every entry is already covered by YAML/DB" do
+    # The real-world case: bare 'lichbot' in UserVars is covered by 'lichbot start'
+    # in YAML; the rest are covered too. No loud warning, just a clearing note.
+    MockUserVars.autostart_scripts = ['lichbot', 'lnet']
+    output = []
+    run_legacy_uservars_migration(covered: ['lichbot', 'lnet'], respond_output: output)
+
+    joined = output.join("\n")
+    expect(joined).to match(/clearing/i)
+    expect(joined).not_to match(/ACTION NEEDED/)
+    expect(MockUserVars.autostart_scripts).to be_nil
+  end
+
+  it "loudly warns about entries missing from both YAML and DB, then clears" do
+    MockUserVars.autostart_scripts = ['lichbot', 'orphan1', 'orphan2']
+    output = []
+    run_legacy_uservars_migration(covered: ['lichbot'], respond_output: output)
+
+    joined = output.join("\n")
+    expect(joined).to match(/ACTION NEEDED/)
+    expect(joined).to match(/orphan1, orphan2/)
+    expect(joined).not_to match(/\blichbot\b/) # covered entry is not called out as a gap
+    expect(joined).to match(/autostarts:/)
+    expect(joined).to match(/autostart add/)
+    expect(MockUserVars.autostart_scripts).to be_nil
+  end
+
+  it "treats every entry as a gap when nothing is covered" do
+    MockUserVars.autostart_scripts = ['a', 'b']
+    output = []
+    run_legacy_uservars_migration(covered: [], respond_output: output)
+    joined = output.join("\n")
+    expect(joined).to match(/ACTION NEEDED/)
+    expect(joined).to match(/a, b/)
+    expect(MockUserVars.autostart_scripts).to be_nil
+  end
+
+  it "fires only once (second run is a no-op after clearing)" do
+    MockUserVars.autostart_scripts = ['orphan']
+    first = []
+    run_legacy_uservars_migration(covered: [], respond_output: first)
+    expect(first).not_to be_empty
+
+    second = []
+    run_legacy_uservars_migration(covered: [], respond_output: second)
+    expect(second).to be_empty
   end
 end


### PR DESCRIPTION
## Summary

Two related changes to `autostart.lic`:

1. **Per-script args for YAML autostarts.** Entries in the profile's `get_settings.autostarts` list may now optionally carry arguments, fully backward-compatible with today's bare-name entries.
2. **Retire the legacy `UserVars.autostart_scripts` store.** It is no longer a launch source; a one-time, read-only login check clears it -- quietly when every entry is already covered by YAML/DB, or with a loud `ACTION NEEDED` notice naming any gap otherwise.

The DB-backed `;autostart add/remove/list` path (which already supports args) is untouched.

## The three accepted entry formats

| Form | Example | Result |
|------|---------|--------|
| Bare name (current) | `- lichbot` | name `lichbot`, no args |
| Name with args | `- lichbot start announce` | name `lichbot`, args `['start', 'announce']` (whitespace-split) |
| Hash | `- { name: lichbot, args: [start, announce] }` | name `lichbot`, args `['start', 'announce']` |

Hash keys may be Symbols (`:name`/`:args`) or Strings (`'name'`/`'args'`), since YAML parses inline hash keys as Strings; both are accepted.

## Motivating case: lichbot

`lichbot` requires a `start` argument as an accidental-launch guard, but is commonly autostarted via the YAML list, which could previously only launch scripts arg-less. That forced users to fork lichbot to make `start` optional. This change removes that need -- `- lichbot start` now works.

## Retiring UserVars.autostart_scripts

`UserVars.autostart_scripts` was the old DR autostart store. **Nothing has written to it since the DR `dependency.lic` autostart path was removed (v0.72)** -- `autostart.lic` was the only functional reader, and `version.lic` had a diagnostic that reported it. It is now retired:

- `autostart.lic` no longer merges it into the launch list; the profile YAML `autostarts:` list is the single source.
- A one-time login check (`migrate_legacy_uservars_autostarts`, **read-only on UserVars**) compares any stale names against what is already covered by the YAML `autostarts:` list and the `;autostart` DB lists (`autostart_covered_names`), then clears the UserVar:
  - **All entries already covered** (the common case) -> clears quietly with a brief "no longer used, no action needed" note.
  - **Any entry missing from both YAML and DB** -> prints a loud `ACTION NEEDED` notice naming exactly which scripts would stop autostarting and the two ways to re-add them (profile YAML `autostarts:` list, or `;autostart add <script> [args]`).
  - Nothing is ever re-added automatically -- the user chooses where each script should live. The UserVar is always cleared so the check runs once.
- `version.lic` (bumped v1.3.1 -> v1.3.2) drops its now-dead "DR autostarts" diagnostic, adds an "Autostart profile (YAML)" line so the YAML source is visible, and labels the existing database lists "(DB)" -- so `;version --details` now shows each autostart source (global DB, per-character DB, YAML profile) distinctly.

This stale store is exactly what silently broke args in the field: a legacy bare `lichbot` lingering in a user's `UserVars.autostart_scripts` beat the profile's `lichbot start` entry during the old merge+dedup, launching lichbot with no args.

## De-dup behavior

Entries are normalized to `[name, args]` and de-duped by name. On a name collision an entry that **carries args wins over a bare (arg-less) duplicate**; if several carry args, the first wins. Start order follows first occurrence. This prevents a duplicate bare `lichbot` from stripping the args off a `lichbot start` entry.

## Backward compatibility

A plain `- somescript` entry still normalizes to `['somescript', []]` and starts exactly as before. Bare-name behavior and the "not found, skipping" notice are preserved. Users with scripts only in `UserVars.autostart_scripts` get a clear one-time notice telling them exactly what to re-add and where.

## Design (SOLID / DRY)

New logic is extracted into small, single-responsibility, fully YARD-documented top-level methods; the main block reads as orchestration only:

- `normalize_autostart_entry(entry) -> [name, args]` -- the single source of truth for entry formats (Open/Closed: a future format is a localized change here).
- `yaml_autostart_entries -> Array<[name, args]>` -- reads `get_settings.autostarts`, normalizes, drops blank names, and de-dups by name (args-carrying entry wins over a bare duplicate).
- `launch_autostart(name, args)` -- the single home for the skip-guards (`dependency`, `DR_OBSOLETE_SCRIPTS`, already-running, missing-on-disk) plus the `start_script(name, args)` call.
- `autostart_covered_names` -- the union of names already autostarted via YAML + the DB lists.
- `migrate_legacy_uservars_autostarts` -- the one-time, coverage-aware UserVars notice + clear.

Args are passed via `start_script(name, args)`, which forwards to `Script.start(name, args.join(' '), {})` and populates `script.vars` for the target's `parse_args` -- the same effect as the DB path's `Script.start(name, :args => args)`.

**DRY note on the DB path:** the normalizer is intentionally scoped to the YAML path and not shared with the Settings/CharSettings DB loop. That loop already stores normalized `{ :name, :args }` hashes and carries a distinct guard set (infomon/repository skips, lich5-update skip, DR dependency removal), so reusing the normalizer there would add coupling without removing duplication. This is documented in an in-code comment.

## Version / changelog

Bumps `autostart.lic` `version:` 0.73 -> 0.74 and `version.lic` 1.3.1 -> 1.3.2, each with a dated changelog entry (required by the files' own conventions). `version.lic` also gains an "Autostart profile (YAML)" report line and "(DB)" labels on the existing lists so all three autostart sources are distinguishable in `;version --details`.

## Tests

`spec/autostart/autostart_spec.rb` reworked for the single YAML source and extended with `describe` blocks that unit-test the normalizer (bare string, string-with-args, symbol-key hash, string-key hash, scalar args, nil/empty/whitespace-name rejection), verify args reach `Script.start`, cover the args-win-over-bare dedup in both orders, cover the coverage computation (YAML + DB union), and cover the legacy-UserVars migration (quiet clear when all covered, loud `ACTION NEEDED` naming only the gaps otherwise, always clears, fires only once). **76 examples, 0 failures.** `ruby -c` and `rubocop` are clean on all changed files (run under Ruby 4.0.1).

## Companion docs (follow-ups)

- **Settings docs:** `autostarts:` is a `get_settings` YAML-profile setting. `get_settings` is **game-agnostic** -- it is provided by core Lich (`lib/global_defs.rb` -> `Lich::Common::SetupFiles`), so the same `autostarts:` syntax applies to both GemStone and DragonRealms; it is not DR-specific. It is **not** currently documented or defaulted as a managed key in any profile defaults (e.g. dr-scripts `profiles/base.yaml` has no `autostarts:` key), so there is no existing example to extend. The canonical format documentation therefore now lives in `autostart.lic` itself (the code that parses the entries), in both a header comment on the normalizer and a comment block above the YAML-autostart section. If a documented default is desired, it could be added to the shared profile defaults for either game.
- **Elanthipedia:** the autostart wiki page should be updated to document the new `name args` / `{name, args}` forms. Wiki edits are out of band -- flagging as a follow-up.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autostart entries can now include optional per-script arguments.
  * Autostart reporting now distinguishes between database-based and YAML-based entries.

* **Bug Fixes**
  * Duplicate YAML autostart entries now resolve consistently, with argument-bearing entries taking priority.
  * Legacy autostart data is now cleared after a one-time gap check, reducing confusion from outdated settings.

* **Documentation**
  * Updated version notes to reflect the latest autostart reporting and retirement changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->