### PR TITLE
fix(eloot): add hook registration and bump version to 2.9.11

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -18,7 +18,7 @@
            version: 2.9.11
   Improvements:
   Major_change.feature_addition.bugfix
-  v2.9.11 (2026-07-03
+  v2.9.11 (2026-07-03)
     - added Lich 5.19.0 check and hook registry for up/downstream persistent hooks
   v2.9.10 (2026-06-18)
     - bugfix for gemshop bulk sell selling an entire sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.9.10
+           version: 2.9.11
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.9.11 (2026-07-03
+    - added Lich 5.19.0 check and hook registry for up/downstream persistent hooks
   v2.9.10 (2026-06-18)
     - bugfix for gemshop bulk sell selling an entire sack when only some gems were sell-excluded; now bulk sells only when the sack has gems and none are excluded
   v2.9.9  (2026-06-18)
@@ -214,16 +216,33 @@ module ELoot # Writes debug output to a file
         log("Starting up!\n#{eloot_details}")
       end
 
+      # v5.19.0 introduces a shared hook registry. Hooks are either
+      # removed when their owning script exits, or explicitly marked
+      # to persist and are cleaned up separately.
+      # Drop conditional at Ruby required > 2.7
       @worker_thread = Thread.new {
-        UpstreamHook.add("debug_upstream_hook", proc { |data|
-          @log_writer << ">#{data.sub(/^<c>/, '')}".strip
-          data
-        })
-
-        DownstreamHook.add("debug_downstream_hook", proc { |data|
-          @log_writer << data.strip
-          data
-        })
+        if UpstreamHook.method(:add).parameters.any? { |_t, n| n == :persist }
+          UpstreamHook.add("debug_upstream_hook", proc { |data|
+            @log_writer << ">#{data.sub(/^<c>/, '')}".strip
+            data
+          }, persist: true)
+        else
+          UpstreamHook.add("debug_upstream_hook", proc { |data|
+            @log_writer << ">#{data.sub(/^<c>/, '')}".strip
+            data
+          })
+        end
+        if DownstreamHook.method(:add).parameters.any? { |_t, n| n == :persist }
+          DownstreamHook.add("debug_downstream_hook", proc { |data|
+            @log_writer << data.strip
+            data
+          }, persist: true)
+        else
+          DownstreamHook.add("debug_downstream_hook", proc { |data|
+            @log_writer << data.strip
+            data
+          })
+        end
 
         loop do
           current_last = $_LASTUPSTREAM_


### PR DESCRIPTION
Updated version to 2.9.11 and added Lich 5.19.0 check with hook registry support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer platform versions.
  * Made debug logging hooks more reliable across supported environments, helping persistent logging continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->