### PR TITLE
fix(autostart.lic): v0.75 adjust ACCOUNT command handling

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.74
+       version: 0.75
       required: Lich >= 4.6.58
 
   changelog:
+    0.75 (2026-07-05):
+      Perform ACCOUNT/PLAYED command non-squelched due to other game feed MONO lines coming in, unable to reliably squelch proper line
     0.74 (2026-07-03):
       YAML autostarts (get_settings.autostarts) accept optional per-script args:
         bare "name", "name arg1 arg2", or { name:, args: } hash forms
@@ -240,9 +242,9 @@ if defined?(Lich::Common::Account) && (Lich::Common::Account.subscription.nil? |
   waitrt?
   case XMLData.game
   when /^DR/i
-    Lich::Util.issue_command("PLAYED", /^Account Info for /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: true)
+    Lich::Util.issue_command("PLAYED", /^Account Info for /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: false)
   when /^GS/i
-    Lich::Util.issue_command("ACCOUNT", /<output class="mono"\/>/, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: true)
+    Lich::Util.issue_command("ACCOUNT", /^Game Instance: /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: false)
   end
   respond "Account subscription detected as #{Lich::Common::Account.subscription}"
 end

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -244,7 +244,7 @@ if defined?(Lich::Common::Account) && (Lich::Common::Account.subscription.nil? |
   when /^DR/i
     Lich::Util.issue_command("PLAYED", /^Account Info for /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: false)
   when /^GS/i
-    Lich::Util.issue_command("ACCOUNT", /^Game Instance: /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: false)
+    Lich::Util.issue_command("ACCOUNT", /^(?:<pushBold\/>)?Game Instance:(?:<popBold\/>)? /, /<prompt/, include_end: true, timeout: 5, silent: false, usexml: true, quiet: false)
   end
   respond "Account subscription detected as #{Lich::Common::Account.subscription}"
 end


### PR DESCRIPTION
Updated version to 0.75 and modified command behavior for ACCOUNT and PLAYED.