### PR TITLE
fix(bigshot): missing regex in cmd_shields

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.14.1
+       version: 5.14.2
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.14.2  (2026-07-06)
+    - fix cmd_shields missing regex
   v5.14.1  (2026-06-18)
     - remove greedy prone check for bullrush
   v5.14.0  (2026-06-17)
@@ -3906,6 +3908,7 @@ class Bigshot
       /diversionary shield bash/i,
       /charge headlong towards/i,
       /attempt to push/i,
+      /You must be wielding a shield\./,
     )
 
     result_regex = Regexp.union(complete_regex, /\.\.\.wait/i)


### PR DESCRIPTION
Adding this regex pattern prevents the command from repeating (and failing) unnecessarily when you don't have your shield out.