### PR TITLE
fix(ebounty.lic): v1.11.2 properly set start_room on script startup

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.12.10
-       version: 1.11.1
+       version: 1.11.2
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.11.2 (2026-07-08)
+    - properly set start room ID
   v1.11.1 (2026-07-05)
     - add red trafel mushroom & black hook mushroom to find herb stow list method
   v1.11.0 (2026-06-07)
@@ -3659,6 +3661,10 @@ end
 # Initialize default settings
 unless EBounty.data
   EBounty.load(EBounty.load_profile())
+end
+
+unless Room.current.id.nil?
+  EBounty.data.start_room = Room.current.id
 end
 
 if EBounty.data.settings[:return_to_group]


### PR DESCRIPTION
Updated version to 1.11.2 and added new feature for start room ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the start room ID was not set correctly in certain cases.
  * The script now initializes the start room ID when a current room is available, helping ensure progression starts from the right location.
  * Updated the release version information to reflect the latest patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->