### PR TITLE
fix(resource.lic): v1.12.1 enable Battle Standard and Bloodstone Jewelry chance calculations

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -31,9 +31,13 @@ contributors: Tysong, FFNG, Xanlin, Rinualdo, Maodan
         game: gemstone
         tags: resource, tears, 330, santify, grit, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic, grit, wps, devotion, jesus juice, sanctify, 330, permabless, 620, ranger, druid fluid, grace, luck inspiration, paladin, empath, bloodstone, 1135
     requires: Lich > 5.5.0
-     version: 1.12.0
+     version: 1.12.1
 
   changelog:
+    1.12.1 (2026-07-13)
+      Add Battle Standard (B1-B6) difficulty calculation
+      Fix Bloodstone Jewelry (J1-J5) to use the same correct formula
+      Add Paladin to auto-bonus profession detection
     1.12.0 (2025-05-01)
       Added option to run silently to update the saved data (for autostarting/autoupdating)
       Updated header version requirement to match tested version

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -462,7 +462,7 @@ class Resource
   end
 
   def self.chance(item_difficulty, type, bonus)
-    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath$/)
+    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath|Paladin$/)
       unless type =~ /^(e(?:50|[1-4][0-9]|[0-9])|[tmj](?:[1-5])|[slb](?:[1-6])|[ra](?:2[0-5]|1[0-9]|[1-9]))$/i
         respond "Need to provide an item difficulty and bonus type too use advanced chance option."
         respond "  ;resource chance <ItemDifficulty> <BonusType> <SkillBonus>"
@@ -475,8 +475,8 @@ class Resource
         respond "    Resistance         - R1 to R25"
         respond "    Covert Arts        - A1 to A25"
         respond "    Luck               - L1 to L6"
-        respond "    Battle Standard    - B1 to B6 (not implemented)"
-        respond "    Bloodstone Jewelry - J1 to J5 (not implemented)"
+        respond "    Battle Standard    - B1 to B6"
+        respond "    Bloodstone Jewelry - J1 to J5"
         respond ""
         respond "  Will attempt to be smart if no SkillBonus given."
         return
@@ -494,8 +494,12 @@ class Resource
         penalty = (($1.to_i == 6) ? 50 : 20)
       when /l([1-6])/i
         penalty = (($1.to_i == 1) ? 150 : 75)
+      when /b([1-6])/i
+        penalty = 75 + ($1.to_i * 75)
+        item_difficulty = 0
       when /j([1-5])/i
-        penalty = (($1.to_i == 1) ? 150 : 75)
+        penalty = 75 + ($1.to_i * 75)
+        item_difficulty = 0
       when /r(2[0-5]|1[0-9]|[1-9])/i
         penalty = $1.to_i
         item_difficulty = 0
@@ -1273,7 +1277,8 @@ class Resource
     respond "       Professions supported: wizard, sorcerer, cleric"
     respond "   ;resource chance <DIFFICULTY> <TYPE> <BONUS> - Will calculate the chance to succeed"
     respond "       Supports Enchant(E1-E50), Ensorcell(T1-T5), Sanctify(S1-S6), Tattooing(M1-M5),"
-    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Bloodstone Jewelry(J1-J5)"
+    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Battle Standard(B1-B6),"
+    respond "                Bloodstone Jewelry(J1-J5)"
     respond ""
     respond "   ;resource chance - Description Of Test CASTs And Chance To Succeed"
     respond "   ;resource rolls  - Numeric Values For Roll Descriptions"


### PR DESCRIPTION
## Summary
- Add Battle Standard (B1-B6) difficulty calculation to `resource.lic` chance command using the formula from gswiki: `75 + (tier * 75)`, giving absolute difficulties of 150, 225, 300, 375, 450, 525
- Fix Bloodstone Jewelry (J1-J5) to use the same correct formula instead of the previous placeholder values (150/75)
- Both use absolute difficulty (`item_difficulty = 0`), matching how Resistance and Covert Arts work
- Add Paladin to auto-bonus profession detection so `;resource chance <difficulty> B1` works without manually specifying a skill bonus
- Remove "(not implemented)" labels and update help text

## Notes
- Difficulty formula sourced from gswiki: both Battle Standard and Bloodstone Jewelry use `75 + (tier * 75)`
- The Paladin bonus formula was already fully implemented in the `bonus` method - only the `chance` method's profession regex was missing it
