### PR TITLE
fix(bigshot.lic): v5.14.3 mismatch in essence command amount regex

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.14.3  (2026-07-13)
+    - fix missing essence regex pattern
   v5.14.2  (2026-07-06)
     - fix cmd_shields missing regex
   v5.14.1  (2026-06-18)
@@ -2614,7 +2616,7 @@ class Bigshot
   def initialize_command_data
     @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
 
-    @COMMAND_AMOUNT_REGEX = /((?:!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
+    @COMMAND_AMOUNT_REGEX = /((?:!?e|!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
     @COMMAND_BUFF_REGEX = /((?:buff))(\d+)/i.freeze
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.14.2
+       version: 5.14.3
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -2614,7 +2614,7 @@ class Bigshot
   def initialize_command_data
     @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
 
-    @COMMAND_AMOUNT_REGEX = /((?:!?e|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
+    @COMMAND_AMOUNT_REGEX = /((?:!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
     @COMMAND_BUFF_REGEX = /((?:buff))(\d+)/i.freeze
 


### PR DESCRIPTION
The amount check for shadow essence doesn't work because the check_type regex is 'e', but we're expecting 'essence' during the lookup to get the actual check lambda:
```
[bigshot: command_check amount | modifier: essence1 | check: e | amount: 1 | called 
by bigshot:3515:in 'Array#each']
```