### PR TITLE
feat(cartographer.lic): v1.1.0 import cartographer + runtime fixes

### DIFF
--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -402,7 +402,7 @@ class CartographerManager
         # Extract stringprocs
         echo "Extracting StringProc files..."
         # system("cd '#{version_dir}' && tar -xzf stringprocs.tar.gz")
-        Gem::Package.new("").extract_tar_gz(File.open(temp_stringprocs), version_dir)
+        Gem::Package.new("").extract_tar_gz(File.open(temp_stringprocs, 'rb'), version_dir)
         if Dir.exist?(File.join(version_dir, "stringprocs"))
           File.delete(temp_stringprocs)
           echo "Successfully extracted StringProc files"

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -717,9 +717,11 @@ end
 # Cartographer class for userland StringProc evaluation
 class Cartographer
   @@base_path ||= nil
+  @@script_cache ||= {}
 
   def self.set_base_path(path)
     @@base_path = path
+    @@script_cache.clear
   end
 
   def self.evaluate_script(relative_path)
@@ -734,19 +736,24 @@ class Cartographer
     end
 
     full_path = File.join(@@base_path, 'stringprocs', relative_path)
-    unless File.exist?(full_path)
-      error_msg = "StringProc file not found: #{full_path}"
-      respond "Error: #{error_msg}"
-      if relative_path.include?('timeto/')
-        return 0.2  # Default timing fallback for timeto only
-      else
-        raise error_msg  # Throw error for wayto
+    script_content = @@script_cache[full_path]
+    if script_content.nil?
+      unless File.exist?(full_path)
+        error_msg = "StringProc file not found: #{full_path}"
+        respond "Error: #{error_msg}"
+        if relative_path.include?('timeto/')
+          return 0.2  # Default timing fallback for timeto only
+        else
+          raise error_msg  # Throw error for wayto
+        end
       end
+      script_content = File.read(full_path)
+      @@script_cache[full_path] = script_content
     end
 
     begin
-      script_content = File.read(full_path)
-      # Evaluate the script content directly - no caching since state can change
+      # Only the file contents are cacheable - the result depends on live
+      # game state (spells, skills), so every call re-evaluates.
       result = eval(script_content)
       return result
     rescue => e

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -729,7 +729,7 @@ class Cartographer
       error_msg = "Cartographer base path not set"
       respond "Error: #{error_msg}"
       if relative_path.include?('timeto/')
-        return 0.2  # Default timing fallback for timeto only
+        return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
       else
         raise error_msg  # Throw error for wayto
       end
@@ -742,7 +742,7 @@ class Cartographer
         error_msg = "StringProc file not found: #{full_path}"
         respond "Error: #{error_msg}"
         if relative_path.include?('timeto/')
-          return 0.2  # Default timing fallback for timeto only
+          return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
         else
           raise error_msg  # Throw error for wayto
         end
@@ -760,7 +760,7 @@ class Cartographer
       error_msg = "Failed to evaluate StringProc #{relative_path}: #{e.message}"
       respond "Error: #{error_msg}"
       if relative_path.include?('timeto/')
-        return 0.2  # Default timing fallback for timeto only
+        return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
       else
         raise error_msg  # Throw error for wayto
       end

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -775,8 +775,14 @@ end
 
 # Main execution
 if defined?(Script.current)
-  manager = CartographerManager.new
-  manager.run(Script.current.vars)
+  if XMLData.game =~ /^GS/
+    manager = CartographerManager.new
+    manager.run(Script.current.vars)
+  else
+    # The mapdb releases contain GemStone rooms only; loading them into a
+    # DragonRealms session would overwrite the DR map with GS data.
+    respond "Error: cartographer distributes the GemStone IV map database and cannot be used with #{XMLData.game}"
+  end
 else
   respond "This script must be run within Lich"
 end

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -679,6 +679,11 @@ if defined?(Map)
       end
 
       begin
+        # StringProcs in this file resolve through Cartographer.evaluate_script,
+        # so the base path must track whichever version gets loaded - even when
+        # this method is called directly instead of via the ;cartographer script.
+        Cartographer.set_base_path(File.join(cartographer_dir, version))
+
         # Use the existing Map.load_json method which handles all the class variable initialization
         if Map.respond_to?(:load_json)
           Map.clear

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -17,8 +17,15 @@
     ;cartographer --help            # Show help
 
   author: Ondreian
-  contributor: Claude Code
-  version: 1.0.0
+  contributors: Claude Code, Nisugi
+  version: 1.1.0
+
+  changelog:
+    v1.1.0 - read stringprocs tarball in binary mode (Windows fix); cache
+             StringProc file reads; failed timeto procs mark the edge
+             unroutable instead of returning a fake 0.2; Map.load_cartographer
+             sets the StringProc base path itself; refuse to run outside GS
+    v1.0.0 - initial release
 
 =end
 

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -29,15 +29,13 @@
 
 =end
 
-
-
 require 'net/http'
 require 'uri'
 require 'json'
 require 'fileutils'
 
 class CartographerManager
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
   GITHUB_API_BASE = "https://api.github.com/repos/elanthia-online/mapdb"
 
   def initialize
@@ -426,7 +424,7 @@ class CartographerManager
     load_cartographer_data(final_mapdb, version)
   end
 
-  def load_cartographer_data(file_path, version)
+  def load_cartographer_data(_file_path, version)
     echo "Loading cartographer version #{version}..."
 
     begin
@@ -449,7 +447,6 @@ class CartographerManager
         echo "Error: Map class doesn't support cartographer loading"
         echo "The Map class needs to be extended with cartographer support"
       end
-
     rescue => e
       echo "Error loading cartographer data: #{e.message}"
     end
@@ -586,7 +583,6 @@ class CartographerManager
       room_count = data.length
       echo "Validation passed: #{room_count} rooms"
       return true
-
     rescue JSON::ParserError => e
       echo "Error: Invalid JSON - #{e.message}"
       return false
@@ -602,22 +598,21 @@ class CartographerManager
     begin
       rooms = Map.list.compact
       room_count = rooms.length
-      echo "  ✓ Total rooms: #{room_count}"
+      echo "  ok Total rooms: #{room_count}"
 
       if rooms.any?
         # Sample a random room for testing
         sample_room = rooms.sample
-        echo "  ✓ Sample room: ##{sample_room.id} - #{sample_room.title.last}"
+        echo "  ok Sample room: ##{sample_room.id} - #{sample_room.title.last}"
 
         # Test room lookup
         test_room = Map[sample_room.id]
         if test_room && test_room.id == sample_room.id
-          echo "  ✓ Room lookup working"
+          echo "  ok Room lookup working"
         end
       end
 
       echo "Map functionality test completed successfully!"
-
     rescue => e
       echo "Warning: Map functionality test failed - #{e.message}"
     end
@@ -654,13 +649,13 @@ if defined?(Map)
       if version.nil?
         # Load newest version by default
         versions = Dir.entries(cartographer_dir)
-                     .reject { |f| f.start_with?('.') }
-                     .select { |entry|
-                       path = File.join(cartographer_dir, entry)
-                       File.directory?(path) && entry =~ /^[\d.]+$/
-                     }
-                     .sort_by { |v| Gem::Version.new(v) rescue v }
-                     .reverse
+                      .reject { |f| f.start_with?('.') }
+                      .select { |entry|
+                        path = File.join(cartographer_dir, entry)
+                        File.directory?(path) && entry =~ /^[\d.]+$/
+                      }
+                      .sort_by { |v| Gem::Version.new(v) rescue v }
+                      .reverse
 
         if versions.empty?
           respond "No cartographer versions found. Use ';cartographer' to download one."
@@ -676,11 +671,11 @@ if defined?(Map)
       unless File.exist?(file_path)
         respond "Cartographer version not found: #{version}"
         available_versions = Dir.entries(cartographer_dir)
-                               .reject { |f| f.start_with?('.') }
-                               .select { |entry|
-                                 path = File.join(cartographer_dir, entry)
-                                 File.directory?(path) && entry =~ /^[\d.]+$/
-                               }
+                                .reject { |f| f.start_with?('.') }
+                                .select { |entry|
+                                  path = File.join(cartographer_dir, entry)
+                                  File.directory?(path) && entry =~ /^[\d.]+$/
+                                }
         respond "Available versions: #{available_versions.join(', ')}"
         return false
       end
@@ -709,7 +704,6 @@ if defined?(Map)
           respond "Error: Map class doesn't support load_json method"
           return false
         end
-
       rescue => e
         respond "Error loading cartographer file: #{e.message}"
         return false
@@ -743,7 +737,7 @@ class Cartographer
       if relative_path.include?('timeto/')
         return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
       else
-        raise error_msg  # Throw error for wayto
+        raise error_msg # Throw error for wayto
       end
     end
 
@@ -756,7 +750,7 @@ class Cartographer
         if relative_path.include?('timeto/')
           return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
         else
-          raise error_msg  # Throw error for wayto
+          raise error_msg # Throw error for wayto
         end
       end
       script_content = File.read(full_path)
@@ -774,7 +768,7 @@ class Cartographer
       if relative_path.include?('timeto/')
         return nil # nil marks the edge unroutable; a made-up weight would corrupt pathfinding
       else
-        raise error_msg  # Throw error for wayto
+        raise error_msg # Throw error for wayto
       end
     end
   end

--- a/scripts/cartographer.lic
+++ b/scripts/cartographer.lic
@@ -1,0 +1,770 @@
+=begin
+
+  Cartographer
+
+  Downloads and loads Elanthia Online mapdb releases from GitHub into a separate
+  cartographer data directory and extends the Map class with version management.
+
+  Usage:
+    ;cartographer                    # Download and load latest release
+    ;cartographer --version 0.2.0   # Download and load specific version
+    ;cartographer --list            # List downloaded versions
+    ;cartographer --load 0.2.0      # Load specific downloaded version
+    ;cartographer --check           # Check current loaded version
+    ;cartographer --force           # Force re-download of latest version
+    ;cartographer --info            # Show architecture and storage information
+    ;cartographer --prune           # Remove all but the 3 newest versions
+    ;cartographer --help            # Show help
+
+  author: Ondreian
+  contributor: Claude Code
+  version: 1.0.0
+
+=end
+
+
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'fileutils'
+
+class CartographerManager
+  VERSION = "1.0.0"
+  GITHUB_API_BASE = "https://api.github.com/repos/elanthia-online/mapdb"
+
+  def initialize
+    @cartographer_dir = File.join(DATA_DIR, XMLData.game, '_cartographer')
+    FileUtils.mkdir_p(@cartographer_dir) unless Dir.exist?(@cartographer_dir)
+  end
+
+  def run(args = [])
+    force_download = args.include?('--force')
+
+    # Use args[1] for the command since args[0] is the full command string
+    case args[1]
+    when '--help', '-h'
+      show_help
+    when '--list', '-l'
+      list_versions
+    when '--check', '-c'
+      check_current_version
+    when '--info', '-i'
+      show_info
+    when '--prune', '-p'
+      prune_old_versions
+    when '--force'
+      download_and_load_latest(true)
+    when '--load'
+      if args[2]
+        load_version(args[2])
+      else
+        echo "Error: --load requires a version number"
+        echo "Example: ;cartographer --load 0.2.0"
+      end
+    when '--version', '-v'
+      if args[2]
+        download_and_load_version(args[2], force_download)
+      else
+        echo "Error: --version requires a version number"
+        echo "Example: ;cartographer --version 0.2.0"
+      end
+    else
+      download_and_load_latest(force_download)
+    end
+  end
+
+  private
+
+  def show_help
+    echo "Cartographer v#{VERSION}"
+    echo "Downloads and manages Elanthia Online mapdb releases from GitHub"
+    echo ""
+    echo "Usage:"
+    echo "  ;cartographer                   # Download and load latest release"
+    echo "  ;cartographer --version 0.2.0   # Download and load specific version"
+    echo "  ;cartographer --list            # List downloaded versions"
+    echo "  ;cartographer --load 0.2.0      # Load specific downloaded version"
+    echo "  ;cartographer --check           # Check current loaded version"
+    echo "  ;cartographer --force           # Force re-download of latest version"
+    echo "  ;cartographer --info            # Show architecture and storage information"
+    echo "  ;cartographer --prune           # Remove all but the 3 newest versions"
+    echo "  ;cartographer --help            # Show this help"
+    echo ""
+    echo "Data directory: #{@cartographer_dir}"
+  end
+
+  def list_versions
+    versions = get_local_versions
+
+    if versions.empty?
+      echo "No cartographer versions downloaded"
+      echo "Use ';cartographer' to download the latest version"
+      return
+    end
+
+    echo "Downloaded cartographer versions:"
+    versions.each do |version|
+      version_dir = version_dir_path(version)
+      mapdb_path = version_mapdb_path(version)
+      stringprocs_path = version_stringprocs_path(version)
+
+      if Dir.exist?(version_dir)
+        # Calculate total size of version directory
+        total_size = Dir.glob(File.join(version_dir, '**', '*')).select { |f| File.file?(f) }.sum { |f| File.size(f) }
+        mtime = File.mtime(version_dir)
+        current = (defined?(Map) && Map.respond_to?(:cartographer_version) && Map.cartographer_version == version) ? " (current)" : ""
+
+        # Check what components are available
+        components = []
+        components << "mapdb" if File.exist?(mapdb_path)
+        components << "stringprocs" if Dir.exist?(stringprocs_path)
+
+        echo "  #{version} (#{format_size(total_size)}, #{mtime.strftime('%Y-%m-%d %H:%M:%S')}, #{components.join('+')})#{current}"
+      else
+        echo "  #{version} (missing directory)"
+      end
+    end
+  end
+
+  def check_current_version
+    if defined?(Map) && Map.respond_to?(:cartographer_version)
+      current = Map.cartographer_version
+      if current
+        echo "Currently loaded cartographer version: #{current}"
+      else
+        echo "No cartographer version currently loaded"
+      end
+    else
+      echo "Map class doesn't support cartographer version tracking"
+    end
+  end
+
+  def show_info
+    echo "Cartographer Architecture Information"
+    echo "===================================="
+    echo ""
+
+    # Directory information
+    echo "Data Directory: #{@cartographer_dir}"
+    echo "Directory exists: #{Dir.exist?(@cartographer_dir) ? 'Yes' : 'No'}"
+
+    if Dir.exist?(@cartographer_dir)
+      # Calculate total directory size recursively
+      total_size = 0
+      file_count = 0
+
+      Dir.glob(File.join(@cartographer_dir, '**', '*')).each do |file|
+        if File.file?(file)
+          total_size += File.size(file)
+          file_count += 1
+        end
+      end
+
+      echo "Total storage used: #{format_size(total_size)}"
+      echo "Number of files: #{file_count}"
+      echo ""
+
+      # Version information
+      versions = get_local_versions
+      if versions.any?
+        echo "Downloaded versions: #{versions.length}"
+        echo "Oldest version: #{versions.last}"
+        echo "Newest version: #{versions.first}"
+
+        # Current version info
+        if defined?(Map) && Map.respond_to?(:cartographer_version)
+          current = Map.cartographer_version
+          if current
+            current_dir = version_dir_path(current)
+            current_file = version_file_path(current)
+            if File.exist?(current_file) && Dir.exist?(current_dir)
+              # Calculate total size of current version directory
+              current_size = Dir.glob(File.join(current_dir, '**', '*')).select { |f| File.file?(f) }.sum { |f| File.size(f) }
+              current_mtime = File.mtime(current_dir)
+              echo "Currently loaded: #{current} (#{format_size(current_size)}, downloaded #{current_mtime.strftime('%Y-%m-%d %H:%M:%S')})"
+
+              # Show 5 largest stringprocs for current version
+              stringprocs_dir = version_stringprocs_path(current)
+              if Dir.exist?(stringprocs_dir)
+                stringprocs = Dir.glob(File.join(stringprocs_dir, '**', '*.rb')).map do |file|
+                  { path: file.sub(stringprocs_dir + '/', ''), size: File.size(file) }
+                end.sort_by { |sp| -sp[:size] }.first(5)
+
+                if stringprocs.any?
+                  echo "5 Largest StringProcs:"
+                  stringprocs.each_with_index do |sp, index|
+                    echo "  #{index + 1}. #{sp[:path]} (#{format_size(sp[:size])})"
+                  end
+                end
+              end
+            end
+          else
+            echo "Currently loaded: None"
+          end
+        end
+      else
+        echo "No versions downloaded"
+      end
+    else
+      echo "Data directory not yet created"
+    end
+
+    echo ""
+    echo "GitHub Repository: https://github.com/elanthia-online/mapdb"
+    echo "Release API: #{GITHUB_API_BASE}/releases"
+    echo ""
+
+    # Map integration status
+    if defined?(Map)
+      echo "Map class integration: Available"
+      if Map.respond_to?(:cartographer_version)
+        echo "Cartographer extensions: Loaded"
+      else
+        echo "Cartographer extensions: Not loaded"
+      end
+
+      if Map.respond_to?(:list)
+        room_count = Map.list.compact.length
+        echo "Currently loaded rooms: #{room_count}"
+      end
+    else
+      echo "Map class integration: Not available"
+    end
+  end
+
+  def prune_old_versions
+    versions = get_local_versions
+
+    if versions.length <= 3
+      echo "Only #{versions.length} version(s) downloaded, nothing to prune"
+      return
+    end
+
+    # Keep the 3 newest versions
+    versions_to_keep = versions.first(3)
+    versions_to_remove = versions[3..-1]
+
+    echo "Keeping #{versions_to_keep.length} newest versions: #{versions_to_keep.join(', ')}"
+    echo "Removing #{versions_to_remove.length} older versions: #{versions_to_remove.join(', ')}"
+
+    # Check if currently loaded version would be removed
+    current_version = nil
+    if defined?(Map) && Map.respond_to?(:cartographer_version)
+      current_version = Map.cartographer_version
+    end
+
+    if current_version && versions_to_remove.include?(current_version)
+      echo "Warning: Currently loaded version #{current_version} will be removed!"
+      echo "You may want to load a newer version first with: ;cartographer --load #{versions_to_keep.first}"
+    end
+
+    # Calculate space to be freed
+    space_freed = 0
+    versions_to_remove.each do |version|
+      version_dir = version_dir_path(version)
+      if Dir.exist?(version_dir)
+        space_freed += Dir.glob(File.join(version_dir, '**', '*')).select { |f| File.file?(f) }.sum { |f| File.size(f) }
+      end
+    end
+
+    echo "Space to be freed: #{format_size(space_freed)}"
+    echo ""
+    echo "Pruning old versions..."
+
+    removed_count = 0
+    versions_to_remove.each do |version|
+      version_dir = version_dir_path(version)
+      if Dir.exist?(version_dir)
+        begin
+          FileUtils.rm_rf(version_dir)
+          echo "  Removed version #{version}/"
+          removed_count += 1
+        rescue => e
+          echo "  Error removing #{version}/: #{e.message}"
+        end
+      else
+        echo "  Version #{version}/ already missing"
+      end
+    end
+
+    echo ""
+    echo "Pruning complete: removed #{removed_count} version(s), freed #{format_size(space_freed)}"
+
+    # Show remaining versions
+    remaining_versions = get_local_versions
+    echo "Remaining versions: #{remaining_versions.join(', ')}"
+  end
+
+  def load_version(version)
+    # Normalize version (remove 'v' prefix if present)
+    version = version.sub(/^v/, '')
+
+    file_path = version_file_path(version)
+
+    unless File.exist?(file_path)
+      echo "Error: Version #{version} not found locally"
+      echo "Available versions: #{get_local_versions.join(', ')}"
+      echo "Use ';cartographer --version #{version}' to download it first"
+      return
+    end
+
+    load_cartographer_data(file_path, version)
+  end
+
+  def download_and_load_latest(force = false)
+    echo "Fetching latest release information..."
+
+    release_info = fetch_json("#{GITHUB_API_BASE}/releases/latest")
+    return unless release_info
+
+    version = release_info['tag_name'].sub(/^v/, '')
+    echo "Latest version: #{version}"
+
+    # Check if version already exists
+    if !force && File.exist?(version_file_path(version))
+      echo "Version #{version} already downloaded, loading..."
+      load_version(version)
+      return
+    end
+
+    download_and_load_release(release_info, version)
+  end
+
+  def download_and_load_version(version, force = false)
+    # Normalize version (remove 'v' prefix if present for storage, keep for API)
+    normalized_version = version.sub(/^v/, '')
+    api_version = version.start_with?('v') ? version : "v#{version}"
+
+    # Check if already downloaded
+    if !force && File.exist?(version_file_path(normalized_version))
+      echo "Version #{normalized_version} already downloaded, loading..."
+      load_version(normalized_version)
+      return
+    end
+
+    echo "Fetching release information for #{api_version}..."
+
+    release_info = fetch_json("#{GITHUB_API_BASE}/releases/tags/#{api_version}")
+    return unless release_info
+
+    download_and_load_release(release_info, normalized_version)
+  end
+
+  def download_and_load_release(release_info, version)
+    assets = release_info['assets']
+
+    mapdb_asset = assets.find { |asset| asset['name'] == 'mapdb.json' }
+    stringprocs_asset = assets.find { |asset| asset['name'] == 'stringprocs.tar.gz' }
+
+    unless mapdb_asset
+      echo "Error: mapdb.json not found in release"
+      echo "Available assets: #{assets.map { |a| a['name'] }.join(', ')}"
+      return
+    end
+
+    # Create version directory
+    version_dir = version_dir_path(version)
+    FileUtils.mkdir_p(version_dir) unless Dir.exist?(version_dir)
+
+    # Download mapdb.json
+    mapdb_url = mapdb_asset['browser_download_url']
+    mapdb_size = mapdb_asset['size']
+    echo "Downloading mapdb.json (#{format_size(mapdb_size)}) for version #{version}..."
+
+    temp_mapdb = File.join(version_dir, "mapdb.tmp")
+    final_mapdb = version_mapdb_path(version)
+
+    unless download_file(mapdb_url, temp_mapdb)
+      FileUtils.rm_rf(version_dir) if Dir.exist?(version_dir)
+      echo "Error: Failed to download mapdb.json"
+      return
+    end
+
+    unless validate_mapdb(temp_mapdb)
+      FileUtils.rm_rf(version_dir) if Dir.exist?(version_dir)
+      echo "Error: Downloaded mapdb.json failed validation"
+      return
+    end
+
+    File.rename(temp_mapdb, final_mapdb)
+    echo "Successfully downloaded and validated mapdb.json"
+
+    # Download stringprocs if available
+    if stringprocs_asset
+      stringprocs_url = stringprocs_asset['browser_download_url']
+      stringprocs_size = stringprocs_asset['size']
+      echo "Downloading stringprocs.tar.gz (#{format_size(stringprocs_size)})..."
+
+      temp_stringprocs = File.join(version_dir, "stringprocs.tar.gz")
+
+      if download_file(stringprocs_url, temp_stringprocs)
+        # Extract stringprocs
+        echo "Extracting StringProc files..."
+        # system("cd '#{version_dir}' && tar -xzf stringprocs.tar.gz")
+        Gem::Package.new("").extract_tar_gz(File.open(temp_stringprocs), version_dir)
+        if Dir.exist?(File.join(version_dir, "stringprocs"))
+          File.delete(temp_stringprocs)
+          echo "Successfully extracted StringProc files"
+        else
+          echo "Warning: Failed to extract stringprocs.tar.gz"
+        end
+      else
+        echo "Warning: Failed to download stringprocs.tar.gz - continuing without StringProcs"
+      end
+    else
+      echo "Note: No stringprocs.tar.gz found in release - using legacy format"
+    end
+
+    load_cartographer_data(final_mapdb, version)
+  end
+
+  def load_cartographer_data(file_path, version)
+    echo "Loading cartographer version #{version}..."
+
+    begin
+      # Set the base path for Cartographer StringProc evaluation
+      version_dir = version_dir_path(version)
+      Cartographer.set_base_path(version_dir)
+      echo "Set Cartographer base path: #{version_dir}"
+
+      if defined?(Map) && Map.respond_to?(:load_cartographer)
+        if Map.load_cartographer(version)
+          room_count = Map.list.compact.length
+          echo "Successfully loaded #{room_count} rooms from cartographer version #{version}"
+          echo "Map database is now ready for use!"
+          test_map_functionality
+          map_post_install_hooks
+        else
+          echo "Error: Failed to load cartographer data into Map class"
+        end
+      else
+        echo "Error: Map class doesn't support cartographer loading"
+        echo "The Map class needs to be extended with cartographer support"
+      end
+
+    rescue => e
+      echo "Error loading cartographer data: #{e.message}"
+    end
+  end
+
+  def get_local_versions
+    Dir.entries(@cartographer_dir)
+       .reject { |f| f.start_with?('.') }
+       .select { |entry|
+         path = File.join(@cartographer_dir, entry)
+         File.directory?(path) && entry =~ /^[\d.]+$/
+       }
+       .sort_by { |v| Gem::Version.new(v) rescue v }
+       .reverse
+  end
+
+  def version_dir_path(version)
+    File.join(@cartographer_dir, version)
+  end
+
+  def version_mapdb_path(version)
+    File.join(version_dir_path(version), "mapdb.json")
+  end
+
+  def version_stringprocs_path(version)
+    File.join(version_dir_path(version), "stringprocs")
+  end
+
+  def version_file_path(version)
+    version_mapdb_path(version)
+  end
+
+  def fetch_json(url)
+    uri = URI(url)
+
+    begin
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        request = Net::HTTP::Get.new(uri)
+        request['User-Agent'] = "Lich-Cartographer/#{VERSION}"
+
+        response = http.request(request)
+
+        if response.code == '200'
+          JSON.parse(response.body)
+        else
+          echo "Error: HTTP #{response.code} - #{response.message}"
+          echo "URL: #{url}"
+          nil
+        end
+      end
+    rescue => e
+      echo "Error fetching #{url}: #{e.message}"
+      nil
+    end
+  end
+
+  def download_file(url, local_path, max_redirects = 5)
+    return false if max_redirects == 0
+
+    uri = URI(url)
+
+    begin
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri)
+        request['User-Agent'] = "Lich-Cartographer/#{VERSION}"
+
+        File.open(local_path, 'wb') do |file|
+          http.request(request) do |response|
+            case response
+            when Net::HTTPSuccess
+              total_size = response['content-length'].to_i
+              downloaded = 0
+              last_progress = 0
+
+              response.read_body do |chunk|
+                file.write(chunk)
+                downloaded += chunk.length
+
+                if total_size > 0
+                  progress = (downloaded.to_f / total_size * 100).to_i
+                  if progress >= last_progress + 10
+                    echo "  Progress: #{progress}% (#{format_size(downloaded)}/#{format_size(total_size)})"
+                    last_progress = progress
+                  end
+                end
+              end
+
+              echo "  Download complete: #{format_size(downloaded)}"
+              return true
+            when Net::HTTPRedirection
+              redirect_url = response['location']
+              file.close
+              File.delete(local_path) if File.exist?(local_path)
+              return download_file(redirect_url, local_path, max_redirects - 1)
+            else
+              echo "Error: HTTP #{response.code} - #{response.message}"
+              return false
+            end
+          end
+        end
+      end
+    rescue => e
+      echo "Error downloading file: #{e.message}"
+      return false
+    end
+  end
+
+  def validate_mapdb(file_path)
+    echo "Validating downloaded mapdb..."
+
+    begin
+      content = File.read(file_path)
+      data = JSON.parse(content)
+
+      unless data.is_a?(Array)
+        echo "Error: mapdb should be an array of rooms"
+        return false
+      end
+
+      if data.empty?
+        echo "Error: mapdb is empty"
+        return false
+      end
+
+      # Validate first few rooms have required fields
+      sample_rooms = data.first(5)
+      sample_rooms.each_with_index do |room, index|
+        unless room.is_a?(Hash) && room['id'] && room['title']
+          echo "Error: Room #{index} missing required fields (id, title)"
+          return false
+        end
+      end
+
+      room_count = data.length
+      echo "Validation passed: #{room_count} rooms"
+      return true
+
+    rescue JSON::ParserError => e
+      echo "Error: Invalid JSON - #{e.message}"
+      return false
+    rescue => e
+      echo "Error validating mapdb: #{e.message}"
+      return false
+    end
+  end
+
+  def test_map_functionality
+    echo "Testing map functionality..."
+
+    begin
+      rooms = Map.list.compact
+      room_count = rooms.length
+      echo "  ✓ Total rooms: #{room_count}"
+
+      if rooms.any?
+        # Sample a random room for testing
+        sample_room = rooms.sample
+        echo "  ✓ Sample room: ##{sample_room.id} - #{sample_room.title.last}"
+
+        # Test room lookup
+        test_room = Map[sample_room.id]
+        if test_room && test_room.id == sample_room.id
+          echo "  ✓ Room lookup working"
+        end
+      end
+
+      echo "Map functionality test completed successfully!"
+
+    rescue => e
+      echo "Warning: Map functionality test failed - #{e.message}"
+    end
+  end
+
+  def map_post_install_hooks
+    Script.run("teleport") if Script.exists?("teleport")
+    Script.run("cartographer_post_install") if Script.exists?("cartographer_post_install")
+  end
+
+  def format_size(bytes)
+    if bytes < 1024
+      "#{bytes}B"
+    elsif bytes < 1024 * 1024
+      "#{(bytes / 1024.0).round(1)}KB"
+    else
+      "#{(bytes / (1024.0 * 1024.0)).round(1)}MB"
+    end
+  end
+
+  def echo(message)
+    respond message
+  end
+end
+
+# Extend the Map class with cartographer support
+if defined?(Map)
+  class << Map
+    attr_accessor :cartographer_version, :cartographer_file
+
+    def load_cartographer(version = nil)
+      cartographer_dir = File.join(DATA_DIR, XMLData.game, '_cartographer')
+
+      if version.nil?
+        # Load newest version by default
+        versions = Dir.entries(cartographer_dir)
+                     .reject { |f| f.start_with?('.') }
+                     .select { |entry|
+                       path = File.join(cartographer_dir, entry)
+                       File.directory?(path) && entry =~ /^[\d.]+$/
+                     }
+                     .sort_by { |v| Gem::Version.new(v) rescue v }
+                     .reverse
+
+        if versions.empty?
+          respond "No cartographer versions found. Use ';cartographer' to download one."
+          return false
+        end
+
+        version = versions.first
+        respond "Loading newest cartographer version: #{version}"
+      end
+
+      file_path = File.join(cartographer_dir, version, "mapdb.json")
+
+      unless File.exist?(file_path)
+        respond "Cartographer version not found: #{version}"
+        available_versions = Dir.entries(cartographer_dir)
+                               .reject { |f| f.start_with?('.') }
+                               .select { |entry|
+                                 path = File.join(cartographer_dir, entry)
+                                 File.directory?(path) && entry =~ /^[\d.]+$/
+                               }
+        respond "Available versions: #{available_versions.join(', ')}"
+        return false
+      end
+
+      begin
+        # Use the existing Map.load_json method which handles all the class variable initialization
+        if Map.respond_to?(:load_json)
+          Map.clear
+          respond "--- Cartographer cleared current Map ---"
+          if Map.load_json(file_path)
+            @cartographer_version = version
+            @cartographer_file = file_path
+            room_count = Map.list.compact.length
+            respond "--- Cartographer v#{version} loaded (#{room_count} rooms)"
+            return true
+          else
+            respond "Error: Map.load_json failed to load cartographer file"
+            return false
+          end
+        else
+          respond "Error: Map class doesn't support load_json method"
+          return false
+        end
+
+      rescue => e
+        respond "Error loading cartographer file: #{e.message}"
+        return false
+      end
+    end
+
+    def cartographer_version
+      @cartographer_version
+    end
+
+    def cartographer_file
+      @cartographer_file
+    end
+  end
+end
+
+# Cartographer class for userland StringProc evaluation
+class Cartographer
+  @@base_path ||= nil
+
+  def self.set_base_path(path)
+    @@base_path = path
+  end
+
+  def self.evaluate_script(relative_path)
+    if @@base_path.nil?
+      error_msg = "Cartographer base path not set"
+      respond "Error: #{error_msg}"
+      if relative_path.include?('timeto/')
+        return 0.2  # Default timing fallback for timeto only
+      else
+        raise error_msg  # Throw error for wayto
+      end
+    end
+
+    full_path = File.join(@@base_path, 'stringprocs', relative_path)
+    unless File.exist?(full_path)
+      error_msg = "StringProc file not found: #{full_path}"
+      respond "Error: #{error_msg}"
+      if relative_path.include?('timeto/')
+        return 0.2  # Default timing fallback for timeto only
+      else
+        raise error_msg  # Throw error for wayto
+      end
+    end
+
+    begin
+      script_content = File.read(full_path)
+      # Evaluate the script content directly - no caching since state can change
+      result = eval(script_content)
+      return result
+    rescue => e
+      error_msg = "Failed to evaluate StringProc #{relative_path}: #{e.message}"
+      respond "Error: #{error_msg}"
+      if relative_path.include?('timeto/')
+        return 0.2  # Default timing fallback for timeto only
+      else
+        raise error_msg  # Throw error for wayto
+      end
+    end
+  end
+end
+
+# Main execution
+if defined?(Script.current)
+  manager = CartographerManager.new
+  manager.run(Script.current.vars)
+else
+  respond "This script must be run within Lich"
+end


### PR DESCRIPTION
## What

Imports `cartographer.lic` (the mapdb release client, currently distributed only via the in-game `;repository`) into this repo so it has a proper git home, then applies five runtime fixes on top. The first commit is the script verbatim as distributed today, so each fix is reviewable as its own diff.

## Fixes

- **Windows: stringprocs extraction crashed** — `File.open` without a mode reads in text mode, which on Windows treats the first `0x1A` byte of the gzip stream as EOF (`Zlib::GzipReader: unexpected end of file`). Now opens `'rb'`.
- **StringProc file reads cached** — `evaluate_script` re-read its `.rb` file from disk on every call; route calculation invokes timeto procs as Dijkstra edge weights, so one pathfinding pass could trigger thousands of redundant reads. Contents are now cached per path (version dirs are immutable after extraction) and invalidated on base-path change. The `eval` still runs every call — results depend on live game state.
- **timeto failures no longer return a fake 0.2** — any error (unset base path, missing file, eval exception) silently fed pathfinding a made-up edge weight. Errors now return `nil`, which Map pathfinding treats as an unroutable edge (`next unless edge_weight`). Errors are still reported; wayto behavior (raise) is unchanged.
- **`Map.load_cartographer` sets the StringProc base path itself** — previously only the script's own download flow set it, so calling the Map extension directly loaded rooms whose StringProcs all failed.
- **GS-only guard** — the data dir is keyed on `XMLData.game` but mapdb releases contain GemStone rooms only; running on a DR character would install GS data into the DR map.

## Verification

- `ruby -c` and RuboCop (repo config) clean
- Standalone harness covering the `Cartographer` shim: happy path, cache-hit-after-file-deletion, fresh eval per call, cache invalidation on `set_base_path`, and nil-vs-raise for timeto/wayto across all three error branches (11 checks)
- Live end-to-end on Windows: `;cartographer --force` → download → extract → load of 36,332 rooms → built-in map self-test passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)