### PR TITLE
fix(blackarts.lic): v1.3.6 sea water vial/flask validation logic

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -6,10 +6,12 @@
   contributors: Deysh, Tysong, Gob
           game: Gemstone
           tags: alchemy
-       version: 1.3.5
+       version: 1.3.6
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.6 (2026-07-12)
+    - sea water vial/flask validation switched from AND to OR logic since you need one or the other but not both
   v1.3.5 (2025-07-30)
     - fix for returning mortar after grinding task
   v1.3.4 (2025-06-19)
@@ -4785,15 +4787,9 @@ module BlackArts
           is_error = true
         end
 
-        # Doe we have a vial for sea water?
-        unless BlackArts.data.sacks["reagent"].contents.find { |obj| obj.name =~ BlackArts.data.sea_water_vial }
-          Util.msg('error', " A vial for sea water was not found in your #{BlackArts.data.sacks["reagent"].name}.")
-          is_error = true
-        end
-
-        # Doe we have a flask for sea water?
-        unless BlackArts.data.sacks["reagent"].contents.find { |obj| obj.name =~ BlackArts.data.sea_water_flask }
-          Util.msg('error', " A flask for sea water was not found in your #{BlackArts.data.sacks["reagent"].name}.")
+        # Do we have a vial or flask for sea water?
+        unless BlackArts.data.sacks["reagent"].contents.find { |obj| obj.name =~ BlackArts.data.sea_water_vial || obj.name =~ BlackArts.data.sea_water_flask }
+          Util.msg('error', " A vial or flask for sea water was not found in your #{BlackArts.data.sacks["reagent"].name}.")
           is_error = true
         end
       end
@@ -6825,7 +6821,7 @@ module BlackArts
           flasks = BlackArts.data.sacks["reagent"].contents.find_all { |obj| obj.name =~ BlackArts.data.sea_water_flask }
           equipment = vials + flasks
 
-          if vials.length.positive? && flasks.length.positive?
+          if vials.length.positive? || flasks.length.positive?
             equipment.each do |item|
               lines = BlackArts::Util.get_lines("look in ##{item.id}", /cork that holds it securely closed|cork that dangles at its side/)
               if lines.grep(/is filled with a dark crimson fluid/i).any?
@@ -8556,7 +8552,7 @@ module BlackArts
       vials = BlackArts.data.sacks["reagent"].contents.find_all { |obj| obj.name =~ BlackArts.data.sea_water_vial }
       flasks = BlackArts.data.sacks["reagent"].contents.find_all { |obj| obj.name =~ BlackArts.data.sea_water_flask }
 
-      unless vials.length.positive? && flasks.length.positive?
+      unless vials.length.positive? || flasks.length.positive?
         Util.msg('error', ' error: failed to find a vial or flask for sea water')
         exit
       end
@@ -8678,7 +8674,7 @@ module BlackArts
       vials = BlackArts.data.sacks["reagent"].contents.find_all { |obj| obj.name =~ BlackArts.data.sea_water_vial }
       flasks = BlackArts.data.sacks["reagent"].contents.find_all { |obj| obj.name =~ BlackArts.data.sea_water_flask }
 
-      unless vials.length.positive? && flasks.length.positive?
+      unless vials.length.positive? || flasks.length.positive?
         Util.msg('error', ' error: failed to find a vial or flask for troll blood')
         exit
       end


### PR DESCRIPTION
## Summary
- Changed sea water vial/flask validation from AND to OR logic since you need one or the other but not both
- This fixes an issue where the script would fail if you had either a vial OR a flask, but required both

## Changes
- Bumped BlackArts to v1.3.6
- Updated validation check to accept either vial or flask for sea water
- Fixed typo in error message check ("Doe" → "Do")

🤖 Generated with [Claude Code](https://claude.com/claude-code)