### PR TITLE
fix(bigshot): fix some beast belly edge cases

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.14.4
+    - fix some beast belly edge cases
   v5.14.3  (2026-07-13)
     - fix missing essence regex pattern
   v5.14.2  (2026-07-06)
@@ -6244,6 +6246,8 @@ class Bigshot
     @followers.add_event(:HUNTING_SCRIPTS_STOP)
     croak_scripts(@HUNTING_SCRIPTS)
 
+    escape_rooms
+
     if @INDEPENDENT_RETURN
       if Lich::Gemstone::Group.length.positive?
         @followers.add_event(:PREP_REST)
@@ -6290,8 +6294,6 @@ class Bigshot
 
       go2(@RESTING_ROOM_ID)
     end
-
-    escape_rooms
 
     if (@QUIET_FOLLOWERS) && !any_wounded
       Lich::Util.quiet_command_xml("group open", /Your group status/) unless solo?
@@ -6548,7 +6550,7 @@ class Bigshot
   def need_to_loot?(final_loot = false)
     return unless bigclaim?(check_disks: false)
     return unless leading?
-    return unless checkroom("Duskruin Arena, Dueling Sands").nil?
+    return unless checkroom("Duskruin Arena, Dueling Sands", "The Belly of the Beast", "Ooze, Innards", "Temporal Rift").nil?
     return if should_flee?
     return if $ambusher_here
     return unless @followers.looting_done
@@ -6653,9 +6655,14 @@ class Bigshot
 
     prepare_for_movement(cast_signs_moving)
 
-    until (Room.current.id == id)
+    5.times do
       run_script('go2', true, "#{id} --disable-confirm")
+      return if Room.current.id == id
+      escape_rooms
     end
+
+    $bigshot_should_rest = true
+    $rest_reason = "Could not reach #{id}"
   end
 
   def start_watch()

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.14.3
+       version: 5.14.4
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot


### PR DESCRIPTION
I've parked one of my characters on plane 4 for a bit now so I noticed a few issues with the built-in escape room stuff bigshot does:
1. If rest is triggered (eg., wounded) then bigshot will try to return to your rest room first, before `escape_rooms` gets called
2. Bigshot can try to loot inside the belly which causes eloot to loop forever because it doesn't handle the `can't do that while being digested` message. This happens every time if you have `final_loot` set.
3. On the way to the starting room, if you get snatched up and end up in the belly, bigshot will loop forever in the `goto` method.