### PR TITLE
feat(bigshot.lic): v5.15.0 add repeatdelay command check

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.14.4
+       version: 5.15.0
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,9 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.15.0  (2026-07-19)
+    - add repeatdelay command check, throttles a command to once per N seconds per room, clears on room change
+    - bugfix for once command check raising when a creature has no prior commands
   v5.14.4
     - fix some beast belly edge cases
   v5.14.3  (2026-07-13)
@@ -2616,11 +2619,13 @@ class Bigshot
   end
 
   def initialize_command_data
-    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
+    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|repeatdelay|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
 
     @COMMAND_AMOUNT_REGEX = /((?:!?e|!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
     @COMMAND_BUFF_REGEX = /((?:buff))(\d+)/i.freeze
+
+    @COMMAND_REPEATDELAY_REGEX = /repeatdelay(\d+)/i.freeze
 
     @COMMAND_AMOUNT_CHECKS = {
       'e'        => ->(amount) { Char.percent_encumbrance < amount },
@@ -3490,11 +3495,19 @@ class Bigshot
   def once_commands_register(npc, command)
     debug_msg(@DEBUG_COMMANDS, "once_commands_register | npc.id: #{npc.id} | command: #{command}")
 
-    if @COMMANDS_REGISTRY[npc.id].nil?
-      @COMMANDS_REGISTRY[npc.id] = [command]
-    elsif !@COMMANDS_REGISTRY[npc.id].include?(command)
-      @COMMANDS_REGISTRY[npc.id].push(command)
-    end
+    @COMMANDS_REGISTRY[npc.id] ||= {}
+    @COMMANDS_REGISTRY[npc.id][command] = Time.now
+  end
+
+  # Returns true when +command+ was last run anywhere in the current room fewer
+  # than +seconds+ ago. Registry values are per-NPC hashes of command => Time and
+  # the registry is cleared on room change (see bs_wander), making this a
+  # per-room throttle. Never-run commands (no recorded time) return false.
+  def repeatdelay_blocked?(command, seconds)
+    last = @COMMANDS_REGISTRY.values.filter_map { |cmds| cmds[command] if cmds.is_a?(Hash) }.max
+    return false if last.nil?
+
+    (Time.now - last) < seconds
   end
 
   def cmd_eachtarget(command, npc)
@@ -3538,6 +3551,15 @@ class Bigshot
 
         if buff_name && Effects::Buffs.time_left(buff_name) <= (amount / 60.0)
           debug_msg(@DEBUG_COMMANDS, "command_check buff | command: #{command} | amount: #{amount} | result: true")
+          return true
+        end
+      end
+
+      # Check repeat-delay throttle (e.g., repeatdelay10)
+      if (repeat_match = modifier.match(@COMMAND_REPEATDELAY_REGEX))
+        seconds = repeat_match[1].to_i
+        if repeatdelay_blocked?(original_command, seconds)
+          debug_msg(@DEBUG_COMMANDS, "command_check repeatdelay | command: #{original_command} | seconds: #{seconds} | result: true")
           return true
         end
       end
@@ -3652,7 +3674,7 @@ class Bigshot
     when '!tier3'     then $bigshot_unarmed_tier == 3
 
     # Room/registry checks
-    when 'once'       then @COMMANDS_REGISTRY[npc.id].include?(original_command)
+    when 'once'       then @COMMANDS_REGISTRY[npc.id]&.include?(original_command)
     when 'room'       then @COMMANDS_REGISTRY.any? { |_k, v| v.include?(original_command) }
     when 'splashy'    then Room.current.tags.include?("meta:splashy")
     when '!splashy'   then !Room.current.tags.include?("meta:splashy")


### PR DESCRIPTION
## Summary
Adds a `repeatdelay<N>` command check so a command runs only if at least N seconds have elapsed since it was last used in the current room. Also fixes a pre-existing crash in the adjacent `once` check.

Example:

    incant 912 (repeatdelay10)

Casts 912 at most once every 10 seconds per room. The timer clears on room change, the same lifecycle as the `once` and `room` checks.

## Behavior
- Blocks (skips) the command when the last run was < N seconds ago.
- Allows it when >= N seconds have passed, or when it has never run in the room.
- Per-room and room-wide: a run against any creature counts (uses the most recent timestamp). Resets when `bs_wander` clears the registry on movement.

## Implementation
`@COMMANDS_REGISTRY` values change from `Array<String>` to `Hash<String, Time>` (command => last-run time), rather than adding a parallel store. `Hash#include?` is key-based, so the existing readers -- the `once` check, the `room` check, and `cmd_depress`, all of which call `.include?(command)` -- behave identically. `repeatdelay_blocked?` reads the most-recent timestamp across the room's entries.

Changes:
- `@COMMAND_MODIFIER_REGEX`: register `repeatdelay` in the modifier alternation.
- New `@COMMAND_REPEATDELAY_REGEX = /repeatdelay(\d+)/i`.
- `once_commands_register`: store `Time.now` per command; add `repeatdelay_blocked?`.
- `command_check`: add the repeatdelay branch, next to the existing `buff` branch since it takes a numeric argument.
- `once` check: guard the per-npc lookup with safe navigation (`&.`) so a `(once)` command run first against a not-yet-registered creature no longer raises `NoMethodError` (it correctly treats the creature as "not yet run" and allows).
- Header: version 5.14.4 -> 5.15.0 (feature) + changelog entries.

## Testing
- `ruby -c`: clean.
- ASCII-only source: verified (no non-ASCII bytes).
- CRLF line endings preserved.
- RSpec: 16 examples, 0 failures, stable across random seeds. Specs source the methods directly from the `.lic` (regex-extract + eval) to prevent drift, covering timestamp storage, the time/scope behaviors (never-run, under/over window, room-wide most-recent, reset-on-clear), the `command_check` wiring end-to-end, regression on `once`/`room` (the same registry-access pattern used by `cmd_depress`), and the fresh-creature `once` case that previously raised.

## Notes
- No behavior change to `once` (except no longer crashing on the fresh-creature edge), `room`, or `cmd_depress`.