### PR TITLE
fix(eloot.lic): v2.10.1enhance downstream hook

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.10.0
+           version: 2.10.1
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.10.1 (2026-07-19)
+    - fix downstreamhook persistance message for Lich 5.19.0+
   v2.10.0 (2026-06-24)
     - add "Over Max Value (not sold)" section to the eloot breakdown: lists items that appraised above your gemshop/pawnshop limit, with their appraised values, so you know what to put in your locker or investigate more deeply
     - add a Selling option "Recheck gemshop-refused items at the pawnshop": when the gemshop won't quote a price ("not buying anything this valuable today"), eloot makes a trip to the pawnshop and appraises the item there (appraise only, never sells) so its real value shows up in the breakdown. These items are grouped under a "Gemshop refused, pawn appraisals:" subheading within the Over Max Value list
@@ -2472,7 +2474,14 @@ module ELoot # Script utility type methods
       end
       server
     }
-    DownstreamHook.add('eloot_diskintegration', eloot_diskintegration)
+    # v5.19.0 introduces a shared hook registry. Hooks are either
+    # removed when their owning script exits, or explicitly marked
+    # to persist and are cleaned up separately.
+    if DownstreamHook.method(:add).parameters.any? { |_t, n| n == :persist }
+      DownstreamHook.add('eloot_diskintegration', eloot_diskintegration, persist: true)
+    else
+      DownstreamHook.add('eloot_diskintegration', eloot_diskintegration)
+    end
   end
 
   def self.reset_disk_full(rebuild: true)


### PR DESCRIPTION
Update version to 2.10.1 and add new features for Lich 5.19.0 compatibility.