### PR TITLE
fix(bigshot.lic): v5.15.1 cmd_force re-issuing maneuver on a passing roll

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.15.0
+       version: 5.15.1
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.15.1  (2026-07-23)
+    - Fix cmd_force re-issuing maneuver on a passing roll (negative slice index collapses result window)
   v5.15.0  (2026-07-19)
     - add repeatdelay command check, throttles a command to once per N seconds per room, clears on room change
     - bugfix for once command check raising when a creature has no prior commands
@@ -4759,7 +4761,7 @@ class Bigshot
         return false if line =~ failure_regex || muckled?
 
         if line =~ /^You.*(#{checknpcs.join('|')})|^You feint (high|low|(to the (left|right)))/
-          if buffer[i - 3..i + 2].reverse.any? { |l| l =~ result_regex }
+          if buffer[[i - 3, 0].max..i + 2].reverse.any? { |l| l =~ result_regex }
             captures = $~.captures.compact
             capture = captures.first # prioritize the first capture
             return true if capture.to_i >= goal # spell/swing/cman


### PR DESCRIPTION
## Problem
cmd_force sometimes fires the maneuver a second time even though the first attempt already met `goal`. Reproduced with `force feint until 101`: the first feint rolls a hit (e.g. SMR 296, SMR 258 — both ≥ 101), but cmd_force falls through to its loop-bottom guards and re-issues feint before proceeding.

## Root cause
`buffer` is `reget(35).reverse` (newest-first), so the "You feint..." trigger line typically lands at index 2 — only two lines (`Roundtime: 3 sec.` and the `R>` prompt) post after it, and the `[SMR result: N]` line sits at index 3.

When the trigger is at i ≤ 2, `i - 3` is negative. `buffer[-1..4]` on a 35-element array normalizes the start to index 34; since 34 > 4 the range is empty, so `.any?` returns false and the result line at i+1 is never scanned. The block finds no match and the loop re-fires. (It's intermittent because whether a third async line has posted by the reget snapshot decides whether the trigger lands at index 2 vs 3+.)

## Fix
Clamp the window's lower bound so it can't go negative: `buffer[[i - 3, 0].max..i + 2]`. For the failing i=2 case this yields `buffer[0..4]`, which includes the result line; no-op for i ≥ 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where forced maneuvers could be issued again after a passing roll.
  * Improved result detection to reliably recognize recent command outcomes.

* **Chores**
  * Updated the Bigshot script version to 5.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->