### PR TITLE
fix(bigshot): v5.15.2 retarget when a higher priority creature arrives mid-fight

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,8 +19,10 @@
   Major_change.feature_addition.bugfix
   v5.15.2  (2026-07-27)
     - fix priority hunt not retargeting when a higher priority creature arrives mid-fight
+    - compare target list rank instead of identity so a lower ranked creature never wins a check
     - match priority targets with the same anchored name and noun rules used to select them
     - keep the current target when a priority retarget has no replacement to offer
+    - fix eachtarget commands skipping every creature except the highest ranked one
     - fix follower priority check reading an instance variable that was never set
     - remove the unused room npc snapshot thread and its globals
   v5.15.1  (2026-07-23)
@@ -3287,7 +3289,7 @@ class Bigshot
     end
   end
 
-  def cmd(command, npc = nil, stance_dance = true)
+  def cmd(command, npc = nil, stance_dance = true, check_priority: true)
     debug_msg(@DEBUG_COMMANDS, "cmd | command: #{command}")
 
     check_for_deaders_prone
@@ -3392,7 +3394,9 @@ class Bigshot
 
     # Target gone or not priority? Then return
     return unless valid_target?(npc)
-    return if @PRIORITY && !priority(npc)
+    # check_priority: false lets cmd_eachtarget sweep the room without the gate
+    # rejecting every creature that is not the highest ranked one
+    return if check_priority && @PRIORITY && !priority(npc)
 
     # Perform the command
     if (command =~ /^(incant)?\s?(\d+)\s?((?:open|closed)?\s?(?:cast|channel|evoke)?\s?(?:cast|channel|evoke)?\s?(?:open|closed)?\s?(?:acid|air|cold|earth|fire|lightning|steam|water)?)?.*$/i)
@@ -3523,7 +3527,7 @@ class Bigshot
     GameObj.targets.each { |target|
       next unless valid_target?(target)
       fput "target ##{target.id}" unless XMLData.current_target_id == target.id
-      cmd(command, target)
+      cmd(command, target, check_priority: false)
     }
     fput "target ##{current_target.id}" unless XMLData.current_target_id == current_target.id
   end
@@ -6967,25 +6971,34 @@ class Bigshot
     return targets
   end
 
+  # Anchored so priority uses the same matching as sort_npcs and can never rank
+  # a creature that find_target would be unable to pick
+  def priority_matchers
+    @TARGETS.keys.map { |name| /^#{name}$/i }
+  end
+
+  # Position of a creature in the ordered target list, infinity when unlisted
+  def priority_rank(npc, matchers)
+    index = matchers.index { |matcher| npc.name =~ matcher || npc.noun =~ matcher }
+    index.nil? ? Float::INFINITY : index
+  end
+
   def priority(target)
     return false if target.nil?
     return true if $bigshot_bandits
     return true if !@PRIORITY
 
-    # Default true: nothing we are set up to hunt is here, so there is nothing to switch to
-    priority = true
+    matchers = priority_matchers
     npcs = GameObj.targets.reject { |npc| CharSettings['untargetable'].include?(npc.name) || invalid_target_with_boons(npc, false) }
+    target_rank = priority_rank(target, matchers)
+    best_rank = npcs.map { |npc| priority_rank(npc, matchers) }.min || Float::INFINITY
 
-    # Anchored to match sort_npcs, so priority never names a creature find_target cannot pick
-    @TARGETS.keys.each do |name|
-      name_regex = /^#{name}$/i
-      if (npc = npcs.find { |s| s.name =~ name_regex || s.noun =~ name_regex })
-        priority = (npc.name == target.name)
-        break
-      end
-    end
+    # Ranks, not identity: GameObj.targets is the game's target dropdown, which is
+    # rebuilt wholesale, so the current target can drop out of it for a moment.
+    # Only a creature that outranks the target may interrupt it.
+    priority = best_rank >= target_rank
 
-    debug_msg(@DEBUG_COMBAT, "priority check | target: #{target} | priority: #{priority}")
+    debug_msg(@DEBUG_COMBAT, "priority check | target: #{target} | priority: #{priority} | target_rank: #{target_rank} | best_rank: #{best_rank}")
     return priority
   end
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.15.1
+       version: 5.15.2
       required: Lich >= 5.17.1
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -17,6 +17,12 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.15.2  (2026-07-27)
+    - fix priority hunt not retargeting when a higher priority creature arrives mid-fight
+    - match priority targets with the same anchored name and noun rules used to select them
+    - keep the current target when a priority retarget has no replacement to offer
+    - fix follower priority check reading an instance variable that was never set
+    - remove the unused room npc snapshot thread and its globals
   v5.15.1  (2026-07-23)
     - Fix cmd_force re-issuing maneuver on a passing roll (negative slice index collapses result window)
   v5.15.0  (2026-07-19)
@@ -484,12 +490,10 @@ $bigshot_unarmed_tier = 1
 $bigshot_rooted = false
 $bigshot_wand = 0
 $current_script_name = Script.current.name
-$current_room_npcs = GameObj.npcs
 $last_loot = nil
 $looting_inactive = true
 $not_hunting_reason = nil
 $rest_reason = nil
-$room_npcs_last_check = []
 $mstrike_taken = false
 $bigshot_single = false
 $bigshot_sneaky_hunt = false
@@ -5727,15 +5731,6 @@ class Bigshot
     return npcs.size.to_i
   end
 
-  def npc_room_check()
-    Thread.new {
-      loop {
-        $current_room_npcs = GameObj.npcs
-        pause 0.5
-      }
-    }
-  end
-
   def wrack()
     debug_msg(@DEBUG_COMMANDS, "wrack")
 
@@ -5965,7 +5960,6 @@ class Bigshot
     debug_msg(@DEBUG_STATUS, "lead")
 
     monitor_interaction()
-    npc_room_check()
     @followers = my_group || Group.new()
     @leader = Char.name
 
@@ -6164,7 +6158,8 @@ class Bigshot
         debug_msg(@DEBUG_COMBAT, "inside do_hunt loop | target: #{target}")
 
         if !priority(target)
-          target = find_target(nil)
+          better_target = find_target(nil)
+          target = better_target if better_target
         end
 
         # Tell follower to attack if its a new target or its been 10 seconds
@@ -6826,11 +6821,13 @@ class Bigshot
     @BOON_CACHE[creature.id] = abilities.empty? ? nil : abilities
   end
 
-  def invalid_target_with_boons(creature)
+  def invalid_target_with_boons(creature, assess = true)
     debug_msg(@DEBUG_COMBAT, "invalid_target_with_boons | creature: #{creature.inspect}")
 
     return false if @BOONS_IGNORE.empty?
     return false unless creature.type.include?("boon")
+    # assess: false answers from @BOON_CACHE only, for callers that must not send commands
+    return false if !assess && !@BOON_CACHE.key?(creature.id)
 
     abilities = check_boons(creature)
     return false unless abilities
@@ -6974,14 +6971,14 @@ class Bigshot
     return false if target.nil?
     return true if $bigshot_bandits
     return true if !@PRIORITY
-    return true if (!$current_room_npcs.zip($room_npcs_last_check).map { |x, y| x.id == y.id }.any? { |s| s == false })
 
-    $room_npcs_last_check = GameObj.npcs
-    priority = false
-    npcs = GameObj.targets.reject { |npc| CharSettings['untargetable'].include?(npc.name) }
+    # Default true: nothing we are set up to hunt is here, so there is nothing to switch to
+    priority = true
+    npcs = GameObj.targets.reject { |npc| CharSettings['untargetable'].include?(npc.name) || invalid_target_with_boons(npc, false) }
 
+    # Anchored to match sort_npcs, so priority never names a creature find_target cannot pick
     @TARGETS.keys.each do |name|
-      name_regex = /#{name}/i
+      name_regex = /^#{name}$/i
       if (npc = npcs.find { |s| s.name =~ name_regex || s.noun =~ name_regex })
         priority = (npc.name == target.name)
         break
@@ -8189,7 +8186,6 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
 
   # Participate
   bs.message("yellow", " Successfully joined group")
-  bs.npc_room_check()
   bs.groupcheck unless checkpcs.nil?
 
   # Don't announce these events
@@ -8277,8 +8273,9 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
           target ||= bs.find_target(target)
 
           # Set priority target if needed
-          if !$bigshot_bandits && @PRIORITY && !bs.priority(target)
-            target = bs.find_target(nil)
+          if !$bigshot_bandits && bs.PRIORITY && !bs.priority(target)
+            better_target = bs.find_target(nil)
+            target = better_target if better_target
           end
 
           # If no target, wait a bit and retry

--- a/spec/bigshot/priority_spec.rb
+++ b/spec/bigshot/priority_spec.rb
@@ -1,0 +1,312 @@
+# Spec for bigshot.lic Priority Hunt retargeting.
+#
+# We do NOT load the .lic file: it needs the whole Lich runtime (Settings,
+# XMLData, Spell, GTK, DRb ...). Instead the real method bodies are extracted
+# from scripts/bigshot.lic and evaluated against stubs, so these specs exercise
+# production code and fail if that code changes shape.
+#
+# Every stub lives inside BigshotPrioritySpec::Harness rather than at top level,
+# so running the whole suite in one process cannot collide with the real GameObj
+# used by the gameobj-data specs.
+#
+# Deliberately no NilClass patch here. Lich patches NilClass#method_missing to
+# return nil (lich-5 lib/common/class_exts/nilclass.rb), which is what let the
+# removed room-composition cache paper over nil comparisons. This code must not
+# depend on that.
+
+module BigshotPrioritySpec
+  SOURCE_PATH = File.expand_path('../../scripts/bigshot.lic', __dir__)
+  SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
+
+  def self.extract(pattern, label)
+    found = SOURCE[pattern]
+    raise "could not extract #{label} from bigshot.lic" unless found
+
+    found
+  end
+
+  PRIORITY_SRC = extract(/^  def priority\(target\).*?^  end$/m, 'priority')
+  SORT_NPCS_SRC = extract(/^  def sort_npcs\(\).*?^  end$/m, 'sort_npcs')
+  FIND_TARGET_SRC = extract(/^  def find_target\(target, just_entered = false\).*?^  end$/m, 'find_target')
+  BOONS_SRC = extract(/^  def invalid_target_with_boons\(creature, assess = true\).*?^  end$/m,
+                      'invalid_target_with_boons')
+  DO_HUNT_RETARGET_SRC = extract(/^        if !priority\(target\)\n.*?^        end$/m,
+                                 'do_hunt retarget block')
+  FOLLOWER_RETARGET_SRC = extract(/^          if !\$bigshot_bandits && bs\.PRIORITY && !bs\.priority\(target\)\n.*?^          end$/m,
+                                  'follower retarget block')
+
+  Creature = Struct.new(:id, :name, :noun, :type, :status) do
+    def to_s
+      name
+    end
+  end
+
+  class Harness
+    # Stubs for the Lich globals the extracted bodies reach for. Nested here so
+    # constant lookup inside the eval'd method bodies finds these, not the real
+    # classes other specs load.
+    module GameObj
+      class << self
+        attr_writer :room_targets
+
+        def targets
+          (@room_targets || []).dup
+        end
+      end
+    end
+
+    module CharSettings
+      class << self
+        attr_accessor :store
+
+        def [](key)
+          store[key]
+        end
+      end
+    end
+
+    attr_accessor :PRIORITY, :TARGETS, :QUICKHUNT_TARGETS, :BOONS_IGNORE, :BOON_CACHE
+    attr_reader :check_boons_calls
+
+    def initialize
+      @PRIORITY = true
+      @TARGETS = {}
+      @QUICKHUNT_TARGETS = {}
+      @BOONS_IGNORE = []
+      @BOON_CACHE = {}
+      @check_boons_calls = []
+      @unpickable = []
+      @DEBUG_COMBAT = false
+      CharSettings.store = { 'untargetable' => [], 'targetable' => [] }
+      GameObj.room_targets = []
+    end
+
+    def room(*creatures)
+      GameObj.room_targets = creatures
+    end
+
+    def untargetable(*names)
+      CharSettings.store['untargetable'] = names
+    end
+
+    # find_target refuses these, standing in for the reasons valid_target? can
+    # reject a creature that priority cannot see (ignored boons, flee checks).
+    def cannot_pick(name)
+      @unpickable << name
+    end
+
+    def debug_msg(*); end
+
+    # Stands in for the real check_boons, which sends "assess #id" to the game
+    # on a cache miss. Recording calls lets us prove priority never gets here.
+    def check_boons(creature)
+      @check_boons_calls << creature.id
+      @BOON_CACHE[creature.id]
+    end
+
+    # Stands in for valid_target?, which probes the game with "target #id".
+    def valid_target?(target, _just_entered = false)
+      return false if target.nil?
+
+      !@unpickable.include?(target.name)
+    end
+
+    eval(PRIORITY_SRC)
+    eval(SORT_NPCS_SRC)
+    eval(FIND_TARGET_SRC)
+    eval(BOONS_SRC)
+
+    # Runs the real do_hunt retarget block with target bound as a local.
+    def do_hunt_retarget(target)
+      instance_eval("lambda { |target| #{DO_HUNT_RETARGET_SRC}\n target }", __FILE__, __LINE__).call(target)
+    end
+
+    # Runs the real follower retarget block, which reaches the script through bs.
+    def follower_retarget(target)
+      eval("lambda { |bs, target| #{FOLLOWER_RETARGET_SRC}\n target }").call(self, target)
+    end
+  end
+
+  module Creatures
+    def mastiff
+      Creature.new('101', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
+    end
+
+    def mystic
+      Creature.new('102', 'illoke mystic', 'mystic', 'aggressive npc', nil)
+    end
+
+    def giant
+      Creature.new('103', 'stone giant', 'giant', 'aggressive npc', nil)
+    end
+
+    def shaman
+      Creature.new('104', 'illoke shaman', 'shaman', 'aggressive npc boon', nil)
+    end
+
+    def troll
+      Creature.new('105', 'ice troll', 'troll', 'aggressive npc', nil)
+    end
+  end
+end
+
+RSpec.describe 'bigshot Priority Hunt' do
+  include BigshotPrioritySpec::Creatures
+
+  let(:bs) { BigshotPrioritySpec::Harness.new }
+
+  before do
+    $bigshot_bandits = false
+    $bigshot_quick = false
+    # user-ordered list: mystic outranks mastiff, which outranks giant
+    bs.TARGETS = { 'illoke mystic' => 'f', 'stone mastiff' => 'f', 'stone giant' => 'd' }
+  end
+
+  describe '#priority' do
+    it 'returns false when there is no target' do
+      bs.room(mastiff)
+      expect(bs.priority(nil)).to be false
+    end
+
+    it 'does not interrupt bandit hunting' do
+      $bigshot_bandits = true
+      bs.room(mystic, mastiff)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'does not interrupt when Priority Hunt is disabled' do
+      bs.PRIORITY = false
+      bs.room(mystic, mastiff)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'accepts the target when it is the highest ranked creature in the room' do
+      bs.room(mastiff, giant)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'rejects the target when a higher ranked creature is in the room' do
+      bs.room(mastiff, mystic)
+      expect(bs.priority(mastiff)).to be false
+    end
+
+    it 'accepts the target when a lower ranked creature joins the room' do
+      bs.room(mastiff)
+      expect(bs.priority(mastiff)).to be true
+
+      bs.room(mastiff, giant)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'rejects the target on a later call, after the same room was already evaluated' do
+      bs.room(mastiff)
+      expect(bs.priority(mastiff)).to be true
+
+      bs.room(mastiff, mystic)
+      expect(bs.priority(mastiff)).to be false
+    end
+
+    it 'keeps rejecting the target while the higher ranked creature stays in the room' do
+      bs.room(mastiff, mystic)
+      expect(Array.new(5) { bs.priority(mastiff) }).to eq([false, false, false, false, false])
+    end
+
+    it 'accepts the target again once the higher ranked creature is gone' do
+      bs.room(mastiff, mystic)
+      expect(bs.priority(mastiff)).to be false
+
+      bs.room(mastiff)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'ignores creatures on the untargetable list' do
+      bs.untargetable('illoke mystic')
+      bs.room(mastiff, mystic)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'accepts the target when none of the configured creatures are in the room' do
+      bs.room(troll)
+      expect(bs.priority(troll)).to be true
+    end
+
+    it 'matches a list entry against the creature noun' do
+      bs.TARGETS = { 'mystic' => 'f', 'stone mastiff' => 'f' }
+      bs.room(mastiff, mystic)
+
+      expect(bs.priority(mystic)).to be true
+      expect(bs.priority(mastiff)).to be false
+    end
+
+    it 'anchors matching so a partial list entry cannot claim a creature find_target could not pick' do
+      bs.TARGETS = { 'illoke' => 'a', 'stone mastiff' => 'f' }
+      bs.room(mastiff, mystic)
+
+      expect(bs.sort_npcs.map(&:name)).to eq(['stone mastiff'])
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'never assesses boons, because a priority check must not send commands' do
+      bs.BOONS_IGNORE = ['spell warded']
+      bs.TARGETS = { 'illoke shaman' => 'a', 'stone mastiff' => 'f' }
+      bs.room(mastiff, shaman)
+
+      expect(bs.priority(mastiff)).to be false
+      expect(bs.check_boons_calls).to be_empty
+    end
+
+    it 'skips creatures whose already-assessed boons are on the ignore list' do
+      bs.BOONS_IGNORE = ['spell warded']
+      bs.BOON_CACHE['104'] = ['spell warded']
+      bs.TARGETS = { 'illoke shaman' => 'a', 'stone mastiff' => 'f' }
+      bs.room(mastiff, shaman)
+
+      expect(bs.priority(mastiff)).to be true
+    end
+  end
+
+  describe 'do_hunt retargeting' do
+    it 'switches to the higher ranked creature when one arrives mid fight' do
+      bs.room(mastiff, mystic)
+      expect(bs.do_hunt_retarget(mastiff).name).to eq('illoke mystic')
+    end
+
+    it 'stays on the current target when nothing outranks it' do
+      bs.room(mastiff, giant)
+      expect(bs.do_hunt_retarget(mastiff).name).to eq('stone mastiff')
+    end
+
+    it 'keeps the current target when the higher ranked creature cannot be picked' do
+      bs.room(mastiff, mystic)
+      bs.cannot_pick('illoke mystic')
+
+      expect(bs.find_target(nil)).to be_nil
+      expect(bs.do_hunt_retarget(mastiff).name).to eq('stone mastiff')
+    end
+  end
+
+  describe 'follower retargeting' do
+    it 'switches to the higher ranked creature through the accessor, not an unset ivar' do
+      bs.room(mastiff, mystic)
+      expect(bs.follower_retarget(mastiff).name).to eq('illoke mystic')
+    end
+
+    it 'honours the follower Priority Hunt setting' do
+      bs.PRIORITY = false
+      bs.room(mastiff, mystic)
+      expect(bs.follower_retarget(mastiff).name).to eq('stone mastiff')
+    end
+
+    it 'keeps the current target when the higher ranked creature cannot be picked' do
+      bs.room(mastiff, mystic)
+      bs.cannot_pick('illoke mystic')
+      expect(bs.follower_retarget(mastiff).name).to eq('stone mastiff')
+    end
+  end
+
+  describe 'the removed room snapshot cache' do
+    it 'leaves no reference to the room composition globals or the snapshot thread' do
+      expect(BigshotPrioritySpec::SOURCE).not_to match(/current_room_npcs|room_npcs_last_check|npc_room_check/)
+    end
+  end
+end

--- a/spec/bigshot/priority_spec.rb
+++ b/spec/bigshot/priority_spec.rb
@@ -26,6 +26,8 @@ module BigshotPrioritySpec
   end
 
   PRIORITY_SRC = extract(/^  def priority\(target\).*?^  end$/m, 'priority')
+  MATCHERS_SRC = extract(/^  def priority_matchers\n.*?^  end$/m, 'priority_matchers')
+  RANK_SRC = extract(/^  def priority_rank\(npc, matchers\).*?^  end$/m, 'priority_rank')
   SORT_NPCS_SRC = extract(/^  def sort_npcs\(\).*?^  end$/m, 'sort_npcs')
   FIND_TARGET_SRC = extract(/^  def find_target\(target, just_entered = false\).*?^  end$/m, 'find_target')
   BOONS_SRC = extract(/^  def invalid_target_with_boons\(creature, assess = true\).*?^  end$/m,
@@ -34,6 +36,7 @@ module BigshotPrioritySpec
                                  'do_hunt retarget block')
   FOLLOWER_RETARGET_SRC = extract(/^          if !\$bigshot_bandits && bs\.PRIORITY && !bs\.priority\(target\)\n.*?^          end$/m,
                                   'follower retarget block')
+  EACHTARGET_SRC = extract(/^  def cmd_eachtarget\(command, npc\).*?^  end$/m, 'cmd_eachtarget')
 
   Creature = Struct.new(:id, :name, :noun, :type, :status) do
     def to_s
@@ -65,8 +68,14 @@ module BigshotPrioritySpec
       end
     end
 
+    module XMLData
+      class << self
+        attr_accessor :current_target_id
+      end
+    end
+
     attr_accessor :PRIORITY, :TARGETS, :QUICKHUNT_TARGETS, :BOONS_IGNORE, :BOON_CACHE
-    attr_reader :check_boons_calls
+    attr_reader :check_boons_calls, :fputs, :cmd_calls
 
     def initialize
       @PRIORITY = true
@@ -75,10 +84,25 @@ module BigshotPrioritySpec
       @BOONS_IGNORE = []
       @BOON_CACHE = {}
       @check_boons_calls = []
+      @fputs = []
+      @cmd_calls = []
       @unpickable = []
       @DEBUG_COMBAT = false
+      @DEBUG_COMMANDS = false
       CharSettings.store = { 'untargetable' => [], 'targetable' => [] }
       GameObj.room_targets = []
+      XMLData.current_target_id = nil
+    end
+
+    def fput(command)
+      @fputs << command
+      XMLData.current_target_id = Regexp.last_match(1) if command =~ /\Atarget #(\d+)\z/
+    end
+
+    # Records what cmd_eachtarget asks of cmd. The other half of the contract,
+    # that cmd honours check_priority, is locked by a source expectation below.
+    def cmd(command, npc = nil, _stance_dance = true, check_priority: true)
+      @cmd_calls << { command: command, npc: npc, check_priority: check_priority }
     end
 
     def room(*creatures)
@@ -112,9 +136,12 @@ module BigshotPrioritySpec
     end
 
     eval(PRIORITY_SRC)
+    eval(MATCHERS_SRC)
+    eval(RANK_SRC)
     eval(SORT_NPCS_SRC)
     eval(FIND_TARGET_SRC)
     eval(BOONS_SRC)
+    eval(EACHTARGET_SRC)
 
     # Runs the real do_hunt retarget block with target bound as a local.
     def do_hunt_retarget(target)
@@ -146,6 +173,27 @@ module BigshotPrioritySpec
 
     def troll
       Creature.new('105', 'ice troll', 'troll', 'aggressive npc', nil)
+    end
+
+    def second_mastiff
+      Creature.new('106', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
+    end
+
+    # From the reported thrash: order was valravn, angargeist, disir
+    def valravn
+      Creature.new('280414583', 'eyeless black valravn', 'valravn', 'aggressive npc', nil)
+    end
+
+    def angargeist
+      Creature.new('280405751', 'roiling crimson angargeist', 'angargeist', 'aggressive npc', nil)
+    end
+
+    def disir
+      Creature.new('280394883', 'shining winged disir', 'disir', 'aggressive npc', nil)
+    end
+
+    def draugr
+      Creature.new('280394876', 'withered shadow-cloaked draugr', 'draugr', 'aggressive npc', nil)
     end
   end
 end
@@ -265,6 +313,65 @@ RSpec.describe 'bigshot Priority Hunt' do
     end
   end
 
+  describe 'rank comparison' do
+    # GameObj.targets is the game's target dropdown (xmlparser dDBTarget), which
+    # is cleared and rebuilt wholesale, so the current target can be missing from
+    # it for a moment. Ranking off the list rather than off dropdown membership
+    # keeps that from handing the fight to a lower ranked creature.
+    it 'keeps the current target when the target itself is missing from the dropdown' do
+      bs.room(giant)
+      expect(bs.priority(mastiff)).to be true
+    end
+
+    it 'switches when a higher ranked creature is in the dropdown and the target is not' do
+      bs.room(mystic)
+      expect(bs.priority(mastiff)).to be false
+    end
+
+    it 'prefers a listed creature over an unlisted target' do
+      bs.room(giant)
+      expect(bs.priority(troll)).to be false
+    end
+
+    it 'does not treat a second creature matching the same entry as an interrupt' do
+      bs.room(mastiff, second_mastiff)
+      expect(bs.priority(mastiff)).to be true
+      expect(bs.priority(second_mastiff)).to be true
+    end
+  end
+
+  describe 'the reported retarget thrash' do
+    before do
+      bs.TARGETS = { 'valravn' => 'a', 'angargeist' => 'b', 'disir' => 'c' }
+    end
+
+    it 'settles on the angargeist once the valravn is known to be untargetable' do
+      bs.untargetable('eyeless black valravn')
+      bs.room(angargeist, disir, valravn)
+
+      expect(bs.priority(angargeist)).to be true
+      expect(bs.do_hunt_retarget(angargeist).name).to eq('roiling crimson angargeist')
+    end
+
+    it 'does not hand the fight to the disir when the angargeist drops out of the dropdown' do
+      bs.untargetable('eyeless black valravn')
+      bs.room(disir)
+
+      expect(bs.priority(angargeist)).to be true
+      expect(bs.do_hunt_retarget(angargeist).name).to eq('roiling crimson angargeist')
+    end
+
+    it 'keeps the angargeist while the valravn is still unclassified but unpickable' do
+      bs.room(angargeist, disir, valravn)
+      bs.cannot_pick('eyeless black valravn')
+
+      # the valravn outranks everything, so the check does report an interrupt
+      expect(bs.priority(angargeist)).to be false
+      # but selection cannot pick it, so the fight stays on the angargeist
+      expect(bs.do_hunt_retarget(angargeist).name).to eq('roiling crimson angargeist')
+    end
+  end
+
   describe 'do_hunt retargeting' do
     it 'switches to the higher ranked creature when one arrives mid fight' do
       bs.room(mastiff, mystic)
@@ -301,6 +408,48 @@ RSpec.describe 'bigshot Priority Hunt' do
       bs.room(mastiff, mystic)
       bs.cannot_pick('illoke mystic')
       expect(bs.follower_retarget(mastiff).name).to eq('stone mastiff')
+    end
+  end
+
+  describe 'eachtarget sweeps' do
+    # From the reported log: routine "eachtarget wandolier guarded noreserve" in a
+    # room holding an angargeist (rank 1), a disir (rank 2) and a draugr (rank 12).
+    # Each creature was targeted and then skipped, because the per-creature cmd
+    # call hit the priority gate.
+    before do
+      bs.TARGETS = { 'valravn' => 'b', 'angargeist' => 'a', 'disir' => 'b', 'draugr' => 'a' }
+      bs.room(angargeist, draugr, disir)
+    end
+
+    it 'issues the command against every creature in the room, not only the highest ranked one' do
+      bs.cmd_eachtarget('wandolier guarded noreserve', angargeist)
+
+      expect(bs.cmd_calls.map { |call| call[:npc].name })
+        .to eq(['roiling crimson angargeist', 'withered shadow-cloaked draugr', 'shining winged disir'])
+    end
+
+    it 'asks cmd to skip the priority gate for creatures inside the sweep' do
+      bs.cmd_eachtarget('wandolier guarded noreserve', angargeist)
+
+      expect(bs.cmd_calls.map { |call| call[:check_priority] }).to all(be false)
+    end
+
+    it 'restores the original target after the sweep' do
+      bs.cmd_eachtarget('wandolier guarded noreserve', angargeist)
+
+      expect(bs.fputs.last).to eq("target ##{angargeist.id}")
+    end
+
+    it 'still skips creatures that cannot be picked' do
+      bs.cannot_pick('shining winged disir')
+      bs.cmd_eachtarget('wandolier guarded noreserve', angargeist)
+
+      expect(bs.cmd_calls.map { |call| call[:npc].name }).not_to include('shining winged disir')
+    end
+
+    it 'keeps the priority gate on every other cmd caller' do
+      expect(BigshotPrioritySpec::SOURCE).to match(/^    return if check_priority && @PRIORITY && !priority\(npc\)$/)
+      expect(BigshotPrioritySpec::SOURCE).to match(/^  def cmd\(command, npc = nil, stance_dance = true, check_priority: true\)$/)
     end
   end
 


### PR DESCRIPTION
## Problem

With Priority Hunt enabled and an ordered target list, bigshot notices when a
higher priority creature enters the room but never switches to it. It keeps
fighting the current, lower priority target until that target dies or leaves, at
which point the arrival is picked up as an ordinary next-target selection rather
than a priority interrupt. Affects normal and quick hunting alike.

## Root cause

`priority(target)` memoized its answer against room composition
(`$current_room_npcs` vs `$room_npcs_last_check`, bigshot.lic:6977-6979), but the
answer is a function of `target`, which was not part of the key.

`priority()` has four callers, and only `do_hunt` (6166-6168) can actually
retarget. `attack_break` (6515) and `cmd` (3391) run far more often, so whichever
of them evaluated first consumed the one fresh computation and stamped the room as
"already evaluated." `do_hunt`'s check then short-circuited to true and never
called `find_target(nil)`. Verified both orderings against the real method body:

- attack_break first -> breaks the command loop, then do_hunt retarget = false
- do_hunt first       -> retargets correctly, then attack_break = false

Recomputing costs about 76 microseconds with a 23-entry target list and three
NPCs in the room, against a call rate bounded by roundtime, so there was nothing
worth caching.

Note for reviewers: the `x.id == y.id` comparison on the removed line did not
raise on `zip`'s nil padding, because Lich patches `NilClass#method_missing` to
return nil (lich-5 `lib/common/class_exts/nilclass.rb`). That nil tolerance was in
fact the only signal that detected an arrival at all, so hardening the comparison
without removing the guard would have made priority hunting worse.

A second, related bug surfaced during testing. `cmd_eachtarget` (3515-3525)
targets every creature in the room and calls `cmd` per creature, and `cmd`'s
priority gate (3391) aborted each of those calls. With a correct `priority()` that
became deterministic: every creature except the highest ranked one was targeted
and then skipped, which reads as target thrash in the log.

## Changes

- `priority()`: drop the room-composition cache and recompute per call.
- `priority()`: compare target list rank rather than identity. `GameObj.targets`
  is the game's target dropdown (`xmlparser.rb:464-478`, cleared and rebuilt
  wholesale), so the current target can be missing from it for a moment. Ranking
  off the list means only a creature that outranks the target may interrupt it,
  and a lower ranked creature can never win a check by default. New helpers
  `priority_matchers` and `priority_rank`; the debug line now reports
  `target_rank` and `best_rank`.
- `priority()`: anchor name and noun matching to match `sort_npcs` (6967), so it
  cannot nominate a creature `find_target` is unable to select.
- `priority()`: skip creatures whose ignored boons are already known.
  `invalid_target_with_boons` (6829) gains `assess = true`; passing false answers
  from `@BOON_CACHE` only, because `check_boons` sends `assess #id` to the game
  and a predicate called several times a second must not do that. The existing
  caller keeps the default and is unchanged.
- `cmd` gains `check_priority: true`; `cmd_eachtarget` passes false for its
  per-creature calls. The gate exists to abandon a single-target attack when
  something better appears, which is meaningless inside a sweep whose purpose is
  to hit everything. `attack_break` still evaluates between routine commands, so
  a genuine priority arrival interrupts at the next command boundary. All other
  `cmd` callers keep the gate.
- `do_hunt` (6166-6168) and the follower ATTACK loop (8280-8282): a retarget that
  finds no replacement keeps the current target instead of setting it to nil,
  which also removes a path that sent a bare `target #` to the game (6536).
- Follower loop: read `bs.PRIORITY` instead of `@PRIORITY`, a top-level instance
  variable that was never set, making follower priority retargeting dead code.
- Remove the unused `npc_room_check` snapshot thread (5730-5737), its two call
  sites (5968, 8192) and its two globals (487, 492). Nothing else in this repo
  referenced them.
- Header bump to v5.15.2 with changelog entry.

## Behavior changes

Reachable only where the priority list disagreed with what target selection can
pick:

- A partial list entry (for example `illoke` against `illoke mystic`) no longer
  claims a creature. Such creatures were never selectable, since `sort_npcs` has
  always matched anchored.
- When nothing that outranks the current target is present, bigshot keeps its
  target instead of dropping it or switching down the list.
- `eachtarget` routines now issue their command against every valid creature in
  the room while Priority Hunt is on, which is what they did before the cache
  stopped masking the gate.

## Testing

`spec/bigshot/priority_spec.rb`, 34 examples. The specs extract the real
`priority`, `priority_matchers`, `priority_rank`, `sort_npcs`, `find_target`,
`invalid_target_with_boons` and `cmd_eachtarget` bodies from `scripts/bigshot.lic`
along with the `do_hunt` and follower retarget blocks, and evaluate them against
stubs, so they fail if that code changes shape rather than drifting from it. Stubs
are namespaced inside the harness so the suite's real `GameObj` is untouched. No
`NilClass` patch: the fixed code must not depend on Lich's nil tolerance.

Coverage includes the reported room from the log (angargeist, disir and draugr
with the reporter's own list and creature ids) and the boon path, asserting that a
priority check never triggers an `assess`.

Targeted reverts confirm the specs bite:

- reverting the comparison to identity fails the two rank examples
- reverting the `cmd_eachtarget` call site fails the gate contract example
- reverting the whole `priority` method fails the spec's extraction guard

Verified locally: `ruby -c` clean, ASCII-only, CRLF preserved (8370 CRLF, zero
bare LF), rubocop reports only the pre-existing `cmd_jewel` offense that is
present on the unmodified file, and the spec subset that runs without the full
gem set passes 139 examples with no failures.

In game: the mid-fight priority arrival now retargets immediately, and
`eachtarget wandolier` hits every creature in the room again.