### PR TITLE
fix(bigshot.lic): v5.13.3 remove experience scraping

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,8 +8,8 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.15.2
-      required: Lich >= 5.17.1
+       version: 5.15.3
+      required: Lich >= 5.19.0
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
       Full Changelog: https://gswiki.play.net/Script_Bigshot/Changelog
@@ -17,6 +17,8 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.15.3  (2026-07-29)
+    - fix to remove EXPERIENCE scraping for field exp, require new Lich to get it automatically from feed
   v5.15.2  (2026-07-27)
     - fix priority hunt not retargeting when a higher priority creature arrives mid-fight
     - compare target list rank instead of identity so a lower ranked creature never wins a check
@@ -7094,11 +7096,6 @@ class Bigshot
 
   def check_mind
     @followers.add_event(:CHECK_MIND)
-
-    @CORRECT_PERCENT_MIND = percentmind
-    return @CORRECT_PERCENT_MIND unless @CORRECT_PERCENT_MIND >= @FRIED
-
-    Lich::Util.quiet_command_xml("experience", /<output class="mono"\/>/)
     @CORRECT_PERCENT_MIND = Lich::Gemstone::Experience.percent_fxp
   end
 


### PR DESCRIPTION
With Lich 5.19+ we now get field exp/max in XML updates fed to the client that Lich ingests. No longer need to send EXP command to scrape that data.