### PR TITLE
fix(go2.lic): v2.3.3 hash iteration error when running go2 with vaalor shortcut

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -944,15 +944,9 @@ module Go2
   }
 
   change_map_vaalor_shortcut = proc { |use_shortcut|
-    unless Map.list.any? { |room| room.timeto.any? { |_adj_id, time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
-      if use_shortcut
-        Room[16745].timeto['16746'] = 15
-        Room[16746].timeto['16745'] = 15
-      else
-        Room[16745].timeto['16746'] = nil
-        Room[16746].timeto['16745'] = nil
-      end
-    end
+    new_time = use_shortcut ? 15 : nil
+    Room[16745].timeto['16746'] = new_time
+    Room[16746].timeto['16745'] = new_time
   }
 
   get_silver_cost = proc { |path|

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -10,10 +10,12 @@
       contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin, Dissonance
               game: any
               tags: core, movement
-           version: 2.3.2
+           version: 2.3.3
           required: Lich >= 5.12.0
 
    changelog:
+      2.3.3 (2026-08-04)
+        Correct vaalor shortcut hash iteration timing update
       2.3.2 (2026-07-02)
         Change Society call to updated API call
       2.3.1 (2026-06-30)
@@ -1034,7 +1036,7 @@ module Go2
       output << " - Known Nexus Rooms"
       output << "---------------------------------------------------------------"
       Map.list.find_all { |iroom| iroom.tags.include?('nexus') }
-              .each { |iroom| output << "#{iroom.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{iroom.id.to_s.rjust(5)}" }
+         .each { |iroom| output << "#{iroom.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{iroom.id.to_s.rjust(5)}" }
     end
     respond output
     exit


### PR DESCRIPTION
This error happens when you have vaalor shortcut on, this function iterates through the entire mapdb which is slow and manipulates the MapDB while trying to read it at the same time.   

Updated the code to remove the slow full mapdb iteration to mitigate the race condition.

 --- Lich: error: hash representation was changed during iteration
         go2:947:in 'Hash#any?'
         go2:947:in 'block (2 levels) in <module:Go2>'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Ta’Vaalor shortcut travel-time handling to reliably set the correct 15-minute or unavailable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->