### PR TITLE
fix(ecleanse.lic): v2.3.1 bound search attempts, validate room between searches, stop duplicate events

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,15 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.12.10
-       version: 2.3.0
+       version: 2.3.1
 
   Improvements:
+  v2.3.1  (2026-08-05)
+    - hive traps: bound search/disarm attempts and add a wall-clock deadline
+    - hive traps: validate room between each search, break early if moved
+    - hive traps: break early if dead or muckled
+    - hive traps: fix SEARCH start_pattern so non-rolled results terminate the loop
+    - hive traps: fix event_stack push precedence that allowed duplicate events
   v2.3.0  (2026-06-08)
     - add break runestones option for Onslaughts
   v2.2.9  (2026-04-21)
@@ -666,6 +672,27 @@ end
 # Main Script Methods
 module Ecleanse
   module Action
+    # Hive trap tuning
+    HIVE_SEARCH_ATTEMPTS = 3  # rolled SEARCH attempts before giving up
+    HIVE_DISARM_ATTEMPTS = 3  # DISARM attempts on a revealed apparatus
+    HIVE_TRAP_DEADLINE   = 20 # hard wall-clock ceiling per event, in seconds
+
+    # Lich::Util.issue_command discards every line before start_pattern and
+    # returns [] on timeout, so every outcome of the command has to be listed
+    # here.  A start_pattern of /d100: / alone means a non-rolled result comes
+    # back empty and cannot be tested for.
+    HIVE_SEARCH_RESULT = Regexp.union(
+      /d100: /,
+      /You don't find anything of interest here/,
+      /You can't see well enough to search around/
+    )
+
+    HIVE_DISARM_RESULT = Regexp.union(
+      /d100: /,
+      /You want to disarm what\?/,
+      /You can't see well enough/
+    )
+
     def self.avoid_webs
       return unless Ecleanse.data.settings[:avoid_webs]
 
@@ -850,33 +877,72 @@ module Ecleanse
       Script.run('go2', "#{place} --disable-confirm", { quiet: true, force: true })
     end
 
+    # SEARCH until the trap resolves, we leave the room, or we run out of
+    # attempts.  Returns a symbol so callers can decide what to do next:
+    #   :found     - rolled Success, trap revealed or disturbed
+    #   :clear     - nothing here to find
+    #   :blind     - cannot see well enough to search
+    #   :moved     - no longer in the room the trap fired in
+    #   :muckled   - dead, stunned, webbed, bound or asleep
+    #   :exhausted - out of attempts
+    #   :timeout   - hit the wall-clock ceiling
+    def self.hive_search
+      deadline = Time.now + HIVE_TRAP_DEADLINE
+      attempts = 0
+
+      loop do
+        return :moved unless hive_trap_room?
+        return :muckled if dead? || muckled?
+        return :timeout if Time.now > deadline
+        return :exhausted if attempts >= HIVE_SEARCH_ATTEMPTS
+
+        Util.wait_rt
+        attempts += 1
+        lines = Util.get_command("search", HIVE_SEARCH_RESULT)
+
+        return :blind if lines.any? { |line| line =~ /You can't see well enough to search around/ }
+        return :clear if lines.any? { |line| line =~ /You don't find anything of interest here/ }
+        return :found if lines.any? { |line| line =~ /Success!/ }
+        # Failure! or an empty result (issue_command timed out) falls through and retries
+      end
+    end
+
+    # Guard against acting on a stale marker: an unmapped room reports nil, and
+    # nil == nil would otherwise read as a match.
+    def self.hive_trap_room?
+      room = Ecleanse.data.hive_trap_room
+      !room.nil? && room == Room.current
+    end
+
     def self.hive_traps_apparatus
       return unless Ecleanse.data.settings[:hive_traps_apparatus]
       return if Script.running?('go2')
-      return unless Ecleanse.data.hive_trap_room == Room.current
+      return unless hive_trap_room?
 
       System.scripts_pause
 
-      search_count = 0
-      loop do
-        Util.wait_rt
-        lines = Util.get_command("search", /d100: /)
-        search_count += 1
-        break if search_count >= 10
-        next if lines.any? { |l| l =~ /Failure!/ }
-        break if lines.any? { |l| l =~ /Success|You don't find anything of interest here/ }
+      result = hive_search
+
+      if result == :found
+        deadline = Time.now + HIVE_TRAP_DEADLINE
+        attempts = 0
+
+        loop do
+          break unless hive_trap_room?
+          break if dead? || muckled?
+          break if Time.now > deadline
+          break if attempts >= HIVE_DISARM_ATTEMPTS
+
+          Util.wait_rt
+          attempts += 1
+          results = Util.get_command("disarm apparatus", HIVE_DISARM_RESULT)
+          break if results.any? { |line| line =~ /Success!|You want to disarm what\?/ }
+        end
       end
 
-      Util.wait_rt
-
-      search_count = 0
-      loop do
-        results = Util.get_command("disarm apparatus", /d100|You want to disarm what\?/)
-        search_count += 1
-        break if results.any? { |l| l =~ /Success|You want to disarm what\?/ }
-        return if search_count >= 10
-        Util.wait_rt
-      end
+      # Clear the marker so queued duplicate events no-op, except when we bailed
+      # for a condition that clears on its own and the trap will re-announce.
+      Ecleanse.data.hive_trap_room = nil unless [:moved, :muckled].include?(result)
 
       Util.wait_rt
     end
@@ -884,19 +950,12 @@ module Ecleanse
     def self.hive_traps_ground
       return unless Ecleanse.data.settings[:hive_traps_ground]
       return if Script.running?('go2')
-      return unless Ecleanse.data.hive_trap_room == Room.current
+      return unless hive_trap_room?
 
       System.scripts_pause
 
-      search_count = 0
-      loop do
-        Util.wait_rt
-        lines = Util.get_command("search", /d100: /)
-        search_count += 1
-        break if search_count >= 10
-        next if lines.any? { |l| l =~ /Failure!/ }
-        break if lines.any? { |l| l =~ /Success|You don't find anything of interest here/ }
-      end
+      result = hive_search
+      Ecleanse.data.hive_trap_room = nil unless [:moved, :muckled].include?(result)
 
       Util.wait_rt
     end
@@ -1484,10 +1543,10 @@ module Ecleanse
           Ecleanse.data.event_stack << :recover_weapon_webbing
         elsif server =~ /You notice a flickering glint in the shadows|The apparatus flickers with deadly radiance/
           Ecleanse.data.hive_trap_room = Room.current
-          Ecleanse.data.event_stack << :hive_traps_apparatus && !Ecleanse.data.event_stack.include?(:hive_traps_apparatus)
+          Ecleanse.data.event_stack << :hive_traps_apparatus unless Ecleanse.data.event_stack.include?(:hive_traps_apparatus)
         elsif server =~ /The ground churns violently as flashes of chitin jut from its depths|The ground underfoot churns violently and huge chitinous mandibles flash as the insectoid monstrosity below goes into a feeding frenzy!|Hindered by the churning terrain, you are helpless as the concealed assailant's mandibles snap at you from the safety of its pit trap!/
           Ecleanse.data.hive_trap_room = Room.current
-          Ecleanse.data.event_stack << :hive_traps_ground && !Ecleanse.data.event_stack.include?(:hive_traps_ground)
+          Ecleanse.data.event_stack << :hive_traps_ground unless Ecleanse.data.event_stack.include?(:hive_traps_ground)
         elsif server =~ /You shiver slightly as an invisible rash covers your body/
           Ecleanse.data.event_stack << :itchy_curse && !Ecleanse.data.event_stack.include?(:itchy_curse)
         elsif server =~ /^An unseen force entangles you, restricting your movement!\r?\n?$/

--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -672,27 +672,6 @@ end
 # Main Script Methods
 module Ecleanse
   module Action
-    # Hive trap tuning
-    HIVE_SEARCH_ATTEMPTS = 3  # rolled SEARCH attempts before giving up
-    HIVE_DISARM_ATTEMPTS = 3  # DISARM attempts on a revealed apparatus
-    HIVE_TRAP_DEADLINE   = 20 # hard wall-clock ceiling per event, in seconds
-
-    # Lich::Util.issue_command discards every line before start_pattern and
-    # returns [] on timeout, so every outcome of the command has to be listed
-    # here.  A start_pattern of /d100: / alone means a non-rolled result comes
-    # back empty and cannot be tested for.
-    HIVE_SEARCH_RESULT = Regexp.union(
-      /d100: /,
-      /You don't find anything of interest here/,
-      /You can't see well enough to search around/
-    )
-
-    HIVE_DISARM_RESULT = Regexp.union(
-      /d100: /,
-      /You want to disarm what\?/,
-      /You can't see well enough/
-    )
-
     def self.avoid_webs
       return unless Ecleanse.data.settings[:avoid_webs]
 
@@ -877,6 +856,40 @@ module Ecleanse
       Script.run('go2', "#{place} --disable-confirm", { quiet: true, force: true })
     end
 
+    # Hive trap tuning.  Methods rather than constants so a re-run of the script
+    # neither warns about an already initialized constant nor pins the old value.
+    def self.hive_search_attempts
+      3 # rolled SEARCH attempts before giving up
+    end
+
+    def self.hive_disarm_attempts
+      3 # DISARM attempts on a revealed apparatus
+    end
+
+    def self.hive_trap_deadline
+      20 # hard wall-clock ceiling per event, in seconds
+    end
+
+    # Lich::Util.issue_command discards every line before start_pattern and
+    # returns [] on timeout, so every outcome of the command has to be listed
+    # here.  A start_pattern of /d100: / alone means a non-rolled result comes
+    # back empty and cannot be tested for.
+    def self.hive_search_result
+      Regexp.union(
+        /d100: /,
+        /You don't find anything of interest here/,
+        /You can't see well enough to search around/
+      )
+    end
+
+    def self.hive_disarm_result
+      Regexp.union(
+        /d100: /,
+        /You want to disarm what\?/,
+        /You can't see well enough/
+      )
+    end
+
     # SEARCH until the trap resolves, we leave the room, or we run out of
     # attempts.  Returns a symbol so callers can decide what to do next:
     #   :found     - rolled Success, trap revealed or disturbed
@@ -887,18 +900,18 @@ module Ecleanse
     #   :exhausted - out of attempts
     #   :timeout   - hit the wall-clock ceiling
     def self.hive_search
-      deadline = Time.now + HIVE_TRAP_DEADLINE
+      deadline = Time.now + hive_trap_deadline
       attempts = 0
 
       loop do
         return :moved unless hive_trap_room?
         return :muckled if dead? || muckled?
         return :timeout if Time.now > deadline
-        return :exhausted if attempts >= HIVE_SEARCH_ATTEMPTS
+        return :exhausted if attempts >= hive_search_attempts
 
         Util.wait_rt
         attempts += 1
-        lines = Util.get_command("search", HIVE_SEARCH_RESULT)
+        lines = Util.get_command("search", hive_search_result)
 
         return :blind if lines.any? { |line| line =~ /You can't see well enough to search around/ }
         return :clear if lines.any? { |line| line =~ /You don't find anything of interest here/ }
@@ -924,18 +937,18 @@ module Ecleanse
       result = hive_search
 
       if result == :found
-        deadline = Time.now + HIVE_TRAP_DEADLINE
+        deadline = Time.now + hive_trap_deadline
         attempts = 0
 
         loop do
           break unless hive_trap_room?
           break if dead? || muckled?
           break if Time.now > deadline
-          break if attempts >= HIVE_DISARM_ATTEMPTS
+          break if attempts >= hive_disarm_attempts
 
           Util.wait_rt
           attempts += 1
-          results = Util.get_command("disarm apparatus", HIVE_DISARM_RESULT)
+          results = Util.get_command("disarm apparatus", hive_disarm_result)
           break if results.any? { |line| line =~ /Success!|You want to disarm what\?/ }
         end
       end

--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -921,10 +921,16 @@ module Ecleanse
     end
 
     # Guard against acting on a stale marker: an unmapped room reports nil, and
-    # nil == nil would otherwise read as a match.
+    # nil == nil would otherwise read as a match.  Room defines no ==, so an
+    # object comparison is identity, which fails across a Map.load that rebuilds
+    # every Room instance.  Compare ids when we have them.
     def self.hive_trap_room?
-      room = Ecleanse.data.hive_trap_room
-      !room.nil? && room == Room.current
+      trap_room = Ecleanse.data.hive_trap_room
+      current = Room.current
+      return false if trap_room.nil? || current.nil?
+      return trap_room.id == current.id unless trap_room.id.nil? || current.id.nil?
+
+      trap_room == current
     end
 
     def self.hive_traps_apparatus
@@ -1547,9 +1553,9 @@ module Ecleanse
           Ecleanse.data.event_stack << :telekinetic_recover
         elsif server =~ /Striking with a serpent's unsettling quickness, (?:.*)\.  Vile (?:.*), kindling it into an unholy semblance of life.  The (?:.*) form twists and mutates, sprouting scales and cold eyes as it transforms into a <a exist="\d+" noun="([^"]+)">[^<]+<\/a>\!/
           Ecleanse.data.creature = Regexp.last_match(1)
-          Ecleanse.data.event_stack << :sanctum_recover && !Ecleanse.data.event_stack.include?(:sanctum_recover)
+          Ecleanse.data.event_stack << :sanctum_recover unless Ecleanse.data.event_stack.include?(:sanctum_recover)
         elsif server =~ /The flesh around the wound feels hot and cold at the same time, heavy with infection./
-          Ecleanse.data.event_stack << :use_vat && !Ecleanse.data.event_stack.include?(:use_vat)
+          Ecleanse.data.event_stack << :use_vat unless Ecleanse.data.event_stack.include?(:use_vat)
         elsif server =~ /The webbing entangles your <a exist=".*?" noun="(.*?)">.*?<\/a>, rendering it useless/
           next if Ecleanse.data.recover_stuff[Regexp.last_match(1)]
           Ecleanse.data.recover_stuff[Regexp.last_match(1)] = Room.current
@@ -1561,9 +1567,9 @@ module Ecleanse
           Ecleanse.data.hive_trap_room = Room.current
           Ecleanse.data.event_stack << :hive_traps_ground unless Ecleanse.data.event_stack.include?(:hive_traps_ground)
         elsif server =~ /You shiver slightly as an invisible rash covers your body/
-          Ecleanse.data.event_stack << :itchy_curse && !Ecleanse.data.event_stack.include?(:itchy_curse)
+          Ecleanse.data.event_stack << :itchy_curse unless Ecleanse.data.event_stack.include?(:itchy_curse)
         elsif server =~ /^An unseen force entangles you, restricting your movement!\r?\n?$/
-          Ecleanse.data.event_stack << :remove_web_bound && !Ecleanse.data.event_stack.include?(:remove_web_bound)
+          Ecleanse.data.event_stack << :remove_web_bound unless Ecleanse.data.event_stack.include?(:remove_web_bound)
         end
         server
       }


### PR DESCRIPTION
## Summary
 
Hive apparatus and ground trap handling could search 30+ times over ~2.5 minutes with combat and support scripts paused, long after the trap had already resolved. The attempt cap of 10 was a symptom, not the cause: the loop's early-exit conditions were unreachable, and duplicate events multiplied whatever the cap allowed.
 
## Root cause
 
**1. The search loop's break conditions were dead code.**
 
```ruby
lines = Util.get_command("search", /d100: /)
...
next if lines.any? { |l| l =~ /Failure!/ }
break if lines.any? { |l| l =~ /Success|You don't find anything of interest here/ }
```
 
`/d100: /` is passed to `Lich::Util.issue_command` as `start_pattern`. `issue_command` discards every line before that pattern and returns `[]` when it times out (`until (line = get) =~ start_pattern; end` — lich-5 `lib/util/util.rb`). Search outcomes that produce no roll — `You don't find anything of interest here.`, `You can't see well enough to search around!` — therefore came back as an empty array after burning the full 5s timeout. Both the `Failure!` retry and the `Success`/nothing-found break were unreachable in exactly the cases they were written for, leaving `search_count >= 10` as the only exit.
 
**2. The duplicate-event guard never worked.**
 
```ruby
Ecleanse.data.event_stack << :hive_traps_ground && !Ecleanse.data.event_stack.include?(:hive_traps_ground)
```
 
`<<` binds tighter than `&&`, so this parses as `(stack << sym) && (!stack.include?(sym))`. The push is unconditional and the boolean is discarded.
 
**Observed in the wild** (Kresh Warrens, 2026-08-05):
 
- `11:14:55` — three matching ground-trap lines arrived in the same second, queuing three runs. 32 searches spanning `11:14:55`–`11:17:24`, with `bigshot`, `volnrestore` and `506-trog2` paused the entire time (`scripts_resume` only fires once `event_stack` drains). The *first* search had already cleared the trap: `As you begin sifting through the churning earth, the creature within retreats deeper into the ground and the shifting silt goes still.`
- `10:15:15` — 11 searches; blinded mid-loop, then knocked unconscious, still searching.
## Changes
 
- **`Action.hive_search`** — single helper shared by both trap types, returning `:found` / `:clear` / `:blind` / `:moved` / `:muckled` / `:exhausted` / `:timeout` so each caller decides what to do next. Removes the duplicated loop body.
- **Room validated before every search**, not just on entry. Returns `:moved` the moment we're somewhere else.
- **Break on incapacitation** — `dead? || muckled?`. `Status.muckled?` covers webbed / dead / stunned / bound / sleeping, and notably *not* prone, so a knockdown from the trap itself won't abort the disarm.
- **Attempt caps of 3** for both SEARCH and DISARM, plus a 20s wall-clock deadline. The deadline is load-bearing: `get_command`'s internal `...wait N seconds` retry re-issues the command without touching the caller's counter, which is how a cap of 10 became 12+ searches in the log.
- **`hive_search_result` / `hive_disarm_result`** — `start_pattern` unions covering every observed outcome, so a non-rolled result exits on attempt one instead of timing out silently.
- **Tuning values are module methods, not constants**, so re-running the script neither emits `already initialized constant` nor pins the previous value until Lich restarts.
- **`Action.hive_trap_room?`** — requires a non-nil marker on both sides, closing the unmapped-room case where `nil == Room.current` read as a match, and compares room ids. `Room` overrides neither `==` nor `eql?`, so the old comparison was object identity, which fails across a `Map.load` that rebuilds every `Room` instance in `@@list`.
- **Event push precedence fixed** to `unless ... include?` for all six guarded pushes: `:hive_traps_apparatus`, `:hive_traps_ground`, `:sanctum_recover`, `:use_vat`, `:itchy_curse`, `:remove_web_bound`. The four unguarded `:recover` pushes are left alone — they dedupe per-noun via `recover_stuff` and a symbol-level guard would drop a second disarmed weapon.
- **Marker lifecycle** — `hive_trap_room` cleared once the trap resolves or we give up, so any queued duplicate no-ops; preserved on `:moved` / `:muckled` so the trap's next announcement can retry.
## Behavior
 
| Scenario | Before | After |
| --- | --- | --- |
| Trap cleared on first search | 10 searches | 1 |
| Nothing to find | 10 searches (~50s) | 1 |
| Rolled `Failure!` | up to 10 | up to 3 |
| Blinded mid-loop | kept searching | breaks immediately |
| Moved out of the room | kept searching | breaks immediately |
| Stunned / webbed / unconscious | kept searching | breaks immediately |
| N duplicate trigger lines | N × 10 searches | 1 run |
 
## Verification
 
- `ruby -c` clean.
- Search state machine exercised against scripted `get_command` outcomes: success first try → 1 search; nothing-found → 1; all failures → 3 and `:exhausted`; empty/timeout → 3; blinded → `:blind` at 1; stale marker → `:moved` with 0 searches; nil marker or nil `Room.current` → `:moved`; muckled → `:muckled` with 0 searches; moved after the first search → `:moved`; same room id via a fresh `Room` instance → `:found`.
- Marker lifecycle: cleared on resolution so a queued duplicate performs 0 searches, preserved on a muckled bail so the next trap announcement can retry.
## Follow-up (not in this PR)
 
The search and disarm loops still share their guard scaffolding (deadline, attempt cap, room, muckled). Collapsing them into one parameterized helper needs an ordered pattern-to-symbol table, since search distinguishes `:blind` / `:clear` / `:found` and retries on `Failure!` while disarm has a single terminal pattern. Roughly 12 lines saved for a layer of indirection — worth doing only if a third trap type shows up.
