### PR TITLE
fix(escortgo2.lic): v1.0.5 hash iteration error when disabling vaalor shortcut

### DIFF
--- a/scripts/escortgo2.lic
+++ b/scripts/escortgo2.lic
@@ -22,12 +22,15 @@
 
   ;ego2 help
 
-   author: elanthia-online
-     game: Gemstone
-     tags: bounty
-  version: 1.0.4
+      author: elanthia-online
+contributors: Drafix
+        game: Gemstone
+        tags: bounty
+     version: 1.0.5
 
   changelog:
+    1.0.5 (2026-08-05):
+      * fix hash iteration error when disabling vaalor shortcut path timing
     1.0.4 (2025-05-06):
       * update silver_check to use Lich::Util.silver_count
     1.0.3 (2025-04-03):
@@ -441,10 +444,8 @@ find_path = proc {
   end
   # disable vaalor shortcut
   $go2_use_vaalor_shortcut = false
-  unless Map.list.any? { |room| room.timeto.any? { |_adj_id, time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
-    Room[16745].timeto['16746'] = 15000
-    Room[16746].timeto['16745'] = 15000
-  end
+  Room[16745].timeto['16746'] = 15000
+  Room[16746].timeto['16745'] = 15000
   # disable seeking
   $go2_use_seeking = false
   # disable portals

--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -7,7 +7,7 @@
 
             author: Tillmen (tillmen@lichproject.org)
    original author: Shaelun
-      contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin, Dissonance
+      contributors: Deysh, Doug, Gildaren, Sarvatt, Tysong, Xanlin, Dissonance, Drafix
               game: any
               tags: core, movement
            version: 2.3.3


### PR DESCRIPTION
## Summary
- Applies the same fix as go2.lic v2.3.3 (#2400) to escortgo2.lic: removes the racy `Map.list.any?` iteration over the entire mapdb while simultaneously mutating it, which could raise `hash representation was changed during iteration`.
- Bumps escortgo2.lic to v1.0.5 with changelog entry.
- Adds Drafix to the contributors list in escortgo2.lic and go2.lic.

## Test plan
- [ ] Run `;ego2` with vaalor shortcut path timing update triggered and confirm no hash iteration error is raised.