### PR TITLE
feat(ledger): v1.5.0 add --rolling option and fix hourly_chart bugs

### DIFF
--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -349,14 +349,21 @@ module Ledger
   #
   # @since 1.5.0
   module Window
+    # Lich re-evaluates a .lic in the same process on each run, so a bare constant
+    # assignment emits "already initialized constant" on every run after the first.
+    # const_defined?(name, false) is used rather than defined?(NAME) because the
+    # latter also searches enclosing scopes and Object: if any other script in the
+    # session defined a top level HOUR or DAY, defined? would report it as present
+    # and this module would silently read that foreign value instead.
+    #
     # Number of seconds in an hour
-    HOUR = 3_600
+    HOUR = 3_600 unless const_defined?(:HOUR, false)
     # Number of seconds in a day
-    DAY = 86_400
+    DAY = 86_400 unless const_defined?(:DAY, false)
     # Days treated as a "month" for the rolling monthly window
-    MONTH_DAYS = 30
+    MONTH_DAYS = 30 unless const_defined?(:MONTH_DAYS, false)
     # Calendar months spanned by the rolling yearly window
-    YEAR_MONTHS = 12
+    YEAR_MONTHS = 12 unless const_defined?(:YEAR_MONTHS, false)
 
     # Whether rolling windows are currently enabled
     #
@@ -906,12 +913,15 @@ module Ledger
       end
     end
 
-    # Half width, in characters, of each side of the zero-centered chart axis
-    HALF_BAR_WIDTH = 20
+    # Half width, in characters, of each side of the zero-centered chart axis.
+    # Guarded for the same reason as the Window constants above: the module body
+    # re-executes when Lich re-runs the script, and const_defined?(name, false)
+    # checks only this module, never enclosing scopes or Object.
+    HALF_BAR_WIDTH = 20 unless const_defined?(:HALF_BAR_WIDTH, false)
     # Character marking the zero axis of the chart
-    BAR_AXIS = '+'.freeze
+    BAR_AXIS = '+'.freeze unless const_defined?(:BAR_AXIS, false)
     # Character used to draw bar segments
-    BAR_SEGMENT = '|'.freeze
+    BAR_SEGMENT = '|'.freeze unless const_defined?(:BAR_SEGMENT, false)
 
     # Renders one zero-centered bar for a signed amount
     #

--- a/scripts/ledger.lic
+++ b/scripts/ledger.lic
@@ -11,7 +11,7 @@
    contributors: Ondreian, Tysong
            game: Gemstone
            tags: silver, bounty, ledger, bank
-        version: 1.4.3
+        version: 1.5.0
    requirements:
     - sequel gem
     - terminal-table
@@ -20,6 +20,25 @@
   Help Contribute: https://github.com/elanthia-online/scripts
   Version Control:
   Major_change.feature_addition.bugfix
+    v1.5.0 - 2026-08-06
+      - Add --rolling flag. When enabled, the report tables and the hourly chart
+        use trailing windows (hourly = last 60 minutes, daily = last 24 hours,
+        monthly = last 30 days, yearly = 12 calendar months back) instead of
+        fixed calendar buckets. Defaults to off; existing behavior is unchanged.
+      - Add --chart flag. Prints the hourly silver chart for the last 6 hours and
+        exits without starting transaction tracking. Not persisted to settings.
+      - Fix terminal-table chart raising ArgumentError (negative argument) whenever
+        a window mixed deposits with withdrawals; bar width could go negative.
+      - Fix terminal-table chart drawing no bars at all when every amount was
+        negative, and reporting "No activity" when the largest amount was 0 but
+        negative activity existed. Bars are now scaled on magnitude and drawn
+        around a zero axis: withdrawals extend left, deposits extend right.
+      - Fix hourly_chart current-hour column always reading zero (offset 0 was
+        mapped to hour 24, which matches no stored hour value).
+      - Fix hourly_chart querying the wrong day/month/year for buckets that wrap
+        past midnight (the day was pinned to the starting day, and month/year
+        were never passed at all).
+      - Add indexes on created_at to support the rolling window filters.
     v1.4.3 - 2026-05-24
       - Change estimate_loot_cap weekly window from Monday-Sunday to Sunday-Saturday (EST/EDT).
     v1.4.2 - 2026-05-11
@@ -102,6 +121,7 @@ optional_gems.each do |gem|
 end
 
 require 'yaml'
+require 'date'
 
 # The Ledger module provides comprehensive tracking of in-game financial transactions
 # including silver, bounty points, and locksmith fees for GemStone IV.
@@ -130,9 +150,11 @@ module Ledger
     @settings_file = File.join(DATA_DIR, 'ledger.yaml')
     @defaults = {
       'report_character' => false,
-      'report_fees'      => false
+      'report_fees'      => false,
+      'rolling'          => false
     }
     @settings = nil
+    @chart_requested = false
 
     # Loads settings from YAML file or creates default settings
     #
@@ -171,6 +193,8 @@ module Ledger
     # Supports flexible argument formats:
     # - --report-character, --report_character, -reportcharacter
     # - --report-fees, --report_fees, --report-fee
+    # - --rolling, --rolling=on, --rolling=off
+    # - --chart
     # - With values: --report-character=on, --report-character=off
     #
     # @param args [Array<String>] array of command-line arguments
@@ -184,6 +208,14 @@ module Ledger
         when /^-?-?report[-_]?fees?(?:=(.+))?$/i
           value = $1
           @settings['report_fees'] = parse_boolean_value(value, true)
+        when /^-?-?rolling(?:=(.+))?$/i
+          value = $1
+          @settings['rolling'] = parse_boolean_value(value, true)
+        when /^-?-?chart$/i
+          # A one-shot action, not a stored preference: kept out of @settings so
+          # save_settings cannot persist it. Were it persisted, every later run
+          # would print a chart and exit instead of tracking transactions.
+          @chart_requested = true
         when /^-?-?help$/i
           display_help
           exit
@@ -227,6 +259,10 @@ module Ledger
         Options:
           --report-character[=<on|off>]   Show per-character statistics        (default: #{@defaults['report_character']})
           --report-fees[=<on|off>]        Track and report locksmith pool fees (default: #{@defaults['report_fees']})
+          --rolling[=<on|off>]            Use trailing windows instead of      (default: #{@defaults['rolling']})
+                                          fixed calendar buckets
+          --chart                         Print the hourly silver chart for the last
+                                          6 hours, then exit without tracking
           --help                          Display this help message
 
         Examples:
@@ -234,6 +270,23 @@ module Ledger
           ;ledger --report-character=on             # Enable character reporting (explicit)
           ;ledger --report-character=off            # Disable character reporting
           ;ledger --report-fees --report-character  # Enable both options
+          ;ledger --rolling                         # Trailing windows
+          ;ledger --rolling=off                     # Back to calendar buckets
+          ;ledger --chart                           # Show the hourly chart and exit
+          ;ledger --chart --rolling                 # Chart with trailing 60 minute slots
+
+        Notes on --chart:
+          Prints a bar chart of the last 6 hours of silver activity and exits, so it
+          does not start transaction tracking. It is an action, not a saved setting,
+          so it never persists to the settings file. Withdrawals are negative and
+          draw to the left of the center axis; deposits draw to the right. Honors
+          --rolling: off gives clock-hour buckets, on gives trailing 60 minute slots.
+
+        Reporting windows:
+          rolling off (default)  hourly = since the top of the hour, daily = since
+                                 midnight, monthly = since the 1st, yearly = since Jan 1
+          rolling on             hourly = last 60 minutes, daily = last 24 hours,
+                                 monthly = last 30 days, yearly = 12 months back
 
         Settings are saved to: #{@settings_file}
         Settings persist across script runs unless overridden by CLI arguments.
@@ -241,6 +294,7 @@ module Ledger
         Current Settings:
           report_character: #{@settings['report_character']}
           report_fees:      #{@settings['report_fees']}
+          rolling:          #{@settings['rolling']}
       HELP
       respond help_text
     end
@@ -270,9 +324,78 @@ module Ledger
       @settings[key] == true
     end
 
+    # Whether --chart was passed on this run
+    #
+    # Deliberately separate from the persisted settings hash: --chart is a one-shot
+    # action that prints a chart and exits, not a mode that should survive the run.
+    #
+    # @return [Boolean] true if --chart was supplied
+    # @since 1.5.0
+    def self.chart_requested?
+      @chart_requested == true
+    end
+
     # Initialize settings on module load
     load_settings
     parse_cli_args(Script.current.vars[1..-1])
+  end
+
+  # Rolling window boundary math
+  #
+  # When the 'rolling' setting is enabled, reports cover a trailing window ending
+  # now instead of the calendar bucket the current time falls into. All boundaries
+  # are machine-local Times, matching how `created_at` is written by
+  # History.record_transaction.
+  #
+  # @since 1.5.0
+  module Window
+    # Number of seconds in an hour
+    HOUR = 3_600
+    # Number of seconds in a day
+    DAY = 86_400
+    # Days treated as a "month" for the rolling monthly window
+    MONTH_DAYS = 30
+    # Calendar months spanned by the rolling yearly window
+    YEAR_MONTHS = 12
+
+    # Whether rolling windows are currently enabled
+    #
+    # @return [Boolean] true when the 'rolling' setting is on
+    def self.rolling?
+      Ledger::Settings.enabled?('rolling')
+    end
+
+    # Computes the inclusive lower bound of a rolling window
+    #
+    # @param period [Symbol] one of :hourly, :daily, :monthly, :yearly
+    # @param from [Time] the end of the window (default: now)
+    # @return [Time] the earliest `created_at` included in the window
+    # @raise [ArgumentError] if the period is not recognized
+    # @example
+    #   Window.start_of(:hourly, from: Time.new(2026, 8, 6, 13, 35, 0))
+    #   #=> 2026-08-06 12:35:00
+    def self.start_of(period, from: Time.now)
+      case period
+      when :hourly  then from - HOUR
+      when :daily   then from - DAY
+      when :monthly then from - (MONTH_DAYS * DAY)
+      when :yearly  then months_ago(YEAR_MONTHS, from)
+      else raise ArgumentError, "unknown rolling period: #{period.inspect}"
+      end
+    end
+
+    # Shifts a Time back by whole calendar months, preserving time of day
+    #
+    # Uses Date#<< so short months clamp instead of raising: 12 months before
+    # 2028-02-29 is 2027-02-28, not an invalid date.
+    #
+    # @param count [Integer] number of calendar months to go back
+    # @param from [Time] the reference time
+    # @return [Time] the shifted local time
+    def self.months_ago(count, from = Time.now)
+      shifted = Date.new(from.year, from.month, from.day) << count
+      Time.local(shifted.year, shifted.month, shifted.day, from.hour, from.min, from.sec)
+    end
   end
 
   # Character-specific transaction queries
@@ -282,11 +405,27 @@ module Ledger
   #
   # @since 1.0.0
   module Character
+    # Sums this character's transactions inside a rolling window
+    #
+    # @param period [Symbol] one of :hourly, :daily, :monthly, :yearly
+    # @param type [String] transaction type ('silver', 'bounty', 'fee')
+    # @return [Integer] sum of transactions in the trailing window
+    # @since 1.5.0
+    def self.rolling(period, type:)
+      window_start = Ledger::Window.start_of(period)
+      Ledger::History::Transactions
+        .where(type: type, character: Char.name, game: XMLData.game)
+        .where { created_at >= window_start }
+        .sum(:amount) || 0
+    end
+
     # Gets yearly transaction sum for current character
     #
     # @param type [String] transaction type ('silver', 'bounty', 'fee')
     # @return [Integer] sum of transactions for the year
     def self.yearly(type: "silver")
+      return rolling(:yearly, type: type) if Ledger::Window.rolling?
+
       Ledger::History::Transactions
         .where(year: Time.now.year, type: type, character: Char.name, game: XMLData.game)
         .sum(:amount) || 0
@@ -297,6 +436,8 @@ module Ledger
     # @param type [String] transaction type ('silver', 'bounty', 'fee')
     # @return [Integer] sum of transactions for the month
     def self.monthly(type: "silver")
+      return rolling(:monthly, type: type) if Ledger::Window.rolling?
+
       Ledger::History::Transactions
         .where(year: Time.now.year, month: Time.now.month, type: type, character: Char.name, game: XMLData.game)
         .sum(:amount) || 0
@@ -307,6 +448,8 @@ module Ledger
     # @param type [String] transaction type ('silver', 'bounty', 'fee')
     # @return [Integer] sum of transactions for the day
     def self.daily(type: "silver")
+      return rolling(:daily, type: type) if Ledger::Window.rolling?
+
       Ledger::History::Transactions
         .where(year: Time.now.year, month: Time.now.month, day: Time.now.day, type: type, character: Char.name, game: XMLData.game)
         .sum(:amount) || 0
@@ -317,6 +460,8 @@ module Ledger
     # @param type [String] transaction type ('silver', 'bounty', 'fee')
     # @return [Integer] sum of transactions for the current hour
     def self.hourly(type: "silver")
+      return rolling(:hourly, type: type) if Ledger::Window.rolling?
+
       Ledger::History::Transactions
         .where(year: Time.now.year, month: Time.now.month, day: Time.now.day, hour: Time.now.hour, type: type, character: Char.name, game: XMLData.game)
         .sum(:amount) || 0
@@ -517,6 +662,18 @@ module Ledger
                        name: :transactions_account_type_index
       end
 
+      # Indexes for rolling window queries, which filter on created_at rather than
+      # the year/month/day/hour bucket columns (Query and Character rolling paths)
+      unless Self.indexes(:transactions).key?(:transactions_game_type_created_at_index)
+        Self.add_index :transactions, [:game, :type, :created_at],
+                       name: :transactions_game_type_created_at_index
+      end
+
+      unless Self.indexes(:transactions).key?(:transactions_character_type_created_at_index)
+        Self.add_index :transactions, [:character, :type, :created_at],
+                       name: :transactions_character_type_created_at_index
+      end
+
       # Update query optimizer statistics
       Self.run("ANALYZE transactions")
     rescue => e
@@ -552,6 +709,37 @@ module Ledger
     #
     # @since 1.0.0
     module Query
+      # Sums transactions across all characters inside a rolling window
+      #
+      # @param period [Symbol] one of :hourly, :daily, :monthly, :yearly
+      # @param type [String] transaction type ('silver', 'bounty', 'fee')
+      # @return [Integer] sum of transactions in the trailing window
+      # @since 1.5.0
+      def self.rolling_gain_loss(period, type:)
+        window_start = Ledger::Window.start_of(period)
+        Transactions
+          .where(type: type, game: XMLData.game)
+          .where { created_at >= window_start }
+          .sum(:amount) || 0
+      end
+
+      # Sums transactions across all characters inside an explicit time range
+      #
+      # Lower bound inclusive, upper bound exclusive, so adjacent ranges do not
+      # double count a transaction landing exactly on a boundary.
+      #
+      # @param type [String] transaction type ('silver', 'bounty', 'fee')
+      # @param from [Time] inclusive start of the range
+      # @param to [Time] exclusive end of the range
+      # @return [Integer] sum of transactions in the range
+      # @since 1.5.0
+      def self.range_gain_loss(type:, from:, to:)
+        Transactions
+          .where(type: type, game: XMLData.game)
+          .where { (created_at >= from) & (created_at < to) }
+          .sum(:amount) || 0
+      end
+
       # Gets yearly transaction sum across all characters
       #
       # @param year [Integer] the year to query (default: current year)
@@ -601,6 +789,29 @@ module Ledger
           .where(month: month, year: year, day: day, hour: hour, type: type, game: XMLData.game)
           .sum(:amount) || 0
       end
+
+      # Gets the transaction sum for the current period, honoring the rolling setting
+      #
+      # The *_gain_loss methods above are bucket addressed: they take explicit
+      # year/month/day/hour and always mean that calendar bucket. This method means
+      # "the current period" and so follows the 'rolling' setting.
+      #
+      # @param period [Symbol] one of :hourly, :daily, :monthly, :yearly
+      # @param type [String] transaction type ('silver', 'bounty', 'fee')
+      # @return [Integer] sum of transactions for the current period
+      # @raise [ArgumentError] if the period is not recognized
+      # @since 1.5.0
+      def self.current_gain_loss(period, type:)
+        return rolling_gain_loss(period, type: type) if Ledger::Window.rolling?
+
+        case period
+        when :hourly  then hourly_gain_loss(type: type)
+        when :daily   then daily_gain_loss(type: type)
+        when :monthly then monthly_gain_loss(type: type)
+        when :yearly  then yearly_gain_loss(type: type)
+        else raise ArgumentError, "unknown period: #{period.inspect}"
+        end
+      end
     end
 
     # Returns the allowed transaction types
@@ -648,31 +859,41 @@ module Ledger
     # @param number [Integer] number of hours to display (default: 6)
     # @return [void]
     def self.hourly_chart(type: "silver", from: Time.now, number: 6)
-      initial_hour = from.hour
-      initial_day  = from.day
+      rolling = Ledger::Window.rolling?
 
+      # Each slot is derived by subtracting whole hours from `from`, so hour 0 stays
+      # 0 and the day/month/year follow the subtraction across midnight, month and
+      # year boundaries.
       hours = (0...number).to_a.map { |offset|
-        position = initial_hour - offset
-        # handle underflow
-        hour = position < 1 ? 24 + position : position
-        [hour, Query.hourly_gain_loss(type: type, hour: hour, day: initial_day)]
+        slot_end = from - (offset * Ledger::Window::HOUR)
+        amount =
+          if rolling
+            Query.range_gain_loss(type: type, from: slot_end - Ledger::Window::HOUR, to: slot_end)
+          else
+            Query.hourly_gain_loss(type: type, hour: slot_end.hour, day: slot_end.day,
+                                   month: slot_end.month, year: slot_end.year)
+          end
+        [slot_end.hour, amount]
       }.reverse
+
+      # Calendar buckets always start on the hour; rolling slots end at `from`.
+      label_minute = rolling ? from.min : 0
 
       # Try to use ascii_charts if available
       if defined?(AsciiCharts)
         _respond AsciiCharts::Cartesian.new(hours, title: "hourly #{type}", bar: true).draw
       else
-        # Fallback to terminal-table based chart
-        max_value = hours.map(&:last).max
-        return _respond "No #{type} activity in the past #{number} hours." if max_value.zero?
+        # Fallback to terminal-table based chart.
+        # Scale on magnitude, not the raw maximum: amounts are signed (withdrawals
+        # are negative), so a plain .max both mis-detects "no activity" when the
+        # largest value is 0 and yields a negative bar width for any amount below
+        # the maximum.
+        max_magnitude = hours.map { |_hour, amount| amount.abs }.max
+        return _respond "No #{type} activity in the past #{number} hours." if max_magnitude.zero?
 
-        max_bar_width = 40
         rows = hours.map do |hour, amount|
-          bar_width = max_value > 0 ? (amount.to_f / max_value * max_bar_width).round : 0
-          bar = '|' * bar_width
-          formatted_amount = with_commas(amount)
-
-          [sprintf("%02d:00", hour), "#{bar} #{formatted_amount}"]
+          [sprintf("%02d:%02d", hour, label_minute),
+           "#{signed_bar(amount, max_magnitude)} #{with_commas(amount)}"]
         end
 
         chart = Terminal::Table.new(
@@ -682,6 +903,38 @@ module Ledger
         )
 
         _respond "<output class=\"mono\"/>\n" + chart.to_s + "\n<output class=\"\"/>"
+      end
+    end
+
+    # Half width, in characters, of each side of the zero-centered chart axis
+    HALF_BAR_WIDTH = 20
+    # Character marking the zero axis of the chart
+    BAR_AXIS = '+'.freeze
+    # Character used to draw bar segments
+    BAR_SEGMENT = '|'.freeze
+
+    # Renders one zero-centered bar for a signed amount
+    #
+    # Negative amounts extend left of the axis and positive amounts extend right.
+    # Both sides are padded to HALF_BAR_WIDTH so every row has the same total width
+    # and the trailing amounts line up in a column.
+    #
+    # @param amount [Integer] the signed amount to draw
+    # @param max_magnitude [Integer] the largest absolute amount in the chart
+    # @return [String] a fixed width bar of 2 * HALF_BAR_WIDTH + 1 characters
+    # @since 1.5.0
+    # @example
+    #   signed_bar(-500, 500) #=> "||||||||||||||||||||+                    "
+    def self.signed_bar(amount, max_magnitude)
+      return (' ' * HALF_BAR_WIDTH) + BAR_AXIS + (' ' * HALF_BAR_WIDTH) if max_magnitude.zero?
+
+      width = (amount.abs.to_f / max_magnitude * HALF_BAR_WIDTH).round
+      width = HALF_BAR_WIDTH if width > HALF_BAR_WIDTH
+
+      if amount.negative?
+        (' ' * (HALF_BAR_WIDTH - width)) + (BAR_SEGMENT * width) + BAR_AXIS + (' ' * HALF_BAR_WIDTH)
+      else
+        (' ' * HALF_BAR_WIDTH) + BAR_AXIS + (BAR_SEGMENT * width) + (' ' * (HALF_BAR_WIDTH - width))
       end
     end
 
@@ -705,10 +958,10 @@ module Ledger
     def self.table
       self.allowed_types(include_fee: Settings.enabled?('report_fees')).map { |resource|
         [resource,
-         with_commas(Query.hourly_gain_loss(type: resource)),
-         with_commas(Query.daily_gain_loss(type: resource)),
-         with_commas(Query.monthly_gain_loss(type: resource)),
-         with_commas(Query.yearly_gain_loss(type: resource))]
+         with_commas(Query.current_gain_loss(:hourly, type: resource)),
+         with_commas(Query.current_gain_loss(:daily, type: resource)),
+         with_commas(Query.current_gain_loss(:monthly, type: resource)),
+         with_commas(Query.current_gain_loss(:yearly, type: resource))]
       }
     end
 
@@ -833,7 +1086,13 @@ module Ledger
       end
     end
 
-    # Start the main event loop
-    self.main()
+    # Print the chart and exit, or start the main event loop.
+    # --chart is a one-shot report: skipping main() ends the script, since the
+    # module body is the last thing the file evaluates.
+    if Ledger::Settings.chart_requested?
+      self.hourly_chart
+    else
+      self.main()
+    end
   end
 end

--- a/spec/scripts/ledger_spec.rb
+++ b/spec/scripts/ledger_spec.rb
@@ -1,0 +1,518 @@
+# Spec for ledger.lic rolling windows and hourly_chart bucket derivation.
+#
+# We do NOT load the .lic file: it opens a SQLite database at require time and
+# needs the whole Lich runtime (Settings, XMLData, Char, Script, DATA_DIR ...).
+# Instead the real method bodies are extracted from scripts/ledger.lic and
+# evaluated against stubs, so these specs exercise production code and fail if
+# that code changes shape.
+#
+# Every stub lives inside LedgerRollingSpec::Harness rather than at top level, so
+# running the whole suite in one process cannot collide with constants other
+# specs define. In particular Harness::Ledger shadows any top level Ledger, which
+# is what the extracted bodies resolve when they say Ledger::Settings.
+
+require 'date'
+
+module LedgerRollingSpec
+  SOURCE_PATH = File.expand_path('../../scripts/ledger.lic', __dir__)
+  SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
+
+  def self.extract(pattern, label)
+    found = SOURCE[pattern]
+    raise "could not extract #{label} from ledger.lic" unless found
+
+    found
+  end
+
+  WINDOW_SRC = extract(/^  module Window\n.*?^  end$/m, 'Window module')
+  CURRENT_GAIN_LOSS_SRC = extract(/^      def self\.current_gain_loss\(period, type:\).*?^      end$/m,
+                                  'Query.current_gain_loss')
+  CHART_SLOTS_SRC = extract(/^      hours = \(0\.\.\.number\)\.to_a\.map \{ \|offset\|\n.*?^      \}\.reverse$/m,
+                            'hourly_chart slot mapping')
+  PARSE_CLI_SRC = extract(/^    def self\.parse_cli_args\(args\).*?^    end$/m, 'parse_cli_args')
+  PARSE_BOOL_SRC = extract(/^    def self\.parse_boolean_value\(value, default_true = true\).*?^    end$/m,
+                           'parse_boolean_value')
+  CHART_REQUESTED_SRC = extract(/^    def self\.chart_requested\?.*?^    end$/m, 'chart_requested?')
+  BAR_CONSTANTS_SRC = extract(/^    HALF_BAR_WIDTH = \d+\n.*?^    BAR_SEGMENT = '\|'\.freeze$/m,
+                              'bar drawing constants')
+  SIGNED_BAR_SRC = extract(/^    def self\.signed_bar\(amount, max_magnitude\).*?^    end$/m, 'signed_bar')
+  NO_ACTIVITY_SRC = extract(/^        max_magnitude = hours\.map.*?if max_magnitude\.zero\?$/m,
+                            'no activity guard')
+
+  class Harness
+    # Stands in for the Ledger namespace the extracted bodies reach for.
+    module Ledger
+      module Settings
+        class << self
+          attr_accessor :rolling
+
+          def enabled?(key)
+            key == 'rolling' && rolling == true
+          end
+        end
+      end
+    end
+
+    # Real Window code under test, evaluated so Ledger:: resolves to the stub above.
+    module_eval(WINDOW_SRC, SOURCE_PATH)
+    Ledger::Window = Window
+
+    # Records what the query layer was asked for instead of touching a database.
+    module Query
+      class << self
+        attr_reader :calls
+
+        def reset!
+          @calls = []
+        end
+
+        # Keyword defaults mirror the real signature so current_gain_loss can call
+        # this with only `type:`.
+        def hourly_gain_loss(type:, hour: Time.now.hour, day: Time.now.day,
+                             month: Time.now.month, year: Time.now.year)
+          @calls << { method: :hourly_gain_loss, type: type, hour: hour, day: day,
+                      month: month, year: year }
+          0
+        end
+
+        def daily_gain_loss(type:)
+          @calls << { method: :daily_gain_loss, type: type }
+          0
+        end
+
+        def monthly_gain_loss(type:)
+          @calls << { method: :monthly_gain_loss, type: type }
+          0
+        end
+
+        def yearly_gain_loss(type:)
+          @calls << { method: :yearly_gain_loss, type: type }
+          0
+        end
+
+        def rolling_gain_loss(period, type:)
+          @calls << { method: :rolling_gain_loss, period: period, type: type }
+          0
+        end
+
+        def range_gain_loss(type:, from:, to:)
+          @calls << { method: :range_gain_loss, type: type, from: from, to: to }
+          0
+        end
+      end
+
+      # Real dispatcher code under test. Evaluated at module level, not inside
+      # `class << self`, so `def self.` lands on Query itself.
+      module_eval(CURRENT_GAIN_LOSS_SRC, SOURCE_PATH)
+    end
+
+    # Wraps the real slot mapping block from hourly_chart so it can be driven
+    # directly. The block closes over `number`, `from`, `rolling` and `type`.
+    def self.chart_slots(type:, from:, number:, rolling:)
+      module_eval(<<~RUBY, SOURCE_PATH)
+        def self.__chart_slots(type, from, number, rolling)
+        #{CHART_SLOTS_SRC}
+          hours
+        end
+      RUBY
+      __chart_slots(type, from, number, rolling)
+    end
+
+    # Settings stub carrying the real CLI parsing code.
+    module CliSettings
+      @defaults = { 'report_character' => false, 'report_fees' => false, 'rolling' => false }
+      @settings = nil
+      @saved = false
+
+      class << self
+        attr_reader :saved
+
+        def reset!
+          @settings = @defaults.dup
+          @saved = false
+          # Mirrors the production module body, which re-runs (and so re-clears this)
+          # each time the script is loaded.
+          @chart_requested = false
+        end
+
+        def [](key)
+          @settings[key]
+        end
+
+        def settings_keys
+          @settings.keys
+        end
+
+        def save_settings
+          @saved = true
+        end
+
+        def display_help
+          @settings['helped'] = true
+        end
+
+        def echo(_msg); end
+      end
+
+      module_eval(PARSE_CLI_SRC, SOURCE_PATH)
+      module_eval(PARSE_BOOL_SRC, SOURCE_PATH)
+      module_eval(CHART_REQUESTED_SRC, SOURCE_PATH)
+    end
+
+    # Real bar drawing code under test, with the chart's own constants.
+    module ChartRender
+      module_eval(BAR_CONSTANTS_SRC, SOURCE_PATH)
+      module_eval(SIGNED_BAR_SRC, SOURCE_PATH)
+
+      class << self
+        # Drives the real no-activity guard. Returns the message when the chart
+        # would bail out, or nil when it considers the window to have activity.
+        def no_activity_message(hours, type = 'silver', number = hours.size)
+          module_eval(<<~RUBY, SOURCE_PATH)
+            def self.__guard(hours, type, number)
+            #{NO_ACTIVITY_SRC}
+              nil
+            end
+          RUBY
+          __guard(hours, type, number)
+        end
+
+        def _respond(msg)
+          msg
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe 'ledger.lic rolling windows' do
+  # Referenced through methods rather than constants: a constant assigned inside a
+  # describe block lands on Object, not the example group, and would collide with
+  # any other spec defining the same name.
+  def harness
+    LedgerRollingSpec::Harness
+  end
+
+  def window
+    LedgerRollingSpec::Harness::Window
+  end
+
+  def query
+    LedgerRollingSpec::Harness::Query
+  end
+
+  def rolling_setting
+    LedgerRollingSpec::Harness::Ledger::Settings
+  end
+
+  def cli_settings
+    LedgerRollingSpec::Harness::CliSettings
+  end
+
+  def chart_render
+    LedgerRollingSpec::Harness::ChartRender
+  end
+
+  describe 'Window.start_of' do
+    # 13:35 on a Thursday, the example from the original report.
+    let(:from) { Time.local(2026, 8, 6, 13, 35, 0) }
+
+    it 'starts the hourly window 60 minutes before now, not at the top of the hour' do
+      expect(window.start_of(:hourly, from: from)).to eq(Time.local(2026, 8, 6, 12, 35, 0))
+    end
+
+    it 'starts the daily window 24 hours before now, not at midnight' do
+      expect(window.start_of(:daily, from: from)).to eq(Time.local(2026, 8, 5, 13, 35, 0))
+    end
+
+    it 'starts the monthly window 30 days before now' do
+      expect(window.start_of(:monthly, from: from)).to eq(Time.local(2026, 7, 7, 13, 35, 0))
+    end
+
+    it 'starts the yearly window 12 calendar months before now' do
+      expect(window.start_of(:yearly, from: from)).to eq(Time.local(2025, 8, 6, 13, 35, 0))
+    end
+
+    it 'rejects an unknown period rather than silently returning nil' do
+      expect { window.start_of(:weekly, from: from) }.to raise_error(ArgumentError, /weekly/)
+    end
+  end
+
+  describe 'Window.months_ago' do
+    it 'preserves time of day' do
+      result = window.months_ago(12, Time.local(2026, 3, 15, 9, 7, 42))
+      expect(result).to eq(Time.local(2025, 3, 15, 9, 7, 42))
+    end
+
+    it 'clamps a leap day back to the last valid day instead of raising' do
+      result = window.months_ago(12, Time.local(2028, 2, 29, 10, 0, 0))
+      expect(result).to eq(Time.local(2027, 2, 28, 10, 0, 0))
+    end
+
+    it 'crosses a year boundary' do
+      result = window.months_ago(12, Time.local(2026, 1, 1, 0, 30, 0))
+      expect(result).to eq(Time.local(2025, 1, 1, 0, 30, 0))
+    end
+  end
+
+  describe 'Window.rolling?' do
+    after { rolling_setting.rolling = nil }
+
+    it 'is false by default' do
+      rolling_setting.rolling = false
+      expect(window.rolling?).to be false
+    end
+
+    it 'is true when the setting is enabled' do
+      rolling_setting.rolling = true
+      expect(window.rolling?).to be true
+    end
+  end
+
+  describe 'hourly_chart slot derivation' do
+    before { query.reset! }
+
+    context 'with calendar buckets (rolling off)' do
+      # 02:30 so the 6 hour window wraps back past midnight.
+      let(:from) { Time.local(2026, 8, 6, 2, 30, 0) }
+      let(:slots) { harness.chart_slots(type: 'silver', from: from, number: 6, rolling: false) }
+
+      it 'includes hour 0 rather than the unmatchable hour 24' do
+        expect(slots.map(&:first)).to eq([21, 22, 23, 0, 1, 2])
+      end
+
+      it 'queries the previous day for buckets that wrap past midnight' do
+        slots
+        queried = query.calls.map { |c| [c[:hour], c[:day]] }
+        expect(queried).to contain_exactly([2, 6], [1, 6], [0, 6], [23, 5], [22, 5], [21, 5])
+      end
+
+      it 'passes month and year so a month boundary is not mis-attributed' do
+        query.reset!
+        harness.chart_slots(type: 'silver', from: Time.local(2026, 1, 1, 1, 0, 0),
+                            number: 3, rolling: false)
+        queried = query.calls.map { |c| [c[:year], c[:month], c[:day], c[:hour]] }
+        expect(queried).to contain_exactly([2026, 1, 1, 1], [2026, 1, 1, 0], [2025, 12, 31, 23])
+      end
+
+      it 'uses the bucket query, not the range query' do
+        slots
+        expect(query.calls.map { |c| c[:method] }.uniq).to eq([:hourly_gain_loss])
+      end
+    end
+
+    context 'with rolling windows (rolling on)' do
+      let(:from) { Time.local(2026, 8, 6, 13, 35, 0) }
+      let(:slots) { harness.chart_slots(type: 'silver', from: from, number: 3, rolling: true) }
+
+      it 'asks for trailing 60 minute ranges ending at from' do
+        slots
+        ranges = query.calls.map { |c| [c[:from], c[:to]] }
+        expect(ranges).to eq([
+                               [Time.local(2026, 8, 6, 12, 35, 0), Time.local(2026, 8, 6, 13, 35, 0)],
+                               [Time.local(2026, 8, 6, 11, 35, 0), Time.local(2026, 8, 6, 12, 35, 0)],
+                               [Time.local(2026, 8, 6, 10, 35, 0), Time.local(2026, 8, 6, 11, 35, 0)]
+                             ])
+      end
+
+      it 'produces contiguous non overlapping slots' do
+        slots
+        ranges = query.calls.map { |c| [c[:from], c[:to]] }.reverse
+        ranges.each_cons(2) { |(_, prev_to), (next_from, _)| expect(next_from).to eq(prev_to) }
+      end
+
+      it 'uses the range query, not the bucket query' do
+        slots
+        expect(query.calls.map { |c| c[:method] }.uniq).to eq([:range_gain_loss])
+      end
+    end
+  end
+
+  describe 'Query.current_gain_loss' do
+    before { query.reset! }
+    after { rolling_setting.rolling = nil }
+
+    context 'when rolling is off' do
+      before { rolling_setting.rolling = false }
+
+      {
+        hourly:  :hourly_gain_loss,
+        daily:   :daily_gain_loss,
+        monthly: :monthly_gain_loss,
+        yearly:  :yearly_gain_loss
+      }.each do |period, expected|
+        it "routes #{period} to #{expected}" do
+          query.current_gain_loss(period, type: 'silver')
+          expect(query.calls.first[:method]).to eq(expected)
+        end
+      end
+    end
+
+    context 'when rolling is on' do
+      before { rolling_setting.rolling = true }
+
+      %i[hourly daily monthly yearly].each do |period|
+        it "routes #{period} to rolling_gain_loss preserving the period" do
+          query.current_gain_loss(period, type: 'bounty')
+          expect(query.calls.first)
+            .to eq({ method: :rolling_gain_loss, period: period, type: 'bounty' })
+        end
+      end
+    end
+
+    it 'rejects an unknown period' do
+      rolling_setting.rolling = false
+      expect { query.current_gain_loss(:weekly, type: 'silver') }
+        .to raise_error(ArgumentError, /weekly/)
+    end
+  end
+
+  describe '--rolling CLI parsing' do
+    before { cli_settings.reset! }
+
+    it 'defaults to off' do
+      cli_settings.parse_cli_args([])
+      expect(cli_settings['rolling']).to be false
+    end
+
+    ['--rolling', '--rolling=on', '--rolling=true', '-rolling', '--ROLLING'].each do |arg|
+      it "enables rolling for #{arg}" do
+        cli_settings.parse_cli_args([arg])
+        expect(cli_settings['rolling']).to be true
+      end
+    end
+
+    ['--rolling=off', '--rolling=false', '--rolling=0', '--rolling=no'].each do |arg|
+      it "disables rolling for #{arg}" do
+        cli_settings.parse_cli_args([arg])
+        expect(cli_settings['rolling']).to be false
+      end
+    end
+
+    it 'persists the change' do
+      cli_settings.parse_cli_args(['--rolling'])
+      expect(cli_settings.saved).to be true
+    end
+
+    it 'leaves the other flags alone' do
+      cli_settings.parse_cli_args(['--rolling'])
+      expect(cli_settings['report_character']).to be false
+      expect(cli_settings['report_fees']).to be false
+    end
+
+    it 'still parses the pre-existing flags' do
+      cli_settings.parse_cli_args(['--report-fees', '--report-character'])
+      expect(cli_settings['report_fees']).to be true
+      expect(cli_settings['report_character']).to be true
+      expect(cli_settings['rolling']).to be false
+    end
+  end
+
+  describe '--chart CLI parsing' do
+    before { cli_settings.reset! }
+
+    it 'is not requested by default' do
+      cli_settings.parse_cli_args([])
+      expect(cli_settings.chart_requested?).to be false
+    end
+
+    ['--chart', '-chart', '--CHART'].each do |arg|
+      it "requests the chart for #{arg}" do
+        cli_settings.parse_cli_args([arg])
+        expect(cli_settings.chart_requested?).to be true
+      end
+    end
+
+    # The whole point of keeping it out of @settings: a persisted --chart would make
+    # every later run print a chart and exit instead of tracking transactions.
+    it 'never becomes a persisted setting' do
+      cli_settings.parse_cli_args(['--chart'])
+      expect(cli_settings['chart']).to be_nil
+      expect(cli_settings.settings_keys).to contain_exactly('report_character', 'report_fees', 'rolling')
+    end
+
+    it 'combines with --rolling without disturbing it' do
+      cli_settings.parse_cli_args(['--chart', '--rolling'])
+      expect(cli_settings.chart_requested?).to be true
+      expect(cli_settings['rolling']).to be true
+    end
+
+    it 'does not enable the chart for an unrelated flag' do
+      cli_settings.parse_cli_args(['--report-fees'])
+      expect(cli_settings.chart_requested?).to be false
+    end
+  end
+
+  describe 'signed_bar rendering' do
+    # 41 chars: HALF_BAR_WIDTH either side plus the axis.
+    let(:full_width) { (chart_render::HALF_BAR_WIDTH * 2) + 1 }
+
+    it 'does not raise when an amount is negative relative to a positive maximum' do
+      # This is the exact shape that raised ArgumentError (negative argument).
+      expect { chart_render.signed_bar(-5000, 1000) }.not_to raise_error
+    end
+
+    it 'draws negative amounts to the left of the axis' do
+      bar = chart_render.signed_bar(-500, 500)
+      left, right = bar.split(chart_render::BAR_AXIS, 2)
+      expect(left.strip).to eq(chart_render::BAR_SEGMENT * chart_render::HALF_BAR_WIDTH)
+      expect(right.strip).to be_empty
+    end
+
+    it 'draws positive amounts to the right of the axis' do
+      bar = chart_render.signed_bar(500, 500)
+      left, right = bar.split(chart_render::BAR_AXIS, 2)
+      expect(left.strip).to be_empty
+      expect(right.strip).to eq(chart_render::BAR_SEGMENT * chart_render::HALF_BAR_WIDTH)
+    end
+
+    it 'draws no segments for zero but keeps the axis' do
+      bar = chart_render.signed_bar(0, 500)
+      expect(bar.delete(' ')).to eq(chart_render::BAR_AXIS)
+    end
+
+    it 'scales proportionally to the magnitude' do
+      bar = chart_render.signed_bar(250, 500)
+      _, right = bar.split(chart_render::BAR_AXIS, 2)
+      expect(right.strip.length).to eq(chart_render::HALF_BAR_WIDTH / 2)
+    end
+
+    it 'clamps a magnitude larger than the maximum instead of overflowing' do
+      bar = chart_render.signed_bar(-9999, 100)
+      expect(bar.length).to eq(full_width)
+      left, = bar.split(chart_render::BAR_AXIS, 2)
+      expect(left.strip.length).to eq(chart_render::HALF_BAR_WIDTH)
+    end
+
+    it 'keeps every bar the same width so amounts align in a column' do
+      widths = [-5000, -1, 0, 1, 5000].map { |a| chart_render.signed_bar(a, 5000).length }
+      expect(widths.uniq).to eq([full_width])
+    end
+
+    it 'tolerates a zero maximum without dividing by zero' do
+      expect { chart_render.signed_bar(0, 0) }.not_to raise_error
+      expect(chart_render.signed_bar(0, 0).length).to eq(full_width)
+    end
+  end
+
+  describe 'chart no-activity detection' do
+    it 'reports no activity when every amount is zero' do
+      result = chart_render.no_activity_message([[9, 0], [10, 0], [11, 0]])
+      expect(result).to match(/No silver activity/)
+    end
+
+    # Previously `max_value.zero?` treated a zero maximum as an empty window even
+    # though negative activity existed.
+    it 'does not report no activity when the maximum is zero but withdrawals exist' do
+      expect(chart_render.no_activity_message([[9, 0], [10, -500], [11, 0]])).to be_nil
+    end
+
+    it 'does not report no activity when every amount is negative' do
+      expect(chart_render.no_activity_message([[9, -100], [10, -500]])).to be_nil
+    end
+
+    it 'does not report no activity for ordinary positive amounts' do
+      expect(chart_render.no_activity_message([[9, 100], [10, 500]])).to be_nil
+    end
+  end
+end

--- a/spec/scripts/ledger_spec.rb
+++ b/spec/scripts/ledger_spec.rb
@@ -33,7 +33,7 @@ module LedgerRollingSpec
   PARSE_BOOL_SRC = extract(/^    def self\.parse_boolean_value\(value, default_true = true\).*?^    end$/m,
                            'parse_boolean_value')
   CHART_REQUESTED_SRC = extract(/^    def self\.chart_requested\?.*?^    end$/m, 'chart_requested?')
-  BAR_CONSTANTS_SRC = extract(/^    HALF_BAR_WIDTH = \d+\n.*?^    BAR_SEGMENT = '\|'\.freeze$/m,
+  BAR_CONSTANTS_SRC = extract(/^    HALF_BAR_WIDTH = .*?^    BAR_SEGMENT = .*?$/m,
                               'bar drawing constants')
   SIGNED_BAR_SRC = extract(/^    def self\.signed_bar\(amount, max_magnitude\).*?^    end$/m, 'signed_bar')
   NO_ACTIVITY_SRC = extract(/^        max_magnitude = hours\.map.*?if max_magnitude\.zero\?$/m,
@@ -405,6 +405,47 @@ RSpec.describe 'ledger.lic rolling windows' do
       expect(cli_settings['report_fees']).to be true
       expect(cli_settings['report_character']).to be true
       expect(cli_settings['rolling']).to be false
+    end
+  end
+
+  describe 'constant redefinition guards' do
+    # Lich re-evaluates a .lic in the same process, so an unguarded constant emits
+    # "already initialized constant" on every run after the first.
+    source = LedgerRollingSpec::SOURCE
+
+    {
+      'Window' => %w[HOUR DAY MONTH_DAYS YEAR_MONTHS],
+      'chart'  => %w[HALF_BAR_WIDTH BAR_AXIS BAR_SEGMENT]
+    }.each do |group, names|
+      names.each do |name|
+        it "guards #{group} constant #{name} against redefinition" do
+          line = source.lines.find { |l| l =~ /^\s+#{name} = / }
+          expect(line).not_to be_nil
+          expect(line).to match(/unless const_defined\?\(:#{name}, false\)/)
+        end
+      end
+    end
+
+    it 'uses const_defined? with inherit false rather than defined?, which would be shadowed' do
+      # defined?(NAME) also searches enclosing scopes and Object, so a top level
+      # constant of the same name from another script would suppress the assignment
+      # and leave this module reading the foreign value.
+      expect(source).not_to match(/^\s+(?:HOUR|DAY|MONTH_DAYS|YEAR_MONTHS|HALF_BAR_WIDTH|BAR_AXIS|BAR_SEGMENT) = .*unless defined\?/)
+    end
+
+    it 're-evaluating the Window module twice emits no warning and keeps its own values' do
+      warnings = []
+      original_warn = Warning.method(:warn)
+      Warning.singleton_class.define_method(:warn) { |msg, **| warnings << msg }
+
+      begin
+        holder = Module.new
+        2.times { holder.module_eval(LedgerRollingSpec::WINDOW_SRC, LedgerRollingSpec::SOURCE_PATH) }
+        expect(warnings.grep(/already initialized constant/)).to be_empty
+        expect(holder.const_get(:Window)::DAY).to eq(86_400)
+      ensure
+        Warning.singleton_class.define_method(:warn) { |*args, **kw| original_warn.call(*args, **kw) }
+      end
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rolling reporting windows for hourly, daily, monthly, and yearly periods.
  * Added a one-shot chart mode that displays results without starting transaction tracking.
  * Improved hourly charts to accurately represent gains, losses, date changes, current-hour activity, and periods with no activity.
  * Added support for querying rolling reports using created-at timestamps.

* **Bug Fixes**
  * Corrected chart rendering for signed, zero, and negative-only activity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->