### PR TITLE
fix(egemhoarder): v2.0.1 correct regex to allow match of jar and bottle

### DIFF
--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -587,7 +587,7 @@ module EGemHoarder
         filled = false
         matching.each do |gem|
           res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
-                              /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+                              /^You add|^You put|filling it|is full|does not appear to be a suitable|^I could not find/
           case res
           when /^You add.*filling it/, /filling it/
             record[:count] = record[:count].to_i + 1
@@ -596,7 +596,7 @@ module EGemHoarder
             gems.delete(gem)
             deposited += 1
             break
-          when /^You add|^You put.*into.*jar/
+          when /^You add|^You put/
             record[:count] = record[:count].to_i + 1
             gems.delete(gem)
             deposited += 1
@@ -667,7 +667,7 @@ module EGemHoarder
 
             group.each do |gem|
               res = dothistimeout "_drag ##{gem.id} ##{jar.id}", 4,
-                                  /^You add|^You put.*into.*jar|filling it|is full|does not appear to be a suitable|^I could not find/
+                                  /^You add|^You put|filling it|is full|does not appear to be a suitable|^I could not find/
               case res
               when /^You add.*filling it/, /filling it/
                 record[:gem]   = clean_name(jar.after_name) unless jar.after_name.to_s.strip.empty?
@@ -677,7 +677,7 @@ module EGemHoarder
                 gems.delete(gem)
                 deposited += 1
                 break
-              when /^You add|^You put.*into.*jar/
+              when /^You add|^You put/
                 record[:gem]   = clean_name(jar.after_name) unless jar.after_name.to_s.strip.empty?
                 record[:count] = record[:count].to_i + 1
                 gems.delete(gem)

--- a/scripts/egemhoarder.lic
+++ b/scripts/egemhoarder.lic
@@ -17,9 +17,11 @@
   contributors: Caithris, Falicor, Yalathanil
   game: gs
   tags: gems, hoarding, locker, jars
-  version: 2.0.0
+  version: 2.0.1
 
   Version Control:
+  V2.0.1 (2026-08-08)
+    - fix: hanging/termiantion when noun was bottle
   Major_change.feature_addition.bugfix
   v2.0.0 (2026-05-11)
     - complete rewrite from egemhoarder v1.x


### PR DESCRIPTION
Issue presented as the script hanging and terminating early when using *bottle*s