### PR TITLE
feat(ebounty) v1.12.0 add basic CLI run support

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,12 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.19.0
-       version: 1.11.3
+       version: 1.12.0
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.12.0 (2026-08-14)
+    - add CLI support for ;ebounty basic (single run with just the basics enabled, without changing saved settings)
   v1.11.3 (2026-08-01)
     - fix to remove EXPERIENCE scraping for field exp, require new Lich to get it automatically from feed
   v1.11.2 (2026-07-08)
@@ -196,6 +198,7 @@ module EBounty
   def self.help
     rows = []
     rows << ["#{$lich_char}#{Script.current.name} setup", "UI configuration tool"]
+    rows << ["#{$lich_char}#{Script.current.name} basic", "Single run with just the basics enabled"]
     rows << ["#{$lich_char}#{Script.current.name} remove", "Removes current bounty"]
     rows << ["#{$lich_char}#{Script.current.name} forage", "Forages requested herbs"]
     rows << ["#{$lich_char}#{Script.current.name} load", "Reloads all settings"]
@@ -3661,7 +3664,7 @@ if EBounty.data.settings[:return_to_group]
   EBounty.data.settings[:leader] = Lich::Gemstone::Group.leader.to_s.capitalize
 end
 
-unless EBounty.data.settings[:basic]
+unless EBounty.data.settings[:basic] || Script.current.vars[1] =~ /basic/i
   required_scripts = %w(bigshot)
   required_scripts.push("eherbs")    if EBounty.data.settings[:healing_script].to_s.empty? && !EBounty.data.settings[:skip_healing]
   required_scripts.push("eloot")     if EBounty.data.settings[:selling_script].to_s.empty?
@@ -3675,7 +3678,7 @@ unless EBounty.data.settings[:basic]
 end
 
 case Script.current.vars[1]
-when nil, /once/
+when nil, /once/, /basic/i
   if Script.current.vars[1] =~ /once/
     basic_setting = EBounty.data.settings[:basic]
     EBounty.data.settings[:basic] = false
@@ -3686,6 +3689,14 @@ when nil, /once/
     before_dying do
       EBounty.data.settings[:basic] = basic_setting
       EBounty.data.settings[:once_and_done] = once_settings
+    end
+  elsif Script.current.vars[1] =~ /basic/i
+    # Single run with just the basics enabled, without persisting the override to the profile
+    basic_setting = EBounty.data.settings[:basic]
+    EBounty.data.settings[:basic] = true
+
+    before_dying do
+      EBounty.data.settings[:basic] = basic_setting
     end
   end
 


### PR DESCRIPTION
Updated version to 1.12.0 and added CLI support for basic functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running a single basic-mode scan from the command line.
  * The temporary mode does not modify saved settings and restores the previous configuration afterward.
  * Updated command-line help to include the new option.

* **Bug Fixes**
  * Improved command handling to recognize the basic mode consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->