### PR TITLE
feat(bigshot.lic): v5.16.0 migrate room-creature targeting to Creature module

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -8,7 +8,7 @@
   contributors: SpiffyJr, Tillmen, Kalros, Hazado, Tysong, Athias, Falicor, Deysh, Nisugi
           game: Gemstone
           tags: hunting, bigshot, combat
-       version: 5.15.4
+       version: 5.16.0
       required: Lich >= 5.19.0
 
   Setup Instructions: https://gswiki.play.net/Script_Bigshot
@@ -428,6 +428,110 @@ if Gem::Version.new(LICH_VERSION) < Gem::Version.new(lich_gem_requires)
     _respond "##" + "########################################"
   end
   exit
+end
+
+# Creature / Combat::Tracker (Lich::Gemstone, requires Lich >= 5.19.0 - already
+# enforced by the version gate above, so no separate respond_to? guard needed).
+# See: https://github.com/elanthia-online/lich-5/wiki/Gemstone-IV-Creature-&-Combat-Module-Guide
+Creature = Lich::Gemstone::Creature unless defined?(Creature)
+Combat   = Lich::Gemstone::Combat   unless defined?(Combat)
+
+# GameObj -> Creature/Combat migration adapter.
+#
+# Wraps a Lich::Gemstone::Creature::CreatureInstance so bigshot's many
+# cmd_* methods, which read .status/.type/.id in the GameObj shape, keep
+# working while the room-creature source of truth comes from Creature.targets/
+# Creature.in_room (the room roster) instead of the (stale-prone) GameObj
+# selected-target list.
+#
+# Most .status-string command checks and the ubiquitous dead/gone liveness
+# check read .creature.crtr_flag?/.creature.has_status? directly (see
+# dead_or_gone?, npc_has_status?, npc_crtr_flag? below) rather than going
+# through this adapter's synthesized strings. New code should do the same.
+#
+# .status and .type are NOT temporary migration debt, though - they stay
+# GameObj-backed permanently, for reasons confirmed against the actual
+# lich-5 source rather than assumed:
+#   - .type (undead/noncorporeal/aggressive npc/companion/familiar/boon/
+#     escort/bandit classification) comes from GameObj's own @@type_data
+#     table (lib/common/gameobj.rb), a static noun/name regex lookup with
+#     no connection to the live <crtrStatus> feed at all. There is no
+#     Creature-module equivalent to migrate to.
+#   - .status is still the source of truth for "frozen"/"prone" and every
+#     other free-text state a regex against the room annotation can catch;
+#     nothing here reads those natively yet.
+class BigshotCreature
+  attr_reader :creature
+
+  # @param creature [Lich::Gemstone::Creature::CreatureInstance] the creature to wrap
+  def initialize(creature)
+    @creature = creature
+  end
+
+  # The matching GameObj entry for this creature, if the parser has indexed
+  # one under the same id. Both systems parse the same room feed, so this is
+  # normally present; nil only in the brief window where Creature has
+  # registered a creature GameObj has not indexed yet.
+  # @return [Lich::Common::GameObj, nil]
+  def gameobj
+    GameObj[id]
+  end
+
+  # @return [String] the creature id, normalized to String to match
+  #   XMLData.current_target_id and the GameObj-shaped ids used throughout
+  def id
+    creature.id.to_s
+  end
+
+  # @return [String] the creature's noun
+  def noun
+    creature.noun
+  end
+
+  # @return [String] the creature's full name
+  def name
+    creature.name
+  end
+
+  # Preserves the exact GameObj status string existing regex checks match
+  # against (e.g. npc.status =~ /dead|gone/, now largely replaced by
+  # dead_or_gone?(npc) - see the notes below). Falls back to a minimal
+  # synthesized string covering only the dead case if no matching GameObj
+  # entry exists yet, rather than raising. Does NOT synthesize "gone" from
+  # valid_target? - valid_target? is false whenever CreatureInstance#dead?
+  # is true, which (see the module-level migration notes) trusts a guessed
+  # max_hp against never-reset accumulated damage, not the game's own
+  # <crtrStatus> dead flag. Synthesizing "gone" from it would let a live
+  # creature be misreported as gone during the brief window before GameObj
+  # has indexed it, the exact failure mode this migration exists to avoid.
+  # @return [String, nil] GameObj's status string, or "dead" when no
+  #   matching GameObj entry exists yet and the live dead flag is set
+  def status
+    go = gameobj
+    return go.status if go
+
+    "dead" if creature.crtr_flag?(:dead)
+  end
+
+  # Preserves the exact GameObj type string (comma-separated classification
+  # tokens like "undead", "aggressive npc", "noncorporeal", "boon" - these
+  # are not all represented as crtrStatus flags, so GameObj remains the
+  # source of truth here). Falls back to the bestiary undead flag, the one
+  # classification also reachable off CreatureInstance directly, if no
+  # matching GameObj entry exists yet.
+  # @return [String] GameObj's comma-separated classification string, or the
+  #   bestiary undead flag alone when no GameObj entry exists yet
+  def type
+    go = gameobj
+    return go.type if go
+
+    creature.template&.undead ? "undead" : ""
+  end
+
+  # @return [String] the creature's name
+  def to_s
+    name
+  end
 end
 
 if UserVars
@@ -2711,6 +2815,11 @@ class Bigshot
     end
     debug_msg(@DEBUG_SYSTEM, "initialize | options: #{options}")
 
+    # Turn on Combat::Tracker so HP/wound/UCS data populates on Creature
+    # objects going forward. Persists per character - this is effectively a
+    # no-op after the first run for a given character.
+    Combat::Tracker.enable! unless Combat::Tracker.enabled?
+
     @followers = nil
     @event_stack = []
 
@@ -3257,11 +3366,17 @@ class Bigshot
     return result
   end
 
+  # Pulls downed players to their feet before engaging.
+  #
+  # Only acts when the +@PULL+ setting is on and there is something hostile in
+  # the room; a player who is merely sitting out of combat is left alone.
+  #
+  # @return [void]
   def check_for_deaders_prone
     debug_msg(@DEBUG_COMMANDS, "check_for_deaders_prone")
     return if GameObj.pcs.nil?
 
-    if @PULL && GameObj.targets.any? { |s| s.type =~ /aggressive npc/ }
+    if @PULL && bs_hostile_creatures.any?
       GameObj.pcs.each do |s|
         if s.status =~ /sitting|^lying|prone/ && s.status !~ /dead/
           fput "pull #{s.noun}"
@@ -3307,7 +3422,7 @@ class Bigshot
     if command.is_a?(Array)
       stance_dance = false if command.any? { |j| j =~ /stance/ }
       command.each do |i|
-        break if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }
+        break if dead_or_gone?(npc) || !still_targetable?(npc.id)
 
         debug_msg(@DEBUG_COMMANDS, "cmd | command array[i]: #{i}")
         cmd(i, npc, stance_dance)
@@ -3319,7 +3434,7 @@ class Bigshot
       command = command.gsub(/\bkick\b/i, "punch")
     end
 
-    $bigshot_dislodge_location = [] if npc.status =~ /dead|gone/
+    $bigshot_dislodge_location = [] if dead_or_gone?(npc)
 
     # waitrt/waitcastrt
     unless (command =~ /^nudgeweapons?|slipperymind/)
@@ -3524,11 +3639,17 @@ class Bigshot
     (Time.now - last) < seconds
   end
 
+  # Runs a command against every valid creature in the room, then restores
+  # the original target.
+  #
+  # @param command [String] the command definition
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the current target, restored afterward
+  # @return [void]
   def cmd_eachtarget(command, npc)
     debug_msg(@DEBUG_COMMANDS, "cmd_eachtarget | npc: #{npc} | command: #{command}")
 
     current_target = npc
-    GameObj.targets.each { |target|
+    bs_targets.each { |target|
       next unless valid_target?(target)
       fput "target ##{target.id}" unless XMLData.current_target_id == target.id
       cmd(command, target, check_priority: false)
@@ -3834,10 +3955,15 @@ class Bigshot
     }
   end
 
+  # Casts a Curse-family effect.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param type [String] curse variant
+  # @return [void]
   def cmd_curse(npc, type)
     debug_msg(@DEBUG_COMMANDS, "cmd_curse | npc: #{npc} | type: #{type}")
 
-    return if npc.status =~ /dead|gone/
+    return if dead_or_gone?(npc)
     return if type == 'star' && Effects::Spells.time_left("Curse of the Star (bonus)") > 0.5
     timeout = Time.now + 10
     loop do
@@ -3848,14 +3974,19 @@ class Bigshot
       fput('release') unless checkprep == "None"
       results = dothistimeout('prep 715', 2, /Your spell is ready\./)
       break if results
-      return if npc.status =~ /dead|gone/
+      return if dead_or_gone?(npc)
       return if Time.now > timeout
     end
     waitrt?
     waitcastrt?
-    fput("curse ##{npc.id} #{type}") unless npc.status =~ /dead|gone/
+    fput("curse ##{npc.id} #{type}") unless dead_or_gone?(npc)
   end
 
+  # Performs a weapon combat maneuver.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param cmd [String] the maneuver name
+  # @return [void]
   def cmd_weapons(npc, cmd)
     debug_msg(@DEBUG_COMMANDS, "cmd_weapons | npc: #{npc} | cmd: #{cmd}")
 
@@ -3998,10 +4129,16 @@ class Bigshot
     }
   end
 
+  # Casts a spell to interrupt a creature's own casting.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param spell [Integer] spell number to cast
+  # @param extra [String, nil] extra cast arguments
+  # @return [void]
   def cmd_caststop(npc, spell, extra)
     debug_msg(@DEBUG_COMMANDS, "cmd_caststop | npc: #{npc} | spell: #{spell} | extra: #{extra}")
-    return if npc.status.match?(/dead|gone/)
-    return unless GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc)
+    return unless still_targetable?(npc.id)
     return unless Spell[spell].known? and Spell[spell].affordable?
     waitrt?
     waitcastrt?
@@ -4009,11 +4146,16 @@ class Bigshot
     fput "stop #{spell}"
   end
 
+  # Casts Song of Depression (1015).
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param original_command [String] the command definition, for logging
+  # @return [void]
   def cmd_depress(npc, original_command)
     debug_msg(@DEBUG_COMMANDS, "cmd_depress | npc: #{npc}")
 
-    return if npc.status.match?(/dead|gone/)
-    return unless GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc)
+    return unless still_targetable?(npc.id)
     return unless Spell[1015].known? && Spell[1015].affordable?
 
     if @COMMANDS_REGISTRY.any? { |_k, v| v.include?(original_command) }
@@ -4033,11 +4175,15 @@ class Bigshot
     end
   end
 
+  # Casts Phase (1130) to make a noncorporeal creature attackable.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_phase(npc)
     debug_msg(@DEBUG_COMMANDS, "cmd_phase | npc: #{npc}")
 
-    return if npc.status.match?(/dead|gone/)
-    return unless GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc)
+    return unless still_targetable?(npc.id)
     return unless Spell[704].known? && Spell[704].affordable?
 
     Spell[704].force_cast("##{npc.id}")
@@ -4045,11 +4191,16 @@ class Bigshot
     waitcastrt?
   end
 
+  # Unravels a creature's active spells.
+  #
+  # @param cmd [String] the unravel command variant
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_unravel(cmd, npc)
     debug_msg(@DEBUG_COMMANDS, "cmd_unravel | npc: #{npc} | cmd: #{cmd}")
 
-    return if npc.status.match?(/dead|gone/)
-    return unless GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc)
+    return unless still_targetable?(npc.id)
     return unless Spell[1013].known? && Spell[1013].affordable?
 
     cast_results = Regexp.union(
@@ -4260,7 +4411,6 @@ class Bigshot
       /^You don't have that property equipped\./, # jewel not equipped
       /^You fail to find a target\./, # no valid target to use gem on
       /^You have not yet unlocked Gemstones\./, # have not unlocked gemstones at all yet, wtf are you doing?
-
       # copied from Spell.cast @result_regex
       /^Cast Roundtime [0-9]+ Seconds?\.$/,
       /keeps? the spell from working\./,
@@ -4501,10 +4651,15 @@ class Bigshot
     sleep(0.5)
   end
 
+  # Repeatedly Smites an undead or noncorporeal creature until it is listed
+  # as smitten, dies, leaves, or the character must flee.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_volnsmite(npc)
     debug_msg(@DEBUG_COMMANDS, "cmd_volnsmite | npc: #{npc}")
 
-    while !$bigshot_smite_list.any? { |a| a.to_i == npc.id.to_i } && npc.status !~ /dead|gone/ && GameObj.targets.any? { |s| s.id == npc.id } && !should_flee? && (npc.type.split(',').any? { |a| a == "undead" } || npc.type.split(',').any? { |a| a == "noncorporeal" })
+    while !$bigshot_smite_list.any? { |a| a.to_i == npc.id.to_i } && !dead_or_gone?(npc) && still_targetable?(npc.id) && !should_flee? && (npc.type.split(',').any? { |a| a == "undead" } || npc.type.split(',').any? { |a| a == "noncorporeal" })
       res = dothistimeout "smite ##{npc.id}", 1, /^Roundtime|^What were you referring to\?$|^It looks like somebody already did the job for you\.$/
       if res =~ /^It looks like somebody already did the job for you\.$/i
         $bigshot_smite_list.push(npc.id.to_i)
@@ -4528,10 +4683,17 @@ class Bigshot
     end
   end
 
+  # Performs an unarmed (UCS) attack.
+  #
+  # @param command [String] the command definition
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param manualaim [String, nil] explicit aim target, if given
+  # @param stance_dance [Boolean] whether stance may be changed
+  # @return [void]
   def cmd_unarmed(command, npc, manualaim, stance_dance)
     debug_msg(@DEBUG_COMMANDS, "cmd_unarmed | npc: #{npc} | command: #{command} | manualaim: #{manualaim}")
 
-    return if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc) || !still_targetable?(npc.id)
 
     $bigshot_aim = -1 if manualaim != "" && $bigshot_aim == 0
     $mstrike_taken = false
@@ -4614,7 +4776,7 @@ class Bigshot
       elsif line =~ /You are unable to muster the will to attack anything\.|Your rage causes you to use all of your skill in an all out attack!/
         Spell[1201].cast if Spell[1201].known? && Spell[1201].affordable?
         break
-      elsif npc.status =~ /dead|gone/ || !(GameObj.targets.any? { |s| s.id == npc.id }) || should_flee? || should_rest? || line =~ /You currently have no valid target\.  You will need to specify one\.|^It looks like somebody already did the job for you\.$|What were you referring to/
+      elsif dead_or_gone?(npc) || !still_targetable?(npc.id) || should_flee? || should_rest? || line =~ /You currently have no valid target\.  You will need to specify one\.|^It looks like somebody already did the job for you\.$|What were you referring to/
         $bigshot_unarmed_tier = 1
         $bigshot_unarmed_followup = false
         $bigshot_unarmed_followup_attack = ""
@@ -4786,18 +4948,23 @@ class Bigshot
       if (force_this =~ /^(\d+) / && !Spell[$1.to_i].affordable?)
         message("yellow", "Force ran out of mana. Giving up."); return;
       end
-      return if GameObj.targets.size.nil? || gameobj_npc_check() == 0
+      return if bs_hostile_creatures.empty? || gameobj_npc_check() == 0
       return if should_flee?
       return if should_rest?
-      return if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }
+      return if dead_or_gone?(npc) || !still_targetable?(npc.id)
       return if (Time.now - start) > 30
     end
   end
 
+  # Casts Tangle Weed (610) at a target.
+  #
+  # @param command [String] the command definition
+  # @param target [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_weed(command, target)
     debug_msg(@DEBUG_COMMANDS, "cmd_weed | command: #{command} | target: #{target}")
 
-    return if target.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == target.id }
+    return if dead_or_gone?(target) || !still_targetable?(target.id)
     return if GameObj.loot.find { |loot| loot.name =~ /\b(?:vine|bramble|widgeonweed|vathor club|swallowwort|smilax|creeper|briar|ivy|tumbleweed)\b/ }
     return unless Spell[610].known? and Spell[610].affordable?
 
@@ -4886,7 +5053,7 @@ class Bigshot
     return if id == 608 && hiding?
     return if id == 703 && $bigshot_703_list.any? { |s| s == target.id }
     return if id == 1614 && $bigshot_1614_list.any? { |s| s == target.id }
-    return if id.to_s !~ /902|411/ && (target.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == target.id })
+    return if id.to_s !~ /902|411/ && (dead_or_gone?(target) || !still_targetable?(target.id))
     return if id == 720 && Effects::Cooldowns.active?("Implosion") # implosion cooldown
     # short duration buff cooldown check
     return if [140, 211, 215, 219, 919, 1619, 1650].include?(Spell[id].num) && Effects::Cooldowns.active?(Spell[id].name)
@@ -5076,11 +5243,16 @@ class Bigshot
     Spell[515].cast
   end
 
+  # Casts Elemental Fury.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param extra [String, nil] extra cast arguments
+  # @return [void]
   def cmd_efury(npc, extra)
     debug_msg(@DEBUG_COMMANDS, "cmd_efury | npc: #{npc} | extra: #{extra}")
 
-    return if npc.status =~ /dead|gone/
-    return unless GameObj.targets.any? { |s| s.id == npc.id }
+    return if dead_or_gone?(npc)
+    return unless still_targetable?(npc.id)
     return unless Spell[917].known? and Spell[917].affordable?
 
     spell_complete = false
@@ -5110,14 +5282,18 @@ class Bigshot
     loop do
       break if Time.now > time_out
       break if should_flee?
-      break if npc.status =~ /dead|gone/
-      break unless GameObj.targets.any? { |s| s.id == npc.id }
+      break if dead_or_gone?(npc)
+      break unless still_targetable?(npc.id)
       break if spell_complete
       stand unless standing?
       sleep(0.5)
     end
   end
 
+  # Attempts to hide, retrying up to a limit.
+  #
+  # @param attempts [Integer] maximum tries
+  # @return [Boolean] whether hiding succeeded
   def cmd_hide(attempts)
     debug_msg(@DEBUG_COMMANDS, "cmd_hide | attempts: #{attempts}")
     tries = 0
@@ -5168,7 +5344,7 @@ class Bigshot
       $mstrike_taken = false
       return
     end
-    if Skills.multiopponentcombat >= 30 && GameObj.targets.all? { |i| i.noun !~ /nest/i }
+    if Skills.multiopponentcombat >= 30 && bs_hostile_creatures.all? { |i| i.noun !~ /nest/i }
       if (!Effects::Cooldowns.active?("Multi-Strike") || (@MSTRIKE_COOLDOWN && Char.stamina >= @MSTRIKE_STAMINA_COOLDOWN))
         if @MSTRIKE_QUICKSTRIKE && Char.stamina >= @MSTRIKE_STAMINA_QUICKSTRIKE && !Effects::Debuffs.active?("Overexerted")
           if (gameobj_npc_check() >= @MSTRIKE_MOB || target.nil?)
@@ -5185,7 +5361,7 @@ class Bigshot
         end
         $mstrike_taken = true
       end
-    elsif Skills.multiopponentcombat >= 5 && GameObj.targets.all? { |i| i.noun !~ /nest/i } && gameobj_npc_check() >= @MSTRIKE_MOB
+    elsif Skills.multiopponentcombat >= 5 && bs_hostile_creatures.all? { |i| i.noun !~ /nest/i } && gameobj_npc_check() >= @MSTRIKE_MOB
       if (!Effects::Cooldowns.active?("Multi-Strike") || (@MSTRIKE_COOLDOWN && Char.stamina >= @MSTRIKE_STAMINA_COOLDOWN))
         if @MSTRIKE_QUICKSTRIKE && Char.stamina >= @MSTRIKE_STAMINA_QUICKSTRIKE && !Effects::Debuffs.active?("Overexerted")
           bs_put "quickstrike 1 #{command}"
@@ -5249,9 +5425,14 @@ class Bigshot
     end
   end
 
+  # Hurls a weapon at a target (Dhurl).
+  #
+  # @param target [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param command [String] the command definition
+  # @return [void]
   def cmd_dhurl(target, command)
     debug_msg(@DEBUG_COMMANDS, "cmd_dhurl")
-    if target.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == target.id }
+    if dead_or_gone?(target) || !still_targetable?(target.id)
       $bigshot_ambush = 0
       return
     end
@@ -5321,10 +5502,14 @@ class Bigshot
     end
   end
 
+  # Performs a ranged (bow/crossbow) attack.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_ranged(npc)
     debug_msg(@DEBUG_COMMANDS, "cmd_ranged | npc: #{npc}")
 
-    if npc.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == npc.id }
+    if dead_or_gone?(npc) || !still_targetable?(npc.id)
       $bigshot_archery_aim = 0
       $bigshot_archery_stuck_location = []
       return
@@ -5390,7 +5575,7 @@ class Bigshot
     waitrt?
     waitcastrt?
     result = dothistimeout("cman dislodge ##{npc.id} #{target}", 2, /attempting to dislodge|suitable weapons lodged|You can't reach|awkward proposition|little bit late|still stunned|too injured|what?|round(time)?|You cannot|Could not find|seconds/i)
-    if (result =~ /You manage to dislodge|You skillfully wrench/ && npc.status =~ /dead|gone/)
+    if (result =~ /You manage to dislodge|You skillfully wrench/ && dead_or_gone?(npc))
       $bigshot_dislodge_location = []
       $bigshot_dislodge_target = nil
     elsif (result =~ /You manage to dislodge|You skillfully wrench/)
@@ -5472,14 +5657,19 @@ class Bigshot
     time.to_i.times do
       sleep(1)
       break if should_rest?
-      break if npc && npc.status =~ /dead|gone/
+      break if npc && dead_or_gone?(npc)
     end
   end
 
+  # Ambushes a target from hiding.
+  #
+  # @param command [String] the command definition
+  # @param target [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @return [void]
   def cmd_ambush(command, target)
     debug_msg(@DEBUG_COMMANDS, "cmd_ambush | target: #{target} | command: #{command}")
 
-    if target.status =~ /dead|gone/ || !GameObj.targets.any? { |s| s.id == target.id }
+    if dead_or_gone?(target) || !still_targetable?(target.id)
       $bigshot_ambush = 0
       return
     end
@@ -5557,8 +5747,8 @@ class Bigshot
 
     attempts = 0
     loop do
-      return if npc.status =~ /dead|gone/
-      return unless GameObj.targets.any? { |s| s.id == npc.id }
+      return if dead_or_gone?(npc)
+      return unless still_targetable?(npc.id)
       return unless Spell[706].known? and Spell[706].affordable?
       waitrt?
       waitcastrt?
@@ -5586,8 +5776,8 @@ class Bigshot
     loop do
       break if Time.now > time_out
       break if should_flee?
-      break if npc.status =~ /dead|gone/
-      break unless GameObj.targets.any? { |s| s.id == npc.id }
+      break if dead_or_gone?(npc)
+      break unless still_targetable?(npc.id)
       break if spell_complete
       stand unless standing?
       sleep(0.5)
@@ -5597,22 +5787,25 @@ class Bigshot
       return if spell_complete || Time.now > time_out || should_flee?
 
       # wait for XMLData.current_target_id to update if DOTs transferred
-      if npc.status =~ /dead|gone/ && reget(10).any? { |line| line =~ tether_transferred }
+      if dead_or_gone?(npc) && reget(10).any? { |line| line =~ tether_transferred }
         sleep(0.5)
       end
 
       # returns if npc died and DOTs didn't transfer
-      return if npc.status =~ /dead|gone/ && npc.id == XMLData.current_target_id
+      return if dead_or_gone?(npc) && npc.id == XMLData.current_target_id
 
       # update npc variable to new possible DOT transferred npc
-      npc = GameObj.npcs.find { |potential_npc| potential_npc.id == XMLData.current_target_id && potential_npc.status !~ /dead|gone/ }
+      npc = bs_room_creatures.find { |potential_npc| potential_npc.id == XMLData.current_target_id && !dead_or_gone?(potential_npc) }
       return if npc.nil?                  # returns if no NPC found
-      return if npc.status =~ /dead|gone/ # returns if NPC dead
+      return if dead_or_gone?(npc)        # returns if NPC dead
       return unless valid_target?(npc)    # returns if NPC isn't valid
       cmd_tether(npc, recast_on_transfer) # recasts tether on new npc
     end
   end
 
+  # Treats status ailments afflicting group members.
+  #
+  # @return [void]
   def group_status_ailments()
     debug_msg(@DEBUG_STATUS, "group_status_ailments")
 
@@ -5730,8 +5923,14 @@ class Bigshot
     end
   end
 
+  # Counts attackable creatures in the room.
+  #
+  # Excludes animated decoys, appendages, and anything the character has marked
+  # untargetable, so the count reflects what would actually be fought.
+  #
+  # @return [Integer]
   def gameobj_npc_check()
-    npcs = GameObj.targets.find_all { |i| i.status !~ /dead|gone/ }
+    npcs = bs_targets
     npcs.delete_if { |npc| (npc.name =~ /animated/ && npc.name !~ /animated slush/) }
     npcs.delete_if { |npc| CharSettings['untargetable'].include?(npc.name) }
     npcs.delete_if { |npc| npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i }
@@ -6537,7 +6736,7 @@ class Bigshot
     if XMLData.current_target_id != target.id
       # Rest variables and retarget if target changed
       reset_variables(false)
-      bs_put "target ##{target.id}" if target.status !~ /dead|gone/
+      bs_put "target ##{target.id}" if !dead_or_gone?(target)
     end
 
     # Make sure followers are attacking
@@ -6637,7 +6836,7 @@ class Bigshot
       end
     else
       dead_npcs.each do |i|
-        next if i.status =~ /gone/
+        next if gone?(i)
         waitrt?
         use_lte_boost()
         add_overkill()
@@ -6844,6 +7043,189 @@ class Bigshot
     return true if (abilities & @BOONS_IGNORE).any?
   end
 
+  # --- Creature/Combat targeting helpers (GameObj -> Creature migration) ---
+
+  # Hostile, attackable creatures in the room, wrapped for GameObj-shape
+  # compatibility with the rest of bigshot. Replaces GameObj.targets as the
+  # source of truth: this reads the room roster directly instead of the
+  # client's selected-target list, so it can't go stale after a kill or room
+  # change. See bs_hostile_creatures for why it is not Creature.targets.
+  # Always an Array (never nil).
+  # @param filters [Array<Symbol, String>] optional Creature filters
+  # @return [Array<BigshotCreature, Lich::Common::GameObj>] wrapped creatures,
+  #   plus any bridged raw GameObj targets
+  def bs_targets(*filters)
+    bs_hostile_creatures(*filters).map do |c|
+      # bs_hostile_creatures can return raw GameObj entries bridged in for
+      # creatures the Creature module cannot represent (see there). Only wrap
+      # real CreatureInstances; the rest already present the GameObj shape.
+      c.respond_to?(:crtr_flag?) ? BigshotCreature.new(c) : c
+    end
+  end
+
+  # Deliberately NOT Creature.targets, despite that being the obvious choice.
+  #
+  # Creature.targets selects on `valid_target? && crtr_flag?(:hostile)`, and
+  # CreatureInstance#valid_target? returns false when #dead? is true - where
+  # #dead? means `max_hp - damage_taken <= 0`, NOT the game's own <crtrStatus>
+  # dead flag. damage_taken is accumulated by Combat::Tracker from every damage
+  # number it parses out of the feed, is never reset (Creature#reset_damage
+  # exists but nothing in lich-5 calls it), and max_hp is frequently a guess:
+  # 131 of the 611 bundled creature templates carry `max_hp: nil`, which falls
+  # through to Tracker.fallback_hp or a hardcoded 400.
+  #
+  # Because bigshot enables Combat::Tracker at startup AND uses this list as
+  # its only source of targets, trusting #dead? means a creature that is very
+  # much alive silently disappears from the target list once its *estimated*
+  # damage crosses that guessed ceiling - bigshot stops attacking while the
+  # creature keeps attacking back. Group hunting makes this the common case
+  # rather than the edge case: every group member's damage on a shared target
+  # is parsed from each client's own feed, so a 4-person group over-attributes
+  # roughly 4x and blows through a 300-400 HP estimate long before the
+  # creature actually dies.
+  #
+  # So: take the room roster, apply the two facts the game itself asserts over
+  # <crtrStatus> (hostile, not dead), and reimplement valid_target?'s other
+  # two exclusions directly. Those must be reimplemented rather than assumed
+  # to be covered elsewhere in bigshot: the animated check is duplicated in
+  # valid_target?, but the appendage-noun check only ever existed in
+  # should_flee? and gameobj_npc_check - both of which count creatures for
+  # flee/mob decisions and sit on neither the sort_npcs -> find_target ->
+  # valid_target? selection path. GameObj.targets used to strip appendages at
+  # the source, so dropping that filter here would let bigshot select and
+  # attack a severed limb it previously never saw.
+  # @param filters [Array<Symbol, String>] optional Creature filters; a filtered
+  #   query returns the native roster alone and is not bridged
+  # @return [Array<Lich::Gemstone::Creature::CreatureInstance, Lich::Common::GameObj>]
+  def bs_hostile_creatures(*filters)
+    native = Creature.in_room(*filters).select do |c|
+      next false unless c.crtr_flag?(:hostile)
+      next false if c.crtr_flag?(:dead)
+      # Reimplemented from CreatureInstance#valid_target? / GameObj.targets
+      # rather than inherited, because valid_target? bundles these two safe
+      # exclusions together with the unsafe HP-estimate death check above.
+      # Both lists must stay byte-identical to lib/gemstone/creature.rb's
+      # valid_target? - if that upstream regex gains a case, mirror it here.
+      next false if c.name =~ /^animated\b/i && c.name !~ /^animated slush/i
+      next false if c.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i &&
+                    c.name !~ /(?:amaranthine|ghostly|grizzled|ancient) kraken tentacle/i
+
+      true
+    end
+
+    # Filters are a Creature-module concept (flag_active?), so a filtered
+    # query can't be bridged and returns the native roster alone.
+    return native unless filters.empty?
+
+    # Bridge in anything GameObj considers an attackable target that the
+    # Creature module has no instance for at all. That is not a hypothetical:
+    # bandit_track() manufactures its quarry with GameObj.new_npc after
+    # scraping a manual "look", precisely because bandits never appear in the
+    # normal room feed - so Creature.register is never called for them, and
+    # they could never carry crtr_flag?(:hostile) even if it were, since that
+    # flag can only come from a <crtrStatus> tag they never send. Without this
+    # bridge $bigshot_bandits finds its target, adds it to
+    # XMLData.current_target_ids, and then sort_npcs never sees it.
+    #
+    # Scoped deliberately to ids Creature has NO instance for. Anything
+    # Creature does know about is left to the native roster above, so the
+    # stale client-dropdown behavior this migration set out to escape does not
+    # leak back in for ordinary creatures. GameObj.targets applies its own
+    # dead/gone, animated and appendage exclusions, so bridged entries arrive
+    # pre-vetted by the same rules.
+    #
+    # These are raw GameObj objects, not CreatureInstances: they quack the
+    # same for id/noun/name/status/type, and creature_backed? already reports
+    # false for them so every native crtrStatus reader degrades safely.
+    bridged = GameObj.targets.reject { |go| Creature[go.id] }
+    native + bridged
+  end
+
+  # All tracked creatures in the room (alive, dead, hostile, or not), wrapped
+  # the same way.
+  #
+  # CAUTION - not a drop-in replacement for GameObj.npcs, despite looking
+  # like one: Creature only registers/re-marks-in-room a bolded room object
+  # when a live <crtrStatus> tag arrives for it OR its id is in the client's
+  # target dropdown (XMLData.current_target_ids) - see the text() handler in
+  # lib/common/xmlparser.rb. GameObj.npcs has no such gate; it tracks every
+  # bolded room object unconditionally. A corpse that stops getting fresh
+  # crtrStatus updates post-mortem, or a named-but-not-currently-hostile NPC
+  # (e.g. a bounty rescue target), can therefore be present in the room and
+  # visible via GameObj.npcs while absent here. Prefer GameObj.npcs directly
+  # for general "is X present in the room" presence checks (see loot()'s
+  # dead_npcs and should_flee?'s ALWAYS_FLEE_FROM for examples); this helper
+  # is safe for id-anchored lookups against an id you already know is live
+  # (e.g. XMLData.current_target_id) or for reading crtrStatus data off a
+  # creature you already have another way.
+  # @param filters [Array<Symbol, String>] optional Creature filters
+  # @return [Array<BigshotCreature>]
+  def bs_room_creatures(*filters)
+    Creature.in_room(*filters).map { |c| BigshotCreature.new(c) }
+  end
+
+  # Is a creature id still present in the current hostile/attackable roster?
+  # Replaces the repeated GameObj.targets.any? { |s| s.id == npc.id } pattern
+  # used throughout the cmd_* methods to check whether a target died or left
+  # before a follow-up command runs.
+  #
+  # @param id [String, Integer] creature id to look for
+  # @return [Boolean]
+  def still_targetable?(id)
+    bs_hostile_creatures.any? { |c| c.id.to_s == id.to_s }
+  end
+
+  # Whether npc carries a live CreatureInstance for native crtrStatus reads
+  # (npc.creature.crtr_flag?/has_status?). True for everything bs_targets/
+  # bs_room_creatures/leader_target? normally hand back. False only for the
+  # rare raw GameObj leader_target? falls back to when a group leader's
+  # selected target has no matching Creature registry entry yet - guard
+  # native-only checks with this rather than assuming it can't happen.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @return [Boolean] true when a live CreatureInstance backs this npc, so
+  #   native crtrStatus reads are available
+  def creature_backed?(npc)
+    !npc.nil? && npc.respond_to?(:creature) && !npc.creature.nil?
+  end
+
+  # Replacement for the old npc.status =~ /dead|gone/ regex, sourced
+  # from the live <crtrStatus> dead flag plus room-roster membership instead
+  # of GameObj's status string. Falls back to the regex for the rare
+  # non-creature-backed npc (see creature_backed?) so it degrades exactly to
+  # the pre-migration behavior rather than raising.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @return [Boolean] true if nil, flagged dead, or reported dead/gone by GameObj
+  def dead_or_gone?(npc)
+    return true if npc.nil?
+    return !!(npc.status =~ /dead|gone/) unless creature_backed?(npc)
+
+    # crtr_flag?(:dead) is the game's own assertion over <crtrStatus>; the
+    # status fallback is GameObj's, which tracks every bolded room object
+    # unconditionally. Deliberately NOT room-roster membership
+    # (bs_room_creatures) - Creature only re-registers an object on a
+    # room-objs refresh when a fresh <crtrStatus> arrives for it or its id is
+    # in the client's target dropdown, so a live creature can drop out of the
+    # roster for a tick and be misreported as gone. See bs_room_creatures.
+    npc.creature.crtr_flag?(:dead) || !!(npc.status =~ /dead|gone/)
+  end
+
+  # Whether a creature has left the room roster entirely - decayed, fully
+  # looted, or otherwise removed - independent of the dead flag. Narrower
+  # than dead_or_gone?: needed for call sites (e.g. the dead_npcs loot loop)
+  # where every candidate is already known dead, so dead_or_gone? would
+  # trivially return true for all of them and skip looting entirely.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @return [Boolean]
+  def gone?(npc)
+    return true if npc.nil?
+
+    # BigshotCreature#status already delegates to the matching GameObj entry,
+    # so this is correct for wrapped and unwrapped npcs alike - and unlike
+    # room-roster membership it isn't subject to Creature's registration gate
+    # (see bs_room_creatures).
+    !!(npc.status =~ /gone/)
+  end
+
   def should_flee_from_boons?
     debug_msg(@DEBUG_COMBAT, "should_flee_from_boons?")
 
@@ -6876,16 +7258,25 @@ class Bigshot
       return true if (@FLEE_VOIDS && i.name =~ /black void/)
     end
 
-    return true if GameObj.npcs.any?  { |i| @ALWAYS_FLEE_FROM.include?(i.noun) or @ALWAYS_FLEE_FROM.include?(i.name) }
-    return true if checkpcs.any?      { |i| @ALWAYS_FLEE_FROM.include?(i) }
+    # Deliberately GameObj.npcs, not bs_room_creatures/Creature.in_room: a
+    # named creature on this list might not be hostile-tagged yet (that's
+    # often exactly why it's feared - see the dead_npcs comment in loot()
+    # for the same Creature registration-gate reasoning), so this shouldn't
+    # depend on Creature's crtrStatus/target-dropdown registration gate.
+    return true if GameObj.npcs.any? { |i| @ALWAYS_FLEE_FROM.include?(i.noun) or @ALWAYS_FLEE_FROM.include?(i.name) }
+    return true if checkpcs.any? { |i| @ALWAYS_FLEE_FROM.include?(i) }
 
     return false if $bigshot_bandits
 
-    return true if @BOONS_FLEE.any? && GameObj.targets.any? { |c| c.type.include?("boon") } && should_flee_from_boons?
+    return true if @BOONS_FLEE.any? && bs_targets.any? { |c| c.type.include?("boon") } && should_flee_from_boons?
     return true if !leading? && checkpcs.empty?
 
-    npcs = GameObj.targets.reject! do |npc|
-      npc.status =~ /dead|gone/ ||
+    # bs_targets always returns a fresh Array (never nil), so plain #reject
+    # (not #reject!) is used here - no need for the `|| GameObj.targets`
+    # fallback the old GameObj#reject! required to cover the "nothing was
+    # rejected" nil-return case.
+    npcs = bs_targets.reject do |npc|
+      dead_or_gone?(npc) ||
         @INVALID_TARGETS.include?(npc.name) ||
         @INVALID_TARGETS.include?(npc.noun) ||
         CharSettings['untargetable'].include?(npc.name) ||
@@ -6893,13 +7284,18 @@ class Bigshot
         npc.noun =~ /^(?:grik|grik'trak|grik'mlar|grik'pwal|grik'tval|verlok|verlok'asha|verlok'cina|verlok'ar|imp|abyran|abyran'a|abyran'sa|grantris|igaesha|haze|rouk|brume|haar|murk|nyle|mist|smoke|vapor|fog|aishan|shien|darkling|shadowling|arashan)$/i ||
         ['quickly growing troll king', 'severed troll arm', 'severed troll leg'].include?(npc.name) ||
         (npc.type =~ /companion|familiar/i && npc.type !~ /aggressive npc/i)
-    end || GameObj.targets
+    end
 
     flee_count = (just_entered && @LONE_TARGETS_ONLY) ? 1 : @FLEE_COUNT
 
     return npcs.size > flee_count
   end
 
+  # Whether a creature may be attacked.
+  #
+  # @param target [BigshotCreature, Lich::Common::GameObj] the creature
+  # @param just_entered [Boolean] forwarded to {#should_flee?}
+  # @return [Boolean]
   def valid_target?(target, just_entered = false)
     debug_msg(@DEBUG_COMBAT, "valid_target? | target: #{target}")
 
@@ -6907,8 +7303,8 @@ class Bigshot
     invalid_conditions = {
       'target == nil || target == false'                         => !target,
       'should_flee?(just_entered)'                               => should_flee?(just_entered),
-      'target.status =~ /dead|gone/'                             => target.status =~ /dead|gone/,
-      'target gone from GameObj.targets collection'              => GameObj.targets.none? { |n| n.id == target.id },
+      'dead_or_gone?(target)'                                    => dead_or_gone?(target),
+      'target gone from hostile room roster'                     => !still_targetable?(target.id),
       'target.name contains animated but not an animated slush/' => target.name =~ /animated/ && target.name !~ /animated slush/,
       'targets with boons are being ignored'                     => (target.type.include?("boon") && invalid_target_with_boons(target))
     }
@@ -6916,7 +7312,7 @@ class Bigshot
     invalid_conditions.each do |condition, result|
       if result
         debug_msg(@DEBUG_COMBAT, "valid_target?| returning false for #{target.name} | reason: #{condition}")
-        if target.name =~ /animated/ && target.name !~ /animated slush/ && target.status !~ /dead|gone/
+        if target.name =~ /animated/ && target.name !~ /animated slush/ && !dead_or_gone?(target)
           CharSettings['untargetable'].push(target.name)
         end
 
@@ -6925,12 +7321,12 @@ class Bigshot
     end
 
     # Still here? Make sure we can target it. If not add to CharSettings['untargetable']
-    if (!CharSettings['targetable'].include?(target.name) && !CharSettings['untargetable'].include?(target.name) && target.status !~ /dead|gone/)
+    if (!CharSettings['targetable'].include?(target.name) && !CharSettings['untargetable'].include?(target.name) && !dead_or_gone?(target))
       result = dothistimeout("target ##{target.id}", 3, /^You are now targeting|^You can't target|^You discern that you are the origin|^You are unable to discern the origin/)
       if (result =~ /^You are now targeting/)
-        CharSettings['targetable'].push(target.name) if target.status !~ /dead|gone/
+        CharSettings['targetable'].push(target.name) if !dead_or_gone?(target)
       elsif (result =~ /^You can't target|^You discern that you are the origin|^You are unable to discern the origin/)
-        CharSettings['untargetable'].push(target.name) if target.status !~ /dead|gone/
+        CharSettings['untargetable'].push(target.name) if !dead_or_gone?(target)
       end
     end
 
@@ -6956,7 +7352,7 @@ class Bigshot
       sorted_targets = {}
 
       if @QUICKHUNT_TARGETS.empty?
-        GameObj.targets.each do |npc|
+        bs_hostile_creatures.each do |npc|
           next if CharSettings['untargetable'].include?(npc.name)
           next if $bigshot_bandits && npc.noun !~ @BANDIT_NOUN_REGEX
 
@@ -6970,7 +7366,7 @@ class Bigshot
       @TARGETS ||= { ".+"=>"a" }
     end
 
-    targets = @TARGETS.keys.flat_map { |target| GameObj.targets.select { |npc| npc.name =~ /^#{target}$/i || npc.noun =~ /^#{target}$/i } }
+    targets = @TARGETS.keys.flat_map { |target| bs_targets.select { |npc| npc.name =~ /^#{target}$/i || npc.noun =~ /^#{target}$/i } }
 
     debug_msg(@DEBUG_COMBAT, "sort_npcs | targets: #{targets}")
     return targets
@@ -6978,28 +7374,40 @@ class Bigshot
 
   # Anchored so priority uses the same matching as sort_npcs and can never rank
   # a creature that find_target would be unable to pick
+  # @return [Array<Regexp>] anchored patterns for the configured target names
   def priority_matchers
     @TARGETS.keys.map { |name| /^#{name}$/i }
   end
 
   # Position of a creature in the ordered target list, infinity when unlisted
+  # Ranks a creature against the configured target list.
+  #
+  # @param npc [BigshotCreature, Lich::Common::GameObj] creature to rank
+  # @param matchers [Array<Regexp>] patterns from {#priority_matchers}
+  # @return [Integer, Float] list index, or +Float::INFINITY+ when unlisted
   def priority_rank(npc, matchers)
     index = matchers.index { |matcher| npc.name =~ matcher || npc.noun =~ matcher }
     index.nil? ? Float::INFINITY : index
   end
 
+  # Whether a target still outranks everything else in the room.
+  #
+  # @param target [BigshotCreature, Lich::Common::GameObj] the creature
+  # @return [Boolean]
+  # @note Compares ranks rather than identity, so a target that briefly drops
+  #   out of the roster is not abandoned to a lower-priority creature.
   def priority(target)
     return false if target.nil?
     return true if $bigshot_bandits
     return true if !@PRIORITY
 
     matchers = priority_matchers
-    npcs = GameObj.targets.reject { |npc| CharSettings['untargetable'].include?(npc.name) || invalid_target_with_boons(npc, false) }
+    npcs = bs_targets.reject { |npc| CharSettings['untargetable'].include?(npc.name) || invalid_target_with_boons(npc, false) }
     target_rank = priority_rank(target, matchers)
     best_rank = npcs.map { |npc| priority_rank(npc, matchers) }.min || Float::INFINITY
 
-    # Ranks, not identity: GameObj.targets is the game's target dropdown, which is
-    # rebuilt wholesale, so the current target can drop out of it for a moment.
+    # Ranks, not identity: the hostile roster is rebuilt from the room feed
+    # each call, so the current target can drop out of it for a moment.
     # Only a creature that outranks the target may interrupt it.
     priority = best_rank >= target_rank
 
@@ -7161,9 +7569,13 @@ class Bigshot
     return poisoned
   end
 
+  # Whether the current bounty is complete.
+  #
+  # @return [Boolean]
+  # @see #set_bounty_eval
   def bounty_check?()
     return false unless @BOUNTY_MODE
-    return false if @BANDIT_HUNTING && GameObj.targets.any? { |target| target.type =~ /bandit/ }
+    return false if @BANDIT_HUNTING && bs_targets.any? { |target| target.type =~ /bandit/ }
 
     if @BOUNTY_EVAL.to_s.empty?
       Lich::Messaging.msg('error', " Bigshot is running in bounty mode and bounty_eval is empty. Exiting...")
@@ -7697,11 +8109,11 @@ class Bigshot
     result = dothistimeout("track #{@TRACKING_CREATURE}", 1, tracking_results)
     case result
     when /Your keen eye spots the beginnings of a trail and you rush to follow it/ # success, new room, so we can go ahead
-      uncover() if GameObj.targets.empty? # maybe remove - probably a lot bigger update to reveal hidden targets universally
+      uncover() if bs_hostile_creatures.empty? # maybe remove - probably a lot bigger update to reveal hidden targets universally
       return true # return true to return out of wander and not change rooms again
     when /^You don't have to go far\./ # success, but target is hidden in the existing room
       if bigclaim?
-        uncover() if GameObj.targets.empty? # probably remove - same as above
+        uncover() if bs_hostile_creatures.empty? # probably remove - same as above
         return true # return true so wander doesn't move us
       elsif !bigclaim?
         return false # if room is claimed, we return false and let wander move us because track kept us in the same room which had to already been claimed
@@ -7709,11 +8121,14 @@ class Bigshot
     end
   end
 
+  # Reveals hidden creatures in the room.
+  #
+  # @return [void]
   def uncover
     debug_msg(@DEBUG_COMBAT, "uncover")
 
     waitrt?
-    return unless GameObj.targets.empty?
+    return unless bs_hostile_creatures.empty?
     if Stats.prof == "Ranger" && Spell[609].known? && Spell[609].affordable?
       waitcastrt?
       fput("incant 609 open")
@@ -8279,7 +8694,7 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
 
           # Sync to leader's target if available, or find one
           leader_tgt = group.leader_target
-          unless leader_tgt.nil? || leader_tgt.status =~ /dead|gone/
+          unless leader_tgt.nil? || bs.dead_or_gone?(leader_tgt)
             target = leader_tgt
           end
 

--- a/spec/scripts/bigshot_spec.rb
+++ b/spec/scripts/bigshot_spec.rb
@@ -1,28 +1,51 @@
-# We do NOT load the .lic file: it needs the whole Lich runtime (Settings,
-# XMLData, Spell, GTK, DRb ...). Instead the real method bodies are extracted
-# from scripts/bigshot.lic and evaluated against stubs, so these specs exercise
-# production code and fail if that code changes shape.
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+# Specs for bigshot.lic. We do NOT load the .lic file: it needs the whole
+# Lich runtime (Settings, XMLData, Spell, GTK, DRb ...). Instead the real
+# method/class bodies are extracted from scripts/bigshot.lic and evaluated
+# against stubs, so these specs exercise production code and fail if that
+# code changes shape. Path lookup and loud-failure-on-miss extraction use
+# the shared helpers in spec/spec_helper.rb.
 #
-# Every stub lives inside BigshotPrioritySpec::Harness rather than at top level,
-# so running the whole suite in one process cannot collide with the real GameObj
-# used by the gameobj-data specs.
+# This file covers independent slices of bigshot, each kept in its own
+# namespaced module (BigshotPrioritySpec, BigshotCreatureAdapterSpec, ...)
+# with its own Harness rather than one shared harness, since each slice
+# needs a differently-shaped Creature/GameObj double. Merging them into one
+# shared harness would blur what each section is actually asserting and
+# risk one section's stub state leaking into another's.
 #
 # Deliberately no NilClass patch here. Lich patches NilClass#method_missing to
 # return nil (lich-5 lib/common/class_exts/nilclass.rb), which is what let the
 # removed room-composition cache paper over nil comparisons. This code must not
 # depend on that.
+#
+# Deliberately no shared GameObj stub from spec_helper.rb either: each
+# section below nests its own GameObj inside its own Harness, per
+# spec_helper.rb's own header note that a shared top-level GameObj stub
+# would corrupt the real, top-level GameObj class spec/gameobj-data
+# exercises directly.
+#
+# Phase 1 of the GameObj -> Creature/Combat migration moved the room-creature
+# source of truth from GameObj.targets to Lich::Gemstone::Creature.targets,
+# behind a BigshotCreature adapter that still exposes GameObj-shaped
+# .status/.type (by delegating to the matching GameObj entry). This harness
+# models both halves: a Creature stub standing in for the room roster, and a
+# GameObj stub standing in for the matching entries the adapter falls back to.
 
 module BigshotPrioritySpec
-  SOURCE_PATH = File.expand_path('../../scripts/bigshot.lic', __dir__)
+  SOURCE_PATH = find_lic_source('bigshot.lic', from: __dir__)
   SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
 
   def self.extract(pattern, label)
-    found = SOURCE[pattern]
-    raise "could not extract #{label} from bigshot.lic" unless found
-
-    found
+    extract_from_source(SOURCE, pattern, label: label, source_path: SOURCE_PATH)
   end
 
+  BIGSHOT_CREATURE_SRC = extract(/^class BigshotCreature\n.*?^end$/m, 'BigshotCreature')
+  BS_TARGETS_SRC = extract(/^  def bs_targets\(\*filters\).*?^  end$/m, 'bs_targets')
+  BS_HOSTILE_SRC = extract(/^  def bs_hostile_creatures\(\*filters\).*?^  end$/m, 'bs_hostile_creatures')
+  BS_ROOM_CREATURES_SRC = extract(/^  def bs_room_creatures\(\*filters\).*?^  end$/m, 'bs_room_creatures')
   PRIORITY_SRC = extract(/^  def priority\(target\).*?^  end$/m, 'priority')
   MATCHERS_SRC = extract(/^  def priority_matchers\n.*?^  end$/m, 'priority_matchers')
   RANK_SRC = extract(/^  def priority_rank\(npc, matchers\).*?^  end$/m, 'priority_rank')
@@ -36,7 +59,12 @@ module BigshotPrioritySpec
                                   'follower retarget block')
   EACHTARGET_SRC = extract(/^  def cmd_eachtarget\(command, npc\).*?^  end$/m, 'cmd_eachtarget')
 
-  Creature = Struct.new(:id, :name, :noun, :type, :status) do
+  # GameObj-shaped fixture data (id/name/noun/type/status). Registered both as
+  # the GameObj stub's lookup-by-id entry (what BigshotCreature#status/#type
+  # fall back to) and as the source for the Creature stub's room roster, so a
+  # single fixture describes "the same creature" the way both real systems
+  # would report it.
+  NpcFixture = Struct.new(:id, :name, :noun, :type, :status) do
     def to_s
       name
     end
@@ -46,12 +74,62 @@ module BigshotPrioritySpec
     # Stubs for the Lich globals the extracted bodies reach for. Nested here so
     # constant lookup inside the eval'd method bodies finds these, not the real
     # classes other specs load.
-    module GameObj
+
+    # Minimal double for Lich::Gemstone::Creature::CreatureInstance. Only the
+    # members id/noun/name are used by the method bodies extracted in this
+    # file; crtr_flag?/has_status?/valid_target?/template are stubbed to
+    # sensible defaults since nothing here reaches them (check_state_condition,
+    # which does use them for the crtrStatus command checks, is not extracted
+    # in this spec).
+    FakeCreatureInstance = Struct.new(:id, :noun, :name, :flags) do
+      def crtr_flag?(key)
+        !!(flags || {})[key.to_sym]
+      end
+
+      def has_status?(_name)
+        false
+      end
+
+      def valid_target?
+        true
+      end
+
+      def template
+        nil
+      end
+    end
+
+    module Creature
       class << self
         attr_writer :room_targets
 
-        def targets
+        def targets(*_filters)
           (@room_targets || []).dup
+        end
+
+        def in_room(*_filters)
+          (@room_targets || []).dup
+        end
+
+        def [](id)
+          (@room_targets || []).find { |c| c.id.to_i == id.to_i }
+        end
+      end
+    end
+
+    module GameObj
+      class << self
+        attr_writer :registry
+
+        # Every fixture here is also a Creature instance, so the
+        # bs_hostile_creatures GameObj bridge finds nothing to add - which is
+        # what we want for the ranking tests.
+        def targets
+          []
+        end
+
+        def [](id)
+          (@registry || {})[id]
         end
       end
     end
@@ -88,7 +166,8 @@ module BigshotPrioritySpec
       @DEBUG_COMBAT = false
       @DEBUG_COMMANDS = false
       CharSettings.store = { 'untargetable' => [], 'targetable' => [] }
-      GameObj.room_targets = []
+      GameObj.registry = {}
+      Creature.room_targets = []
       XMLData.current_target_id = nil
     end
 
@@ -103,8 +182,16 @@ module BigshotPrioritySpec
       @cmd_calls << { command: command, npc: npc, check_priority: check_priority }
     end
 
-    def room(*creatures)
-      GameObj.room_targets = creatures
+    # Registers each fixture as both a GameObj entry (what the BigshotCreature
+    # adapter's .status/.type fall back to) and a Creature room-roster entry
+    # (what bs_targets/bs_room_creatures/Creature.targets iterate).
+    def room(*fixtures)
+      GameObj.registry = fixtures.each_with_object({}) { |f, h| h[f.id] = f }
+      # hostile so bs_hostile_creatures keeps them; these fixtures stand in for
+      # live attackable creatures.
+      Creature.room_targets = fixtures.map do |f|
+        FakeCreatureInstance.new(f.id.to_i, f.noun, f.name, { hostile: true })
+      end
     end
 
     def untargetable(*names)
@@ -133,6 +220,10 @@ module BigshotPrioritySpec
       !@unpickable.include?(target.name)
     end
 
+    eval(BIGSHOT_CREATURE_SRC)
+    eval(BS_TARGETS_SRC)
+    eval(BS_HOSTILE_SRC)
+    eval(BS_ROOM_CREATURES_SRC)
     eval(PRIORITY_SRC)
     eval(MATCHERS_SRC)
     eval(RANK_SRC)
@@ -154,44 +245,44 @@ module BigshotPrioritySpec
 
   module Creatures
     def mastiff
-      Creature.new('101', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
+      NpcFixture.new('101', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
     end
 
     def mystic
-      Creature.new('102', 'illoke mystic', 'mystic', 'aggressive npc', nil)
+      NpcFixture.new('102', 'illoke mystic', 'mystic', 'aggressive npc', nil)
     end
 
     def giant
-      Creature.new('103', 'stone giant', 'giant', 'aggressive npc', nil)
+      NpcFixture.new('103', 'stone giant', 'giant', 'aggressive npc', nil)
     end
 
     def shaman
-      Creature.new('104', 'illoke shaman', 'shaman', 'aggressive npc boon', nil)
+      NpcFixture.new('104', 'illoke shaman', 'shaman', 'aggressive npc boon', nil)
     end
 
     def troll
-      Creature.new('105', 'ice troll', 'troll', 'aggressive npc', nil)
+      NpcFixture.new('105', 'ice troll', 'troll', 'aggressive npc', nil)
     end
 
     def second_mastiff
-      Creature.new('106', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
+      NpcFixture.new('106', 'stone mastiff', 'mastiff', 'aggressive npc', nil)
     end
 
     # From the reported thrash: order was valravn, angargeist, disir
     def valravn
-      Creature.new('280414583', 'eyeless black valravn', 'valravn', 'aggressive npc', nil)
+      NpcFixture.new('280414583', 'eyeless black valravn', 'valravn', 'aggressive npc', nil)
     end
 
     def angargeist
-      Creature.new('280405751', 'roiling crimson angargeist', 'angargeist', 'aggressive npc', nil)
+      NpcFixture.new('280405751', 'roiling crimson angargeist', 'angargeist', 'aggressive npc', nil)
     end
 
     def disir
-      Creature.new('280394883', 'shining winged disir', 'disir', 'aggressive npc', nil)
+      NpcFixture.new('280394883', 'shining winged disir', 'disir', 'aggressive npc', nil)
     end
 
     def draugr
-      Creature.new('280394876', 'withered shadow-cloaked draugr', 'draugr', 'aggressive npc', nil)
+      NpcFixture.new('280394876', 'withered shadow-cloaked draugr', 'draugr', 'aggressive npc', nil)
     end
   end
 end
@@ -312,16 +403,16 @@ RSpec.describe 'bigshot Priority Hunt' do
   end
 
   describe 'rank comparison' do
-    # GameObj.targets is the game's target dropdown (xmlparser dDBTarget), which
-    # is cleared and rebuilt wholesale, so the current target can be missing from
-    # it for a moment. Ranking off the list rather than off dropdown membership
-    # keeps that from handing the fight to a lower ranked creature.
-    it 'keeps the current target when the target itself is missing from the dropdown' do
+    # Creature.targets is rebuilt from the room roster on every call, so the
+    # current target can be momentarily missing from it (e.g. between XML
+    # updates). Ranking off the list rather than off list membership keeps
+    # that from handing the fight to a lower ranked creature.
+    it 'keeps the current target when the target itself is missing from the roster' do
       bs.room(giant)
       expect(bs.priority(mastiff)).to be true
     end
 
-    it 'switches when a higher ranked creature is in the dropdown and the target is not' do
+    it 'switches when a higher ranked creature is in the roster and the target is not' do
       bs.room(mystic)
       expect(bs.priority(mastiff)).to be false
     end
@@ -351,7 +442,7 @@ RSpec.describe 'bigshot Priority Hunt' do
       expect(bs.do_hunt_retarget(angargeist).name).to eq('roiling crimson angargeist')
     end
 
-    it 'does not hand the fight to the disir when the angargeist drops out of the dropdown' do
+    it 'does not hand the fight to the disir when the angargeist drops out of the roster' do
       bs.untargetable('eyeless black valravn')
       bs.room(disir)
 
@@ -454,6 +545,430 @@ RSpec.describe 'bigshot Priority Hunt' do
   describe 'the removed room snapshot cache' do
     it 'leaves no reference to the room composition globals or the snapshot thread' do
       expect(BigshotPrioritySpec::SOURCE).not_to match(/current_room_npcs|room_npcs_last_check|npc_room_check/)
+    end
+  end
+end
+
+# Spec for bigshot.lic's Phase 2 native crtrStatus/HP/UCS reads.
+#
+# Same extraction-and-eval approach as BigshotPrioritySpec above, but a
+# separate Harness: this section exercises a different slice of bigshot -
+# the BigshotCreature adapter boundary and the helpers that read
+# Combat::Tracker data (dead_or_gone?, gone?, creature_backed?,
+# leader_target?) - rather than targeting/ranking. Kept independent of
+# BigshotPrioritySpec's Harness so neither section's stub state can leak
+# into the other.
+module BigshotCreatureAdapterSpec
+  SOURCE_PATH = find_lic_source('bigshot.lic', from: __dir__)
+  SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
+
+  def self.extract(pattern, label)
+    extract_from_source(SOURCE, pattern, label: label, source_path: SOURCE_PATH)
+  end
+
+  BIGSHOT_CREATURE_SRC = extract(/^class BigshotCreature\n.*?^end$/m, 'BigshotCreature')
+  BS_ROOM_CREATURES_SRC = extract(/^  def bs_room_creatures\(\*filters\).*?^  end$/m, 'bs_room_creatures')
+  BS_HOSTILE_SRC = extract(/^  def bs_hostile_creatures\(\*filters\).*?^  end$/m, 'bs_hostile_creatures')
+  BS_TARGETS_SRC = extract(/^  def bs_targets\(\*filters\).*?^  end$/m, 'bs_targets')
+  CREATURE_BACKED_SRC = extract(/^  def creature_backed\?\(npc\).*?^  end$/m, 'creature_backed?')
+  DEAD_OR_GONE_SRC = extract(/^  def dead_or_gone\?\(npc\).*?^  end$/m, 'dead_or_gone?')
+  GONE_SRC = extract(/^  def gone\?\(npc\).*?^  end$/m, 'gone?')
+  LEADER_TARGET_SRC = extract(/^  def leader_target\?\n.*?^  end$/m, 'leader_target?')
+
+  # Configurable double for CreatureInstance. statuses/flags start empty so
+  # each test opts in only to the state it's asserting on - a status/flag
+  # that isn't set behaves exactly like the real has_status?/crtr_flag?
+  # default (false).
+  FakeCreatureInstance = Struct.new(:id, :noun, :name, :statuses, :flags, :low_hp, :fatal_crit, :smote, :ucs_pos, :ucs_tierup, :valid_target_override) do
+    def initialize(*)
+      super
+      self.statuses ||= []
+      self.flags ||= {}
+    end
+
+    def has_status?(status_name)
+      statuses.include?(status_name.to_s)
+    end
+
+    def crtr_flag?(key)
+      !!flags[key.to_sym]
+    end
+
+    # Real CreatureInstance#valid_target? is false whenever the guessed
+    # max_hp/damage_taken heuristic says #dead? - independently of the live
+    # <crtrStatus> dead flag. valid_target_override lets a test put the
+    # double into that same divergent state without a real damage model.
+    def valid_target?
+      return valid_target_override unless valid_target_override.nil?
+
+      !crtr_flag?(:dead)
+    end
+
+    def template
+      nil
+    end
+
+    def low_hp?(_threshold = 25)
+      !!low_hp
+    end
+
+    def fatal_crit?
+      !!fatal_crit
+    end
+
+    def smote?
+      !!smote
+    end
+
+    def ucs_position
+      ucs_pos
+    end
+  end
+
+  # A bare GameObj-shaped double with no .creature accessor at all - what
+  # leader_target? falls back to when GameObj.target has no matching Creature
+  # registry entry, and the shape creature_backed? must recognize as false.
+  RawGameObj = Struct.new(:id, :noun, :name, :status, :type) do
+    def to_s
+      name
+    end
+  end
+
+  class Harness
+    module Creature
+      class << self
+        attr_writer :room_targets, :registry
+
+        def in_room(*_filters)
+          (@room_targets || []).dup
+        end
+
+        def [](id)
+          (@registry || {})[id.to_i]
+        end
+      end
+    end
+
+    module GameObj
+      class << self
+        attr_accessor :target
+        attr_accessor :registry
+        attr_writer :target_list
+
+        def [](id)
+          (@registry || {})[id]
+        end
+
+        # Stands in for the real GameObj.targets, which bs_hostile_creatures
+        # bridges from for creatures Creature cannot represent (bandits).
+        def targets
+          (@target_list || []).dup
+        end
+      end
+    end
+
+    def initialize
+      Creature.room_targets = []
+      Creature.registry = {}
+      GameObj.registry = {}
+      GameObj.target = nil
+      GameObj.target_list = []
+    end
+
+    # Registers a creature in both the Creature id registry and the current
+    # room roster, wrapped for the methods under test the way bs_room_creatures
+    # would wrap it.
+    def room(*fake_creatures)
+      Creature.room_targets = fake_creatures
+      Creature.registry = fake_creatures.each_with_object({}) { |c, h| h[c.id] = c }
+    end
+
+    def wrap(fake_creature)
+      BigshotCreature.new(fake_creature)
+    end
+
+    eval(BIGSHOT_CREATURE_SRC)
+    eval(BS_ROOM_CREATURES_SRC)
+    eval(BS_HOSTILE_SRC)
+    eval(BS_TARGETS_SRC)
+    eval(CREATURE_BACKED_SRC)
+    eval(DEAD_OR_GONE_SRC)
+    eval(GONE_SRC)
+    eval(LEADER_TARGET_SRC)
+  end
+
+  RSpec.describe 'BigshotCreature adapter and native crtrStatus/HP/UCS reads' do
+    subject(:bs) { Harness.new }
+
+    # bigshot's PRONE constant, as evaluated into the harness.
+    def described_class_prone_regex
+      Harness::PRONE
+    end
+
+    let(:goblin) { FakeCreatureInstance.new(201, 'goblin', 'a snarling goblin') }
+
+    describe '#creature_backed?' do
+      it 'is true for a BigshotCreature wrapping a real CreatureInstance' do
+        expect(bs.creature_backed?(bs.wrap(goblin))).to be true
+      end
+
+      it 'is false for a bare GameObj-shaped double with no .creature accessor' do
+        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, 'aggressive npc')
+        expect(bs.creature_backed?(raw)).to be false
+      end
+
+      it 'is false for nil' do
+        expect(bs.creature_backed?(nil)).to be false
+      end
+    end
+
+    describe '#status (BigshotCreature, no matching GameObj entry yet)' do
+      it 'is "dead" when the live dead flag is set' do
+        goblin.flags[:dead] = true
+        bs.room(goblin)
+
+        expect(bs.wrap(goblin).status).to eq('dead')
+      end
+
+      it 'is nil for a live, present creature' do
+        bs.room(goblin)
+
+        expect(bs.wrap(goblin).status).to be_nil
+      end
+
+      it 'does NOT synthesize "gone" from valid_target? for a live creature the damage heuristic misjudges' do
+        # Regression guard: real CreatureInstance#valid_target? is false
+        # whenever the guessed max_hp/damage_taken heuristic says #dead?,
+        # independently of the live <crtrStatus> dead flag. Synthesizing
+        # "gone" from that would feed straight into dead_or_gone?/gone? and
+        # misreport a live creature - the exact failure mode this migration
+        # exists to avoid (see the module-level migration notes).
+        goblin.valid_target_override = false
+        bs.room(goblin)
+
+        expect(bs.wrap(goblin).status).to be_nil
+        expect(bs.dead_or_gone?(bs.wrap(goblin))).to be false
+        expect(bs.gone?(bs.wrap(goblin))).to be false
+      end
+    end
+
+    describe '#dead_or_gone?' do
+      it 'is true when the live dead flag is set, regardless of room presence' do
+        goblin.flags[:dead] = true
+        bs.room(goblin)
+
+        expect(bs.dead_or_gone?(bs.wrap(goblin))).to be true
+      end
+
+      it 'does NOT report a live creature as gone merely because it dropped out of the room roster' do
+        # Creature.clear_room fires on every room-objs refresh and only
+        # re-registers an object when a fresh <crtrStatus> arrives for it or
+        # its id is in the client's target dropdown. Treating roster absence
+        # as death made bigshot abandon live creatures for a tick.
+        bs.room # empty roster, but the creature is alive and has no dead flag
+
+        expect(bs.dead_or_gone?(bs.wrap(goblin))).to be false
+      end
+
+      it 'is true when the GameObj status says gone' do
+        bs.room(goblin)
+        Harness::GameObj.registry = { '201' => RawGameObj.new('201', 'goblin', 'a snarling goblin', 'gone', nil) }
+
+        expect(bs.dead_or_gone?(bs.wrap(goblin))).to be true
+      end
+
+      it 'is false for a live, present creature' do
+        bs.room(goblin)
+
+        expect(bs.dead_or_gone?(bs.wrap(goblin))).to be false
+      end
+
+      it 'falls back to the GameObj status regex for a non-creature-backed npc' do
+        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', 'dead', 'aggressive npc')
+        expect(bs.dead_or_gone?(raw)).to be true
+
+        raw.status = nil
+        expect(bs.dead_or_gone?(raw)).to be false
+      end
+
+      it 'is true for nil' do
+        expect(bs.dead_or_gone?(nil)).to be true
+      end
+    end
+
+    describe '#gone?' do
+      it 'does NOT trivially return true for an already-dead creature still in the room' do
+        # Regression guard: gone? must stay narrower than dead_or_gone? or the
+        # dead_npcs loot loop (which only ever holds already-dead entries)
+        # would skip every corpse instead of looting it.
+        goblin.flags[:dead] = true
+        bs.room(goblin)
+
+        expect(bs.gone?(bs.wrap(goblin))).to be false
+      end
+
+      it 'is true once the GameObj status says gone, not merely on roster absence' do
+        bs.room # roster absence alone must not count
+        expect(bs.gone?(bs.wrap(goblin))).to be false
+
+        Harness::GameObj.registry = { '201' => RawGameObj.new('201', 'goblin', 'a snarling goblin', 'gone', nil) }
+        expect(bs.gone?(bs.wrap(goblin))).to be true
+      end
+    end
+
+    describe '#leader_target?' do
+      # As of this PR, leader_target? still returns GameObj.target verbatim -
+      # the single client-selected target has no Creature-module equivalent,
+      # and nothing in this PR calls .creature on it unguarded (dead_or_gone?/
+      # gone?/still_targetable? already degrade safely for a non-creature-
+      # backed npc). Wrapping this consistently becomes necessary once native
+      # crtrStatus reads land - see the crtrStatus command checks PR, which
+      # revises this method and its spec.
+      it 'returns nil when the client has no selected target' do
+        Harness::GameObj.target = nil
+        expect(bs.leader_target?).to be_nil
+      end
+
+      it "returns the client's selected target as-is" do
+        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)
+        bs.room # instantiates bs (which resets GameObj.target) before we set it below
+        Harness::GameObj.target = raw
+
+        expect(bs.leader_target?).to equal(raw)
+      end
+    end
+
+    describe 'targeting must not depend on Combat::Tracker HP estimates' do
+      # CreatureInstance#valid_target? (and therefore Creature.targets) is
+      # false once #dead? is true, where #dead? means
+      # `max_hp - damage_taken <= 0`. damage_taken is accumulated by
+      # Combat::Tracker from every damage number in the feed, is never reset,
+      # and max_hp is often a guess (131 of 611 bundled templates carry
+      # max_hp: nil -> fallback/400). Group hunting over-attributes damage
+      # roughly per-member. If bigshot trusted that, a live creature would
+      # silently vanish from its target list mid-fight.
+      it 'keeps a creature the tracker believes is dead when the game has not flagged it dead' do
+        tracker_thinks_dead = FakeCreatureInstance.new(301, 'kraken', 'an ancient kraken')
+        tracker_thinks_dead.flags[:hostile] = true
+        # simulates damage_taken >= max_hp with no <crtrStatus> dead flag
+        def tracker_thinks_dead.valid_target? = false
+
+        bs.room(tracker_thinks_dead)
+
+        expect(bs.bs_hostile_creatures.map(&:id)).to include(301)
+        expect(bs.bs_targets.map(&:id)).to include('301')
+      end
+
+      it 'drops a creature the game itself flags dead over <crtrStatus>' do
+        really_dead = FakeCreatureInstance.new(302, 'goblin', 'a snarling goblin')
+        really_dead.flags[:hostile] = true
+        really_dead.flags[:dead] = true
+
+        bs.room(really_dead)
+
+        expect(bs.bs_hostile_creatures).to be_empty
+      end
+
+      it 'excludes appendages and animated decoys, as GameObj.targets did' do
+        # These only ever lived in should_flee?/gameobj_npc_check inside
+        # bigshot - neither is on the sort_npcs -> find_target selection path -
+        # so dropping them here would let bigshot attack a severed limb.
+        arm = FakeCreatureInstance.new(401, 'arm', 'severed troll arm')
+        arm.flags[:hostile] = true
+        # Real GS creature names carry no leading article (the bundled
+        # templates are 'animated guardian', 'animated slush', ...), so
+        # upstream's anchored /^animated\b/ does fire on them.
+        decoy = FakeCreatureInstance.new(402, 'guardian', 'animated guardian')
+        decoy.flags[:hostile] = true
+        slush = FakeCreatureInstance.new(403, 'slush', 'animated slush')
+        slush.flags[:hostile] = true
+        kraken = FakeCreatureInstance.new(404, 'tentacle', 'ghostly kraken tentacle')
+        kraken.flags[:hostile] = true
+
+        bs.room(arm, decoy, slush, kraken)
+
+        ids = bs.bs_hostile_creatures.map(&:id)
+        expect(ids).not_to include(401)
+        expect(ids).not_to include(402)
+        # carve-outs upstream keeps, so we keep them too
+        expect(ids).to include(403)
+        expect(ids).to include(404)
+      end
+
+      it 'drops a non-hostile creature' do
+        bystander = FakeCreatureInstance.new(303, 'child', 'a frightened child')
+
+        bs.room(bystander)
+
+        expect(bs.bs_hostile_creatures).to be_empty
+      end
+    end
+
+    describe 'GameObj-only targets (bandits) must still reach the targeting pipeline' do
+      # bandit_track manufactures its quarry with GameObj.new_npc after
+      # scraping a manual "look", because bandits never appear in the normal
+      # room feed. Creature.register is therefore never called for them, and
+      # they could not carry crtr_flag?(:hostile) even if it were, since that
+      # flag only ever comes from a <crtrStatus> tag they never send. Sourcing
+      # targets purely from Creature silently broke $bigshot_bandits: the
+      # bandit was found, added to XMLData.current_target_ids, and then never
+      # targeted.
+      let(:bandit) { RawGameObj.new('88801', 'bandit', 'a grizzled bandit', nil, 'aggressive npc') }
+
+      it 'bridges in a GameObj target that Creature has no instance for' do
+        bs.room # Creature knows about nothing at all
+        Harness::GameObj.target_list = [bandit]
+
+        expect(bs.bs_hostile_creatures).to include(bandit)
+        expect(bs.bs_targets.map(&:id)).to include('88801')
+      end
+
+      it 'hands the bridged GameObj through unwrapped, so it degrades safely' do
+        # The actual native-read degradation (npc_has_status?, etc.) is
+        # exercised once those readers exist - see the crtrStatus command
+        # checks spec.
+        bs.room
+        Harness::GameObj.target_list = [bandit]
+
+        picked = bs.bs_targets.find { |t| t.id == '88801' }
+        expect(picked).not_to be_nil # else the assertions below pass vacuously
+        expect(picked).to equal(bandit) # handed through, not wrapped
+        expect(bs.creature_backed?(picked)).to be false
+      end
+
+      it 'does not double-list a creature Creature already knows about' do
+        # Anything Creature can represent stays on the native roster, so the
+        # stale client-dropdown behavior this migration escaped cannot leak
+        # back in for ordinary creatures.
+        goblin.flags[:hostile] = true
+        bs.room(goblin)
+        Harness::GameObj.target_list = [RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)]
+
+        expect(bs.bs_hostile_creatures.size).to eq(1)
+        expect(bs.bs_hostile_creatures.first).to equal(goblin)
+      end
+    end
+
+    describe 'GameObj.npcs presence checks that must NOT be migrated to Creature.in_room' do
+      # lib/common/xmlparser.rb only registers a room object into Creature
+      # (and re-marks it present on every subsequent room-objs refresh, which
+      # fires far more often than a full room change) when a live
+      # <crtrStatus> tag arrives for it or its id is in the client's target
+      # dropdown (XMLData.current_target_ids). GameObj.npcs has no such gate.
+      # A corpse that stops getting <crtrStatus> updates post-mortem, or a
+      # named-but-not-currently-hostile NPC (a bounty rescue target, a feared
+      # creature that hasn't aggroed yet), can be a real, present room object
+      # while invisible to Creature.in_room/bs_room_creatures. These specific
+      # call sites were migrated to Creature.in_room and then reverted after
+      # tracing that gate in the real parser source - this guards against a
+      # future re-migration repeating the mistake without knowing why.
+      it 'keeps loot()/need_to_loot?/should_flee?/the bounty child-rescue check on GameObj.npcs' do
+        expect(SOURCE).to match(/dead_npcs = GameObj\.npcs\.find_all \{ \|i\| i\.status == 'dead' && i\.type !~ \/escort\/i \}/)
+        expect(SOURCE).to match(/break unless GameObj\.npcs\.any\? \{ \|npc\| npc\.status == 'dead' && npc\.type !~ \/escort\/i \}/)
+        expect(SOURCE).to match(/GameObj\.npcs\.any\? \{ \|i\| @ALWAYS_FLEE_FROM\.include\?\(i\.noun\) or @ALWAYS_FLEE_FROM\.include\?\(i\.name\) \}/)
+        expect(SOURCE).to match(/GameObj\.npcs\.find \{ \|n\| n\.name =~ \/child\/i \}/)
+        expect(SOURCE).to match(/GameObj\.npcs\.any\? \{ \|npc\| npc\.name =~ \/\\\\bchild\\\\b\/ \}/)
+      end
     end
   end
 end


### PR DESCRIPTION
feat(bigshot.lic): v5.16.0 migrate room-creature targeting to Creature module

GameObj.targets is built from XMLData.current_target_ids, the client's
target dropdown, which can go stale after a kill or a room change. This
swaps the targeting pipeline (sort_npcs, priority, valid_target?,
should_flee?, cmd_eachtarget, and the ~40 "is this npc still alive"
liveness checks scattered through the cmd_* methods) onto
Lich::Gemstone::Creature, which reads the room roster directly instead.

Targets do NOT come from Creature.targets, which is the obvious choice
and the one most likely to look wrong on review. Creature.targets
selects on CreatureInstance#valid_target?, which is false once #dead? is
true - and #dead? means max_hp - damage_taken <= 0, not the game's own
<crtrStatus> dead flag. damage_taken accumulates from every damage
number Combat::Tracker parses out of the feed and is never reset
(Creature#reset_damage exists but nothing in lich-5 calls it), and
max_hp falls back to a guess for 131 of the 611 bundled creature
templates. Trusting #dead? would let a live creature silently vanish
from the target list once its estimated damage crosses a guessed
ceiling - and group hunting makes that the common case, since every
member's damage on a shared target is parsed from every member's own
feed. bs_hostile_creatures instead takes the room roster and applies
only the two facts the game itself asserts over <crtrStatus>: hostile,
and not dead. It reimplements valid_target?'s other two exclusions
(animated decoys, appendage nouns) directly rather than inheriting them,
mirroring lib/gemstone/creature.rb.

bs_hostile_creatures also bridges in GameObj.targets entries that
Creature has no instance for at all. bandit_track manufactures its
quarry with GameObj.new_npc after scraping a manual look, because
bandits never appear in the normal room feed - so Creature.register is
never called for them, and they could not carry crtr_flag?(:hostile)
regardless, since that flag only ever comes from a live <crtrStatus>
tag. Without the bridge, bandit hunting finds its target and then never
attacks it. The bridge is scoped to ids Creature has never seen, so
ordinary creatures still come from the fresh roster.

BigshotCreature wraps a CreatureInstance so the cmd_* methods keep
their GameObj-shaped .id/.status/.type. .status and .type deliberately
stay GameObj-backed: GameObj#type (undead, noncorporeal, aggressive
npc, companion, familiar, boon, escort) comes from a static noun/name
lookup table with no <crtrStatus> equivalent at all.

Room-presence checks (loot()'s dead_npcs, should_flee?'s
ALWAYS_FLEE_FROM, the bounty child-rescue check) deliberately stay on
GameObj.npcs rather than Creature.in_room. Creature only registers a
room object when a live <crtrStatus> tag arrives for it or its id is in
the target dropdown, and that registration clears on every room-objs
refresh, not just room changes - so a corpse that stops getting status
updates post-mortem, or a named-but-not-yet-hostile NPC, can be present
and lootable while invisible to Creature.in_room.

Combat::Tracker is enabled once at startup (persists per character,
enable! is a no-op when already on) so HP/wound/UCS data populates
going forward - consumed starting in the next PR.

Testing: spec/bigshot/priority_spec.rb updated for the new object
shape; spec/bigshot/creature_adapter_spec.rb added, covering the
adapter boundary, dead_or_gone?/gone? (including the corpse-vs-dead
distinction that made gone? necessary as a narrower sibling), the
GameObj-npcs regression guards, and the bandit bridge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Bigshot to version 5.16.0 with improved creature targeting and combat tracking.
  - Added more reliable target validation, priority selection, fleeing, bounty checks, tracking, uncovering, looting, and combat safeguards.
  - Improved support for creatures that are unavailable through the primary targeting system.

- **Bug Fixes**
  - Improved handling of defeated, missing, or no-longer-targetable creatures.
  - Prevented duplicate targets and improved support for bandit encounters.

- **Tests**
  - Expanded coverage for targeting, creature selection, exclusions, priority ranking, and room presence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->