### PR TITLE
feat(bigshot.lic): v5.16.0 add crtrStatus command checks, migrate flying/rooted/frozen/prone

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -17,6 +17,26 @@
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v5.16.0  (2026-08-13)
+    - migrate room-creature targeting from GameObj.targets/.npcs to the Lich::Gemstone::Creature / Combat::Tracker APIs (Lich >= 5.19.0). GameObj.targets is built from XMLData.current_target_ids (the client's target dropdown), which can go stale after a kill or a room change; Creature reads the room roster instead
+    - add BigshotCreature, an adapter wrapping a CreatureInstance so the cmd_* methods keep their GameObj-shaped .id/.status/.type. The Integer creature id is normalized to String at the boundary
+    - replace the npc.status =~ /dead|gone/ idiom across ~40 call sites with dead_or_gone?, reading the <crtrStatus> dead flag plus GameObj's status string
+    - enable Combat::Tracker at startup (persists per character; enable! is a no-op when already on)
+    - add command checks for crtrStatus statuses: calm, disoriented, hovering, immobilized, kneeling, sitting, sleeping, stunned, webbed
+    - add command checks for crtrStatus classification flags: ascended, ascension_boss, challenging, disengaged, inferior, mini_boss, mount, rider, sympathetic
+    - add command checks for Combat::Tracker data: wounded, fatalcrit, smote, ucsdecent, ucsgood, ucsexcellent, ucstierup. These are additive and do not alter $bigshot_unarmed_tier or any existing tier/targeting logic
+    - migrate flying and rooted from status-string regex to native has_status? reads
+
+    Deliberate limits on the migration, verified against lich-5 source:
+    - targets come from bs_hostile_creatures (room roster filtered on hostile and not dead), NOT Creature.targets. Creature.targets selects on CreatureInstance#valid_target?, which is false once #dead? is true - and #dead? means max_hp - damage_taken <= 0, not the game's <crtrStatus> dead flag. damage_taken accumulates from every damage number Combat::Tracker parses and is never reset (Creature#reset_damage exists but nothing in lich-5 calls it), and max_hp falls back to Tracker.fallback_hp or a hardcoded 400 for the 131 of 611 bundled templates carrying max_hp: nil. Since this release both enables the tracker and makes this the only source of targets, trusting #dead? would drop a live creature from the target list once its estimated damage crossed a guessed ceiling - and group hunting over-attributes damage, because every member's damage on a shared target is parsed from every member's own feed
+    - bs_hostile_creatures reimplements valid_target?'s other two exclusions (animated decoys, appendage nouns) rather than inheriting them, mirroring lib/gemstone/creature.rb. If that upstream regex gains a case, mirror it here
+    - bs_hostile_creatures also bridges in GameObj.targets entries that Creature has no instance for. bandit_track manufactures its quarry with GameObj.new_npc after scraping a manual look, because bandits never appear in the room feed, so Creature.register is never called for them and they could not carry crtr_flag?(:hostile) regardless. Scoped to ids Creature has never seen, so ordinary creatures still come from the fresh roster
+    - the frozen command check reads the immobilized status natively. "frozen" is the same state the feed calls immobilized: lich-5 maps <crtrStatus immobile="1"> to the canonical immobilized status, and the message parser reaches it from the entangling/restricting-force messages. No immobile="1" appears in the GS4 logs sampled here, so the room-text rendering is unverified; reading it natively removes the dependency on that rendering. The /frozen/i string match is retained as a fallback, so the check is a strict superset of the old one; polarity is unchanged
+    - read creature statuses from <crtrStatus> rather than the GameObj status string. A creature can hold several statuses at once, but GameObj.status is single-valued - the parser assigns one capture from the room annotation - and the game renders only the highest-precedence one. Measured over ~1000 creature observations from real GS4 logs: prone alone renders "that is lying down.", prone + stunned renders "that appears stunned.", prone + dead renders "that appears dead.". This masking is why the new individual status modifiers (stunned, sleeping, sitting, calm) read natively; a creature holding two statuses only ever advertises one
+    - npc_prone? likewise reads sleeping/webbed/stunned/kneeling/sitting/prone/immobilized natively, keeping the PRONE regex as a fallback for npcs with no CreatureInstance behind them. Note this is a robustness change, not a bug fix: across those same logs the old regex and the native read agree on every live creature, because each masking status observed is itself in PRONE and "lying down" matches ^lying. The one case the string cannot see is dead + prone, which dead_or_gone? gates first. Polarity is unchanged
+    - .type stays GameObj-backed permanently: GameObj#type (undead, noncorporeal, aggressive npc, companion, familiar, boon, escort) comes from the static @@type_data lookup table with no <crtrStatus> equivalent, so the undead and noncorporeal command checks are unchanged
+    - room-presence checks stay on GameObj.npcs (loot/need_to_loot?, should_flee?'s ALWAYS_FLEE_FROM, the bounty child-rescue check). Creature only registers a room object when a live <crtrStatus> arrives or its id is in the target dropdown, and clear_room fires on every room-objs refresh, so a corpse or a named-but-not-hostile NPC can be present while absent from Creature.in_room
+    - leader_target? still sources the id from GameObj.target (the client's single selected target has no Creature equivalent) but wraps the result, falling back to the raw GameObj when no registry entry exists
   v5.15.4  (2026-08-05)
     - add additional messaging for cmd_unravel
   v5.15.3  (2026-07-29)
@@ -457,9 +477,10 @@ Combat   = Lich::Gemstone::Combat   unless defined?(Combat)
 #     table (lib/common/gameobj.rb), a static noun/name regex lookup with
 #     no connection to the live <crtrStatus> feed at all. There is no
 #     Creature-module equivalent to migrate to.
-#   - .status is still the source of truth for "frozen"/"prone" and every
-#     other free-text state a regex against the room annotation can catch;
-#     nothing here reads those natively yet.
+#   - .status is still consulted as a fallback by npc_prone?/npc_frozen? for
+#     npcs with no CreatureInstance behind them (bridged bandits,
+#     leader_target?'s fallback), but every state those checks care about now
+#     reads natively when a creature is available.
 class BigshotCreature
   attr_reader :creature
 
@@ -2423,6 +2444,20 @@ class Bigshot
 
   PRONE ||= /sleeping|webbed|stunned|kneeling|sitting|^lying|prone|frozen|held in place|entangled/
 
+  # The native <crtrStatus> statuses covering everything the PRONE regex
+  # matches. Every token maps: "frozen", "entangled" and "held in place" all
+  # reconcile to immobilized (see npc_frozen?), and "^lying" is the same state
+  # crtrStatus calls prone - real logs render prone as "that is lying down.".
+  PRONE_STATUSES ||= %w[sleeping webbed stunned kneeling sitting prone immobilized].freeze
+
+  # Starts or stops the ambush/interference downstream monitor.
+  #
+  # Watches the feed for creatures leaping from hiding and for other players
+  # acting in the room, setting the globals the hunting loop consults. Group
+  # members are excluded so a companion's arrival is not mistaken for an ambush.
+  #
+  # @param cur_action [String] +'start'+ or +'stop'+
+  # @return [void]
   def hunt_monitor(cur_action)
     bigshot_monitor = proc { |server_string|
       if !$bigshot_bandits && server_string =~ /<a exist="\d+" noun="([a-zA-Z]*?)">[a-zA-Z]*?<\/a> leaps from hiding to attack!/i
@@ -2734,8 +2769,13 @@ class Bigshot
     end
   end
 
+  # Compiles the command-modifier regexes used to parse command definitions.
+  #
+  # @return [void]
+  # @note The modifier whitelist is a single alternation; a new modifier must be
+  #   added here as well as to {#check_state_condition}, or it will never parse.
   def initialize_command_data
-    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?barrage|!?bearhug|buff|!?burst|!?celerity|censer|!?coupdegrace|!?disease|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?justice|!?k|!?m|!?mob|!?momentum|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|repeatdelay|room|!?rooted|!?s|!?scourge|!?shout|!?splashy|!?surge|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?yowlp).*?)\)$/i.freeze
+    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?ascended|!?ascension_boss|!?barrage|!?bearhug|buff|!?burst|!?calm|!?celerity|censer|!?challenging|!?coupdegrace|!?disease|!?disengaged|!?disoriented|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?fatalcrit|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?hovering|!?immobilized|!?inferior|!?justice|!?k|!?kneeling|!?m|!?mini_boss|!?mob|!?momentum|!?mount|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|repeatdelay|!?rider|room|!?rooted|!?s|!?scourge|!?shout|!?sitting|!?sleeping|!?smote|!?splashy|!?stunned|!?surge|!?sympathetic|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?ucsdecent|!?ucsexcellent|!?ucsgood|!?ucstierup|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?webbed|!?wounded|!?yowlp).*?)\)$/i.freeze
 
     @COMMAND_AMOUNT_REGEX = /((?:!?e|!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
@@ -3787,18 +3827,93 @@ class Bigshot
     # NPC-specific checks
     when 'ancient'    then npc.name !~ /^(?:grizzled|ancient) / || npc.name == 'ancient ghoul master'
     when '!ancient'   then npc.name =~ /^(?:grizzled|ancient) / && npc.name != 'ancient ghoul master'
-    when 'flying'     then !npc.status.include?("flying")
-    when '!flying'    then npc.status.include?("flying")
-    when 'frozen'     then npc.status =~ /frozen/i
-    when '!frozen'    then npc.status !~ /frozen/i
+    when 'flying'     then !npc_has_status?(npc, "flying")
+    when '!flying'    then npc_has_status?(npc, "flying")
+    # "frozen" is the same game state the feed calls immobilized: lich-5 maps
+    # the <crtrStatus immobile="1"> attribute to the canonical 'immobilized'
+    # status (CRTR_STATUS_FLAGS in lib/common/creature/creature_base.rb), and
+    # the message parser reaches it too (defs/statuses.rb :immobilized, from
+    # the entangling/restricting-force messages). No immobile="1" appears in
+    # the GS4 logs sampled for this change, so how the room text renders it
+    # is unverified - reading it natively removes the dependency on that
+    # rendering either way. The string match is retained as a fallback so
+    # nothing the old check caught is lost. Polarity is unchanged: as with
+    # prone/rooted, (frozen) skips the command when the target IS frozen.
+    when 'frozen'     then npc_frozen?(npc)
+    when '!frozen'    then !npc_frozen?(npc)
+    # noncorporeal/undead classification comes from GameObj's own
+    # @@type_data static lookup table (lib/common/gameobj.rb), matched by
+    # regex against noun/name - a completely separate system from the live
+    # <crtrStatus> feed, with no Creature-module equivalent. These stay on
+    # npc.type (GameObj-backed via the adapter) permanently.
     when 'noncorporeal' then !npc.type.split(',').any? { |a| a == "noncorporeal" }
     when '!noncorporeal' then npc.type.split(',').any? { |a| a == "noncorporeal" }
-    when 'prone'      then npc.status =~ PRONE
-    when '!prone'     then npc.status !~ PRONE
-    when 'rooted'     then npc.status =~ /rooted/i
-    when '!rooted'    then npc.status !~ /rooted/i
+    # Polarity unchanged: (prone) skips the command when the target IS prone.
+    when 'prone'      then npc_prone?(npc)
+    when '!prone'     then !npc_prone?(npc)
+    when 'rooted'     then npc_has_status?(npc, "rooted")
+    when '!rooted'    then !npc_has_status?(npc, "rooted")
     when 'undead'     then !npc.type.split(',').any? { |a| a == "undead" }
     when '!undead'    then npc.type.split(',').any? { |a| a == "undead" }
+
+    # crtrStatus status checks (message-driven statuses need Combat::Tracker
+    # enabled to populate - see initialize, which enables it at startup)
+    when 'calm'         then !npc_has_status?(npc, "calm")
+    when '!calm'        then npc_has_status?(npc, "calm")
+    when 'disoriented'  then !npc_has_status?(npc, "disoriented")
+    when '!disoriented' then npc_has_status?(npc, "disoriented")
+    when 'hovering'     then !npc_has_status?(npc, "hovering")
+    when '!hovering'    then npc_has_status?(npc, "hovering")
+    when 'immobilized'  then !npc_has_status?(npc, "immobilized")
+    when '!immobilized' then npc_has_status?(npc, "immobilized")
+    when 'kneeling'     then !npc_has_status?(npc, "kneeling")
+    when '!kneeling'    then npc_has_status?(npc, "kneeling")
+    when 'sitting'      then !npc_has_status?(npc, "sitting")
+    when '!sitting'     then npc_has_status?(npc, "sitting")
+    when 'sleeping'     then !npc_has_status?(npc, "sleeping")
+    when '!sleeping'    then npc_has_status?(npc, "sleeping")
+    when 'stunned'      then !npc_has_status?(npc, "stunned")
+    when '!stunned'     then npc_has_status?(npc, "stunned")
+    when 'webbed'       then !npc_has_status?(npc, "webbed")
+    when '!webbed'      then npc_has_status?(npc, "webbed")
+
+    # crtrStatus classification-flag checks
+    when 'ascended'       then !npc_crtr_flag?(npc, :ascended)
+    when '!ascended'      then npc_crtr_flag?(npc, :ascended)
+    when 'ascension_boss' then !npc_crtr_flag?(npc, :ascension_boss)
+    when '!ascension_boss' then npc_crtr_flag?(npc, :ascension_boss)
+    when 'challenging'    then !npc_crtr_flag?(npc, :challenging)
+    when '!challenging'   then npc_crtr_flag?(npc, :challenging)
+    when 'disengaged'     then !npc_crtr_flag?(npc, :disengaged)
+    when '!disengaged'    then npc_crtr_flag?(npc, :disengaged)
+    when 'inferior'       then !npc_crtr_flag?(npc, :inferior)
+    when '!inferior'      then npc_crtr_flag?(npc, :inferior)
+    when 'mini_boss'      then !npc_crtr_flag?(npc, :mini_boss)
+    when '!mini_boss'     then npc_crtr_flag?(npc, :mini_boss)
+    when 'mount'          then !npc_crtr_flag?(npc, :mount)
+    when '!mount'         then npc_crtr_flag?(npc, :mount)
+    when 'rider'          then !npc_crtr_flag?(npc, :rider)
+    when '!rider'         then npc_crtr_flag?(npc, :rider)
+    when 'sympathetic'    then !npc_crtr_flag?(npc, :sympathetic)
+    when '!sympathetic'   then npc_crtr_flag?(npc, :sympathetic)
+
+    # crtrStatus/Combat::Tracker HP, wound, and UCS checks (additive - none
+    # of these replace $bigshot_unarmed_tier or any other existing tier/
+    # targeting logic, they're new opt-in signals for command definitions)
+    when 'wounded'      then !npc_low_hp?(npc)
+    when '!wounded'     then npc_low_hp?(npc)
+    when 'fatalcrit'    then !npc_fatal_crit?(npc)
+    when '!fatalcrit'   then npc_fatal_crit?(npc)
+    when 'smote'        then !npc_smote?(npc)
+    when '!smote'       then npc_smote?(npc)
+    when 'ucsdecent'    then npc_ucs_position(npc) != 1
+    when '!ucsdecent'   then npc_ucs_position(npc) == 1
+    when 'ucsgood'      then npc_ucs_position(npc) != 2
+    when '!ucsgood'     then npc_ucs_position(npc) == 2
+    when 'ucsexcellent' then npc_ucs_position(npc) != 3
+    when '!ucsexcellent' then npc_ucs_position(npc) == 3
+    when 'ucstierup'    then npc_ucs_tierup(npc).nil?
+    when '!ucstierup'   then !npc_ucs_tierup(npc).nil?
 
     # Tier checks
     when 'tier1'      then $bigshot_unarmed_tier != 1
@@ -6012,18 +6127,22 @@ class Bigshot
     ExecScript.start(wait_for_swing_exec, :quiet => true)
 
     loop do
-      change_stance(@WANDER_STANCE, false) unless target && target.status =~ PRONE
+      change_stance(@WANDER_STANCE, false) unless target && npc_prone?(target)
       stand() if !standing?
       break if $stop_wait
-      break if GameObj.targets.size.nil? || gameobj_npc_check.zero?
+      break if bs_hostile_creatures.empty? || gameobj_npc_check.zero?
       break if should_flee?
-      break if target && target.status =~ PRONE
+      break if target && npc_prone?(target)
       break if (Time.now - start) > seconds
 
       sleep(0.25)
     end
   end
 
+  # Reports a fatal problem and exits the script.
+  #
+  # @param message [String] reason to display
+  # @return [void] does not return; terminates the script
   def croak(message)
     debug_msg(@DEBUG_SYSTEM, "croak | message: #{message}")
 
@@ -7226,12 +7345,134 @@ class Bigshot
     !!(npc.status =~ /gone/)
   end
 
+  # Guarded npc.creature.has_status?/crtr_flag? readers for the crtrStatus
+  # command checks in check_state_condition. Degrade to false rather than
+  # raising for the rare non-creature-backed npc (see creature_backed?) - a
+  # status/flag check failing safe matches how these modifiers behave for
+  # any other unrecognized/unavailable state (the `else false` branch).
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @param status_name [String, Symbol] canonical crtrStatus status name
+  # @return [Boolean] false rather than raising when npc is not creature-backed
+  def npc_has_status?(npc, status_name)
+    creature_backed?(npc) && npc.creature.has_status?(status_name)
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @param flag [Symbol] classification flag key
+  # @return [Boolean] false rather than raising when npc is not creature-backed
+  def npc_crtr_flag?(npc, flag)
+    creature_backed?(npc) && npc.creature.crtr_flag?(flag)
+  end
+
+  # "frozen" and "immobilized" are the same state under two names - see the
+  # 'frozen' branch in check_state_condition. Native read first, legacy
+  # GameObj string as a fallback so this is a strict superset of the old
+  # check.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @return [Boolean]
+  def npc_frozen?(npc)
+    return false if npc.nil?
+
+    npc_has_status?(npc, "immobilized") || !!(npc.status =~ /frozen/i)
+  end
+
+  # A creature can hold several <crtrStatus> statuses at once, but GameObj's
+  # status string holds exactly one - the parser assigns a single capture from
+  # the room annotation (@last_npc&.status = $1 in xmlparser.rb). A real feed
+  # line makes the gap concrete:
+  #
+  #   <crtrStatus exist="153281570" hostile="1" stunned="1" prone="1" inferior="1"/>
+  #   ...<a exist="153281570" noun="dybbuk">dybbuk</a> that appears stunned.
+  #
+  # The creature is stunned AND prone; the annotation carries only "stunned",
+  # so GameObj.status is "stunned".
+  #
+  # Measured against ~1000 creature observations from real GS4 logs, the
+  # renderings are:
+  #
+  #   prone (alone)      -> "that is lying down."   -> "lying down"
+  #   prone + stunned    -> "that appears stunned." -> "stunned"
+  #   prone + sleeping   -> "that is sleeping,"     -> "sleeping"
+  #   prone + dead       -> "that appears dead."    -> "dead"
+  #   sitting            -> "that is sitting."      -> "sitting"
+  #   calmed             -> "that appears rather calm." -> "rather calm"
+  #
+  # So GameObj.status is single-valued with a precedence order, and a lower
+  # status is masked whenever a higher one co-occurs. For PRONE specifically
+  # that turns out to be harmless on live creatures - every masking status
+  # observed (stunned, sleeping) is itself in the regex, and "lying down"
+  # matches ^lying - so this native read is NOT fixing an observed miss. It
+  # is the more direct source, and it does see through the one masking case
+  # that the string cannot: dead + prone, where GameObj reports only "dead".
+  # That case is academic here since dead_or_gone? gates first.
+  #
+  # The masking does matter for the individual status modifiers (stunned,
+  # sleeping, sitting, calm), which read natively for exactly this reason: a
+  # creature holding two statuses only ever advertises one of them.
+  #
+  # The regex is kept as a fallback for npcs with no CreatureInstance behind
+  # them - the GameObj entries bridged in by bs_hostile_creatures for bandits,
+  # and leader_target?'s fallback - where npc_has_status? has nothing to read
+  # and the status string is all there is.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @return [Boolean]
+  def npc_prone?(npc)
+    return false if npc.nil?
+    return true if PRONE_STATUSES.any? { |status| npc_has_status?(npc, status) }
+
+    !!(npc.status =~ PRONE)
+  end
+
+  # HP/wound/UCS readers backing the additive command checks below (wounded,
+  # fatalcrit, smote, ucsdecent/ucsgood/ucsexcellent, ucstierup). Populated by
+  # Combat::Tracker, enabled once at startup in initialize. All degrade to a
+  # safe default (false/nil) rather than raising for a non-creature-backed
+  # npc, same as npc_has_status?/npc_crtr_flag? above.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @param threshold [Integer] percentage at or below which the creature counts
+  #   as wounded
+  # @return [Boolean]
+  def npc_low_hp?(npc, threshold = 25)
+    creature_backed?(npc) && npc.creature.low_hp?(threshold)
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @return [Boolean]
+  def npc_fatal_crit?(npc)
+    creature_backed?(npc) && npc.creature.fatal_crit?
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @return [Boolean]
+  def npc_smote?(npc)
+    creature_backed?(npc) && npc.creature.smote?
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @return [Integer, nil] UCS position tier, or nil if unavailable
+  def npc_ucs_position(npc)
+    return nil unless creature_backed?(npc)
+
+    npc.creature.ucs_position
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @return [String, nil] the tier-up maneuver, or nil if unavailable
+  def npc_ucs_tierup(npc)
+    return nil unless creature_backed?(npc)
+
+    npc.creature.ucs_tierup
+  end
+
+  # Whether any creature in the room carries a boon the character flees from.
+  #
+  # @return [Boolean]
   def should_flee_from_boons?
     debug_msg(@DEBUG_COMBAT, "should_flee_from_boons?")
 
     return false if @BOONS_FLEE.empty?
 
-    GameObj.targets.each do |creature|
+    bs_targets.each do |creature|
       next unless creature.type.include?("boon")
 
       # Convert adjectives -> trait names
@@ -7429,18 +7670,37 @@ class Bigshot
     return nil
   end
 
+  # GameObj.target (the client's single currently-selected target) has no
+  # Creature-module equivalent - Creature.targets/in_room deliberately don't
+  # model "the selected one," only room membership/hostility - so the id
+  # itself still has to come from GameObj. Wrapping the lookup result in
+  # BigshotCreature (rather than returning the raw GameObj) keeps this
+  # consistent with every other npc/target object flowing through bigshot, so
+  # it doesn't crash the native crtr_flag?/has_status? checks.
+  # Falls back to the raw GameObj only in the rare case the id has no
+  # matching Creature registry entry yet; dead_or_gone?/check_state_condition
+  # degrade gracefully for that case rather than assuming it can't happen.
+  # @return [BigshotCreature, Lich::Common::GameObj, nil] the client's selected
+  #   target, wrapped when a Creature registry entry exists
   def leader_target?
-    GameObj.target
+    go = GameObj.target
+    return nil if go.nil?
+
+    creature = Creature[go.id]
+    creature ? BigshotCreature.new(creature) : go
   end
 
+  # @return [Integer] remaining roundtime in seconds
   def rt?()
     return checkrt()
   end
 
+  # @return [Boolean] whether rest preparation has completed
   def rest_prep_done?
     @REST_PREP || false
   end
 
+  # @return [Boolean] whether field experience is too saturated to keep hunting
   def fried?()
     debug_msg(@DEBUG_STATUS, "fried? | @CORRECT_PERCENT_MIND: #{@CORRECT_PERCENT_MIND} | @FRIED: #{@FRIED}")
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -2863,6 +2863,8 @@ class Bigshot
     # objects going forward. Persists per character - this is effectively a
     # no-op after the first run for a given character.
     Combat::Tracker.enable! unless Combat::Tracker.enabled?
+    debug_msg(@DEBUG_COMBAT, "startup | Combat::Tracker.enabled?: #{Combat::Tracker.enabled?} | Combat::Tracker.stats: #{Combat::Tracker.stats}")
+    debug_msg(@DEBUG_COMBAT, "startup | Lich::Gemstone::Creature.stats: #{Lich::Gemstone::Creature.stats}")
 
     @followers = nil
     @event_stack = []
@@ -3473,6 +3475,8 @@ class Bigshot
       end
       return
     end
+
+    debug_creature_snapshot("before cmd: #{command}", npc)
 
     if command =~ /\bkick\b/i && $bigshot_rooted
       command = command.gsub(/\bkick\b/i, "punch")
@@ -6905,6 +6909,11 @@ class Bigshot
   end
 
   def attack_break(target)
+    if !target.nil? && dead_or_gone?(target) && @debug_death_snapshot_id != target.id
+      debug_creature_snapshot("target died: #{target}", target)
+      @debug_death_snapshot_id = target.id
+    end
+
     break_conditions = {
       "No Claim"                  => -> { !bigclaim?(check_disks: false) },
       "Invalid target"            => -> { !valid_target?(target) },
@@ -7382,6 +7391,30 @@ class Bigshot
   #   native crtrStatus reads are available
   def creature_backed?(npc)
     !npc.nil? && npc.respond_to?(:creature) && !npc.creature.nil?
+  end
+
+  # Temporary diagnostic for the thp<N>/empowered<N> HP-tracking rollout -
+  # logs one line of a creature's tracked HP/status data under
+  # @DEBUG_COMBAT. Called at every cmd() dispatch and once on death
+  # detection, so a debug run can be replayed end-to-end: acquisition,
+  # every command attempted against it (with the HP/statuses command_check
+  # saw at that instant), and the final death snapshot, all keyed by id.
+  # @param label [String] where in the lifecycle this snapshot was taken
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] the creature to read
+  # @return [void]
+  def debug_creature_snapshot(label, npc)
+    return if npc.nil?
+
+    unless creature_backed?(npc)
+      debug_msg(@DEBUG_COMBAT, "creature_snapshot | #{label} | id: #{npc.id} | NOT creature-backed (no CreatureInstance)")
+      return
+    end
+
+    c = npc.creature
+    debug_msg(@DEBUG_COMBAT,
+              "creature_snapshot | #{label} | id: #{c.id} | name: #{c.name} | " \
+              "hp: #{c.current_hp}/#{c.max_hp} (#{c.hp_percent}%) | damage_taken: #{c.damage_taken} | " \
+              "dead: #{c.crtr_flag?(:dead)} | statuses: #{c.statuses.join(',')}")
   end
 
   # Replacement for the old npc.status =~ /dead|gone/ regex, sourced

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -19,6 +19,7 @@
   Major_change.feature_addition.bugfix
   v5.16.0  (2026-08-13)
     - coup de grace eligibility gate, on by default: cmd_cmans re-tests the skill's real requirements at the moment of send - <= (rank*10)% HP incapacitated / (rank*5)% otherwise, 200 HP absolute cap (the binding limit on large creatures) - using the trained rank from CMan and live HP/statuses from the CreatureInstance. Holds the coup instead of wasting 20 stamina on a refusal; unknown targets (no creature data) pass through untouched. Incapacitating statuses in COUP_INCAP_STATUSES (positional states prone/kneeling/sitting deliberately excluded)
+    - added debug logging that tracks a target's health and status from when it's first engaged through every command tried against it to its death, for troubleshooting combat behavior
     - add empowered<N> command check: skip when an Empowered buff of +N or more is already active (!empowered<N> = skip unless). Guards a strong coup de grace endroll ((endroll - 100) / 5) from being overwritten by a weaker recast; the plain coupdegrace modifier only tests presence
     - add thp<N> command check: target HP percentage at or below N (!thp<N> = above N). Reads CreatureInstance#hp_percent - bestiary template max_hp minus Combat::Tracker-parsed damage. 589 of 628 bundled templates (Lich >= 5.21) carry a measured max_hp; the remaining 39 fall back to a guessed 400. Residual drift: regeneration/healing never credit damage back (regenerators read more wounded than reality) and damage with uncatalogued messaging is silently missed (reads less wounded)
     - fix buff<N> modifier lookup: resolve the buff from the command being run; the old lookup keyed on the paren content and could never match a bare-name key, making buff<N> a silent no-op
@@ -7393,12 +7394,13 @@ class Bigshot
     !npc.nil? && npc.respond_to?(:creature) && !npc.creature.nil?
   end
 
-  # Temporary diagnostic for the thp<N>/empowered<N> HP-tracking rollout -
-  # logs one line of a creature's tracked HP/status data under
+  # Logs one line of a creature's tracked HP/status data under
   # @DEBUG_COMBAT. Called at every cmd() dispatch and once on death
   # detection, so a debug run can be replayed end-to-end: acquisition,
   # every command attempted against it (with the HP/statuses command_check
-  # saw at that instant), and the final death snapshot, all keyed by id.
+  # saw at that instant), and the final death snapshot, all keyed by id -
+  # the main tool for troubleshooting the thp<N>/empowered<N>/crtrStatus
+  # command checks and Combat::Tracker/Creature HP tracking they depend on.
   # @param label [String] where in the lifecycle this snapshot was taken
   # @param npc [BigshotCreature, Lich::Common::GameObj, nil] the creature to read
   # @return [void]

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -650,7 +650,7 @@ class Bigshot
       @log_file = File.join(debug_dir, "#{@script_name}.log")
       @logger = Logger.new(@log_file, 'daily')
       @logger.formatter = proc do |_, datetime, _, msg|
-        formatted_time = datetime.strftime("%Y-%m-%d %H:%M:%S") # Excludes timezone
+        formatted_time = datetime.strftime("%Y-%m-%d %H:%M:%S.%L") # Excludes timezone, includes milliseconds
         "[#{formatted_time}]: #{msg}\n"
       end
 

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -6910,10 +6910,7 @@ class Bigshot
   end
 
   def attack_break(target)
-    if !target.nil? && dead_or_gone?(target) && @debug_death_snapshot_id != target.id
-      debug_creature_snapshot("target died: #{target}", target)
-      @debug_death_snapshot_id = target.id
-    end
+    debug_note_death(target)
 
     break_conditions = {
       "No Claim"                  => -> { !bigclaim?(check_disks: false) },
@@ -6971,6 +6968,7 @@ class Bigshot
       debug_msg(@DEBUG_COMBAT, "reaction_check | $bigshot_reaction: #{$bigshot_reaction} | weapon reaction enabled: #{@WEAPON_REACTION}")
       perform_reaction if ($bigshot_reaction != nil) && @WEAPON_REACTION
       cmd(i, target)
+      debug_note_death(target)
     end
 
     # Check for Roa'ter swallowing or Hinterwilds Ooze swallowing
@@ -7392,6 +7390,22 @@ class Bigshot
   #   native crtrStatus reads are available
   def creature_backed?(npc)
     !npc.nil? && npc.respond_to?(:creature) && !npc.creature.nil?
+  end
+
+  # Logs the death snapshot exactly once per creature id, whichever call
+  # site notices first. attack_break's own pre-command check misses a kill
+  # that happens on the LAST queued command in a cycle - the command loop
+  # just ends, so there's no next iteration left to re-check dead_or_gone?
+  # before the death snapshot would fire. Calling this again right after
+  # cmd() dispatch closes that gap; the id-dedup guard makes calling it
+  # from both places harmless.
+  # @param target [BigshotCreature, Lich::Common::GameObj, nil] the creature to test
+  # @return [void]
+  def debug_note_death(target)
+    return if target.nil? || !dead_or_gone?(target) || @debug_death_snapshot_id == target.id
+
+    debug_creature_snapshot("target died: #{target}", target)
+    @debug_death_snapshot_id = target.id
   end
 
   # Logs one line of a creature's tracked HP/status data under

--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -18,6 +18,10 @@
   Version Control:
   Major_change.feature_addition.bugfix
   v5.16.0  (2026-08-13)
+    - coup de grace eligibility gate, on by default: cmd_cmans re-tests the skill's real requirements at the moment of send - <= (rank*10)% HP incapacitated / (rank*5)% otherwise, 200 HP absolute cap (the binding limit on large creatures) - using the trained rank from CMan and live HP/statuses from the CreatureInstance. Holds the coup instead of wasting 20 stamina on a refusal; unknown targets (no creature data) pass through untouched. Incapacitating statuses in COUP_INCAP_STATUSES (positional states prone/kneeling/sitting deliberately excluded)
+    - add empowered<N> command check: skip when an Empowered buff of +N or more is already active (!empowered<N> = skip unless). Guards a strong coup de grace endroll ((endroll - 100) / 5) from being overwritten by a weaker recast; the plain coupdegrace modifier only tests presence
+    - add thp<N> command check: target HP percentage at or below N (!thp<N> = above N). Reads CreatureInstance#hp_percent - bestiary template max_hp minus Combat::Tracker-parsed damage. 589 of 628 bundled templates (Lich >= 5.21) carry a measured max_hp; the remaining 39 fall back to a guessed 400. Residual drift: regeneration/healing never credit damage back (regenerators read more wounded than reality) and damage with uncatalogued messaging is silently missed (reads less wounded)
+    - fix buff<N> modifier lookup: resolve the buff from the command being run; the old lookup keyed on the paren content and could never match a bare-name key, making buff<N> a silent no-op
     - migrate room-creature targeting from GameObj.targets/.npcs to the Lich::Gemstone::Creature / Combat::Tracker APIs (Lich >= 5.19.0). GameObj.targets is built from XMLData.current_target_ids (the client's target dropdown), which can go stale after a kill or a room change; Creature reads the room roster instead
     - add BigshotCreature, an adapter wrapping a CreatureInstance so the cmd_* methods keep their GameObj-shaped .id/.status/.type. The Integer creature id is normalized to String at the boundary
     - replace the npc.status =~ /dead|gone/ idiom across ~40 call sites with dead_or_gone?, reading the <crtrStatus> dead flag plus GameObj's status string
@@ -2775,7 +2779,7 @@ class Bigshot
   # @note The modifier whitelist is a single alternation; a new modifier must be
   #   added here as well as to {#check_state_condition}, or it will never parse.
   def initialize_command_data
-    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?ascended|!?ascension_boss|!?barrage|!?bearhug|buff|!?burst|!?calm|!?celerity|censer|!?challenging|!?coupdegrace|!?disease|!?disengaged|!?disoriented|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?e|!?essence|!?fatalcrit|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?hovering|!?immobilized|!?inferior|!?justice|!?k|!?kneeling|!?m|!?mini_boss|!?mob|!?momentum|!?mount|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|repeatdelay|!?rider|room|!?rooted|!?s|!?scourge|!?shout|!?sitting|!?sleeping|!?smote|!?splashy|!?stunned|!?surge|!?sympathetic|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thrash|!?ucsdecent|!?ucsexcellent|!?ucsgood|!?ucstierup|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?webbed|!?wounded|!?yowlp).*?)\)$/i.freeze
+    @COMMAND_MODIFIER_REGEX = /\((.*?(?:!?506|!?ancient|!?animate|!?ascended|!?ascension_boss|!?barrage|!?bearhug|buff|!?burst|!?calm|!?celerity|censer|!?challenging|!?coupdegrace|!?disease|!?disengaged|!?disoriented|!?EB"[^"]*"|!?EC"[^"]*"|!?ED"[^"]*"|!?ES"[^"]*"|!?empowered|!?e|!?essence|!?fatalcrit|!?frozen|!?flurry|!?flying|!?fury|!?garrote|!?h|!?hidden|!?holler|!?hovering|!?immobilized|!?inferior|!?justice|!?k|!?kneeling|!?m|!?mini_boss|!?mob|!?momentum|!?mount|!?noncorporeal|once|!?outside|!?pcs|!?poison|!?prone|!?pummel|!?rapid|!?rebuke|!?reflex|repeatdelay|!?rider|room|!?rooted|!?s|!?scourge|!?shout|!?sitting|!?sleeping|!?smote|!?splashy|!?stunned|!?surge|!?sympathetic|!?tailwind|!?tier|!?tier1|!?tier2|!?tier3|!?thp|!?thrash|!?ucsdecent|!?ucsexcellent|!?ucsgood|!?ucstierup|!?undead|!?v|!?valid|!?vigor|!?voidweaver|!?webbed|!?wounded|!?yowlp).*?)\)$/i.freeze
 
     @COMMAND_AMOUNT_REGEX = /((?:!?e|!?essence|!?h|!?k|!?m|!?mob|!?s|!?tier|!?v|!?valid))(\d+)/i.freeze
 
@@ -3722,9 +3726,28 @@ class Bigshot
       # Check buff time conditions (e.g., buff60 with command 'barrage')
       if (buff_match = modifier.match(@COMMAND_BUFF_REGEX))
         amount = buff_match[2].to_i
-        buff_name = @COMMAND_BUFF_CHECKS[command]
+        # Resolve the buff from the command being run (e.g. "barrage
+        # (buff60)" -> barrage), anchored to the leading word - matching
+        # the dispatch idiom below - so a co-occurring modifier that is
+        # also a COMMAND_BUFF_CHECKS key (e.g. "shout (buff60 barrage)")
+        # cannot steal the lookup. The old lookup keyed on the paren
+        # content itself, which can never equal a bare-name key once a
+        # digit-bearing modifier is present - buff_name was always nil
+        # and buffN a silent no-op.
+        buff_key = @COMMAND_BUFF_CHECKS.keys.find { |k| original_command =~ /^#{Regexp.escape(k)}\b/i }
+        buff_name = buff_key && @COMMAND_BUFF_CHECKS[buff_key]
 
-        if buff_name && Effects::Buffs.time_left(buff_name) <= (amount / 60.0)
+        # Veto only when the buff is UP with <= N seconds left ("don't
+        # fire into the expiry window"). time_left returns 0 for an
+        # absent buff, so without an active-presence guard buffN would
+        # veto whenever the buff is down - deadlocking commands whose
+        # buff comes FROM the command (coup de grace -> Empowered: never
+        # fires, so never buffs). Resolve regex buff names to a concrete
+        # dialog key first: Effects#expiration raises NoMethodError
+        # (nil[1]) when a Regexp matches no key, so active?/time_left on
+        # a bare regex crash while the buff has never been up.
+        active_key = buff_name && Effects::Buffs.to_h.keys.find { |k| buff_name.is_a?(Regexp) ? k.to_s =~ buff_name : k.to_s == buff_name.to_s }
+        if active_key && Effects::Buffs.active?(active_key) && Effects::Buffs.time_left(active_key) <= (amount / 60.0)
           debug_msg(@DEBUG_COMMANDS, "command_check buff | command: #{command} | amount: #{amount} | result: true")
           return true
         end
@@ -3747,6 +3770,16 @@ class Bigshot
     return false
   end
 
+  # Evaluates a single state-based command modifier.
+  #
+  # @param modifier [String] one modifier token, optionally +!+-negated
+  # @param command [String] the modifier list with parens stripped (NOT the ability name)
+  # @param npc [BigshotCreature, Lich::Common::GameObj] the target creature
+  # @param original_command [String] the full command definition, ability name and modifiers
+  # @return [Boolean, nil] truthy when this modifier means SKIP the command
+  # @note The modifier whitelist in {#initialize_command_data} is a single
+  #   alternation; a new modifier must be added there as well as here, or it
+  #   will never parse.
   def check_state_condition(modifier, command, npc, original_command)
     # Generic Effects checks: ES"text", EB"text", EC"text", ED"text" (and negated !ES, !EB, !EC, !ED)
     if (effects_match = modifier.match(/^(!?E[SBCD])"(.+)"$/i))
@@ -3763,6 +3796,36 @@ class Bigshot
       when 'ED'  then return !Effects::Debuffs.active?(pattern)
       when '!ED' then return Effects::Debuffs.active?(pattern)
       end
+    end
+
+    # Empowered strength guard: (empowered30) skips when an Empowered buff
+    # of +30 or more is already up - protects a strong coup-de-grace
+    # endroll ((endroll - 100) / 5) from being overwritten by a weaker one.
+    # (!empowered30) inverts: skips unless already at +30 or more. Compare
+    # with the plain coupdegrace modifier, which only tests presence.
+    if (emp_match = modifier.match(/^(!?)empowered(\d+)$/i))
+      bonus = Effects::Buffs.to_h.keys.filter_map { |k| k.to_s[/^Empowered \(\+(\d+)\)/, 1]&.to_i }.max
+      strong = !bonus.nil? && bonus >= emp_match[2].to_i
+      return emp_match[1].empty? ? strong : !strong
+    end
+
+    # Target HP percentage: (thp20) runs the command only when the target is
+    # at or below 20% of its estimated max HP; (!thp20) only above. Reads
+    # CreatureInstance#hp_percent - template max_hp minus damage parsed by
+    # Combat::Tracker. Most bundled templates (589/628 as of Lich 5.21)
+    # carry a measured max_hp, so the percentage is usually grounded. Every
+    # parsed damage line counts once - yours and other group members' alike,
+    # which is correct for a shared HP pool. Residual drift: regeneration
+    # and healing are never credited back (regenerators read MORE wounded
+    # than reality), and damage whose messaging no def covers is silently
+    # missed (reads LESS wounded). Skips when the npc has no
+    # CreatureInstance behind it.
+    if (hp_match = modifier.match(/^(!?)thp(\d+)$/i))
+      pct = npc_hp_percent(npc)
+      return true if pct.nil?
+
+      threshold = hp_match[2].to_i
+      return hp_match[1].empty? ? pct > threshold : pct <= threshold
     end
 
     case modifier.downcase
@@ -4357,6 +4420,20 @@ class Bigshot
 
   def cmd_cmans(npc, cmd)
     debug_msg(@DEBUG_COMMANDS, "cmd_cmans | npc: #{npc} | cmd: #{cmd}")
+
+    # Built-in last-moment gate for coup de grace. Statuses and HP move
+    # between command_check and the actual send - the previous attack's
+    # stun may not have resolved when the modifiers ran, or may have worn
+    # off since - so re-test eligibility here, at the moment of send.
+    # Saves the 20 stamina and the attack roundtime of a coup the game
+    # would refuse. Only active when the target is creature-backed with
+    # usable HP data; unknown targets (e.g. bandit-track quarry) pass
+    # through untouched.
+    if cmd =~ /^coupdegrace/i && (rank = trained_coup_rank) > 0 &&
+       creature_backed?(npc) && npc.creature.current_hp && !npc_coup_ready?(npc, rank)
+      debug_msg(@DEBUG_COMMANDS, "cmd_cmans | coup gate: target not eligible at rank #{rank}, holding")
+      return
+    end
 
     complete_regex = Regexp.union(
       /awkward proposition|You can't reach|little bit late|still stunned|too injured|what?|You cannot|Could not find|seconds/i,
@@ -7355,6 +7432,54 @@ class Bigshot
   # @return [Boolean] false rather than raising when npc is not creature-backed
   def npc_has_status?(npc, status_name)
     creature_backed?(npc) && npc.creature.has_status?(status_name)
+  end
+
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read
+  # @return [Float, nil] estimated HP percentage (0-100), or nil when npc is
+  #   not creature-backed or carries no usable max HP
+  def npc_hp_percent(npc)
+    return nil unless creature_backed?(npc)
+
+    npc.creature.hp_percent
+  end
+
+  # Statuses that satisfy Coup de Grace's "incapacitated in some way"
+  # requirement, unlocking the R*10% threshold instead of R*5%. Read
+  # natively off <crtrStatus>/message-derived statuses. Positional states
+  # (prone/kneeling/sitting) are deliberately excluded. Edit here if live
+  # testing shows the game honors more (or fewer) states.
+  COUP_INCAP_STATUSES = %w[stunned immobilized webbed sleeping bound].freeze
+
+  # @return [Integer] the character's trained Coup de Grace rank, 0 when
+  #   untrained or the PSM registry is unavailable
+  def trained_coup_rank
+    return 0 unless defined?(Lich::Gemstone::CMan)
+
+    Lich::Gemstone::CMan["coupdegrace"].to_i
+  rescue StandardError
+    0
+  end
+
+  # Whether the target currently qualifies for Coup de Grace at the given
+  # rank: at or below (rank * 10)% HP incapacitated / (rank * 5)% HP
+  # otherwise, hard-capped at 200 HP either way. The cap is what binds on
+  # large creatures (20% of a gigas is far over 200), so this compares raw
+  # HP, not percentage.
+  # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to test
+  # @param rank [Integer] trained Coup de Grace rank (1-5)
+  # @return [Boolean] false rather than raising when data is missing
+  def npc_coup_ready?(npc, rank)
+    return false unless creature_backed?(npc)
+
+    creature = npc.creature
+    current = creature.current_hp
+    max = creature.max_hp
+    return false unless current && max && max > 0
+
+    incap = COUP_INCAP_STATUSES.any? { |s| creature.has_status?(s) }
+    pct = rank * (incap ? 10 : 5)
+    threshold = [(max * pct) / 100.0, 200].min
+    current <= threshold
   end
 
   # @param npc [BigshotCreature, Lich::Common::GameObj, nil] npc to read

--- a/spec/scripts/bigshot_spec.rb
+++ b/spec/scripts/bigshot_spec.rb
@@ -555,9 +555,10 @@ end
 # separate Harness: this section exercises a different slice of bigshot -
 # the BigshotCreature adapter boundary and the helpers that read
 # Combat::Tracker data (dead_or_gone?, gone?, creature_backed?,
-# leader_target?) - rather than targeting/ranking. Kept independent of
-# BigshotPrioritySpec's Harness so neither section's stub state can leak
-# into the other.
+# npc_has_status?, npc_crtr_flag?, npc_low_hp?, npc_fatal_crit?,
+# npc_smote?, npc_ucs_position, npc_ucs_tierup, leader_target?) - rather
+# than targeting/ranking. Kept independent of BigshotPrioritySpec's Harness
+# so neither section's stub state can leak into the other.
 module BigshotCreatureAdapterSpec
   SOURCE_PATH = find_lic_source('bigshot.lic', from: __dir__)
   SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
@@ -573,6 +574,16 @@ module BigshotCreatureAdapterSpec
   CREATURE_BACKED_SRC = extract(/^  def creature_backed\?\(npc\).*?^  end$/m, 'creature_backed?')
   DEAD_OR_GONE_SRC = extract(/^  def dead_or_gone\?\(npc\).*?^  end$/m, 'dead_or_gone?')
   GONE_SRC = extract(/^  def gone\?\(npc\).*?^  end$/m, 'gone?')
+  NPC_HAS_STATUS_SRC = extract(/^  def npc_has_status\?\(npc, status_name\).*?^  end$/m, 'npc_has_status?')
+  NPC_CRTR_FLAG_SRC = extract(/^  def npc_crtr_flag\?\(npc, flag\).*?^  end$/m, 'npc_crtr_flag?')
+  NPC_FROZEN_SRC = extract(/^  def npc_frozen\?\(npc\).*?^  end$/m, 'npc_frozen?')
+  NPC_PRONE_SRC = extract(/^  def npc_prone\?\(npc\).*?^  end$/m, 'npc_prone?')
+  PRONE_CONSTS_SRC = extract(/^  PRONE \|\|=.*?^  PRONE_STATUSES \|\|=.*?$/m, 'PRONE constants')
+  NPC_LOW_HP_SRC = extract(/^  def npc_low_hp\?\(npc, threshold = 25\).*?^  end$/m, 'npc_low_hp?')
+  NPC_FATAL_CRIT_SRC = extract(/^  def npc_fatal_crit\?\(npc\).*?^  end$/m, 'npc_fatal_crit?')
+  NPC_SMOTE_SRC = extract(/^  def npc_smote\?\(npc\).*?^  end$/m, 'npc_smote?')
+  NPC_UCS_POSITION_SRC = extract(/^  def npc_ucs_position\(npc\).*?^  end$/m, 'npc_ucs_position')
+  NPC_UCS_TIERUP_SRC = extract(/^  def npc_ucs_tierup\(npc\).*?^  end$/m, 'npc_ucs_tierup')
   LEADER_TARGET_SRC = extract(/^  def leader_target\?\n.*?^  end$/m, 'leader_target?')
 
   # Configurable double for CreatureInstance. statuses/flags start empty so
@@ -694,6 +705,16 @@ module BigshotCreatureAdapterSpec
     eval(CREATURE_BACKED_SRC)
     eval(DEAD_OR_GONE_SRC)
     eval(GONE_SRC)
+    eval(NPC_HAS_STATUS_SRC)
+    eval(NPC_CRTR_FLAG_SRC)
+    eval(PRONE_CONSTS_SRC)
+    eval(NPC_FROZEN_SRC)
+    eval(NPC_PRONE_SRC)
+    eval(NPC_LOW_HP_SRC)
+    eval(NPC_FATAL_CRIT_SRC)
+    eval(NPC_SMOTE_SRC)
+    eval(NPC_UCS_POSITION_SRC)
+    eval(NPC_UCS_TIERUP_SRC)
     eval(LEADER_TARGET_SRC)
   end
 
@@ -816,25 +837,210 @@ module BigshotCreatureAdapterSpec
       end
     end
 
+    describe '#npc_has_status?' do
+      it 'reads the live status list' do
+        goblin.statuses << 'stunned'
+
+        expect(bs.npc_has_status?(bs.wrap(goblin), 'stunned')).to be true
+        expect(bs.npc_has_status?(bs.wrap(goblin), 'webbed')).to be false
+      end
+
+      it 'degrades to false rather than raising for a non-creature-backed npc' do
+        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)
+        expect { bs.npc_has_status?(raw, 'stunned') }.not_to raise_error
+        expect(bs.npc_has_status?(raw, 'stunned')).to be false
+      end
+    end
+
+    describe '#npc_crtr_flag?' do
+      it 'reads the live classification flags' do
+        goblin.flags[:mini_boss] = true
+
+        expect(bs.npc_crtr_flag?(bs.wrap(goblin), :mini_boss)).to be true
+        expect(bs.npc_crtr_flag?(bs.wrap(goblin), :ascended)).to be false
+      end
+    end
+
+    describe '#npc_frozen? ("frozen" is the immobilized status)' do
+      it 'reads the native immobilized status, which the legacy string match misses' do
+        # The room text renders this as "(immobile)", so GameObj's status
+        # string never contains "frozen" for an XML-driven immobilize.
+        goblin.statuses << 'immobilized'
+        bs.room(goblin)
+        Harness::GameObj.registry = { '201' => RawGameObj.new('201', 'goblin', 'a snarling goblin', 'immobile', nil) }
+
+        expect(bs.npc_frozen?(bs.wrap(goblin))).to be true
+      end
+
+      it 'still honours the legacy GameObj "frozen" string as a fallback' do
+        bs.room(goblin) # no immobilized status set
+        Harness::GameObj.registry = { '201' => RawGameObj.new('201', 'goblin', 'a snarling goblin', 'frozen', nil) }
+
+        expect(bs.npc_frozen?(bs.wrap(goblin))).to be true
+      end
+
+      it 'is false when the creature is neither' do
+        bs.room(goblin)
+
+        expect(bs.npc_frozen?(bs.wrap(goblin))).to be false
+      end
+
+      it 'is false for a nil npc rather than raising' do
+        expect(bs.npc_frozen?(nil)).to be false
+      end
+    end
+
+    describe '#npc_prone? (crtrStatus carries several statuses; GameObj.status carries one)' do
+      it 'sees prone on a creature whose room text advertises a different status' do
+        # Straight from a real feed line:
+        #   <crtrStatus exist="153281570" hostile="1" stunned="1" prone="1" inferior="1"/>
+        #   ...<a exist="153281570" noun="dybbuk">dybbuk</a> that appears stunned.
+        # The parser assigns a single capture, so GameObj.status is "stunned"
+        # even though the creature is also prone. The old regex also returned
+        # true here (because "stunned" is itself in PRONE); this asserts the
+        # native read reaches the same answer from the accurate source.
+        dybbuk = FakeCreatureInstance.new(153281570, 'dybbuk', 'a dybbuk')
+        dybbuk.flags[:hostile] = true
+        dybbuk.flags[:inferior] = true
+        dybbuk.statuses.push('stunned', 'prone')
+        bs.room(dybbuk)
+        Harness::GameObj.registry = {
+          '153281570' => RawGameObj.new('153281570', 'dybbuk', 'a dybbuk', 'stunned', nil)
+        }
+
+        expect(bs.npc_prone?(bs.wrap(dybbuk))).to be true
+      end
+
+      it 'catches a prone creature whose single status annotation is NOT in the PRONE regex' do
+        # The case the string match misses outright rather than by luck.
+        creature = FakeCreatureInstance.new(501, 'dybbuk', 'a dybbuk')
+        creature.statuses << 'prone'
+        bs.room(creature)
+        Harness::GameObj.registry = {
+          '501' => RawGameObj.new('501', 'dybbuk', 'a dybbuk', 'disoriented', nil)
+        }
+
+        expect(bs.npc_prone?(bs.wrap(creature))).to be true
+      end
+
+      it 'treats immobilized as prone, covering frozen/entangled/held in place' do
+        creature = FakeCreatureInstance.new(502, 'goblin', 'a snarling goblin')
+        creature.statuses << 'immobilized'
+        bs.room(creature)
+
+        expect(bs.npc_prone?(bs.wrap(creature))).to be true
+      end
+
+      it 'agrees with the old regex on a prone-only creature, which really renders "lying down"' do
+        # Measured from real GS4 logs: prone alone renders
+        # "that is lying down.", so GameObj.status is "lying down" and the
+        # old ^lying regex matched it too. Both paths must say true - this
+        # guards against anyone "fixing" one of them apart from the other.
+        creature = FakeCreatureInstance.new(503, 'worm', 'a carrion worm')
+        creature.statuses << 'prone'
+        bs.room(creature)
+        Harness::GameObj.registry = {
+          '503' => RawGameObj.new('503', 'worm', 'a carrion worm', 'lying down', nil)
+        }
+
+        expect(bs.npc_prone?(bs.wrap(creature))).to be true
+      end
+
+      it 'sees prone that the status string masks behind "dead"' do
+        # The one masking case the string cannot express, from real logs:
+        #   <crtrStatus ... hostile="1" dead="1" prone="1"/> ... "that appears dead."
+        # dead_or_gone? gates before this matters, but the native read is
+        # the only path that can see it.
+        corpse = FakeCreatureInstance.new(504, 'fanatic', 'a triton fanatic')
+        corpse.statuses << 'prone'
+        corpse.flags[:dead] = true
+        bs.room(corpse)
+        Harness::GameObj.registry = {
+          '504' => RawGameObj.new('504', 'fanatic', 'a triton fanatic', 'dead', nil)
+        }
+
+        wrapped = bs.wrap(corpse)
+        expect(wrapped.status =~ described_class_prone_regex).to be_nil # string cannot see it
+        expect(bs.npc_prone?(wrapped)).to be true
+      end
+
+      it 'falls back to the regex for an npc with no CreatureInstance behind it' do
+        # Bridged bandits and leader_target?'s fallback have no statuses to
+        # read, so the status string is all there is. "lying down" is the
+        # room-players phrasing for the same state crtrStatus calls prone.
+        raw = RawGameObj.new('88802', 'bandit', 'a grizzled bandit', 'lying down', nil)
+
+        expect(bs.creature_backed?(raw)).to be false
+        expect(bs.npc_prone?(raw)).to be true
+      end
+
+      it 'is false for an upright creature, and nil-safe' do
+        bs.room(goblin)
+
+        expect(bs.npc_prone?(bs.wrap(goblin))).to be false
+        expect(bs.npc_prone?(nil)).to be false
+      end
+    end
+
+    describe 'HP/UCS readers' do
+      it 'npc_low_hp? reads the tracked low-HP state' do
+        goblin.low_hp = true
+        expect(bs.npc_low_hp?(bs.wrap(goblin))).to be true
+      end
+
+      it 'npc_fatal_crit? reads the tracked fatal-crit flag' do
+        goblin.fatal_crit = true
+        expect(bs.npc_fatal_crit?(bs.wrap(goblin))).to be true
+      end
+
+      it 'npc_smote? reads the tracked smite state' do
+        goblin.smote = true
+        expect(bs.npc_smote?(bs.wrap(goblin))).to be true
+      end
+
+      it 'npc_ucs_position/npc_ucs_tierup read the tracked UCS state' do
+        goblin.ucs_pos = 2
+        goblin.ucs_tierup = 'kick'
+
+        wrapped = bs.wrap(goblin)
+        expect(bs.npc_ucs_position(wrapped)).to eq(2)
+        expect(bs.npc_ucs_tierup(wrapped)).to eq('kick')
+      end
+
+      it 'all degrade to a safe default rather than raising for a non-creature-backed npc' do
+        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)
+
+        expect(bs.npc_low_hp?(raw)).to be false
+        expect(bs.npc_fatal_crit?(raw)).to be false
+        expect(bs.npc_smote?(raw)).to be false
+        expect(bs.npc_ucs_position(raw)).to be_nil
+        expect(bs.npc_ucs_tierup(raw)).to be_nil
+      end
+    end
+
     describe '#leader_target?' do
-      # As of this PR, leader_target? still returns GameObj.target verbatim -
-      # the single client-selected target has no Creature-module equivalent,
-      # and nothing in this PR calls .creature on it unguarded (dead_or_gone?/
-      # gone?/still_targetable? already degrade safely for a non-creature-
-      # backed npc). Wrapping this consistently becomes necessary once native
-      # crtrStatus reads land - see the crtrStatus command checks PR, which
-      # revises this method and its spec.
       it 'returns nil when the client has no selected target' do
         Harness::GameObj.target = nil
         expect(bs.leader_target?).to be_nil
       end
 
-      it "returns the client's selected target as-is" do
-        raw = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)
+      it 'wraps the selected target in BigshotCreature when a Creature registry entry exists' do
+        bs.room(goblin)
+        Harness::GameObj.target = RawGameObj.new('201', 'goblin', 'a snarling goblin', nil, nil)
+
+        result = bs.leader_target?
+        expect(bs.creature_backed?(result)).to be true
+        expect(result.name).to eq('a snarling goblin')
+      end
+
+      it 'falls back to the raw GameObj when no Creature registry entry exists yet' do
+        raw = RawGameObj.new('999', 'orc', 'a hulking orc', nil, nil)
         bs.room # instantiates bs (which resets GameObj.target) before we set it below
         Harness::GameObj.target = raw
 
-        expect(bs.leader_target?).to equal(raw)
+        result = bs.leader_target?
+        expect(bs.creature_backed?(result)).to be false
+        expect(result).to equal(raw)
       end
     end
 
@@ -923,10 +1129,7 @@ module BigshotCreatureAdapterSpec
         expect(bs.bs_targets.map(&:id)).to include('88801')
       end
 
-      it 'hands the bridged GameObj through unwrapped, so it degrades safely' do
-        # The actual native-read degradation (npc_has_status?, etc.) is
-        # exercised once those readers exist - see the crtrStatus command
-        # checks spec.
+      it 'hands the bridged GameObj through unwrapped, and it degrades safely' do
         bs.room
         Harness::GameObj.target_list = [bandit]
 
@@ -934,6 +1137,8 @@ module BigshotCreatureAdapterSpec
         expect(picked).not_to be_nil # else the assertions below pass vacuously
         expect(picked).to equal(bandit) # handed through, not wrapped
         expect(bs.creature_backed?(picked)).to be false
+        expect { bs.npc_has_status?(picked, 'stunned') }.not_to raise_error
+        expect(bs.npc_has_status?(picked, 'stunned')).to be false
       end
 
       it 'does not double-list a creature Creature already knows about' do


### PR DESCRIPTION
feat(bigshot.lic): v5.16.0 add crtrStatus command checks, migrate flying/rooted/frozen/prone

Adds command-check modifiers for the crtrStatus data the previous
migration made available, and moves the checks that have a clean
native equivalent off GameObj's status/type strings.

New modifiers, all with !-negation:
  - statuses (has_status?): calm, disoriented, hovering, immobilized,
    kneeling, sitting, sleeping, stunned, webbed
  - classification flags (crtr_flag?): ascended, ascension_boss,
    challenging, disengaged, inferior, mini_boss, mount, rider,
    sympathetic
  - Combat::Tracker data: wounded, fatalcrit, smote, ucsdecent,
    ucsgood, ucsexcellent, ucstierup - additive only, none of these
    touch $bigshot_unarmed_tier or any other existing tier/targeting
    logic, since replacing that load-bearing engine wasn't asked for
    and carries real regression risk for a smaller, unconfirmed
    benefit

flying and rooted move to native has_status? reads, both clean 1:1
mappings with no ambiguity.

frozen and prone are the more interesting migrations, and were wrong
twice before landing here:
  - frozen was first assumed to have no crtrStatus equivalent at all.
    It does: the feed's immobile="1" attribute maps to the canonical
    immobilized status, and the message parser reaches the same state
    from the entangling/restricting-force messages.
  - prone was then assumed to be a compound state needing the GameObj
    regex kept around for "^lying", on the theory that crtrStatus has
    no equivalent for lying down. It does - "^lying" is the room-
    players phrasing for the same state crtrStatus calls prone, not a
    separate condition. Confirmed against real GS4 session logs: a
    creature that is prone and nothing else renders "that is lying
    down.", so GameObj.status is "lying down" and the old ^lying regex
    always matched it. This makes the native prone read a robustness
    improvement rather than a bug fix - across ~1000 creature
    observations in those logs, the old regex and the native read
    agree on every live creature, because GameObj.status is single-
    valued with a precedence order (a creature holding two statuses
    only ever advertises the higher one - <crtrStatus stunned="1"
    prone="1"/> renders as "that appears stunned.") and every masking
    status observed is itself in the old PRONE regex. The one case
    the string genuinely cannot see is dead+prone, where GameObj
    reports only "dead"; dead_or_gone? gates that case first regardless.

Both npc_frozen? and npc_prone? keep the GameObj-string read as a
fallback for npcs with no CreatureInstance behind them (bridged
bandits, leader_target?'s fallback - see the previous PR), so they're
a strict superset of the pre-existing checks, not a narrowing.

leader_target? now wraps its result in BigshotCreature (looking up the
Creature registry by GameObj.target's id) instead of returning a raw
GameObj. This PR is what makes that necessary: once check_state_condition
calls .creature.crtr_flag?/.creature.has_status? on whatever it's
handed, a raw GameObj reaching those calls would raise. Falls back to
the raw GameObj only if no registry entry exists yet; every native-only
reader added here (npc_has_status?, npc_crtr_flag?, npc_frozen?,
npc_prone?, and the five Tracker-data readers) guards against that case
via creature_backed? and degrades to a safe default rather than raising.

Testing: spec/bigshot/creature_adapter_spec.rb extended with coverage
for every new reader, the frozen/prone native-vs-fallback behavior
(including a case built directly from a real feed line), and
leader_target?'s wrapping. Each new check verified non-tautological
against its pre-fix baseline.
