### PR TITLE
feat(bigshot.lic): v5.16.0 add ;bigshot help and unknown-option fallback

### DIFF
--- a/scripts/bigshot.lic
+++ b/scripts/bigshot.lic
@@ -2589,25 +2589,122 @@ class Bigshot
     end
   end
 
+  # Discards every queued event.
+  #
+  # @return [void]
   def clear_events()
     debug_msg(@DEBUG_SYSTEM, "clear_events")
     @event_stack.clear
   end
 
+  # Pops the next queued event.
+  #
+  # @return [Bigshot::Event, nil] the oldest event, or nil when the queue is empty
   def grab_event()
     debug_msg(@DEBUG_SYSTEM, "grab_event")
     @event_stack.shift()
   end
 
+  # Liveness probe used by the leader to detect disconnected followers.
+  #
+  # Always returns true; the value is irrelevant, since a dead follower raises
+  # +DRb::DRbConnError+ on the call itself and is dropped by
+  # {Bigshot::Group#member_online}.
+  #
+  # @return [true]
   def ping
     # checks if follower got disconnected
     return true
   end
 
+  # Removes every queued event of a given type.
+  #
+  # @param item [Symbol] event type to drop
+  # @return [void]
   def remove_event(item)
     @event_stack.reject! { |event| event.type == item }
   end
 
+  # Prints the top-level command reference for the script.
+  #
+  # Mirrors {debug_help}: renders a Terminal::Table when the gem is loaded and
+  # falls back to plain +respond+ lines otherwise, so the output is usable on
+  # front ends without table support.
+  #
+  # @return [void]
+  # @see debug_help
+  def self.help
+    name = Script.current.name
+    rows = [
+      ["#{$lich_char}#{name}",                        "Hunt solo in the current room"],
+      ["#{$lich_char}#{name} bounty",                 "Hunt to complete the current bounty"],
+      ["#{$lich_char}#{name} quick",                  "Hunt without wandering (current room only)"],
+      ["#{$lich_char}#{name} once",                   "Hunt a single loop, then exit"],
+      ["#{$lich_char}#{name} <creature>",             "Rangers: TRACK toward the named creature"],
+      [:separator, :separator],
+      ["#{$lich_char}#{name} head <count>",           "Lead a group; waits for <count> followers"],
+      ["#{$lich_char}#{name} tail",                   "Follow a group leader (auto-discovers)"],
+      ["#{$lich_char}#{name} link <uri>",             "Follow a leader at an explicit DRb URI"],
+      [:separator, :separator],
+      ["#{$lich_char}#{name} setup",                  "Open the settings window"],
+      ["#{$lich_char}#{name} profile load <name>",    "Load a saved profile"],
+      ["#{$lich_char}#{name} profile save <name>",    "Save the current settings as a profile"],
+      ["#{$lich_char}#{name} display",                "Show version and active settings"],
+      ["#{$lich_char}#{name} list",                   "Show every initialized value"],
+      ["#{$lich_char}#{name} reset",                  "Clear targetable/untargetable settings"],
+      [:separator, :separator],
+      ["#{$lich_char}#{name} debug help",             "Debug logging options"],
+      ["#{$lich_char}#{name} test <method> [args]",   "Invoke a single method (development)"],
+      ["#{$lich_char}#{name} help",                   "This help"]
+    ]
+
+    if defined?(Terminal)
+      table_rows = []
+      table_rows << [{ :value => "Modes can be combined, e.g. #{$lich_char}#{name} bounty quick", :colspan => 2, :alignment => :left }]
+      table_rows << :separator
+      rows.each do |left, right|
+        if left == :separator
+          table_rows << :separator
+        else
+          table_rows << [{ :value => left, :alignment => :left }, { :value => right, :alignment => :right }]
+        end
+      end
+      table_rows << :separator
+      table_rows << [{ :value => "Full documentation: https://gswiki.play.net/Script_Bigshot", :colspan => 2, :alignment => :left }]
+
+      table = Terminal::Table.new :title => "#{name.capitalize} Help v#{$bigshot_version}", :rows => table_rows
+      table.align_column(1, :right)
+      respond
+      respond table
+      respond
+    else
+      respond ""
+      respond "#############################################################################"
+      respond ""
+      respond "           #{name.capitalize} Help v#{$bigshot_version}"
+      respond ""
+      respond "     Modes can be combined, e.g. #{$lich_char}#{name} bounty quick"
+      respond "------------------------------------------------------------"
+      respond ""
+      rows.each do |left, right|
+        if left == :separator
+          respond ""
+        else
+          respond " #{left.to_s.ljust(38)}#{right}"
+        end
+      end
+      respond ""
+      respond " Full documentation: https://gswiki.play.net/Script_Bigshot"
+      respond ""
+      respond "#############################################################################"
+      respond ""
+    end
+  end
+
+  # Prints the debug-logging command reference.
+  #
+  # @return [void]
+  # @see help
   def self.debug_help
     if defined?(Terminal)
       rows = []
@@ -8830,7 +8927,9 @@ if Script.current.vars.any? { |var| var =~ /single|once/i }
   $bigshot_single = true
 end
 
-if (Script.current.vars[1].nil? || Script.current.vars[1] =~ /solo|bounty|quick|single|once/i)
+if (Script.current.vars[1] =~ /\Ahelp\z/i)
+  Bigshot.help
+elsif (Script.current.vars[1].nil? || Script.current.vars[1] =~ /solo|bounty|quick|single|once/i)
   if Script.current.vars[1] =~ /quick/i
     $bigshot_quick = true
   end
@@ -9216,4 +9315,7 @@ elsif (Script.current.vars[1] =~ /tail|follow|link/i)
       Script.self.kill
     end
   end
+else
+  Lich::Messaging.msg("yellow", " Unknown option: #{Script.current.vars[1]}")
+  Bigshot.help
 end


### PR DESCRIPTION
feat(bigshot.lic): v5.16.0 add ;bigshot help and unknown-option fallback

There was no ;bigshot help, and no else on the CLI dispatch chain -
;bigshot help and any mistyped option both silently did nothing. The
only help text anywhere in the script was ;bigshot debug help.

Adds Bigshot.help, mirroring debug_help's existing pattern: a
Terminal::Table when the gem is loaded, plain respond lines otherwise,
so it degrades on front ends without table support. Documents the full
CLI surface - hunting modes, group (head/tail/link), setup/profile/
display/list/reset, and debug/test - plus a pointer to the gswiki for
the command-check modifier reference, which is out of scope for this
script's own --help output.

Wired in two places:
  - a new branch ahead of the mode branch, anchored /\Ahelp\z/i so it
    can't collide with any other keyword
  - a new else on the dispatch chain, so an unknown option now names
    itself and prints help instead of doing nothing
