### PR TITLE
fix(eloot.lic): v2.11.2 route_town_then_pool respects  always_check_pool

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,14 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.1
+           version: 2.11.2
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.2 (2026-08-18)
+    - fix: "Locksmith First" priority ignored "always check pool" -- route_town_then_pool
+      only visited the pool when boxes were left over after the town run, so an empty-handed
+      pool-return check never fired. Now mirrors the Pool First branch's should_check_pool
+      condition.
   v2.11.1 (2026-08-05)
     - feature: add "Locksmith Priority" option (Pool First / Locksmith First) for when
       both locksmith routes are enabled. Locksmith First tries town first, then pools
@@ -7398,7 +7403,7 @@ module ELoot # Sells the loot
       Sell.locksmith(town_boxes) if town_boxes.any?
 
       boxes = ELoot.find_boxes
-      if boxes.any? && Sell.pool_available?
+      if (ELoot.data.settings[:always_check_pool] || boxes.any?) && Sell.pool_available?
         Sell.locksmith_pool(boxes)
         Sell.pool_return
         boxes = ELoot.find_boxes

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -7403,8 +7403,11 @@ module ELoot # Sells the loot
       Sell.locksmith(town_boxes) if town_boxes.any?
 
       boxes = ELoot.find_boxes
-      if (ELoot.data.settings[:always_check_pool] || boxes.any?) && Sell.pool_available?
+      if boxes.any? && Sell.pool_available?
         Sell.locksmith_pool(boxes)
+        Sell.pool_return
+        boxes = ELoot.find_boxes
+      elsif ELoot.data.settings[:always_check_pool]
         Sell.pool_return
         boxes = ELoot.find_boxes
       end

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -603,15 +603,18 @@ RSpec.describe 'ELoot::Sell locksmith_priority routing' do
     let(:town_openable) { {} } # box name => bool, defaults to true
     let(:find_boxes_queue) { [] } # successive ELoot.find_boxes return values
     let(:pool_available) { true }
+    let(:always_check_pool) { false } # ELoot.data.settings[:always_check_pool]
 
     let(:harness) do
       log = calls
       openable = town_openable
       queue = find_boxes_queue
       avail = pool_available
+      always_check = always_check_pool
 
       eloot = Module.new
       eloot.define_singleton_method(:find_boxes) { queue.shift || [] }
+      eloot.define_singleton_method(:data) { Struct.new(:settings).new({ always_check_pool: always_check }) }
 
       mod = Module.new
       mod.const_set(:ELoot, eloot)
@@ -657,6 +660,31 @@ RSpec.describe 'ELoot::Sell locksmith_priority routing' do
       harness.route_town_then_pool([box])
 
       expect(calls.map(&:first)).not_to include(:locksmith_pool)
+    end
+
+    context 'when always_check_pool is set and nothing is left to drop off' do
+      let(:always_check_pool) { true }
+
+      it 'still checks the pool for returns, without a drop-off attempt' do
+        box = obj('a steel strongbox', 'strongbox')
+        find_boxes_queue.replace([[]])
+
+        harness.route_town_then_pool([box])
+
+        expect(calls.map(&:first)).not_to include(:locksmith_pool)
+        expect(calls).to include([:pool_return])
+      end
+    end
+
+    context 'when always_check_pool is not set and nothing is left to drop off' do
+      it 'does not check the pool for returns' do
+        box = obj('a steel strongbox', 'strongbox')
+        find_boxes_queue.replace([[]])
+
+        harness.route_town_then_pool([box])
+
+        expect(calls.map(&:first)).not_to include(:pool_return)
+      end
     end
 
     context 'when the pool is unavailable' do


### PR DESCRIPTION
Locksmith Priority = 'locksmith' (town first) routed through route_town_then_pool, which only visited the locksmith pool when boxes remained after the town run (boxes.any?). It never consulted always_check_pool, so with both routes enabled and town priority set, an empty-handed pool-return check never fired -- unlike the Pool First branch, which explicitly ORs always_check_pool into should_check_pool.
 
Fix mirrors that same OR condition in route_town_then_pool so a pool visit (and therefore Sell.pool_return) happens whenever always_check_pool is set, regardless of whether any boxes are in hand/room at that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “Locksmith First” routing so returned pool boxes are checked even when no boxes remain after town processing, when the relevant setting is enabled.
  * Preserved the existing behavior of skipping the pool when the setting is disabled.

* **Tests**
  * Added coverage for both enabled and disabled pool-checking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->