### PR TITLE
fix(repository): v2.74 fix dependency constant author update

### DIFF
--- a/scripts/repository.lic
+++ b/scripts/repository.lic
@@ -10,9 +10,11 @@
           game: any
           tags: core
       required: Lich > 5.0.1
-       version: 2.73
+       version: 2.74
 
   changelog:
+    2.74 (2026-08-18):
+      Fix message about updating dependency.lic's owner showing every time you run the script
     2.73 (2026-05-12):
       Validate scripts and map databases for non-ASCII characters before upload
       Aborts upload with a per-character report (line, column, codepoint) when found
@@ -2286,7 +2288,9 @@ module RepositoryTillmen
 
     def self.update_script_author(filename, old_author, new_author, game: nil)
       idx = Settings['updatable'][:scripts].find_index do |s|
-        s[:filename] == filename && (old_author.nil? || s[:author] != new_author)
+        next false unless s[:filename] == filename
+
+        old_author.nil? ? s[:author] != new_author : s[:author] == old_author
       end
 
       return unless idx


### PR DESCRIPTION
Updated version to 2.74 and fixed changelog entry for dependency.lic's owner message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated dependency ownership-update messages.
  * Improved ownership updates so they apply only to matching files and when the owner actually changes.
  * Preserved filtering by previous owner when specified.
* **Chores**
  * Updated the repository license metadata to version 2.74.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->