### PR TITLE
fix(eloot.lic): v2.11.3 locksmith priority and retry routing bugs

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -24,6 +24,9 @@
     - fix: a box already in hand when eloot starts always went to the locksmith pool
       first, even with Locksmith Priority set to town locksmith first, and could get
       walked to the town locksmith even on boxes it always refuses. Both are fixed.
+    - fix: a successful insufficient-silver retry double-counted the town locksmith fee
+      and open in the end-of-run silver breakdown, since the fee was recorded as soon as
+      it was quoted rather than once payment was actually accepted. Now recorded once.
   v2.11.2 (2026-08-18)
     - fix: "Locksmith First" priority ignored "always check pool" -- route_town_then_pool
       only visited the pool when boxes were left over after the town run, so an empty-handed
@@ -6978,18 +6981,24 @@ module ELoot # Sells the loot
             return
           end
 
-          if res =~ /Gimme ([\d,]+) silvers/
-            ELoot.data.silver_breakdown["Town Locksmith"] += -1 * $1.delete(",").to_i
-            ELoot.data.silver_breakdown["Town Open"] += 1
-          end
-
           unless res
             ELoot.msg(type: "error", text: ' Unknown locksmith response.')
             Inventory.single_drag(box, false)
             return
           end
 
+          quoted_fee = res[/Gimme ([\d,]+) silvers/, 1]&.delete(",")&.to_i
+
           result = dothistimeout('pay', 2, /accepts|have enough/)
+
+          # Record the fee only once payment actually succeeds -- a quote alone doesn't
+          # spend anything, and recording it here too would double-count both the silver
+          # and the open on a retry that succeeds the second time around.
+          if result =~ /accepts/ && quoted_fee
+            ELoot.data.silver_breakdown["Town Locksmith"] -= quoted_fee
+            ELoot.data.silver_breakdown["Town Open"] += 1
+          end
+
           if result =~ /have enough/
             Inventory.single_drag(box, false)
 
@@ -7004,7 +7013,6 @@ module ELoot # Sells the loot
               return
             end
 
-            quoted_fee = res[/Gimme ([\d,]+) silvers/, 1]&.delete(",")&.to_i
             withdraw_amount = [quoted_fee, ELoot.data.settings[:locksmith_withdraw_amount]].compact.max
 
             # Route back through Sell.locksmith rather than recursing into

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,15 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.2
+           version: 2.11.3
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.3 (2026-08-21)
+    - fix: boxes that ran out of silver mid-open at the town locksmith could end up
+      getting sent to the locksmith pool instead of actually being opened. This is fixed.
+    - fix: a box already in hand when eloot starts always went to the locksmith pool
+      first, even with Locksmith Priority set to town locksmith first, and could get
+      walked to the town locksmith even on boxes it always refuses. Both are fixed.
   v2.11.2 (2026-08-18)
     - fix: "Locksmith First" priority ignored "always check pool" -- route_town_then_pool
       only visited the pool when boxes were left over after the town run, so an empty-handed
@@ -5838,6 +5844,15 @@ module ELoot # Sells the loot
         exit
       end
 
+      # locksmith_priority only means anything with both routes enabled -- same gate
+      # used in process_boxes/route_town_then_pool.
+      locksmith_first = ELoot.data.settings[:sell_locksmith_pool] && ELoot.data.settings[:sell_locksmith] &&
+                        ELoot.data.settings[:locksmith_priority] == 'locksmith'
+
+      if locksmith_first && (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && Sell.town_openable?(item)
+        Sell.locksmith([item])
+      end
+
       loop do
         item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }
         break unless item && ELoot.data.settings[:sell_locksmith_pool]
@@ -5848,7 +5863,7 @@ module ELoot # Sells the loot
         break if item.id == [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }.id
       end
 
-      if (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && ELoot.data.settings[:sell_locksmith]
+      if (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && ELoot.data.settings[:sell_locksmith] && Sell.town_openable?(item)
         Sell.locksmith([item])
       end
 
@@ -6974,10 +6989,13 @@ module ELoot # Sells the loot
           result = dothistimeout('pay', 2, /accepts|have enough/)
           if result =~ /have enough/
             Inventory.single_drag(box, false)
-            ELoot.silver_withdraw(ELoot.data.settings[:locksmith_withdraw_amount])
-            ELoot.go2('locksmith')
-
-            return Sell.locksmith_open(box, activator)
+            # Route back through Sell.locksmith rather than recursing into
+            # locksmith_open directly with the room/activator state captured before
+            # the bank trip. Sell.locksmith re-withdraws, re-navigates (including any
+            # town-specific room hop, e.g. Kraken's Fall's outer-wagon-to-Smithing-room
+            # step), and re-derives the table/activator fresh for whatever room and
+            # town we land in, instead of assuming that state is still valid.
+            return Sell.locksmith([box])
           end
         end
       end

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5845,9 +5845,12 @@ module ELoot # Sells the loot
       end
 
       # locksmith_priority only means anything with both routes enabled -- same gate
-      # used in process_boxes/route_town_then_pool.
-      locksmith_first = ELoot.data.settings[:sell_locksmith_pool] && ELoot.data.settings[:sell_locksmith] &&
-                        ELoot.data.settings[:locksmith_priority] == 'locksmith'
+      # used in process_boxes/route_town_then_pool. The gem-bounty override also sends
+      # boxes to town first regardless of that setting, same as process_boxes.
+      pool_enabled = ELoot.data.settings[:sell_locksmith_pool]
+      town_enabled = ELoot.data.settings[:sell_locksmith]
+      locksmith_first = pool_enabled && town_enabled &&
+                        (Sell.gem_bounty_override? || ELoot.data.settings[:locksmith_priority] == 'locksmith')
 
       if locksmith_first && (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && Sell.town_openable?(item)
         Sell.locksmith([item])
@@ -5855,7 +5858,7 @@ module ELoot # Sells the loot
 
       loop do
         item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }
-        break unless item && ELoot.data.settings[:sell_locksmith_pool]
+        break unless item && pool_enabled
 
         Sell.locksmith_pool([item], deposit)
 
@@ -5863,7 +5866,7 @@ module ELoot # Sells the loot
         break if item.id == [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }.id
       end
 
-      if (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && ELoot.data.settings[:sell_locksmith] && Sell.town_openable?(item)
+      if (item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.type == "box" }) && town_enabled && Sell.town_openable?(item)
         Sell.locksmith([item])
       end
 
@@ -6909,12 +6912,12 @@ module ELoot # Sells the loot
       end
     end
 
-    def self.locksmith(boxes)
+    def self.locksmith(boxes, withdraw_amount: ELoot.data.settings[:locksmith_withdraw_amount], retries: 0)
       ELoot.msg(type: "debug", text: "boxes: #{boxes}")
       # if we're here, assume we emptied out the disk some
       ELoot.reset_disk_full
 
-      ELoot.silver_withdraw(ELoot.data.settings[:locksmith_withdraw_amount])
+      ELoot.silver_withdraw(withdraw_amount)
 
       ELoot.go2('locksmith')
       move "east" if Room.current.uid.include?(7118381)
@@ -6941,7 +6944,7 @@ module ELoot # Sells the loot
               next unless Sell.town_openable?(box)
 
               Inventory.free_hands(both: true) unless ELoot.in_hand?(box)
-              Sell.locksmith_open(box, activator)
+              Sell.locksmith_open(box, activator, retries: retries)
             }
           else
             ELoot.msg(type: "error", text: " Failed to find a bell, keys, or chime on the table", space: true)
@@ -6952,7 +6955,7 @@ module ELoot # Sells the loot
       end
     end
 
-    def self.locksmith_open(box, activator)
+    def self.locksmith_open(box, activator, retries: 0)
       lines = ELoot.get_command("look in ##{box.id}", /<container|That is closed|You see the shifting form/, silent: true, quiet: true)
       if lines.any? { |line| line =~ /That is closed|You see the shifting form/i }
         Inventory.drag(box) unless ELoot.in_hand?(box)
@@ -6989,13 +6992,28 @@ module ELoot # Sells the loot
           result = dothistimeout('pay', 2, /accepts|have enough/)
           if result =~ /have enough/
             Inventory.single_drag(box, false)
+
+            # Bound to a single retry -- a locksmith_withdraw_amount smaller than the
+            # quoted fee would otherwise withdraw-and-fail forever. Withdraw at least
+            # what was actually quoted rather than the configured amount so the retry
+            # has a real chance of succeeding.
+            if retries.positive?
+              ELoot.msg(type: "yellow", space: true,
+                        text: " Still couldn't afford to open #{box.name} after a second" \
+                              " withdrawal. Leaving it for the pool or a player locksmith.")
+              return
+            end
+
+            quoted_fee = res[/Gimme ([\d,]+) silvers/, 1]&.delete(",")&.to_i
+            withdraw_amount = [quoted_fee, ELoot.data.settings[:locksmith_withdraw_amount]].compact.max
+
             # Route back through Sell.locksmith rather than recursing into
             # locksmith_open directly with the room/activator state captured before
             # the bank trip. Sell.locksmith re-withdraws, re-navigates (including any
             # town-specific room hop, e.g. Kraken's Fall's outer-wagon-to-Smithing-room
             # step), and re-derives the table/activator fresh for whatever room and
             # town we land in, instead of assuming that state is still valid.
-            return Sell.locksmith([box])
+            return Sell.locksmith([box], withdraw_amount: withdraw_amount, retries: retries + 1)
           end
         end
       end
@@ -7354,6 +7372,13 @@ module ELoot # Sells the loot
         (ELoot.data.settings[:use_standard_tipping] || ELoot.data.settings[:use_incremental_tipping])
     end
 
+    # Shared with process_boxes so the gem-bounty override can't drift out of sync
+    # between the batch flow and the box-in-hand flow.
+    # @return [Boolean]
+    def self.gem_bounty_override?
+      Bounty.task.gem? && ELoot.data.settings[:locksmith_when_gem_bounty]
+    end
+
     def self.process_boxes
       boxes = ELoot.find_boxes
       return unless boxes.any? || ELoot.data.settings[:always_check_pool]
@@ -7362,7 +7387,7 @@ module ELoot # Sells the loot
 
       pool_enabled = ELoot.data.settings[:sell_locksmith_pool]
       town_enabled = ELoot.data.settings[:sell_locksmith]
-      skip_for_gem_bounty = Bounty.task.gem? && town_enabled && ELoot.data.settings[:locksmith_when_gem_bounty] && boxes.any?
+      skip_for_gem_bounty = Sell.gem_bounty_override? && town_enabled && boxes.any?
 
       # locksmith_priority only has an effect with both routes enabled, and only for the
       # general case -- the gem bounty setting is a narrower override and keeps its

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -1067,6 +1067,21 @@ RSpec.describe 'ELoot::Sell.locksmith insufficient-silver retry' do
     expect(locksmith_open).not_to match(/return Sell\.locksmith_open\(box, activator\)/)
     expect(locksmith_open).to match(/return Sell\.locksmith\(\[box\], withdraw_amount: withdraw_amount, retries: retries \+ 1\)/)
   end
+
+  it 'only records the town-locksmith fee and open once payment is accepted, not merely quoted' do
+    expect(locksmith_open).to match(/if result =~ \/accepts\/ && quoted_fee/)
+    expect(locksmith_open).to match(/ELoot\.data\.silver_breakdown\["Town Locksmith"\] -= quoted_fee/)
+    expect(locksmith_open).to match(/ELoot\.data\.silver_breakdown\["Town Open"\] \+= 1/)
+  end
+
+  it 'checks the payment result before touching the silver breakdown, so a successful retry cannot double-count' do
+    pay_call_pos = locksmith_open.index("result = dothistimeout('pay'")
+    breakdown_pos = locksmith_open.index('ELoot.data.silver_breakdown["Town Locksmith"]')
+
+    expect(pay_call_pos).not_to be_nil
+    expect(breakdown_pos).not_to be_nil
+    expect(breakdown_pos).to be > pay_call_pos
+  end
 end
 
 # RSpec for the gem_bounty_override? dedup: process_boxes must go through the same

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -713,6 +713,394 @@ RSpec.describe 'ELoot::Sell locksmith_priority routing' do
   end
 end
 
+# RSpec for ELoot::Sell.gem_bounty_override? (extracted so process_boxes and box_in_hand
+# cannot drift out of sync on what counts as the gem-bounty override).
+
+RSpec.describe 'ELoot::Sell.gem_bounty_override?' do
+  let(:eloot_path) do
+    path = [
+      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
+      File.expand_path('../eloot.lic', __dir__),
+      File.expand_path('../../eloot.lic', __dir__),
+      File.expand_path('../scripts/eloot.lic', __dir__),
+      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+    ].find { |p| File.exist?(p) }
+    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
+
+    path
+  end
+
+  let(:source) { File.read(eloot_path) }
+
+  let(:method_body) do
+    body = source[/^ {4}def self\.gem_bounty_override\?[\s\S]*?^ {4}end$/]
+    raise "gem_bounty_override? could not be extracted from #{eloot_path}" unless body
+
+    body
+  end
+
+  let(:gem_task) { true }
+  let(:setting) { true }
+
+  let(:harness) do
+    task_gem = gem_task
+    setting_val = setting
+
+    data = Object.new
+    data.define_singleton_method(:settings) { { locksmith_when_gem_bounty: setting_val } }
+
+    eloot = Module.new
+    eloot.define_singleton_method(:data) { data }
+
+    task = Object.new
+    task.define_singleton_method(:gem?) { task_gem }
+
+    bounty = Module.new
+    bounty.define_singleton_method(:task) { task }
+
+    mod = Module.new
+    mod.const_set(:ELoot, eloot)
+    mod.const_set(:Bounty, bounty)
+    mod.module_eval(method_body)
+    mod
+  end
+
+  it 'is true when a gem bounty is active and the override setting is on' do
+    expect(harness.gem_bounty_override?).to be true
+  end
+
+  context 'gem bounty active, override setting off' do
+    let(:setting) { false }
+
+    it 'returns false' do
+      expect(harness.gem_bounty_override?).to be false
+    end
+  end
+
+  context 'override setting on, no gem bounty active' do
+    let(:gem_task) { false }
+
+    it 'returns false' do
+      expect(harness.gem_bounty_override?).to be false
+    end
+  end
+
+  context 'neither condition holds' do
+    let(:gem_task) { false }
+    let(:setting) { false }
+
+    it 'returns false' do
+      expect(harness.gem_bounty_override?).to be false
+    end
+  end
+end
+
+# RSpec for ELoot::Sell.box_in_hand's Locksmith Priority handling (v2.11.3/v2.11.4).
+#
+# box_in_hand previously always tried the locksmith pool first, ignoring the
+# Locksmith Priority setting entirely, and could walk a pool-only box to the town
+# locksmith on the final fallback. This exercises the real method body -- unlike
+# locksmith/locksmith_open, box_in_hand's own collaborators (GameObj, ELoot::Inventory,
+# Sell.locksmith/locksmith_pool/town_openable?/gem_bounty_override?) are all easily
+# stubbed, with no direct Lich-runtime primitives (dothistimeout, fput, move) in its
+# own body, so it does not need to fall back to structural-only assertions.
+
+RSpec.describe 'ELoot::Sell.box_in_hand' do
+  let(:eloot_path) do
+    path = [
+      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
+      File.expand_path('../eloot.lic', __dir__),
+      File.expand_path('../../eloot.lic', __dir__),
+      File.expand_path('../scripts/eloot.lic', __dir__),
+      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+    ].find { |p| File.exist?(p) }
+    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
+
+    path
+  end
+
+  let(:source) { File.read(eloot_path) }
+
+  let(:method_body) do
+    body = source[/^ {4}def self\.box_in_hand\b[\s\S]*?^ {4}end$/]
+    raise "box_in_hand could not be extracted from #{eloot_path}" unless body
+
+    body
+  end
+
+  let(:hand_class) { Struct.new(:type, :noun, :id) }
+
+  def hand(type, noun = 'strongbox', id = '111')
+    hand_class.new(type, noun, id)
+  end
+
+  let(:empty_hand) { hand('Empty', nil, nil) }
+
+  # Mutable hand state: the fake GameObj reads these, and the fake Sell.locksmith
+  # (never Sell.locksmith_pool -- see note below) can clear whichever hand holds the
+  # box under test, simulating a successful town open.
+  let(:right) { hand('box') }
+  let(:left) { empty_hand }
+
+  let(:calls) { [] }
+  let(:pool_enabled) { true }
+  let(:town_enabled) { true }
+  let(:priority) { 'pool' }
+  let(:gem_bounty_override) { false }
+  let(:town_openable) { true }
+
+  # What Sell.locksmith_pool does to the hand it's given: :clear removes the box
+  # (accepted), :noop leaves it (declined/full). Only :noop is used below -- whether
+  # a single-box pool give-away leaves both hands truly empty afterward is a
+  # pre-existing, unrelated question this spec does not need to settle; every
+  # scenario here either never reaches the pool call or treats it as a decline,
+  # which is exactly what "pool is full" already covers.
+  let(:pool_result) { :noop }
+
+  let(:harness) do
+    r = right
+    l = left
+    log = calls
+    settings_hash = {
+      sell_locksmith_pool: pool_enabled,
+      sell_locksmith: town_enabled,
+      locksmith_priority: priority
+    }
+    override = gem_bounty_override
+    openable = town_openable
+    pool_res = pool_result
+    empty = empty_hand
+
+    gameobj = Module.new
+    gameobj.define_singleton_method(:right_hand) { r }
+    gameobj.define_singleton_method(:left_hand) { l }
+
+    data = Object.new
+    data.define_singleton_method(:settings) { settings_hash }
+
+    eloot = Module.new
+    eloot.define_singleton_method(:data) { data }
+    eloot.define_singleton_method(:msg) { |**kw| log << [:msg, kw] }
+
+    inventory = Module.new
+    inventory.define_singleton_method(:free_hands) { |**kw| log << [:free_hands, kw] }
+    eloot.const_set(:Inventory, inventory)
+
+    mod = Module.new
+    mod.const_set(:ELoot, eloot)
+    mod.const_set(:GameObj, gameobj)
+    mod.define_singleton_method(:town_openable?) { |_item| openable }
+    mod.define_singleton_method(:gem_bounty_override?) { override }
+    mod.define_singleton_method(:locksmith) do |items|
+      log << [:locksmith, items.map(&:noun)]
+      items.each do |it|
+        l = empty if l.equal?(it)
+        r = empty if r.equal?(it)
+      end
+    end
+    mod.define_singleton_method(:locksmith_pool) do |items, dep|
+      log << [:locksmith_pool, items.map(&:noun), dep]
+      next unless pool_res == :clear
+
+      items.each do |it|
+        l = empty if l.equal?(it)
+        r = empty if r.equal?(it)
+      end
+    end
+    mod.define_singleton_method(:exit) { raise 'exit called' }
+    mod.const_set(:Sell, mod)
+    mod.module_eval(method_body)
+    mod
+  end
+
+  # Only entries relevant to routing order/coverage; free_hands/msg noise filtered out.
+  def routing_calls(calls)
+    calls.select { |c| %i[locksmith locksmith_pool].include?(c.first) }
+  end
+
+  context 'default priority (pool), both routes enabled, box is town-openable' do
+    it 'tries the pool before the town locksmith' do
+      harness.box_in_hand
+
+      expect(routing_calls(calls).first).to eq([:locksmith_pool, ['strongbox'], true])
+    end
+
+    it 'falls through to town once the pool declines it' do
+      harness.box_in_hand
+
+      expect(routing_calls(calls).map(&:first)).to eq(%i[locksmith_pool locksmith])
+    end
+  end
+
+  context 'Locksmith Priority set to town first, both routes enabled' do
+    let(:priority) { 'locksmith' }
+
+    it 'tries the town locksmith before ever touching the pool' do
+      harness.box_in_hand
+
+      expect(routing_calls(calls)).to eq([[:locksmith, ['strongbox']]])
+    end
+  end
+
+  context 'gem-bounty override active, even with default Locksmith Priority (pool)' do
+    let(:priority) { 'pool' }
+    let(:gem_bounty_override) { true }
+
+    it 'still tries the town locksmith first -- this is the bug this override fixes' do
+      harness.box_in_hand
+
+      expect(routing_calls(calls)).to eq([[:locksmith, ['strongbox']]])
+    end
+  end
+
+  context 'Locksmith Priority set to town first, but the box is pool-only (e.g. a case)' do
+    let(:priority) { 'locksmith' }
+    let(:town_openable) { false }
+
+    it 'never sends a pool-only box to town, even with town-first priority' do
+      expect { harness.box_in_hand }.to raise_error('exit called')
+
+      expect(routing_calls(calls).map(&:first)).not_to include(:locksmith)
+      expect(routing_calls(calls).map(&:first)).to include(:locksmith_pool)
+    end
+  end
+
+  context 'only the pool is enabled (sell_locksmith is off)' do
+    let(:town_enabled) { false }
+    let(:priority) { 'locksmith' } # should have no effect with only one route enabled
+    let(:gem_bounty_override) { true } # same -- neither can turn on a disabled route
+
+    it 'never calls the town locksmith at all' do
+      expect { harness.box_in_hand }.to raise_error('exit called')
+
+      expect(routing_calls(calls).map(&:first)).not_to include(:locksmith)
+    end
+  end
+
+  context 'the pool is full and the box is pool-only, so nothing can process it' do
+    let(:town_openable) { false }
+
+    it 'does not walk it to town as a last resort' do
+      expect { harness.box_in_hand }.to raise_error('exit called')
+
+      expect(routing_calls(calls).map(&:first)).not_to include(:locksmith)
+    end
+
+    it 'reports it instead of silently giving up' do
+      begin
+        harness.box_in_hand
+      rescue RuntimeError
+        nil
+      end
+
+      expect(calls).to include([:msg, { text: ' Not able to process the box in your hand. Exiting...', space: true }])
+    end
+  end
+
+  it 'threads the deposit flag through to the pool' do
+    harness.box_in_hand(false)
+
+    expect(calls).to include([:locksmith_pool, ['strongbox'], false])
+  end
+end
+
+# RSpec for the insufficient-silver retry in Sell.locksmith/locksmith_open (v2.11.4).
+#
+# The retry previously recursed with the configured locksmith_withdraw_amount every
+# time, which withdraws-and-fails forever if that setting is smaller than the box's
+# actual fee. locksmith/locksmith_open cannot be exercised without the Lich runtime
+# (dothistimeout, ELoot.get_command, Room, move, ...), so -- same as the rest of
+# process_boxes' routing above -- this is pinned structurally against the shipped
+# source rather than executed.
+
+RSpec.describe 'ELoot::Sell.locksmith insufficient-silver retry' do
+  let(:eloot_path) do
+    path = [
+      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
+      File.expand_path('../eloot.lic', __dir__),
+      File.expand_path('../../eloot.lic', __dir__),
+      File.expand_path('../scripts/eloot.lic', __dir__),
+      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+    ].find { |p| File.exist?(p) }
+    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
+
+    path
+  end
+
+  let(:source) { File.read(eloot_path) }
+
+  def method_body(source, name)
+    body = source[/^ {4}def self\.#{Regexp.escape(name)}\b[\s\S]*?^ {4}end$/]
+    raise "#{name} could not be extracted from eloot.lic" unless body
+
+    body
+  end
+
+  let(:locksmith) { method_body(source, 'locksmith') }
+  let(:locksmith_open) { method_body(source, 'locksmith_open') }
+
+  it 'accepts a withdraw_amount/retries override and threads retries into locksmith_open' do
+    expect(locksmith).to match(/def self\.locksmith\(boxes, withdraw_amount: .*, retries: 0\)/)
+    expect(locksmith).to match(/Sell\.locksmith_open\(box, activator, retries: retries\)/)
+  end
+
+  it 'gives up after exactly one retry instead of withdrawing forever' do
+    expect(locksmith_open).to match(/def self\.locksmith_open\(box, activator, retries: 0\)/)
+    expect(locksmith_open).to match(/if retries\.positive\?/)
+  end
+
+  it 'leaves the box for the pool or a player locksmith when the retry is exhausted' do
+    give_up = locksmith_open[/if retries\.positive\?[\s\S]*?^ {12}end$/]
+    expect(give_up).not_to be_nil, 'could not find the retries-exhausted branch'
+    expect(give_up).to match(/Leaving it for the pool or a player locksmith/)
+    expect(give_up).not_to match(/Sell\.locksmith/)
+  end
+
+  it 'withdraws at least the quoted fee, not just the (possibly too small) configured amount' do
+    expect(locksmith_open).to match(/quoted_fee = res\[\/Gimme \(\[\\d,\]\+\) silvers\/, 1\]/)
+    expect(locksmith_open).to match(
+      /withdraw_amount = \[quoted_fee, ELoot\.data\.settings\[:locksmith_withdraw_amount\]\]\.compact\.max/
+    )
+  end
+
+  it 'retries through Sell.locksmith rather than recursing into locksmith_open directly' do
+    expect(locksmith_open).not_to match(/return Sell\.locksmith_open\(box, activator\)/)
+    expect(locksmith_open).to match(/return Sell\.locksmith\(\[box\], withdraw_amount: withdraw_amount, retries: retries \+ 1\)/)
+  end
+end
+
+# RSpec for the gem_bounty_override? dedup: process_boxes must go through the same
+# predicate as box_in_hand rather than keeping its own inline copy, or the two can
+# silently drift apart again the way box_in_hand's did before v2.11.4.
+
+RSpec.describe 'ELoot::Sell.process_boxes gem-bounty predicate reuse' do
+  let(:eloot_path) do
+    path = [
+      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
+      File.expand_path('../eloot.lic', __dir__),
+      File.expand_path('../../eloot.lic', __dir__),
+      File.expand_path('../scripts/eloot.lic', __dir__),
+      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+    ].find { |p| File.exist?(p) }
+    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
+
+    path
+  end
+
+  let(:source) { File.read(eloot_path) }
+
+  let(:process_boxes) do
+    body = source[/^ {4}def self\.process_boxes\b[\s\S]*?^ {4}end$/]
+    raise "process_boxes could not be extracted from #{eloot_path}" unless body
+
+    body
+  end
+
+  it 'computes skip_for_gem_bounty from the shared predicate' do
+    expect(process_boxes).to match(/skip_for_gem_bounty = Sell\.gem_bounty_override\? && town_enabled && boxes\.any\?/)
+  end
+end
+
 # RSpec for ELoot.marked_unsellable? and ELoot.toss (the trash/drop helper).
 #
 # box_loot_ground and Sell.save_trash_box each carried their own inline copies of the


### PR DESCRIPTION
## Summary
Two locksmith-routing bugs, both bumped as v2.11.3:

1. A box already in hand when eloot starts always went to the locksmith pool first, ignoring the Locksmith Priority setting.
2. A box that ran out of silver mid-open at the town locksmith could silently fail and end up routed to the pool instead of actually being opened at town.

## 1. `Sell.box_in_hand` ignored `locksmith_priority`

`box_in_hand` unconditionally tried the locksmith pool first whenever `sell_locksmith_pool` was enabled, with no check on `locksmith_priority` at all — unlike `process_boxes`/`route_town_then_pool`, which do gate on it. A box in hand at startup with Locksmith Priority set to "town locksmith first" still went straight to the pool.

Fix: added the same `locksmith_first` gate used elsewhere (`sell_locksmith_pool && sell_locksmith && locksmith_priority == 'locksmith'`), and try town first (skipping pool-only/"case" boxes via `town_openable?`) before falling into the existing pool-then-town flow.

While in there: the pre-existing town fallback at the end of `box_in_hand` had no `town_openable?` check either, so a pool-only box could get walked to town and refused there instead of going straight to the pool. Added the same guard.

## 2. Insufficient-silver retry sent boxes to the pool instead of opening them

Repro: town locksmith quotes a fee, `pay` comes back `"But you don't have enough!"`, eloot withdraws more and returns — box ends up unopened and routed to the pool instead, even with town locksmith priority enabled.

Root cause: the retry recursed directly into `Sell.locksmith_open(box, activator)` reusing the room/activator state captured *before* the bank trip, instead of going back through `Sell.locksmith`. Two independent manifestations of this, both fixed by the same change:
  - Some towns (e.g. Kraken's Fall) need an extra room hop after `go2('locksmith')` to reach the actual NPC room; the retry skipped it and acted on the table/bell while standing in the wrong room.
  - Even in single-room towns, the box — freshly stowed into a disk right before the bank trip — can't be resolved by ID (`"I could not find what you were referring to"`) until something re-looks into the disk after the room changes. The first, successful attempt at each box always does this as part of its normal setup; the direct recursion never did.

Fix: the retry now calls `Sell.locksmith([box])` instead of recursing into `locksmith_open` directly. This re-withdraws, re-navigates (including any town-specific room hop), calls `ELoot.wait_for_disk` (which re-syncs the disk's contents), and re-derives the table/activator fresh — i.e. it's the exact same path that already works for every box on its first attempt, rather than a parallel, partially-copied version of it.

## Testing
Verified against two independent player logs showing both failure modes at two different towns (Kraken's Fall, and a second town where the retry failed with no room-hop involved at all, confirming the fix isn't town-specific). No RSpec/RuboCop run yet — flagging for review before merge.

## Changelog
```
v2.11.3 (2026-08-21)
  - fix: boxes that ran out of silver mid-open at the town locksmith could end up
    getting sent to the locksmith pool instead of actually being opened. This is fixed.
  - fix: a box already in hand when eloot starts always went to the locksmith pool
    first, even with Locksmith Priority set to town locksmith first, and could get
    walked to the town locksmith even on boxes it always refuses. Both are fixed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed town-locksmith routing for boxes already in hand, ensuring Locksmith First priority is honored.
  - Prevented boxes refused by the town locksmith from being routed there again.
  - Improved payment retry handling so locksmith processing resumes correctly with refreshed navigation and state.
  - Improved gem-bounty override handling across routing options.
  - Made breakdown generation more reliable when appraisal data is missing.
  - Added clearer reporting for over-limit appraisals and pawnshop rechecks.
  - Updated eLoot to version 2.11.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->