### PR TITLE
feat(treim.lic): v3.0.0 modernize for Ruby 4.0 / current Lich5 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .bundle
 Gemfile.lock
 temp/
+spec/.rspec_status

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 =begin
     REIM Reactive Script
     Will do one round of attack per spawned wave of creatures.
@@ -11,18 +13,19 @@
     ATTACKOPTION Selections Include:
          <SPELLNUMBER> - use a spell to cast once per wave/boss IE. 908 Major Fire
          SLEEP         - symbol of voln sleep
-   ATTACK	       - single-target attack
-   FIRE	       - single-target ranged attack
+         ATTACK        - single-target attack
+         FIRE          - single-target ranged attack
          MSTRIKE       - mstrike attack (works for ranged if you set FIRE as default)
          UAC           - mstrike punch and punch boss for all your UAC needs
-         JAB	       - single-target jab
-   PUNCH	       - single-target punch
-   GRAPPLE       - single-target grapple
-   KICK	       - single-target kick
-   SCRUB         - combination mstrike and 435 cast routine
-   BARDASS       - combination mstrike and 1030 cast routine
-   DREDD         - combination mstrike and 1630 cast routine
+         JAB           - single-target jab
+         PUNCH         - single-target punch
+         GRAPPLE       - single-target grapple
+         KICK          - single-target kick
+         SCRUB         - combination mstrike and 435 cast routine
+         BARDASS       - combination mstrike and 1030 cast routine
+         DREDD         - combination mstrike and 1630 cast routine
          NONE          - won't attack, useful if manually wish to attack
+         <SCRIPTNAME>.lic - starts a custom attack script instead
 
     Running Commands
          ;send reimcount   - shows current group leader, group count, and previous group count
@@ -37,14 +40,20 @@
          Add scripts to be auto-started and killed with TREIM, default is NONE
          ;e echo UserVars.treim[:activescripts] = ["stand", "symbolz"]
 
-         Enable auto-clearing of Reim titles upon complition, default is FALSE
+         Add script arguments to use at launch of an activescript or spam_script
+         ;e UserVars.treim[:script_args] = { "scriptname1" => "args", "scriptname2" => "args" }
+
+         Enable auto-clearing of Reim titles upon completion, default is FALSE
          ;e echo UserVars.treim[:clear_title] = true
 
          Enable SPAM filtering scripts, default is TRUE
          ;e echo UserVars.treim[:spam_control] = false
 
-         Enable killing of known lag enducing scripts, default is FALSE
+         Enable killing of known lag inducing scripts, default is FALSE
          ;e echo UserVars.treim[:lag_control] = TRUE
+
+         Enable announcing of rares on wave spawn, default is FALSE for most characters
+         ;e echo UserVars.treim[:announce_rares] = TRUE
 
          Enable toggling of FLAG NoAmbientMsg, default is FALSE
          ;e echo UserVars.treim[:toggle_ambients] = TRUE
@@ -53,11 +62,45 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 2.24.2
+    version: 3.0.0
 
   To help contribute or open an issue: https://github.com/elanthia-online/scripts
 
     changelog:
+      3.0.0 (2026-08-21)
+        Modernized for Ruby 4.0 / current Lich5 conventions:
+        - Namespaced everything under `Treim`; all constants guarded with
+          `unless const_defined?` so repeated `;treim` invocations in the same
+          Lich process never warn/redefine.
+        - Replaced manual `GROUP` command parsing with the native `Group` API
+          (lib/gemstone/group.rb), which tracks membership/leader passively.
+        - Replaced the hand-rolled `silence` proc + DownstreamHook add/remove
+          pairs with `Lich::Util.issue_command` for REIM INFO and title-show
+          parsing; this also removed the last need for the old silence proc
+          entirely, since neither replacement leaves anything to suppress.
+        - Replaced the `$frontend =~ /stormfront|profanity/` check with
+          `Lich::Common::Frontend.supports_xml?`.
+        - Boss-wave stage progression (Village -> Road -> ... -> Royal) is now
+          data-driven (Treim::Geography::STAGES) instead of five copy-pasted
+          `elsif` branches.
+        - The ~10 near-identical stance-dance/attack blocks in the old
+          attack_routine collapsed into a handful of shared helpers behind a
+          `case` dispatch in Treim::Attack.
+        - Bugfix: `variable[2].downcase == "leader"` raised NoMethodError on
+          every invocation that didn't pass a second argument (i.e. almost
+          always) because `variable[2]` is nil, not "". Now uses `&.downcase`.
+        - Bugfix: the help-vs-reuse-last-attack-type check raised the same
+          NoMethodError when re-running `;treim` with no arguments after an
+          attack type had already been configured. Rewritten as an explicit,
+          non-crashing branch.
+        - Removed a room-marker check in the main loop that could never take
+          its "already visited" branch (the branch that would have updated
+          the marker was unreachable), so the wave/whisper handling block ran
+          unconditionally on every line anyway; the dead branch is gone and
+          behavior is unchanged.
+        - Removed a redundant second re-scan of "unseen bosses" during the
+          stage-hold path; the ids were already marked seen immediately above
+          it, so the second scan was always a no-op.
       2.24.2 (2023-05-19)
       Fix for new GROUP output
       Rubocop cleanup
@@ -152,637 +195,1069 @@
         Tgo01 as I canabalized his silence routine from ;dreavening.
         Ragz for his assistance with physical attacking and hold hands idea.
 =end
-=begin
-;e echo GameObj.npcs.each { |npc| echo "Name: #{npc.name} - Type: #{npc.type}" }
-;e echo GameObj.npcs.select{|npc| ((npc.type !~ /familiar|companion|passive|skin/) && (npc.noun !~ /arm|arms/))}.each { |npc| echo "Name: #{npc.name} - Type: #{npc.type}" }
-;e echo GameObj.type_data['aggressive npc']
-;e echo GameObj.npcs.count { |npc| ((npc.name !~ /arm}/) && !(npc.type !~ /companion|familiar|passive/)) }
 
-scripts to kill: rnum, duskruin_watch, prettiernum, killcounter, title, sorter, inspectweight, inspectarmor, uberbounty, autovote, chatfail, enchantnotes
-=end
+module Treim
+  # REIM room ids grouped by stage, and the order stages clear in.
+  #
+  # Drives boss-wave "hold or fight" decisions: when the group's reported
+  # clear-to progress has already moved past the stage the character is
+  # physically standing in, {stage_holding} tells the caller to hold rather
+  # than re-fight a boss the group already cleared.
+  module Geography
+    # One area of REIM (e.g. "village") and where it leads next.
+    #
+    # @!attribute [r] name
+    #   @return [String] lowercase stage identifier, matches the "clearto"
+    #     value REIM INFO reports (e.g. "village", "road")
+    # @!attribute [r] rooms
+    #   @return [Array<Integer>] room ids that belong to this stage
+    # @!attribute [r] next_stage
+    #   @return [String] the stage name that follows this one
+    # @!attribute [r] pause_before_next
+    #   @return [Boolean] whether to `pause 2` before continuing when
+    #     holding at this stage; true for every stage except village, which
+    #     is legacy-inconsistent with the rest but preserved verbatim from
+    #     the original per-stage elsif chain rather than "fixed" silently
+    Stage = Data.define(:name, :rooms, :next_stage, :pause_before_next) unless const_defined?(:Stage)
 
-Village         = Array[24888, 24900, 24904, 24909, 24935, 24936, 24912, 24919, 24946, 24945, 24952, 24964, 24971, 24972, 24958, 24959, 24931, 24932, 24966, 24953, 25300, 24901, 24930, 23484, 24941, 23650]
-Road            = Array[24977, 24978, 24989, 24990, 24991, 24994, 24995, 24996, 24998, 25003, 25004, 25020, 25019, 25021, 24997, 25022, 25029, 25030, 25035, 25042, 25047, 25046, 25043, 25041, 25048, 25049, 25050, 25051, 25052, 25053, 25054, 25056, 25057, 25058, 25059, 25064, 25055, 25060, 25061, 25062, 25063]
-Courtyard       = Array[25104, 25103, 25101, 25100, 25105, 25102, 25106, 25107, 25108, 25099, 25098, 25097, 25069, 25068, 25070, 25071, 25072, 25082, 25084, 25083, 25081, 25078, 25085, 25086, 25087, 25088, 25096, 25095, 25094, 25093, 25092, 25091, 25090, 25089, 25080, 25079, 25077, 25075, 25073, 25076, 25074, 25067, 25066, 25065]
-Servant         = Array[25113, 25114, 25115, 25119, 25118, 25117, 25116, 25112, 25111, 25110, 25109]
-Visitor         = Array[25125, 25124, 25123, 25129, 25128, 25127, 25126, 25122, 25121, 25120]
-Royal           = Array[25141, 25140, 25132, 25134, 25136, 25135, 25137, 25138, 25139, 25133, 25131, 25130]
-MiscAreas       = Array[24965]
-AreaReim        = (Village | Road | Courtyard | Servant | Visitor | Royal | MiscAreas).sort
-ReimBosses      = Array["The Shopkeeper", "The Innkeeper", "The Bartender", "The Patrol Leader", "The Bandit Lord", "The Bandit Lady", "The Gypsy Queen", "The Gypsy King", "The Guard Captain", "The Wall Captain", "The The Drill Sergeant", "The Stable Hostler", "The Dungeon Master", "The Master Torturer", "The Butler", "The Cook", "The Knight Captain", "The Foreign Dignitary", "The Royal Prince", "The Royal Princess", "The Royal Jester", "The Emperor", "The Empress"]
-ReimBossSearch  = Regexp.union(ReimBosses)
-reim_npcs       = "ethereal (?:commoner|denizen|guard|guardsman|guardswoman|inmate|lunatic|madman|madwoman|peasant|prisoner|squire|swordsman|swordswoman|traveller|townsman|townswoman|villager)|ghostly (?:bandit|highwayman|highwaywoman|marauder|waylayer)|unworldly (?:guest|maid|noble|royal guard|royal knight|servant|slave|steward|visitor)|celestial (?:dancer|juggler|nomad|traveller)|Shopkeeper|Innkeeper|Bartender|Patrol Leader|Bandit Lord|Bandit Lady|Gypsy Queen|Gypsy King|Guard Captain|Wall Captain|Drill Sergeant|Stable Hostler|Dungeon Master|Master Torturer|Butler|Cook|Knight Captain|Foreign Dignitary|Royal Prince|Royal Princess|Royal Jester|Royal Emperor|Royal Empress"
-npc_commons     = ["commoner", "denizen", "guard", "guardsman", "guardswoman", "inmate", "lunatic", "madman", "madwoman", "peasant", "prisoner", "squire", "swordsman", "swordswoman", "traveller", "townsman", "townswoman", "villager", "bandit", "highwayman", "highwaywoma", "marauder", "waylayer", "guest", "maid", "noble", "guard", "knight", "servant", "slave", "steward", "visitor", "dancer", "juggler", "nomad", "traveller"]
-npc_bosses      = ["Cook", "Shopkeeper", "Innkeeper", "Bartender", "Leader", "Lord", "Lady", "Queen", "King", "Captain", "Captain", "Sergeant", "Hostler", "Master", "Torturer", "Butler", "ook", "Captain", "Dignitary", "Prince", "Princess", "Jester", "Emperor", "Empress"]
-bossname        = ""
-leader          = ""
-title_prename   = nil
-members         = 0
-previousmembers = 0
-reim_current_room = 0
-lag_scripts    = Array["rnum", "duskruin_watch", "prettiernum", "killcounter", "title", "sorter", "inspectweight", "inspectarmor", "uberbounty", "autovote", "chatfail", "enchantnotes"]
-spam_scripts   = Array["briefcombat", "spellmerge"]
+    # @return [Array<Integer>] room ids for the Village stage
+    VILLAGE   = [24888, 24900, 24904, 24909, 24935, 24936, 24912, 24919, 24946, 24945, 24952, 24964, 24971, 24972, 24958, 24959, 24931, 24932, 24966, 24953, 25300, 24901, 24930, 23484, 24941, 23650].freeze unless const_defined?(:VILLAGE)
+    # @return [Array<Integer>] room ids for the Road stage
+    ROAD      = [24977, 24978, 24989, 24990, 24991, 24994, 24995, 24996, 24998, 25003, 25004, 25020, 25019, 25021, 24997, 25022, 25029, 25030, 25035, 25042, 25047, 25046, 25043, 25041, 25048, 25049, 25050, 25051, 25052, 25053, 25054, 25056, 25057, 25058, 25059, 25064, 25055, 25060, 25061, 25062, 25063].freeze unless const_defined?(:ROAD)
+    # @return [Array<Integer>] room ids for the Courtyard stage
+    COURTYARD = [25104, 25103, 25101, 25100, 25105, 25102, 25106, 25107, 25108, 25099, 25098, 25097, 25069, 25068, 25070, 25071, 25072, 25082, 25084, 25083, 25081, 25078, 25085, 25086, 25087, 25088, 25096, 25095, 25094, 25093, 25092, 25091, 25090, 25089, 25080, 25079, 25077, 25075, 25073, 25076, 25074, 25067, 25066, 25065].freeze unless const_defined?(:COURTYARD)
+    # @return [Array<Integer>] room ids for the Servant Quarters stage
+    SERVANT   = [25113, 25114, 25115, 25119, 25118, 25117, 25116, 25112, 25111, 25110, 25109].freeze unless const_defined?(:SERVANT)
+    # @return [Array<Integer>] room ids for the Visitor's Quarters stage
+    VISITOR   = [25125, 25124, 25123, 25129, 25128, 25127, 25126, 25122, 25121, 25120].freeze unless const_defined?(:VISITOR)
+    # @return [Array<Integer>] room ids for the Royal Quarters stage
+    ROYAL     = [25141, 25140, 25132, 25134, 25136, 25135, 25137, 25138, 25139, 25133, 25131, 25130].freeze unless const_defined?(:ROYAL)
+    # @return [Array<Integer>] room ids outside the main stage progression
+    #   that are still considered "in REIM" (e.g. the entry room)
+    MISC_AREAS = [24965].freeze unless const_defined?(:MISC_AREAS)
 
-UserVars.treim                    ||= {}
-UserVars.treim[:stance_dance]       = true	if UserVars.treim[:stance_dance].nil?
-UserVars.treim[:attack_type]	= ""	if UserVars.treim[:attack_type].nil?
-UserVars.treim[:activescripts]	= Array[]	if UserVars.treim[:activescripts].nil?
-UserVars.treim[:clear_title]	= false		if UserVars.treim[:clear_title].nil?
-UserVars.treim[:spam_control]	= true		if UserVars.treim[:spam_control].nil?
-UserVars.treim[:script_args]		= {}	if UserVars.treim[:script_args].nil?
-UserVars.treim[:lag_control]		= false	if UserVars.treim[:lag_control].nil?
-UserVars.treim[:toggle_ambients]	= false	if UserVars.treim[:toggle_ambients].nil?
+    # @return [Integer] room id of the throne room, where the script idles
+    #   between runs
+    THRONE_ROOM_ID = 25142 unless const_defined?(:THRONE_ROOM_ID)
+    # @return [Integer] room id the character lands in when REIM ends,
+    #   which triggers {Treim::Runner#finish}
+    EXIT_ROOM_ID   = 25143 unless const_defined?(:EXIT_ROOM_ID)
 
-UserVars.treim[:script_args].default = ""
+    # @return [Array<Stage>] every stage in clear-order, village through royal
+    STAGES = [
+      Stage.new(name: "village",   rooms: VILLAGE,   next_stage: "road", pause_before_next: false),
+      Stage.new(name: "road",      rooms: ROAD,      next_stage: "courtyard", pause_before_next: true),
+      Stage.new(name: "courtyard", rooms: COURTYARD, next_stage: "servant",   pause_before_next: true),
+      Stage.new(name: "servant",   rooms: SERVANT,   next_stage: "visitor",   pause_before_next: true),
+      Stage.new(name: "visitor",   rooms: VISITOR,   next_stage: "royal",     pause_before_next: true),
+      Stage.new(name: "royal",     rooms: ROYAL,     next_stage: "throne",    pause_before_next: true)
+    ].freeze unless const_defined?(:STAGES)
 
-if UserVars.treim[:announce_rares].nil?
-  if Char.name =~ /Tysong|Durakar|Siierra|Ragz|Nairdin|Ylandra|Gharr|Ordim/
-    UserVars.treim[:announce_rares] = true
-  else
-    UserVars.treim[:announce_rares] = false
-  end
-end
+    # @return [Array<Integer>] every room id considered "in REIM", sorted;
+    #   the union of every stage's rooms plus {MISC_AREAS}
+    ALL_ROOMS = (STAGES.flat_map(&:rooms) | MISC_AREAS).sort.freeze unless const_defined?(:ALL_ROOMS)
 
-KillNouns = Array['Murder', 'Kill', 'Slaughter', 'Abolish', 'Exterminate', 'Wreck', 'Demolish', 'Massacre', 'Obliterate', 'Crush', 'Tickley tickle', 'Kiss', 'Hug']
+    module_function
 
-if $frontend =~ /stormfront|profanity/
-  fam_window_begin = "<pushStream id=\"familiar\" ifClosedStyle=\"watching\"/>"
-  fam_window_end   = "<popStream/>\r\n"
-else
-  fam_window_begin = "\034GSe\r\n"
-  fam_window_end   = "\034GSf\r\n"
-end
+    # Whether a room is inside the REIM instance (any stage, or a misc area).
+    #
+    # @param room_id [Integer] room id to check; defaults to the character's
+    #   current room
+    # @return [Boolean]
+    def in_reim?(room_id = Room.current.id)
+      ALL_ROOMS.include?(room_id)
+    end
 
-class CappedCollection
-  MAX_SIZE = 200
-  attr_accessor :list, :max_size
-
-  def initialize(max_size = MAX_SIZE)
-    @list = []
-    @max_size = max_size
-  end
-
-  def <<(id)
-    @list << id
-    while @list.size > @max_size
-      @list.shift
+    # Finds the stage that should be held at, if any.
+    #
+    # Returns the Stage whose rooms include room_id when clear_to names that
+    # stage's next_stage -- i.e. "we're still in this stage but the group has
+    # already cleared past it, so hold rather than re-fight the boss."
+    #
+    # @param room_id [Integer] the character's current room id
+    # @param clear_to [String, nil] the group's reported clear-to stage name,
+    #   as returned by {Treim::ClearProgress::Result#clear_to}
+    # @return [Stage, nil] the stage to hold at, or nil if the character
+    #   should proceed with fighting the current wave
+    def stage_holding(room_id, clear_to)
+      STAGES.find { |stage| stage.rooms.include?(room_id) && stage.next_stage == clear_to }
     end
   end
 
-  def include?(id)
-    @list.include?(id)
+  # Name/noun lookups used to classify spawned REIM NPCs as common trash,
+  # bosses/rares, or neither.
+  module Bosses
+    # @return [Array<String>] `GameObj#noun` values for ordinary (non-boss)
+    #   REIM trash mobs
+    COMMON_NOUNS = %w[
+      commoner denizen guard guardsman guardswoman inmate lunatic madman madwoman peasant prisoner
+      squire swordsman swordswoman traveller townsman townswoman villager bandit highwayman
+      highwaywoma marauder waylayer guest maid noble knight servant slave steward visitor dancer
+      juggler nomad traveller
+    ].freeze unless const_defined?(:COMMON_NOUNS)
+
+    # @return [Array<String>] `GameObj#noun` values for rare/boss REIM NPCs
+    BOSS_NOUNS = %w[
+      Cook Shopkeeper Innkeeper Bartender Leader Lord Lady Queen King Captain Captain Sergeant
+      Hostler Master Torturer Butler ook Captain Dignitary Prince Princess Jester Emperor Empress
+    ].freeze unless const_defined?(:BOSS_NOUNS)
+
+    # @return [Regexp] matches the full `GameObj#name` (ethereal-flavor
+    #   prefix plus noun, or a bare boss name) of any REIM NPC, common or
+    #   boss; used to count total spawned mobs for status messages
+    NPC_NAME_REGEX = /
+      ethereal\ (?:commoner|denizen|guard|guardsman|guardswoman|inmate|lunatic|madman|madwoman|peasant|prisoner|squire|swordsman|swordswoman|traveller|townsman|townswoman|villager)|
+      ghostly\ (?:bandit|highwayman|highwaywoman|marauder|waylayer)|
+      unworldly\ (?:guest|maid|noble|royal\ guard|royal\ knight|servant|slave|steward|visitor)|
+      celestial\ (?:dancer|juggler|nomad|traveller)|
+      Shopkeeper|Innkeeper|Bartender|Patrol\ Leader|Bandit\ Lord|Bandit\ Lady|Gypsy\ Queen|Gypsy\ King|
+      Guard\ Captain|Wall\ Captain|Drill\ Sergeant|Stable\ Hostler|Dungeon\ Master|Master\ Torturer|
+      Butler|Cook|Knight\ Captain|Foreign\ Dignitary|Royal\ Prince|Royal\ Princess|Royal\ Jester|
+      Royal\ Emperor|Royal\ Empress
+    /x unless const_defined?(:NPC_NAME_REGEX)
   end
-end
 
-npc_ids	= CappedCollection.new
+  # Fixed-size ring buffer of already-seen NPC ids, so a wave's mobs are
+  # only announced/attacked once even as GameObj.npcs gets rescanned.
+  class SeenIds
+    # @return [Integer] default capacity when none is given to {#initialize}
+    DEFAULT_MAX_SIZE = 200 unless const_defined?(:DEFAULT_MAX_SIZE)
 
-def attack_routine(_attack_target)
-  if UserVars.treim[:attack_type] =~ /\.lic$/i
-    Script.start(UserVars.treim[:attack_type].gsub('.lic', ''))
-  elsif UserVars.treim[:attack_type] == "sleep"
-    waitcastrt?
-    fput "symbol of sleep"
-  elsif UserVars.treim[:attack_type] =~ /physical|mstrike/
-    waitrt?
-    if UserVars.treim[:stance_dance]
+    # @param max_size [Integer] how many ids to retain before the oldest
+    #   are evicted
+    def initialize(max_size: DEFAULT_MAX_SIZE)
+      @max_size = max_size
+      @ids = []
+    end
+
+    # Records an id as seen, evicting the oldest entries past max_size.
+    #
+    # @param id [String, Integer] the NPC id (`GameObj#id`) to record
+    # @return [SeenIds] self, so calls can be chained
+    def <<(id)
+      @ids << id
+      @ids.shift while @ids.size > @max_size
+      self
+    end
+
+    # @param id [String, Integer] the NPC id (`GameObj#id`) to check
+    # @return [Boolean] whether id has already been recorded
+    def include?(id)
+      @ids.include?(id)
+    end
+  end
+
+  # Thin, named wrapper around the `UserVars.treim` settings hash, so the
+  # rest of the script reads `Config.stance_dance?` instead of reaching
+  # into `UserVars.treim[:stance_dance]` directly everywhere.
+  #
+  # Persistence and defaulting both live in {UserVars.treim}, which Lich
+  # saves per-character; {.setup!} only fills in keys that are still nil.
+  module Config
+    # @return [Regexp] characters that get rares announced by default when
+    #   {UserVars.treim}[:announce_rares] hasn't been set yet
+    DEFAULT_ANNOUNCER_NAMES = /Tysong|Durakar|Siierra|Ragz|Nairdin|Ylandra|Gharr|Ordim/ unless const_defined?(:DEFAULT_ANNOUNCER_NAMES)
+
+    module_function
+
+    # Fills in any unset `UserVars.treim` keys with their defaults.
+    # Idempotent: safe to call on every run, only touches nil keys.
+    #
+    # @return [void]
+    def setup!
+      UserVars.treim ||= {}
+      store = UserVars.treim
+
+      store[:stance_dance]    = true  if store[:stance_dance].nil?
+      store[:attack_type]     = ""    if store[:attack_type].nil?
+      store[:activescripts]   = []    if store[:activescripts].nil?
+      store[:clear_title]     = false if store[:clear_title].nil?
+      store[:spam_control]    = true  if store[:spam_control].nil?
+      store[:script_args]     = {}    if store[:script_args].nil?
+      store[:lag_control]     = false if store[:lag_control].nil?
+      store[:toggle_ambients] = false if store[:toggle_ambients].nil?
+      store[:announce_rares]  = !!(Char.name =~ DEFAULT_ANNOUNCER_NAMES) if store[:announce_rares].nil?
+
+      store[:script_args].default = ""
+    end
+
+    # @return [Boolean] whether to switch to offensive stance before
+    #   attacking and back to defensive afterward
+    def stance_dance? = UserVars.treim[:stance_dance]
+
+    # @return [String] the configured attack type (a spell number, a named
+    #   routine like "mstrike", or a "*.lic" custom script name)
+    def attack_type = UserVars.treim[:attack_type]
+
+    # @param value [String] the new attack type to persist
+    # @return [void]
+    def attack_type=(value)
+      UserVars.treim[:attack_type] = value
+    end
+
+    # @return [Array<String>] names of scripts to start alongside Treim and
+    #   kill when it stops
+    def active_scripts = UserVars.treim[:activescripts]
+
+    # @return [Boolean] whether to restore/clear the character's prename
+    #   title when REIM finishes
+    def clear_title? = UserVars.treim[:clear_title]
+
+    # @return [Boolean] whether to auto-manage the built-in spam-filter
+    #   scripts ({Treim::SPAM_SCRIPTS})
+    def spam_control? = UserVars.treim[:spam_control]
+
+    # @return [Boolean] whether to kill known lag-inducing scripts
+    #   ({Treim::LAG_SCRIPTS}) and enable brief/no-numbers combat flags
+    def lag_control? = UserVars.treim[:lag_control]
+
+    # @return [Boolean] whether to toggle `FLAG NOAMBIENTMSG` on for the
+    #   duration of the run
+    def toggle_ambients? = UserVars.treim[:toggle_ambients]
+
+    # @return [Boolean] whether to announce rare/boss spawns to the room via
+    #   a `'` speech command
+    def announce_rares? = UserVars.treim[:announce_rares]
+
+    # @param name [String] the script name to look up
+    # @return [String, Object] the configured CLI args for name, or `""`
+    #   (the hash default) if none were configured
+    def script_args_for(name) = UserVars.treim[:script_args][name]
+  end
+
+  # Performs one round of whatever attack_type is configured.
+  # Every branch returns a truthy value once its round completes, so
+  # callers can drive it with `until Treim::Attack.perform; end`.
+  module Attack
+    module_function
+
+    # Dispatches to the handler for the currently configured
+    # {Config.attack_type} and performs one attack round.
+    #
+    # @return [true] always truthy once a round completes, so callers can
+    #   loop `until Attack.perform`
+    def perform
+      type = Config.attack_type
+      case type
+      when /\.lic$/i               then run_custom_script(type)
+      when "sleep"                 then cast_sleep
+      when /physical|mstrike/      then physical("mstrike")
+      when "attack"                then physical("attack")
+      when /fire|ranged/           then physical("fire")
+      when /jab|punch|grapple|kick/ then physical(type)
+      when "uac"                   then physical("mstrike punch")
+      when "scrub"                 then spell_then_mstrike(435, "435")
+      when "bardass"                then spell_then_mstrike(1030, "1030 open")
+      when "dredd"                  then spell_then_mstrike(1630, "1630 open")
+      when "none"                   then true
+      when "1030"                   then cast_only(1030, "1030 open", pause_before: 2)
+      when "709"                    then cast_and_release(709, "stop 709")
+      when /435|635/                then cast_only(type, type, pause_before: 2)
+      else                          cast_generic(type)
+      end
+    end
+
+    # Starts a custom attack script named by attack_type (e.g. "duskattack.lic")
+    # in place of a built-in routine, if it isn't already running.
+    #
+    # @param script_name [String] attack_type value ending in ".lic"
+    # @return [true]
+    def run_custom_script(script_name)
+      name = script_name.sub(/\.lic\z/i, '')
+      Script.start(name) unless Script.running?(name)
+      true
+    end
+
+    # Casts Symbol of Voln's sleep.
+    #
+    # @return [true]
+    def cast_sleep
+      waitcastrt?
+      fput "symbol of sleep"
+      true
+    end
+
+    # Performs a single melee/ranged command (attack, mstrike, fire, jab,
+    # punch, grapple, kick, or "mstrike punch" for UAC), stance-dancing to
+    # offensive first and back to defensive after if configured.
+    #
+    # @param command [String] the game command to send, e.g. "mstrike"
+    # @return [true]
+    def physical(command)
+      waitrt?
+      offensive_stance! if Config.stance_dance?
+      fput command
+      defensive_stance! if Config.stance_dance?
+      true
+    end
+
+    # Casts a setup spell (if affordable) and follows it with an mstrike;
+    # falls back to a plain mstrike when the spell can't be cast. Used for
+    # the "scrub" (435), "bardass" (1030), and "dredd" (1630) combo routines.
+    #
+    # @param spell_number [Integer] the spell to check affordability/cast
+    # @param incant [String] the incant argument, e.g. "1030 open"
+    # @return [true]
+    def spell_then_mstrike(spell_number, incant)
+      return physical("mstrike") unless Spell[spell_number].affordable?
+
+      waitrt?
+      waitcastrt?
+      put "incant #{incant}"
+      pause 1
+      waitcastrt?
+      offensive_stance! if Config.stance_dance?
+      fput "mstrike"
+      true
+    end
+
+    # Casts a spell with no follow-up attack and no stance dancing. Used
+    # for the bare "1030" and "435"/"635" attack types.
+    #
+    # @param spell_number [Integer, String] the spell to check
+    #   affordability/cast
+    # @param incant [String] the incant argument
+    # @param pause_before [Numeric] seconds to pause before casting, once
+    #   roundtime/cast-roundtime have cleared
+    # @return [true]
+    def cast_only(spell_number, incant, pause_before: 0)
+      return true unless Spell[spell_number].affordable?
+
+      waitrt?
+      waitcastrt?
+      pause pause_before if pause_before.positive?
+      put "incant #{incant}"
+      true
+    end
+
+    # Casts a spell and immediately sends a release/stop command. Used for
+    # the "709" attack type (cast then `stop 709`).
+    #
+    # @param spell_number [Integer] the spell to check affordability/cast
+    # @param release_command [String] the follow-up command, e.g. "stop 709"
+    # @return [true]
+    def cast_and_release(spell_number, release_command)
+      return true unless Spell[spell_number].affordable?
+
+      waitrt?
+      waitcastrt?
+      put "incant #{spell_number}"
+      put release_command
+      true
+    end
+
+    # Casts any other spell number directly, stance-dancing around it if
+    # configured. This is the fallback for attack types that don't match
+    # any of the named routines.
+    #
+    # @param spell_number [String] the spell number to check
+    #   affordability/cast
+    # @return [true]
+    def cast_generic(spell_number)
+      return true unless Spell[spell_number].affordable?
+
+      waitrt?
+      waitcastrt?
+      offensive_stance! if Config.stance_dance?
+      put "incant #{spell_number}"
+      defensive_stance! if Config.stance_dance?
+      true
+    end
+
+    # Switches to offensive stance if not already there.
+    #
+    # @return [void]
+    def offensive_stance!
       fput "stance offensive" if checkstance != "offensive"
     end
-    fput "mstrike"
-    if UserVars.treim[:stance_dance]
+
+    # Waits out roundtime and switches back to defensive stance.
+    #
+    # @return [void]
+    def defensive_stance!
       pause 1
       waitrt?
       fput "stance defensive"
     end
-    return 1
-  elsif UserVars.treim[:attack_type] == "attack"
-    waitrt?
-    if UserVars.treim[:stance_dance]
-      fput "stance offensive" if checkstance != "offensive"
-    end
-    fput "attack"
-    if UserVars.treim[:stance_dance]
-      pause 1
-      waitrt?
-      fput "stance defensive"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] =~ /fire|ranged/
-    waitrt?
-    if UserVars.treim[:stance_dance]
-      fput "stance offensive" if checkstance != "offensive"
-    end
-    fput "fire"
-    if UserVars.treim[:stance_dance]
-      pause 1
-      waitrt?
-      fput "stance defensive"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] =~ /jab|punch|grapple|kick/
-    waitrt?
-    if UserVars.treim[:stance_dance]
-      fput "stance offensive" if checkstance != "offensive"
-    end
-    fput "#{UserVars.treim[:attack_type]}"
-    if UserVars.treim[:stance_dance]
-      pause 1
-      waitrt?
-      fput "stance defensive"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] == "uac"
-    waitrt?
-    if UserVars.treim[:stance_dance]
-      fput "stance offensive" if checkstance != "offensive"
-    end
-    fput "mstrike punch"
-    if UserVars.treim[:stance_dance]
-      pause 1
-      waitrt?
-      fput "stance defensive"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] == "scrub"
-    if Spell[435].affordable?
-      waitrt?
-      waitcastrt?
-      put "incant 435"
-      pause 1
-      waitcastrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      return 1
-    else
-      waitrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      if UserVars.treim[:stance_dance]
-        pause 1
-        waitrt?
-        fput "stance defensive"
-      end
-      return 1
-    end
-  elsif UserVars.treim[:attack_type] == "bardass"
-    if Spell[1030].affordable?
-      waitrt?
-      waitcastrt?
-      put "incant 1030 open"
-      pause 1
-      waitcastrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      return 1
-    else
-      waitrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      if UserVars.treim[:stance_dance]
-        pause 1
-        waitrt?
-        fput "stance defensive"
-      end
-      return 1
-    end
-  elsif UserVars.treim[:attack_type] == "dredd"
-    if Spell[1630].affordable?
-      waitrt?
-      waitcastrt?
-      put "incant 1630 open"
-      pause 1
-      waitcastrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      return 1
-    else
-      waitrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      fput "mstrike"
-      if UserVars.treim[:stance_dance]
-        pause 1
-        waitrt?
-        fput "stance defensive"
-      end
-      return 1
-    end
-  elsif UserVars.treim[:attack_type] == "none"
-    return 1
-  elsif UserVars.treim[:attack_type] == "1030"
-    if Spell[1030].affordable?
-      waitrt?
-      waitcastrt?
-      pause 2
-      put "incant 1030 open"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] == "709"
-    if Spell[709].affordable?
-      waitrt?
-      waitcastrt?
-      put "incant 709"
-      put "stop 709"
-    end
-    return 1
-  elsif UserVars.treim[:attack_type] =~ /435|635/
-    if Spell[UserVars.treim[:attack_type]].affordable?
-      waitrt?
-      waitcastrt?
-      pause 2
-      put "incant #{UserVars.treim[:attack_type]}"
-    end
-    return 1
-  else
-    if Spell[UserVars.treim[:attack_type]].affordable?
-      waitrt?
-      waitcastrt?
-      if UserVars.treim[:stance_dance]
-        fput "stance offensive" if checkstance != "offensive"
-      end
-      put "incant #{UserVars.treim[:attack_type]}"
-      if UserVars.treim[:stance_dance]
-        pause 1
-        waitrt?
-        fput "stance defensive"
-      end
-    end
-    return 1
   end
-end
 
-def checkclear(bossname)
-  # GameObj.npcs.select{ |npc| npc.id == bossname.id }.count
-  while GameObj.npcs.select { |npc| npc.id == bossname && !npc.status.include?("dead") }.count > 0 do
-    pause 0.5
-  end
-  waitrt?
-  pause 0.5
-  waitrt?
-  fput "REIM INFO"
-  line = get
-  until line =~ /You have slain a total of (.*) creatures within Reim./
-    if line =~ /currently flagged for entry for up to the(.*)./
-      clearto = $1.split.first
-    elsif line =~ /Total Ethereal Scrip for this run: (.*)\/./
-      scrip = $1.to_i
-    elsif line =~ /You have (.*) hour and (.*) minutes? remaining/
-      timeleft = "#{$1}H #{$2}M"
-    elsif line =~ /You have ([0-9]{1,2}) minutes? remaining./
-      timeleft = "#{$1}M"
-    end
-    line = get
-  end
-  return clearto, scrip, timeleft
-end
+  # Parses `REIM INFO` via Lich::Util.issue_command instead of a hand-rolled
+  # DownstreamHook + silence proc.
+  module ClearProgress
+    # @return [Regexp] matches the first line of the REIM INFO response, so
+    #   `issue_command` starts capturing immediately
+    START_PATTERN = /\S/ unless const_defined?(:START_PATTERN)
+    # @return [Regexp] matches the final line of the REIM INFO response,
+    #   ending capture
+    END_PATTERN   = /You have slain a total of/ unless const_defined?(:END_PATTERN)
 
-def checkgroup()
-  group_count = 1
-  group_members = []
-  group_leader = nil
-  group_members.push(Char.name)
-  fput 'GROUP'
-  line = get
-  until line =~ /for a list of other options./
-    if line =~ /You are (?:leading|grouped with) (.*)\./
-      last_match = Regexp.last_match(1)
-      last_match.split(/,(?:\s+and)?| and /).map { |x| x.gsub(/ (?:who is \w+|\(\w+\))/, '').strip }.each { |member|
-        group_members.push(member)
-        group_count += 1
-      }
-      if (leader = last_match.split(/,(?:\s+and)?| and /).find { |x| x =~ /who is leading|\(leading\)/ })
-        group_leader = leader.gsub(/ (?:who is \w+|\(\w+\))/, '').strip
-      else
-        group_leader = Char.name
-      end
-    end
-    group_leader = Char.name if line =~ /^You are not currently in a group\.$/
-    line = get
-  end
-  return group_leader, group_members
-end
+    # @return [Regexp] captures the stage name the group is cleared through
+    CLEAR_TO_PATTERN = /currently flagged for entry for up to the(.*)\./ unless const_defined?(:CLEAR_TO_PATTERN)
+    # @return [Regexp] captures the ethereal scrip earned this run
+    SCRIP_PATTERN    = %r{Total Ethereal Scrip for this run: (.*)/} unless const_defined?(:SCRIP_PATTERN)
+    # @return [Regexp] captures "H hour(s) and M minute(s) remaining"
+    HOURS_PATTERN    = /You have (.*) hour and (.*) minutes? remaining/ unless const_defined?(:HOURS_PATTERN)
+    # @return [Regexp] captures "M minute(s) remaining" (under an hour left)
+    MINUTES_PATTERN  = /You have ([0-9]{1,2}) minutes? remaining\./ unless const_defined?(:MINUTES_PATTERN)
 
-silence = proc {
-  action = proc { |server_string|
-    if server_string.strip.length == 0
-      next
-    end
-    #		if server_string =~ /Current quest status\:|Time until next premium entry\:|Your reputation rank with the Reim Base Camp|Total Reputation|Total Quest Energy|Total Ethereal Scrip|Total Ethereal Scrip for this run|You are currently questing in the Settlement of Reim.|You are currently flagged for entry for up to the|You have slain a total of|REIM INFO|Your group status is currently|for a list of other options|is following you|is also a member of your group|is the leader of your group/
-    if server_string =~ /Current quest status\:|Time until next premium entry\:|Your reputation rank with the Reim Base Camp|Total Reputation|Total Quest Energy|Total Ethereal Scrip|Total Ethereal Scrip for this run|You are currently questing in the Settlement of Reim.|You are currently flagged for entry for up to the|You have slain a total of|REIM INFO|Your group status is currently|for a list of other options|is following you|is also a member of your group|is the leader of your group|Reim Fortress Defense|Current quest status|Times Defended|Times Failed|Highest Round Completed|Highest Score|Total Contribution|General Information|The Settlement of Reim/
-      nil
-    else
-      server_string
-    end
-  }
-  DownstreamHook.add("#{script.name}_silence", action)
-}
+    # @!attribute [r] clear_to
+    #   @return [String, nil] stage name the group is cleared through
+    #     (e.g. "road"), or nil if REIM INFO didn't report one
+    # @!attribute [r] scrip
+    #   @return [Integer, nil] ethereal scrip earned this run
+    # @!attribute [r] time_left
+    #   @return [String, nil] remaining time as "XH YM" or "YM"
+    Result = Data.define(:clear_to, :scrip, :time_left) unless const_defined?(:Result)
 
-before_dying {
-  DownstreamHook.remove("#{script.name}_silence")
-  if variable[2] == "leader"
-    kill_script "holdhands"
-  end
-  UserVars.treim[:activescripts].each { |script|
-    kill_script script if Script.running?(script)
-  }
-  Script.kill("tspam") if Script.running?("tspam")
-  Script.kill("tkill") if Script.running?("tkill")
-  Script.kill("looploot") if Script.running?("looploot")
-  if UserVars.treim[:spam_control]
-    spam_scripts.each { |script|
-      Script.kill(script) if Script.running?(script)
-    }
-  end
-  fput "FLAG NOAMBIENTMSG OFF" if UserVars.treim[:toggle_ambients]
-}
+    module_function
 
-blacklist = Array[]
-if blacklist.include? Char.name
-  exit
-end
+    # Waits for an optional target to die, then issues `REIM INFO` and
+    # parses the clear-to stage, scrip total, and time remaining from it.
+    #
+    # @param target_id [String, Integer, nil] id of an NPC to wait on
+    #   dying before checking, or nil to check immediately
+    # @return [Result] the parsed REIM INFO status
+    def check(target_id: nil)
+      wait_for_death(target_id) if target_id
+      waitrt?
+      pause 0.5
+      waitrt?
 
-if variable[1] && variable[1].downcase != "help"
-  UserVars.treim[:attack_type] = variable[1].downcase
-elsif ((variable[1] == nil || variable[1].downcase == "help") && UserVars.treim[:attack_type] == "") || variable[1].downcase == "help"
-  _respond "\n
-  SYNTAX - ;treim <ATTACKOPTION>
-  Will remember last used attack option if none given.
+      clear_to = nil
+      scrip = nil
+      time_left = nil
 
-  ATTACKOPTION Selections Include:
-      <SPELLNUMBER> - use a spell to cast once per wave/boss IE. 908 Major Fire
-      SLEEP         - symbol of voln sleep
-      PHYSICAL      - mstrike and attack boss for all you physical attackers
-      UAC           - mstrike punch and punch boss for all your UAC needs
-      RANGED        - ranged attack
-      NONE          - won't attack, useful if manually wish to attack
-
-  Running Commands
-     ;send reimcount   - shows current group leader, group count, and previos group count
-     whisper ooc group clearcheck - if group members are running script,
-                    reports back clear and scrip status
-                    MUST BE LEADER TO HAVE GROUP MEMBERS RESPOND
-
-
-  Variables to set:
-     Stance dance back to defensive after attack, default is TRUE
-     ;e echo UserVars.treim[:stance_dance] = FALSE
-
-     Add scripts to be auto-started and killed with TREIM, default is NONE
-     ;e echo UserVars.treim[:activescripts] = [\"stand\", \"symbolz\"]
-
-     Add script arguments to use at launch of of an activescript or spam_script
-     ;e UserVars.treim[:script_args] = { \"scriptname1\" => \"args\", \"scriptname2\" => \"args\" }
-
-     Enable auto-clearing of Reim titles upon complition, default is FALSE
-     ;e echo UserVars.treim[:clear_title] = true
-
-     Enable SPAM filtering scripts, default is TRUE
-     ;e echo UserVars.treim[:spam_control] = false
-
-     Enable killing of known lag enducing scripts, default is FALSE
-     ;e echo UserVars.treim[:lag_control] = TRUE
-
-     Enable announcing of rares on wave spawn, default is FALSE
-     ; echo UserVars.treim[:announce_rares] = TRUE
-
-     Enable toggling of FLAG NoAmbientMsg, default is FALSE
-     ;e echo UserVars.treim[:toggle_ambients] = TRUE"
-  exit
-end
-
-if variable[2].downcase == "leader"
-  start_script "holdhands", ["reim"]
-end
-
-fput "FLAG NOAMBIENTMSG ON" if UserVars.treim[:toggle_ambients]
-
-if UserVars.treim[:lag_control]
-  lag_scripts.each { |script|
-    if Script.running?(script)
-      Script.kill(script)
-    end
-  }
-  put "FLAG COMBATBRIEF ON"
-  put "FLAG COMBATNONUMBERS ON"
-end
-if UserVars.treim[:spam_control]
-  spam_scripts.each { |script|
-    if Script.exists?(script)
-      Script.start(script, UserVars.treim[:script_args][script]) if !Script.running?(script)
-    else
-      echo "You should strongly consider downloading ;repo download #{script} to help with spam/lag while here"
-    end
-  }
-end
-if UserVars.treim[:clear_title]
-  result = dothistimeout "title show", 5, /(.*?)#{Char.name}/
-  if result =~ /(.*?) #{Char.name}/
-    title_prename = $1
-  end
-end
-
-loop {
-  if AreaReim.include? Room.current.id
-    respond "You're in REIM, lets get to work!!!!"
-    silence.call
-    clearto, scrip, _timeleft = checkclear(bossname)
-    echo scrip if Char.name =~ /Tysong/
-    DownstreamHook.remove("#{script.name}_silence")
-    # Script.unpause("tspam") if Script.running?("tspam")
-    # Script.unpause("tkill") if Script.running?("tkill")
-    Script.unpause("looploot") if Script.running?("looploot")
-    UserVars.treim[:activescripts].each { |script|
-      Script.start(script, UserVars.treim[:script_args][script])
-    }
-    while AreaReim.include? Room.current.id do
-      line = get
-      if reim_current_room != Room.current.id
-        if line =~ /(?:strides|rushes|leaps|strolls) toward/
-          counter_time = Time.now
-          sleep 0.1 until (GameObj.npcs.count { |npc| ((npc_commons.include? npc.noun) && !(npc_ids.include? npc.id)) } > 0 || Time.now - counter_time > 2.5)
-          # sleep 0.1 until (GameObj.npcs.count{ |npc| ((npc_commons.include? npc.noun) && !(npc_ids.include? npc.id)) } > 0)
-          if GameObj.npcs.count { |npc| ((npc.name =~ /#{reim_npcs}/) && !(npc_ids.include? npc.id)) } > 30 && Char.name =~ /Tysong/
-            _respond("#{fam_window_begin}Mob Count: #{GameObj.npcs.count { |npc| (npc.name =~ /#{reim_npcs}/ && !(npc_ids.include? npc.id)) }} \r\n#{fam_window_end}") if Char.name =~ /Tysong|Gharr|Rasko/
-            put "incant 435"
-            # put "stance offensive"
-            # put "incant 950 413 512 512 510 510 510"
-            # pause 0.5
-            # put "stance defensive"
-            GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) }
-          elsif GameObj.npcs.count { |npc| ((npc_bosses.include? npc.noun) && (npc.status !~ /dead|gone/) && !(npc_ids.include? npc.id)) } > 0
-            _respond("#{fam_window_begin}Mob Count: #{GameObj.npcs.count { |npc| npc.name =~ /#{reim_npcs}/ }} \r\n#{fam_window_end}") if Char.name =~ /Tysong|Gharr|Rasko/
-            bossname = GameObj.npcs.select { |npc| ((npc_bosses.include? npc.noun) && (npc.status !~ /dead|gone/) && !(npc_ids.include? npc.id)) }.sample
-            bosses_found = GameObj.npcs.select { |npc| ((npc_bosses.include? npc.noun) && (npc.status !~ /dead|gone/) && !(npc_ids.include? npc.id)) }
-            bosses_found.each { |boss|
-              put "'#{KillNouns.sample} the #{boss.name}" if UserVars.treim[:announce_rares]
-              npc_ids << boss.id
-            }
-            if Village.include? Room.current.id and clearto == "road"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              next
-              # until attack_routine(""); end
-            elsif Road.include? Room.current.id and clearto == "courtyard"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              pause 2
-              next # if UserVars.treim[:attack_type] !~ /410|909|709|512|sleep/
-              # until attack_routine(""); end
-            elsif Courtyard.include? Room.current.id and clearto == "servant"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              pause 2
-              next # if UserVars.treim[:attack_type] !~ /410|909|709|512|sleep/
-              # until attack_routine(""); end
-            elsif Servant.include? Room.current.id and clearto == "visitor"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              pause 2
-              next # if UserVars.treim[:attack_type] !~ /410|909|709|512|sleep/
-              # until attack_routine(""); end
-            elsif Visitor.include? Room.current.id and clearto == "royal"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              pause 2
-              next # if UserVars.treim[:attack_type] !~ /410|909|709|512|sleep/
-              # until attack_routine(""); end
-            elsif Royal.include? Room.current.id and clearto == "throne"
-              GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) && (npc_bosses.include? npc.noun) }
-              pause 2
-              next # if UserVars.treim[:attack_type] !~ /410|909|709|512|sleep/
-              # until attack_routine(""); end
-            else
-              echo bossname.noun if Char.name =~ /Tysong/
-              until attack_routine("#{bossname.noun}"); end
-              silence.call
-              clearto, scrip, timeleft = checkclear(bossname.id)
-              _respond "\nCleared Through: #{clearto}
-							Total Scrip: #{scrip}"
-              DownstreamHook.remove("#{script.name}_silence")
-            end
-          elsif GameObj.npcs.count { |npc| ((npc_commons.include? npc.noun) && (npc.status !~ /dead|gone/) && !(npc_ids.include? npc.id)) } > 0
-            total_mobs = GameObj.npcs.count { |npc| npc.name =~ /#{reim_npcs}/ }
-            _respond("#{fam_window_begin}Mob Count: #{total_mobs} - Players: #{checkpcs.count.to_i + 1} \r\n#{fam_window_end}") if Char.name =~ /Tysong|Gharr|Rasko/
-            GameObj.npcs.each { |npc| npc_ids << npc.id if !(npc_ids.include? npc.id) }
-            until attack_routine(""); end
-          end
-        elsif line =~ /reimcount/
-          silence.call
-          leader, members = checkgroup
-          DownstreamHook.remove("#{script.name}_silence")
-          respond "Group Leader:    #{leader}"
-          respond "Group Members:   #{members}"
-          respond "Previous Check:  #{previousmembers}"
-          previousmembers = members
-        elsif line =~ /\(OOC\) (.*)'s player whispers to the group, "Clearcheck."/
-          whisperperson = $1.split.first
-          silence.call if Char.name !~ /Tysong|Rasko/
-          echo "Current Leader: #{leader}" if Char.name =~ /Tysong/
-          leader, members = checkgroup
-          echo "Current Leader: #{leader}" if Char.name =~ /Tysong/
-          # echo leader
-          # echo members
-          # echo whisperperson
-          if whisperperson == leader
-            clearto, scrip, timeleft = checkclear(bossname)
-            fput "whisper ooc #{leader} Clear: #{clearto}, Scrip: #{scrip}, Timeleft: #{timeleft}"
-          else
-            put "whisper ooc #{whisperperson} You're not the leader, #{whisperperson}!"
-          end
-          DownstreamHook.remove("#{script.name}_silence") if Char.name !~ /Tysong|Rasko/
-        elsif line =~ /\(OOC\) (.*)'s player whispers to the group, "Pause attack."/
-          whisperperson = $1.split.first
-          silence.call
-          leader, members = checkgroup
-          DownstreamHook.remove("#{script.name}_silence")
-          if whisperperson == leader
-            echo "PAUSING TREIM UNTIL RESUMED BY LEADER"
-            while line !~ /\(OOC\) (.*)#{whisperperson}'s player whispers to the group, "Resume attack."/ do
-              line = get
-            end
-            echo "RESUMING TREIM"
-          else
-            put "whisper ooc #{whisperperson} You're not the leader, #{whisperperson}!"
-          end
-        elsif line =~ /\(OOC\) (.*)'s player whispers to the group, "Cease fire."/ || line =~ /\(OOC\) (.*)'s player whispers to the group, ".*KILL THY SCRIPTS/i
-          whisperperson = $1.split.first
-          silence.call
-          leader, members = checkgroup
-          DownstreamHook.remove("#{script.name}_silence")
-          if whisperperson == leader
-            while line !~ /\(OOC\) (.*)#{whisperperson}'s player whispers to the group, "Resume fire."/
-              break unless AreaReim.include?(Room.current.id)
-              line = get
-            end
-          end
-        elsif line =~ /You realize that (.*) (?:were|was) left behind./
-          _respond "#{monsterbold_start}You left #{$1} behind#{monsterbold_end}"
-          fput "say We left #{$1} behind"
-          send_to_script('lnet', "chat to #{Char.name} You left #{$1} behind") if Script.running?("lnet")
-          send_to_script('0net', "chat to #{Char.name} You left #{$1} behind") if Script.running?("0net")
+      Lich::Util.issue_command("REIM INFO", START_PATTERN, END_PATTERN, silent: true, quiet: true).each do |line|
+        case line
+        when CLEAR_TO_PATTERN then clear_to = Regexp.last_match(1).split.first
+        when SCRIP_PATTERN    then scrip = Regexp.last_match(1).to_i
+        when HOURS_PATTERN    then time_left = "#{Regexp.last_match(1)}H #{Regexp.last_match(2)}M"
+        when MINUTES_PATTERN  then time_left = "#{Regexp.last_match(1)}M"
         end
-      else
-        reim_current_room = Room.current.id
-        echo "Setting reim_current_room(#{reim_current_room}) = Room.current.id(#{Room.current.id})" if Char.name =~ /Tysong/
       end
-      # TRAP Stuff
-      if line == "A slender ethereal blowgun appears from the shadows nearby, aimed right for you!"
-        waitrt?
-        fput "lean"
-      elsif line == "An ethereal bow appears from the shadows nearby, aimed right for you!"
-        waitrt?
-        fput "lean"
-      elsif line == "A pair of ethereal hands shoot up from the ground, straight for your legs!"
-        waitrt?
-        fput "jump"
-      elsif line == "An ethereal chain lashes out from the shadows straight for your head!"
-        waitrt?
-        fput "duck"
-      elsif line == "An ethereal chain lashes out from the shadows straight for your legs!"
-        waitrt?
-        fput "jump"
-      end
-      XMLData.reset
+
+      Result.new(clear_to: clear_to, scrip: scrip, time_left: time_left)
     end
-  elsif Room.current.id == 25142
-    _respond "\n
-		###############################################################
-		##                                                           ##
-		##               You're in the throne room                   ##
-		##                  IDLING TREIM SCRIPT                      ##
-		##                                                           ##
-		###############################################################\n\n\n"
-    kill_script "tkill" if Script.running?("tkill")
-    kill_script "tspam" if Script.running?("tspam")
-    kill_script "looploot" if Script.running?("looploot")
-    until (Room.current.id != 25142) do
-      XMLData.reset
-      sleep(1)
-    end
-  elsif Room.current.id == 25143
-    respond "DONE WITH REIM, EXITING"
-    if UserVars.treim[:clear_title]
-      if title_prename.length > 0
-        multifput "title set prename #{title_prename}"
-      else
-        multifput "title set prename Lord", "title clear Lord"
-      end
-    end
-    exit
-  else
-    _respond "\nScript will only run in creature only REIM rooms.
-		The script will wait until you get your arse inside REIM!!!"
-    Script.pause("tspam") if Script.running?("tspam")
-    Script.pause("tkill") if Script.running?("tkill")
-    Script.pause("looploot") if Script.running?("looploot")
-    until (AreaReim.include? Room.current.id) do
-      XMLData.reset
-      sleep(1)
+
+    # Blocks until the given NPC is confirmed dead (or was never alive).
+    #
+    # @param target_id [String, Integer] id of the NPC to wait on
+    # @return [void]
+    def wait_for_death(target_id)
+      pause 0.5 while GameObj.npcs.any? { |npc| npc.id == target_id && !npc.status.include?("dead") }
     end
   end
-}
+
+  # Thin wrapper over the native Group API (lib/gemstone/group.rb),
+  # replacing manual `fput 'GROUP'` + text parsing entirely.
+  module Party
+    module_function
+
+    # Forces a synchronous group-status refresh from the game.
+    #
+    # @return [void]
+    def refresh!
+      ::Group.check
+    end
+
+    # @return [String, nil] the group leader's name; the character's own
+    #   name if leading, the leader's noun otherwise (nil if unknown)
+    def leader_name
+      ::Group.leader? ? Char.name : ::Group.leader&.noun
+    end
+
+    # @return [Array<String>] every group member's name, including the
+    #   character's own
+    def member_names
+      ([Char.name] + ::Group.members.map(&:noun)).uniq
+    end
+  end
+
+  # Pushes status text to the familiar/thoughts stream on frontends that
+  # support it, falling back to the legacy GSe/GSf tags.
+  module FamiliarWindow
+    # @return [String] opening tag for the modern pushStream-based familiar window
+    STREAM_BEGIN = "<pushStream id=\"familiar\" ifClosedStyle=\"watching\"/>" unless const_defined?(:STREAM_BEGIN)
+    # @return [String] closing tag for the modern pushStream-based familiar window
+    STREAM_END   = "<popStream/>\r\n" unless const_defined?(:STREAM_END)
+    # @return [String] opening escape sequence for the legacy familiar window
+    LEGACY_BEGIN = "\034GSe\r\n" unless const_defined?(:LEGACY_BEGIN)
+    # @return [String] closing escape sequence for the legacy familiar window
+    LEGACY_END   = "\034GSf\r\n" unless const_defined?(:LEGACY_END)
+
+    module_function
+
+    # Wraps message in the appropriate familiar-window tags for the
+    # current frontend.
+    #
+    # @param message [String] the status text to display
+    # @return [String] message wrapped in stream or legacy escape tags,
+    #   ready to pass to `_respond`
+    def wrap(message)
+      if Lich::Common::Frontend.supports_xml?
+        "#{STREAM_BEGIN}#{message} \r\n#{STREAM_END}"
+      else
+        "#{LEGACY_BEGIN}#{message} \r\n#{LEGACY_END}"
+      end
+    end
+  end
+
+  # @return [Array<String>] verbs sampled for the `'<verb> the <boss>` room
+  #   announcement when {Treim::Config.announce_rares?} is enabled
+  KILL_NOUNS = [
+    "Murder", "Kill", "Slaughter", "Abolish", "Exterminate", "Wreck", "Demolish", "Massacre",
+    "Obliterate", "Crush", "Tickley tickle", "Kiss", "Hug"
+  ].freeze unless const_defined?(:KILL_NOUNS)
+
+  # @return [Array<String>] script names killed when
+  #   {Treim::Config.lag_control?} is enabled, before combat brief/no-numbers
+  #   flags are turned on
+  LAG_SCRIPTS = %w[
+    rnum duskruin_watch prettiernum killcounter title sorter inspectweight inspectarmor uberbounty
+    autovote chatfail enchantnotes
+  ].freeze unless const_defined?(:LAG_SCRIPTS)
+
+  # @return [Array<String>] spam-filter script names auto-started (if
+  #   installed) when {Treim::Config.spam_control?} is enabled, and killed
+  #   on shutdown
+  SPAM_SCRIPTS = %w[briefcombat spellmerge].freeze unless const_defined?(:SPAM_SCRIPTS)
+
+  # @return [Array<String>] characters excluded from running this script.
+  #   Empty by default; edit locally if you need to keep a specific
+  #   character off of it.
+  BLACKLIST = [].freeze unless const_defined?(:BLACKLIST)
+
+  # @return [Hash{String => String}] exact REIM trap warning lines mapped
+  #   to the command that dodges them
+  TRAP_RESPONSES = {
+    "A slender ethereal blowgun appears from the shadows nearby, aimed right for you!" => "lean",
+    "An ethereal bow appears from the shadows nearby, aimed right for you!"            => "lean",
+    "A pair of ethereal hands shoot up from the ground, straight for your legs!"       => "jump",
+    "An ethereal chain lashes out from the shadows straight for your head!"            => "duck",
+    "An ethereal chain lashes out from the shadows straight for your legs!"            => "jump"
+  }.freeze unless const_defined?(:TRAP_RESPONSES)
+
+  # @return [String] the `;treim help` / no-argument-and-unconfigured usage text
+  HELP_TEXT = <<~HELP unless const_defined?(:HELP_TEXT)
+    SYNTAX - ;treim <ATTACKOPTION>
+    Will remember last used attack option if none given.
+
+    ATTACKOPTION Selections Include:
+        <SPELLNUMBER> - use a spell to cast once per wave/boss IE. 908 Major Fire
+        SLEEP         - symbol of voln sleep
+        ATTACK        - single-target attack
+        FIRE          - single-target ranged attack
+        MSTRIKE       - mstrike attack (works for ranged if you set FIRE as default)
+        UAC           - mstrike punch and punch boss for all your UAC needs
+        JAB           - single-target jab
+        PUNCH         - single-target punch
+        GRAPPLE       - single-target grapple
+        KICK          - single-target kick
+        SCRUB         - combination mstrike and 435 cast routine
+        BARDASS       - combination mstrike and 1030 cast routine
+        DREDD         - combination mstrike and 1630 cast routine
+        NONE          - won't attack, useful if manually wish to attack
+        <SCRIPTNAME>.lic - starts a custom attack script instead
+
+    Running Commands
+       ;send reimcount   - shows current group leader, group count, and previous group count
+       whisper ooc group clearcheck - if group members are running script,
+                      reports back clear and scrip status
+                      MUST BE LEADER TO HAVE GROUP MEMBERS RESPOND
+
+    Variables to set:
+       Stance dance back to defensive after attack, default is TRUE
+       ;e echo UserVars.treim[:stance_dance] = FALSE
+
+       Add scripts to be auto-started and killed with TREIM, default is NONE
+       ;e echo UserVars.treim[:activescripts] = ["stand", "symbolz"]
+
+       Add script arguments to use at launch of an activescript or spam_script
+       ;e UserVars.treim[:script_args] = { "scriptname1" => "args", "scriptname2" => "args" }
+
+       Enable auto-clearing of Reim titles upon completion, default is FALSE
+       ;e echo UserVars.treim[:clear_title] = true
+
+       Enable SPAM filtering scripts, default is TRUE
+       ;e echo UserVars.treim[:spam_control] = false
+
+       Enable killing of known lag inducing scripts, default is FALSE
+       ;e echo UserVars.treim[:lag_control] = TRUE
+
+       Enable announcing of rares on wave spawn, default is FALSE
+       ;e echo UserVars.treim[:announce_rares] = TRUE
+
+       Enable toggling of FLAG NoAmbientMsg, default is FALSE
+       ;e echo UserVars.treim[:toggle_ambients] = TRUE
+  HELP
+
+  # The main reactive loop, once setup/config is done.
+  #
+  # Dispatches on the character's current room: fights waves while inside
+  # REIM proper ({#run_wave_room}), idles in the throne room between runs
+  # ({#idle_in_throne_room}), wraps up on exit ({#finish}), or waits outside
+  # REIM entirely ({#await_entry}).
+  class Runner
+    # @param title_prename [String, nil] the prename captured before
+    #   entering REIM (via {Treim.capture_title_prename}), restored by
+    #   {#finish} if {Config.clear_title?} is enabled
+    def initialize(title_prename: nil)
+      @seen_ids = SeenIds.new
+      @previous_members = []
+      @current_boss_id = nil
+      @title_prename = title_prename
+    end
+
+    # Runs forever, dispatching on the character's current room. Only
+    # returns via {#finish} calling `exit`.
+    #
+    # @return [void]
+    def run
+      loop do
+        if Geography.in_reim?
+          run_wave_room
+        elsif Room.current.id == Geography::THRONE_ROOM_ID
+          idle_in_throne_room
+        elsif Room.current.id == Geography::EXIT_ROOM_ID
+          finish
+        else
+          await_entry
+        end
+      end
+    end
+
+    private
+
+    # Checks current clear progress, starts configured helper scripts, then
+    # processes game lines (wave spawns, whispered commands, traps) for as
+    # long as the character stays inside REIM.
+    #
+    # @return [void]
+    def run_wave_room
+      respond "You're in REIM, lets get to work!!!!"
+
+      progress = ClearProgress.check
+      echo progress.scrip if Char.name =~ /Tysong/
+      Script.unpause("looploot") if Script.running?("looploot")
+      Config.active_scripts.each { |name| Script.start(name, Config.script_args_for(name)) }
+
+      clear_to = progress.clear_to
+
+      while Geography.in_reim?
+        line = get
+        clear_to = handle_wave_line(line, clear_to)
+        handle_trap_line(line)
+        XMLData.reset
+      end
+    end
+
+    # Routes one game line to the matching wave/whisper/trap handler.
+    #
+    # @param line [String] a single line of game output
+    # @param clear_to [String, nil] the current known clear-to stage name
+    # @return [String, nil] the (possibly updated) clear-to stage name
+    def handle_wave_line(line, clear_to)
+      case line
+      when /(?:strides|rushes|leaps|strolls) toward/
+        clear_to = handle_wave_spawn(clear_to)
+      when /reimcount/
+        report_group_status
+      when /\(OOC\) (.*)'s player whispers to the group, "Clearcheck\."/
+        handle_clearcheck(Regexp.last_match(1).split.first)
+      when /\(OOC\) (.*)'s player whispers to the group, "Pause attack\."/
+        handle_pause_attack(Regexp.last_match(1).split.first)
+      when /\(OOC\) (.*)'s player whispers to the group, "Cease fire\."/, /\(OOC\) (.*)'s player whispers to the group, ".*KILL THY SCRIPTS/i
+        handle_cease_fire(Regexp.last_match(1).split.first)
+      when /You realize that (.*) (?:were|was) left behind\./
+        announce_left_behind(Regexp.last_match(1))
+      end
+      clear_to
+    end
+
+    # Dodges a REIM trap if line is an exact trap-warning match.
+    #
+    # @param line [String] a single line of game output
+    # @return [void]
+    def handle_trap_line(line)
+      dodge = TRAP_RESPONSES[line]
+      return unless dodge
+
+      waitrt?
+      fput dodge
+    end
+
+    # Handles a "creature strides/rushes/leaps/strolls toward you" spawn
+    # line: waits for the room to populate, then routes to the flood, boss,
+    # or common-wave handler based on what spawned.
+    #
+    # @param clear_to [String, nil] the current known clear-to stage name
+    # @return [String, nil] the (possibly updated) clear-to stage name
+    def handle_wave_spawn(clear_to)
+      wait_for_npc_population
+
+      if flood_wave?
+        handle_flood_wave
+        clear_to
+      elsif (bosses = unseen_bosses).any?
+        handle_boss_wave(bosses, clear_to)
+      elsif unseen_commons.any?
+        handle_common_wave
+        clear_to
+      else
+        clear_to
+      end
+    end
+
+    # Blocks briefly for GameObj.npcs to populate after a room change,
+    # since the XML feed can lag behind the room-window update.
+    #
+    # @return [void]
+    def wait_for_npc_population
+      deadline = Time.now + 2.5
+      sleep 0.1 until unseen_common_npc_count.positive? || Time.now > deadline
+    end
+
+    # Whether this spawn is a mob flood needing an AoE response instead of
+    # normal single-target handling. Gated to a specific character.
+    #
+    # @return [Boolean]
+    def flood_wave?
+      Char.name =~ /Tysong/ && unseen_named_npc_count > 30
+    end
+
+    # Responds to a flood wave by casting an AoE spell and marking every
+    # visible NPC seen.
+    #
+    # @return [void]
+    def handle_flood_wave
+      announce_mob_count("Mob Count: #{unseen_named_npc_count}")
+      put "incant 435"
+      mark_all_seen
+    end
+
+    # Announces and marks any newly-spawned bosses/rares seen, then either
+    # holds (if the group has already cleared past this stage) or fights
+    # one sampled boss and rechecks clear progress afterward.
+    #
+    # @param bosses [Array<GameObj>] unseen boss/rare NPCs from this spawn
+    # @param clear_to [String, nil] the current known clear-to stage name
+    # @return [String, nil] the (possibly updated) clear-to stage name
+    def handle_boss_wave(bosses, clear_to)
+      announce_mob_count("Mob Count: #{named_npc_count}")
+      bosses.each do |boss|
+        put "'#{KILL_NOUNS.sample} the #{boss.name}" if Config.announce_rares?
+        @seen_ids << boss.id
+      end
+
+      boss = bosses.sample
+      @current_boss_id = boss.id
+
+      stage = Geography.stage_holding(Room.current.id, clear_to)
+      if stage
+        pause 2 if stage.pause_before_next
+        return clear_to
+      end
+
+      echo boss.noun if Char.name =~ /Tysong/
+      until Attack.perform; end
+
+      progress = ClearProgress.check(target_id: boss.id)
+      _respond "\nCleared Through: #{progress.clear_to}\nTotal Scrip: #{progress.scrip}"
+      progress.clear_to
+    end
+
+    # Responds to an ordinary (non-boss) wave: marks everything visible
+    # seen and attacks until the round completes.
+    #
+    # @return [void]
+    def handle_common_wave
+      announce_mob_count("Mob Count: #{named_npc_count} - Players: #{checkpcs.count.to_i + 1}")
+      mark_all_seen
+      until Attack.perform; end
+    end
+
+    # @return [Integer] count of common NPCs not yet marked seen
+    def unseen_common_npc_count
+      GameObj.npcs.count { |npc| Bosses::COMMON_NOUNS.include?(npc.noun) && !@seen_ids.include?(npc.id) }
+    end
+
+    # @return [Integer] count of any REIM NPCs (common or boss) not yet
+    #   marked seen
+    def unseen_named_npc_count
+      GameObj.npcs.count { |npc| npc.name =~ Bosses::NPC_NAME_REGEX && !@seen_ids.include?(npc.id) }
+    end
+
+    # @return [Integer] total count of visible REIM NPCs, seen or not
+    def named_npc_count
+      GameObj.npcs.count { |npc| npc.name =~ Bosses::NPC_NAME_REGEX }
+    end
+
+    # @return [Array<GameObj>] living boss/rare NPCs not yet marked seen
+    def unseen_bosses
+      GameObj.npcs.select { |npc| Bosses::BOSS_NOUNS.include?(npc.noun) && npc.status !~ /dead|gone/ && !@seen_ids.include?(npc.id) }
+    end
+
+    # @return [Array<GameObj>] living common NPCs not yet marked seen
+    def unseen_commons
+      GameObj.npcs.select { |npc| Bosses::COMMON_NOUNS.include?(npc.noun) && npc.status !~ /dead|gone/ && !@seen_ids.include?(npc.id) }
+    end
+
+    # Marks every currently-visible NPC as seen in {#@seen_ids}.
+    #
+    # @return [void]
+    def mark_all_seen
+      GameObj.npcs.each { |npc| @seen_ids << npc.id unless @seen_ids.include?(npc.id) }
+    end
+
+    # Sends message to the familiar window, gated to a set of characters
+    # who want the extra status chatter.
+    #
+    # @param message [String] the status text to display
+    # @return [void]
+    def announce_mob_count(message)
+      return unless Char.name =~ /Tysong|Gharr|Rasko/
+
+      _respond FamiliarWindow.wrap(message)
+    end
+
+    # Handles the `;send reimcount` trigger: reports the current group
+    # leader/members and the previous check's member list.
+    #
+    # @return [void]
+    def report_group_status
+      Party.refresh!
+      leader = Party.leader_name
+      members = Party.member_names
+      respond "Group Leader:    #{leader}"
+      respond "Group Members:   #{members}"
+      respond "Previous Check:  #{@previous_members}"
+      @previous_members = members
+    end
+
+    # Refreshes group status and checks whether whisperperson is the group
+    # leader, whispering a rejection back to them if not.
+    #
+    # @param whisperperson [String] first name parsed from the whisper line
+    # @return [Boolean] whether whisperperson is the group leader
+    def leader?(whisperperson)
+      Party.refresh!
+      return true if whisperperson == Party.leader_name
+
+      put "whisper ooc #{whisperperson} You're not the leader, #{whisperperson}!"
+      false
+    end
+
+    # Handles a whispered "Clearcheck" OOC command: if whisperperson is the
+    # group leader, reports clear progress/scrip/time remaining back to them.
+    #
+    # @param whisperperson [String] first name parsed from the whisper line
+    # @return [void]
+    def handle_clearcheck(whisperperson)
+      return unless leader?(whisperperson)
+
+      progress = ClearProgress.check(target_id: @current_boss_id)
+      fput "whisper ooc #{whisperperson} Clear: #{progress.clear_to}, Scrip: #{progress.scrip}, Timeleft: #{progress.time_left}"
+    end
+
+    # Handles a whispered "Pause attack" OOC command: if whisperperson is
+    # the group leader, blocks until they whisper "Resume attack".
+    #
+    # @param whisperperson [String] first name parsed from the whisper line
+    # @return [void]
+    def handle_pause_attack(whisperperson)
+      return unless leader?(whisperperson)
+
+      echo "PAUSING TREIM UNTIL RESUMED BY LEADER"
+      resume_pattern = /\(OOC\) (.*)#{Regexp.escape(whisperperson)}'s player whispers to the group, "Resume attack\."/
+      loop do
+        break if get =~ resume_pattern
+      end
+      echo "RESUMING TREIM"
+    end
+
+    # Handles a whispered "Cease fire" (or "KILL THY SCRIPTS") OOC command:
+    # if whisperperson is the group leader, blocks until they whisper
+    # "Resume fire" or the character leaves REIM.
+    #
+    # @param whisperperson [String] first name parsed from the whisper line
+    # @return [void]
+    def handle_cease_fire(whisperperson)
+      Party.refresh!
+      return unless whisperperson == Party.leader_name
+
+      resume_pattern = /\(OOC\) (.*)#{Regexp.escape(whisperperson)}'s player whispers to the group, "Resume fire\."/
+      loop do
+        break unless Geography.in_reim?
+        break if get =~ resume_pattern
+      end
+    end
+
+    # Announces a group member left behind and relays it over lnet/0net if
+    # those scripts are running.
+    #
+    # @param name [String] the name of the member left behind
+    # @return [void]
+    def announce_left_behind(name)
+      _respond "#{monsterbold_start}You left #{name} behind#{monsterbold_end}"
+      fput "say We left #{name} behind"
+      send_to_script('lnet', "chat to #{Char.name} You left #{name} behind") if Script.running?("lnet")
+      send_to_script('0net', "chat to #{Char.name} You left #{name} behind") if Script.running?("0net")
+    end
+
+    # Displays the idling banner, stops helper scripts that shouldn't run
+    # outside a wave, and blocks until the character leaves the throne room.
+    #
+    # @return [void]
+    def idle_in_throne_room
+      _respond "\n\t\t###############################################################\n" \
+               "\t\t##                                                           ##\n" \
+               "\t\t##               You're in the throne room                   ##\n" \
+               "\t\t##                  IDLING TREIM SCRIPT                      ##\n" \
+               "\t\t##                                                           ##\n" \
+               "\t\t###############################################################\n\n\n"
+      %w[tkill tspam looploot].each { |name| kill_script name if Script.running?(name) }
+      until Room.current.id != Geography::THRONE_ROOM_ID
+        XMLData.reset
+        sleep 1
+      end
+    end
+
+    # Pauses helper scripts and blocks until the character enters REIM.
+    #
+    # @return [void]
+    def await_entry
+      _respond "\nScript will only run in creature only REIM rooms.\n" \
+               "\t\tThe script will wait until you get your arse inside REIM!!!"
+      %w[tspam tkill looploot].each { |name| Script.pause(name) if Script.running?(name) }
+      until Geography.in_reim?
+        XMLData.reset
+        sleep 1
+      end
+    end
+
+    # Restores/clears the character's prename title if configured, then
+    # ends the script.
+    #
+    # @return [void]
+    def finish
+      respond "DONE WITH REIM, EXITING"
+      if Config.clear_title?
+        if @title_prename && !@title_prename.empty?
+          multifput "title set prename #{@title_prename}"
+        else
+          multifput "title set prename Lord", "title clear Lord"
+        end
+      end
+      exit
+    end
+  end
+
+  module_function
+
+  # Script entry point: validates the blacklist, applies configuration and
+  # CLI arguments, wires up lag/spam control and the shutdown hook, then
+  # hands off to {Runner#run}.
+  #
+  # @return [void]
+  def start
+    return if BLACKLIST.include?(Char.name)
+
+    Config.setup!
+    return unless handle_arguments
+
+    Script.start("holdhands", "reim") if leader_flag?
+
+    register_shutdown_hook
+
+    fput "FLAG NOAMBIENTMSG ON" if Config.toggle_ambients?
+    apply_lag_control
+    apply_spam_control
+
+    title_prename = capture_title_prename if Config.clear_title?
+
+    Runner.new(title_prename: title_prename).run
+  end
+
+  # @return [Boolean] whether the script was invoked with "leader" as its
+  #   second CLI argument (`;treim <attack> leader`)
+  def leader_flag?
+    Script.current.vars[2]&.downcase == "leader"
+  end
+
+  # Sets the attack type from args if given; otherwise reuses the last
+  # configured attack type. Shows help (and signals "stop") when asked, or
+  # when there's no argument and nothing configured yet.
+  #
+  # @return [Boolean] true if the script should proceed, false if help was
+  #   shown and the caller should stop
+  def handle_arguments
+    requested = Script.current.vars[1]
+
+    if requested && requested.downcase != "help"
+      Config.attack_type = requested.downcase
+      return true
+    end
+
+    return true if requested.nil? && !Config.attack_type.empty?
+
+    _respond "\n#{HELP_TEXT}"
+    false
+  end
+
+  # Registers cleanup to run when the script dies: kills holdhands (if
+  # leading), configured active scripts, known helper scripts, and spam
+  # scripts (if enabled), and restores the ambient-message flag.
+  #
+  # @return [void]
+  def register_shutdown_hook
+    before_dying do
+      kill_script "holdhands" if leader_flag?
+      Config.active_scripts.each { |name| kill_script name if Script.running?(name) }
+      %w[tspam tkill looploot].each { |name| Script.kill(name) if Script.running?(name) }
+      SPAM_SCRIPTS.each { |name| Script.kill(name) if Script.running?(name) } if Config.spam_control?
+      fput "FLAG NOAMBIENTMSG OFF" if Config.toggle_ambients?
+    end
+  end
+
+  # Kills known lag-inducing scripts and enables brief/no-numbers combat
+  # flags, if {Config.lag_control?} is enabled.
+  #
+  # @return [void]
+  def apply_lag_control
+    return unless Config.lag_control?
+
+    LAG_SCRIPTS.each { |name| Script.kill(name) if Script.running?(name) }
+    put "FLAG COMBATBRIEF ON"
+    put "FLAG COMBATNONUMBERS ON"
+  end
+
+  # Starts each configured spam-filter script (if installed and not
+  # already running), or nudges the user to install it, if
+  # {Config.spam_control?} is enabled.
+  #
+  # @return [void]
+  def apply_spam_control
+    return unless Config.spam_control?
+
+    SPAM_SCRIPTS.each do |name|
+      unless Script.exists?(name)
+        echo "You should strongly consider downloading ;repo download #{name} to help with spam/lag while here"
+        next
+      end
+      Script.start(name, Config.script_args_for(name)) unless Script.running?(name)
+    end
+  end
+
+  # Captures the character's current prename title (if any) so
+  # {Runner#finish} can restore it after REIM clears titles.
+  #
+  # @return [String, nil] the prename text before the character's name, or
+  #   nil if there wasn't one
+  def capture_title_prename
+    lines = Lich::Util.issue_command("title show", /#{Regexp.escape(Char.name)}/, silent: true, quiet: true, timeout: 5)
+    match = lines.first&.match(/(.*?) #{Regexp.escape(Char.name)}/)
+    match && match[1]
+  end
+end
+
+Treim.start

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -76,100 +76,99 @@
 
     changelog:
       3.0.0 (2026-08-22)
-      Full rewrite for current Ruby/Lich5 compatibility, no setup changes needed
-      Fixed a couple rare crash bugs (missing leader argument, re-running with no attack type set)
-      Fixed REIM INFO time-remaining not showing once 2+ hours were left
-      Fixed a whisper "clearcheck" possibly freezing the script during a hold
-      Fixed title restore after REIM sometimes including extra text
-      Fixed a couple mistyped creature names that could cause a wave to be skipped
-      Added debug_echo and mob_count_window UserVars options (previously hardcoded to a few characters)
+        * Full rewrite for current Ruby/Lich5 compatibility, no setup changes needed
+        * Fixed a couple rare crash bugs (missing leader argument, re-running with no attack type set)
+        * Fixed REIM INFO time-remaining not showing once 2+ hours were left
+        * Fixed a whisper "clearcheck" possibly freezing the script during a hold
+        * Fixed title restore after REIM sometimes including extra text
+        * Fixed a couple mistyped creature names that could cause a wave to be skipped
+        * Added debug_echo and mob_count_window UserVars options (previously hardcoded to a few characters)
       2.24.2 (2023-05-19)
-      Fix for new GROUP output
-      Rubocop cleanup
+        * Fix for new GROUP output
+        * Rubocop cleanup
       2.24.1 (2023-01-10)
-      Bug fix for using custom attack
+        * Bug fix for using custom attack
       2.24.0 (2022-04-14)
-      Add option to start custom attack script (eg ;treim tysong-duskattack.lic)
+        * Add option to start custom attack script (eg ;treim tysong-duskattack.lic)
       2.23.1 (2021-03-08)
-      Add UserVars.treim[:script_args] to launch spam_scripts or activescripts with arguments
-      Set via ;e UserVars.treim[:script_args] = { "scriptname1" => "args", "scriptname2" => "args" }
+        * Add UserVars.treim[:script_args] to launch spam_scripts or activescripts with arguments
+        * Set via ;e UserVars.treim[:script_args] = { "scriptname1" => "args", "scriptname2" => "args" }
       2.22 (2020-12-27)
-      Recognize "KILL THY SCRIPTS" as a "cease fire" command
+        * Recognize "KILL THY SCRIPTS" as a "cease fire" command
       2.21 (2020-05-23)
-      Added support for "cease fire" and "resume fire"
+        * Added support for "cease fire" and "resume fire"
       2.20 (2020-05-19)
-      Added "FIRE" routine for single target attacks
-      Removed "FURY" routine
-      Simplified a bunch of routines
-      Removed mstrike_limit variable
+        * Added "FIRE" routine for single target attacks
+        * Removed "FURY" routine
+        * Simplified a bunch of routines
+        * Removed mstrike_limit variable
 =end
 =begin
       2.19 (2020-05-17)
-      Added "ATTACK" routine for single target attacks
-      Added a 2 second pause for 635 and 1030
-        2.18 (2020-05-01)
-      Added FLAG NOAMBIENTMSG toggling, default FALSE (if true, toggles on while running treim and toggles off after)
-        2.17 (2020-04-29)
-      Adding a new variable to define focused mstrike targets (default of 2)
-        2.16 (2020-04-06)
-      Added "FURY" routine
-        2.15 (2020-01-05)
-      Added "DREDD" routine
-        2.14 (2019-11-02)
-      Improved 1030 performance
-        2.13 (2019-10-05)
-      Added the "bardass" option
-        2.12 (2019-09-03)
-            Adding scrub option
-        2.11 (2019-08-05)
-            Stopped spam control scripts IF enabled.
-        2.10 (2019-07-21)
-            Changed the 709 stop to only be for lvl 90+ characters (for capped Reim)
-        2.9 (2019-05-01)
-            Added forced 335 incant evoke and 312 for boss waves if using 335.
-        2.8.3 (2019-04-21)
-            Added some additional pause/unpause/kill for specific addon scripts
-        2.8.2 (2019-04-04)
-            Added a max 2.5 to the sleep for populating GameObj.npcs in case they die before populating.
-        2.8.1 (2019-03-28)
-            Fixed issue with title reseting.
-        2.8 (2019-03-26)
-            Added sleep until GameObj.npcs > 0 after wave spawn to wait for XML feed update due to Room window changes
-        2.7.1 (2019-03-17)
-            Added 635 forced incant due to spell-list.xml forcing prep/cast
-        2.7 (2018-11-15)
-            Added detection of existing prename title at start of script if using clear_title option
-        2.6 (2018-03-27)
-            Added spam/lag routine to auto-kill scripts and start others that help.
-        2.5 (2018-01-12)
-            Changed boss wave detection for Road through Royal to hold attack if cleared already
-        2.4 (2017-11-29)
-            Added clear_title variable to clear prename title upon completion
-        2.3 (2017-11-29)
-            Updated spawn detection to decrease "lag" issue.
-        2.2 (2017-11-18)
-            Fixed stance dancing for casting to respect UserVar
-        2.1 (2017-11-18)
-            Added some help verbage
-        2.0 (2017-11-11)
-            Rewrite of mob detection mechanic
-            Added ability to use 1030 for Bards
-            Attempt at adding initial "pause attack" on moving rooms.
-                      (pause attack & resume attack)
-        1.8 (2017-04-08)
-            Corrected bug with bosscheck for physical/uac attack
-            Added timeleft to clearcheck command
-        1.7 (2017-03-22)
-            Changed physical roundtime wait, added NONE command
-        1.6 (2017-03-17)
-            Believe to have fixed double/triple attacks on boss waves
-        1.5 (2017-03-17)
-            Added skip boss/named creature check if clear to next area
-            Added a few other otions for leaders.
-        1.1 (2017-03-16)
-            Fixed some bugs
-        1.0 (2017-03-15)
-            Initial Release
+        * Added "ATTACK" routine for single target attacks
+        * Added a 2 second pause for 635 and 1030
+      2.18 (2020-05-01)
+        * Added FLAG NOAMBIENTMSG toggling, default FALSE (if true, toggles on while running treim and toggles off after)
+      2.17 (2020-04-29)
+        * Adding a new variable to define focused mstrike targets (default of 2)
+      2.16 (2020-04-06)
+        * Added "FURY" routine
+      2.15 (2020-01-05)
+        * Added "DREDD" routine
+      2.14 (2019-11-02)
+        * Improved 1030 performance
+      2.13 (2019-10-05)
+        * Added the "bardass" option
+      2.12 (2019-09-03)
+        * Adding scrub option
+      2.11 (2019-08-05)
+        * Stopped spam control scripts IF enabled.
+      2.10 (2019-07-21)
+        * Changed the 709 stop to only be for lvl 90+ characters (for capped Reim)
+      2.9 (2019-05-01)
+        * Added forced 335 incant evoke and 312 for boss waves if using 335.
+      2.8.3 (2019-04-21)
+        * Added some additional pause/unpause/kill for specific addon scripts
+      2.8.2 (2019-04-04)
+        * Added a max 2.5 to the sleep for populating GameObj.npcs in case they die before populating.
+      2.8.1 (2019-03-28)
+        * Fixed issue with title reseting.
+      2.8 (2019-03-26)
+        * Added sleep until GameObj.npcs > 0 after wave spawn to wait for XML feed update due to Room window changes
+      2.7.1 (2019-03-17)
+        * Added 635 forced incant due to spell-list.xml forcing prep/cast
+      2.7 (2018-11-15)
+        * Added detection of existing prename title at start of script if using clear_title option
+      2.6 (2018-03-27)
+        * Added spam/lag routine to auto-kill scripts and start others that help.
+      2.5 (2018-01-12)
+        * Changed boss wave detection for Road through Royal to hold attack if cleared already
+      2.4 (2017-11-29)
+        * Added clear_title variable to clear prename title upon completion
+      2.3 (2017-11-29)
+        * Updated spawn detection to decrease "lag" issue.
+      2.2 (2017-11-18)
+        * Fixed stance dancing for casting to respect UserVar
+      2.1 (2017-11-18)
+        * Added some help verbage
+      2.0 (2017-11-11)
+        * Rewrite of mob detection mechanic
+        * Added ability to use 1030 for Bards
+        * Attempt at adding initial "pause attack" on moving rooms (pause attack & resume attack)
+      1.8 (2017-04-08)
+        * Corrected bug with bosscheck for physical/uac attack
+        * Added timeleft to clearcheck command
+      1.7 (2017-03-22)
+        * Changed physical roundtime wait, added NONE command
+      1.6 (2017-03-17)
+        * Believe to have fixed double/triple attacks on boss waves
+      1.5 (2017-03-17)
+        * Added skip boss/named creature check if clear to next area
+        * Added a few other otions for leaders.
+      1.1 (2017-03-16)
+        * Fixed some bugs
+      1.0 (2017-03-15)
+        * Initial Release
 
     credit & thanks:
         Durakar for his help/collaboration in general for a lot of this script.

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -70,11 +70,25 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 3.0.1
+    version: 3.0.2
 
   To help contribute or open an issue: https://github.com/elanthia-online/scripts
 
     changelog:
+      3.0.2 (2026-08-22)
+        Nitpick follow-ups on top of 3.0.1:
+        - The hard-coded `Char.name =~ /Tysong/`-style gates (progress-scrip
+          echo, flood-wave AoE response, sampled-boss-noun echo, familiar-
+          window mob-count status) are now two Config keys instead:
+          `debug_echo` and `mob_count_window`. Both default to true for
+          exactly the names the old hard-coded checks used, so behavior is
+          unchanged by default; everyone else can now opt in via
+          `;e UserVars.treim[:debug_echo] = TRUE` /
+          `;e UserVars.treim[:mob_count_window] = TRUE` instead of needing
+          a script edit.
+        - Documented that `spell_then_mstrike` intentionally leaves the
+          character in offensive stance after an affordable round, matching
+          the legacy attack_routine this replaced.
       3.0.1 (2026-08-22)
         Review fixes on top of the 3.0.0 rewrite:
         - Bugfix: `COMMON_NOUNS` had a truncated "highwaywoma" (never matched

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -58,6 +58,14 @@
          Enable toggling of FLAG NoAmbientMsg, default is FALSE
          ;e echo UserVars.treim[:toggle_ambients] = TRUE
 
+         Enable extra debug echoes (scrip on wave entry, sampled boss noun)
+         and the flood-wave AoE response, default is FALSE for most characters
+         ;e echo UserVars.treim[:debug_echo] = TRUE
+
+         Enable pushing mob-count status to the familiar window each wave,
+         default is FALSE for most characters
+         ;e echo UserVars.treim[:mob_count_window] = TRUE
+
        todo: add parsing of reim info command and show condensed info
      author: Tysong (horibu on PC)
        name: treim
@@ -391,6 +399,14 @@ module Treim
     #   {UserVars.treim}[:announce_rares] hasn't been set yet
     DEFAULT_ANNOUNCER_NAMES = /Tysong|Durakar|Siierra|Ragz|Nairdin|Ylandra|Gharr|Ordim/ unless const_defined?(:DEFAULT_ANNOUNCER_NAMES, false)
 
+    # @return [Regexp] characters that get extra debug echoes (scrip/boss
+    #   noun) and the flood-wave AoE response by default
+    DEFAULT_DEBUG_NAMES = /Tysong/ unless const_defined?(:DEFAULT_DEBUG_NAMES, false)
+
+    # @return [Regexp] characters that get mob-count status pushed to their
+    #   familiar window by default
+    DEFAULT_MOB_COUNT_NAMES = /Tysong|Gharr|Rasko/ unless const_defined?(:DEFAULT_MOB_COUNT_NAMES, false)
+
     module_function
 
     # Fills in any unset `UserVars.treim` keys with their defaults.
@@ -410,6 +426,8 @@ module Treim
       store[:lag_control]     = false if store[:lag_control].nil?
       store[:toggle_ambients] = false if store[:toggle_ambients].nil?
       store[:announce_rares]  = !!(Char.name =~ DEFAULT_ANNOUNCER_NAMES) if store[:announce_rares].nil?
+      store[:debug_echo]      = !!(Char.name =~ DEFAULT_DEBUG_NAMES) if store[:debug_echo].nil?
+      store[:mob_count_window] = !!(Char.name =~ DEFAULT_MOB_COUNT_NAMES) if store[:mob_count_window].nil?
 
       store[:script_args].default = ""
     end
@@ -451,6 +469,15 @@ module Treim
     # @return [Boolean] whether to announce rare/boss spawns to the room via
     #   a `'` speech command
     def announce_rares? = UserVars.treim[:announce_rares]
+
+    # @return [Boolean] whether to echo extra debug info (current scrip on
+    #   wave entry, the sampled boss's noun) and respond to mob floods with
+    #   an AoE cast
+    def debug_echo? = UserVars.treim[:debug_echo]
+
+    # @return [Boolean] whether to push mob-count status text to the
+    #   familiar window on each wave
+    def mob_count_window? = UserVars.treim[:mob_count_window]
 
     # @param name [String] the script name to look up
     # @return [String, Object] the configured CLI args for name, or `""`
@@ -527,6 +554,11 @@ module Treim
     # Casts a setup spell (if affordable) and follows it with an mstrike;
     # falls back to a plain mstrike when the spell can't be cast. Used for
     # the "scrub" (435), "bardass" (1030), and "dredd" (1630) combo routines.
+    #
+    # Unlike {#physical}, this doesn't switch back to defensive stance
+    # afterward -- an affordable round intentionally leaves the character in
+    # offensive stance once the mstrike lands, matching the legacy
+    # attack_routine this replaced.
     #
     # @param spell_number [Integer] the spell to check affordability/cast
     # @param incant [String] the incant argument, e.g. "1030 open"
@@ -850,6 +882,12 @@ module Treim
 
        Enable toggling of FLAG NoAmbientMsg, default is FALSE
        ;e echo UserVars.treim[:toggle_ambients] = TRUE
+
+       Enable extra debug echoes and the flood-wave AoE response, default is FALSE
+       ;e echo UserVars.treim[:debug_echo] = TRUE
+
+       Enable pushing mob-count status to the familiar window, default is FALSE
+       ;e echo UserVars.treim[:mob_count_window] = TRUE
   HELP
 
   # The main reactive loop, once setup/config is done.
@@ -898,7 +936,7 @@ module Treim
       respond "You're in REIM, lets get to work!!!!"
 
       progress = ClearProgress.check
-      echo progress.scrip if Char.name =~ /Tysong/
+      echo progress.scrip if Config.debug_echo?
       Script.unpause("looploot") if Script.running?("looploot")
       Config.active_scripts.each { |name| Script.start(name, Config.script_args_for(name)) }
 
@@ -979,11 +1017,11 @@ module Treim
     end
 
     # Whether this spawn is a mob flood needing an AoE response instead of
-    # normal single-target handling. Gated to a specific character.
+    # normal single-target handling. Gated behind {Config.debug_echo?}.
     #
     # @return [Boolean]
     def flood_wave?
-      Char.name =~ /Tysong/ && unseen_named_npc_count > 30
+      Config.debug_echo? && unseen_named_npc_count > 30
     end
 
     # Responds to a flood wave by casting an AoE spell and marking every
@@ -1024,7 +1062,7 @@ module Treim
 
       boss = bosses.sample
       @current_boss_id = boss.id
-      echo boss.noun if Char.name =~ /Tysong/
+      echo boss.noun if Config.debug_echo?
       until Attack.perform; end
 
       progress = ClearProgress.check(target_id: boss.id)
@@ -1075,13 +1113,13 @@ module Treim
       GameObj.npcs.each { |npc| @seen_ids << npc.id unless @seen_ids.include?(npc.id) }
     end
 
-    # Sends message to the familiar window, gated to a set of characters
-    # who want the extra status chatter.
+    # Sends message to the familiar window, gated behind
+    # {Config.mob_count_window?} for players who want the extra chatter.
     #
     # @param message [String] the status text to display
     # @return [void]
     def announce_mob_count(message)
-      return unless Char.name =~ /Tysong|Gharr|Rasko/
+      return unless Config.mob_count_window?
 
       _respond FamiliarWindow.wrap(message)
     end

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -651,7 +651,7 @@ module Treim
       scrip = nil
       time_left = nil
 
-      Lich::Util.issue_command("REIM INFO", START_PATTERN, END_PATTERN, silent: true, quiet: true).each do |line|
+      Lich::Util.issue_command("REIM INFO", START_PATTERN, END_PATTERN, usexml: false, silent: true, quiet: true).each do |line|
         case line
         when CLEAR_TO_PATTERN then clear_to = Regexp.last_match(1).split.first
         when SCRIP_PATTERN    then scrip = Regexp.last_match(1).to_i
@@ -1298,7 +1298,7 @@ module Treim
   # @return [String, nil] the prename text before the character's name, or
   #   nil if there wasn't one
   def capture_title_prename
-    lines = Lich::Util.issue_command("title show", /#{Regexp.escape(Char.name)}/, silent: true, quiet: true, timeout: 5)
+    lines = Lich::Util.issue_command("title show", /#{Regexp.escape(Char.name)}/, usexml: false, silent: true, quiet: true, timeout: 5)
     # "title show" responds e.g. "Your current TITLE display is: High Lady
     # <name> the Runemaster." -- capture only what's between the label's
     # trailing colon and the character's name, not the label text itself.

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -70,92 +70,19 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 3.0.2
+    version: 3.0.0
 
   To help contribute or open an issue: https://github.com/elanthia-online/scripts
 
     changelog:
-      3.0.2 (2026-08-22)
-        Nitpick follow-ups on top of 3.0.1:
-        - The hard-coded `Char.name =~ /Tysong/`-style gates (progress-scrip
-          echo, flood-wave AoE response, sampled-boss-noun echo, familiar-
-          window mob-count status) are now two Config keys instead:
-          `debug_echo` and `mob_count_window`. Both default to true for
-          exactly the names the old hard-coded checks used, so behavior is
-          unchanged by default; everyone else can now opt in via
-          `;e UserVars.treim[:debug_echo] = TRUE` /
-          `;e UserVars.treim[:mob_count_window] = TRUE` instead of needing
-          a script edit.
-        - Documented that `spell_then_mstrike` intentionally leaves the
-          character in offensive stance after an affordable round, matching
-          the legacy attack_routine this replaced.
-      3.0.1 (2026-08-22)
-        Review fixes on top of the 3.0.0 rewrite:
-        - Bugfix: `COMMON_NOUNS` had a truncated "highwaywoma" (never matched
-          the real "highwaywoman" noun, so a wave containing only that NPC
-          could be skipped); `BOSS_NOUNS` had a bogus truncated "ook" entry
-          and duplicate "Captain"/"traveller" entries. Fixed/deduped.
-        - Bugfix: `Spell[n].affordable?` raised NoMethodError for any
-          unrecognized spell number (`Spell[]` returns nil, not an
-          affordability object) -- reachable via a typo'd `;treim <number>`.
-          Added a shared `Attack.affordable?` guard used everywhere the
-          old direct call was.
-        - Bugfix: `ClearProgress::HOURS_PATTERN` required the literal
-          singular "hour", so it never matched REIM's own "2 hours and 15
-          minutes remaining" phrasing once 2+ hours were left; `time_left`
-          silently came back nil in that window. Now matches "hour(s)".
-        - Bugfix: a Clearcheck whisper sent while holding a stage the group
-          already cleared past could hang forever -- `@current_boss_id` was
-          being set to a boss the run had detected but was intentionally
-          not attacking (holding), and `ClearProgress.wait_for_death` had no
-          timeout. Moved `@current_boss_id` back to only track a boss that's
-          actually about to be fought, and added `DEATH_WAIT_TIMEOUT` (30s)
-          to `wait_for_death` as a backstop against any other case.
-        - Bugfix: `capture_title_prename` captured the whole "Your current
-          TITLE display is:" label along with the prename, not just the
-          prename, so a restored title after REIM would have included the
-          label text. Anchored the capture to start after the label's colon.
-        - Every `unless const_defined?(:X)` guard in this file now passes
-          `inherit: false` (`const_defined?(:X, false)`). Lich runs every
-          `.lic` script in one process; without this, a guard here could
-          find an unrelated top-level constant of the same name defined by
-          some *other* script (e.g. a top-level `VILLAGE` or `Result`) and
-          skip defining this file's own version, leaving bare references
-          inside `Treim` silently resolving to that foreign constant.
-      3.0.0 (2026-08-21)
-        Modernized for Ruby 4.0 / current Lich5 conventions:
-        - Namespaced everything under `Treim`; all constants guarded with
-          `unless const_defined?` so repeated `;treim` invocations in the same
-          Lich process never warn/redefine.
-        - Replaced manual `GROUP` command parsing with the native `Group` API
-          (lib/gemstone/group.rb), which tracks membership/leader passively.
-        - Replaced the hand-rolled `silence` proc + DownstreamHook add/remove
-          pairs with `Lich::Util.issue_command` for REIM INFO and title-show
-          parsing; this also removed the last need for the old silence proc
-          entirely, since neither replacement leaves anything to suppress.
-        - Replaced the `$frontend =~ /stormfront|profanity/` check with
-          `Lich::Common::Frontend.supports_xml?`.
-        - Boss-wave stage progression (Village -> Road -> ... -> Royal) is now
-          data-driven (Treim::Geography::STAGES) instead of five copy-pasted
-          `elsif` branches.
-        - The ~10 near-identical stance-dance/attack blocks in the old
-          attack_routine collapsed into a handful of shared helpers behind a
-          `case` dispatch in Treim::Attack.
-        - Bugfix: `variable[2].downcase == "leader"` raised NoMethodError on
-          every invocation that didn't pass a second argument (i.e. almost
-          always) because `variable[2]` is nil, not "". Now uses `&.downcase`.
-        - Bugfix: the help-vs-reuse-last-attack-type check raised the same
-          NoMethodError when re-running `;treim` with no arguments after an
-          attack type had already been configured. Rewritten as an explicit,
-          non-crashing branch.
-        - Removed a room-marker check in the main loop that could never take
-          its "already visited" branch (the branch that would have updated
-          the marker was unreachable), so the wave/whisper handling block ran
-          unconditionally on every line anyway; the dead branch is gone and
-          behavior is unchanged.
-        - Removed a redundant second re-scan of "unseen bosses" during the
-          stage-hold path; the ids were already marked seen immediately above
-          it, so the second scan was always a no-op.
+      3.0.0 (2026-08-22)
+      Full rewrite for current Ruby/Lich5 compatibility, no setup changes needed
+      Fixed a couple rare crash bugs (missing leader argument, re-running with no attack type set)
+      Fixed REIM INFO time-remaining not showing once 2+ hours were left
+      Fixed a whisper "clearcheck" possibly freezing the script during a hold
+      Fixed title restore after REIM sometimes including extra text
+      Fixed a couple mistyped creature names that could cause a wave to be skipped
+      Added debug_echo and mob_count_window UserVars options (previously hardcoded to a few characters)
       2.24.2 (2023-05-19)
       Fix for new GROUP output
       Rubocop cleanup

--- a/scripts/treim.lic
+++ b/scripts/treim.lic
@@ -62,11 +62,44 @@
      author: Tysong (horibu on PC)
        name: treim
        tags: reim
-    version: 3.0.0
+    version: 3.0.1
 
   To help contribute or open an issue: https://github.com/elanthia-online/scripts
 
     changelog:
+      3.0.1 (2026-08-22)
+        Review fixes on top of the 3.0.0 rewrite:
+        - Bugfix: `COMMON_NOUNS` had a truncated "highwaywoma" (never matched
+          the real "highwaywoman" noun, so a wave containing only that NPC
+          could be skipped); `BOSS_NOUNS` had a bogus truncated "ook" entry
+          and duplicate "Captain"/"traveller" entries. Fixed/deduped.
+        - Bugfix: `Spell[n].affordable?` raised NoMethodError for any
+          unrecognized spell number (`Spell[]` returns nil, not an
+          affordability object) -- reachable via a typo'd `;treim <number>`.
+          Added a shared `Attack.affordable?` guard used everywhere the
+          old direct call was.
+        - Bugfix: `ClearProgress::HOURS_PATTERN` required the literal
+          singular "hour", so it never matched REIM's own "2 hours and 15
+          minutes remaining" phrasing once 2+ hours were left; `time_left`
+          silently came back nil in that window. Now matches "hour(s)".
+        - Bugfix: a Clearcheck whisper sent while holding a stage the group
+          already cleared past could hang forever -- `@current_boss_id` was
+          being set to a boss the run had detected but was intentionally
+          not attacking (holding), and `ClearProgress.wait_for_death` had no
+          timeout. Moved `@current_boss_id` back to only track a boss that's
+          actually about to be fought, and added `DEATH_WAIT_TIMEOUT` (30s)
+          to `wait_for_death` as a backstop against any other case.
+        - Bugfix: `capture_title_prename` captured the whole "Your current
+          TITLE display is:" label along with the prename, not just the
+          prename, so a restored title after REIM would have included the
+          label text. Anchored the capture to start after the label's colon.
+        - Every `unless const_defined?(:X)` guard in this file now passes
+          `inherit: false` (`const_defined?(:X, false)`). Lich runs every
+          `.lic` script in one process; without this, a guard here could
+          find an unrelated top-level constant of the same name defined by
+          some *other* script (e.g. a top-level `VILLAGE` or `Result`) and
+          skip defining this file's own version, leaving bare references
+          inside `Treim` silently resolving to that foreign constant.
       3.0.0 (2026-08-21)
         Modernized for Ruby 4.0 / current Lich5 conventions:
         - Namespaced everything under `Treim`; all constants guarded with
@@ -218,30 +251,30 @@ module Treim
     #     holding at this stage; true for every stage except village, which
     #     is legacy-inconsistent with the rest but preserved verbatim from
     #     the original per-stage elsif chain rather than "fixed" silently
-    Stage = Data.define(:name, :rooms, :next_stage, :pause_before_next) unless const_defined?(:Stage)
+    Stage = Data.define(:name, :rooms, :next_stage, :pause_before_next) unless const_defined?(:Stage, false)
 
     # @return [Array<Integer>] room ids for the Village stage
-    VILLAGE   = [24888, 24900, 24904, 24909, 24935, 24936, 24912, 24919, 24946, 24945, 24952, 24964, 24971, 24972, 24958, 24959, 24931, 24932, 24966, 24953, 25300, 24901, 24930, 23484, 24941, 23650].freeze unless const_defined?(:VILLAGE)
+    VILLAGE   = [24888, 24900, 24904, 24909, 24935, 24936, 24912, 24919, 24946, 24945, 24952, 24964, 24971, 24972, 24958, 24959, 24931, 24932, 24966, 24953, 25300, 24901, 24930, 23484, 24941, 23650].freeze unless const_defined?(:VILLAGE, false)
     # @return [Array<Integer>] room ids for the Road stage
-    ROAD      = [24977, 24978, 24989, 24990, 24991, 24994, 24995, 24996, 24998, 25003, 25004, 25020, 25019, 25021, 24997, 25022, 25029, 25030, 25035, 25042, 25047, 25046, 25043, 25041, 25048, 25049, 25050, 25051, 25052, 25053, 25054, 25056, 25057, 25058, 25059, 25064, 25055, 25060, 25061, 25062, 25063].freeze unless const_defined?(:ROAD)
+    ROAD      = [24977, 24978, 24989, 24990, 24991, 24994, 24995, 24996, 24998, 25003, 25004, 25020, 25019, 25021, 24997, 25022, 25029, 25030, 25035, 25042, 25047, 25046, 25043, 25041, 25048, 25049, 25050, 25051, 25052, 25053, 25054, 25056, 25057, 25058, 25059, 25064, 25055, 25060, 25061, 25062, 25063].freeze unless const_defined?(:ROAD, false)
     # @return [Array<Integer>] room ids for the Courtyard stage
-    COURTYARD = [25104, 25103, 25101, 25100, 25105, 25102, 25106, 25107, 25108, 25099, 25098, 25097, 25069, 25068, 25070, 25071, 25072, 25082, 25084, 25083, 25081, 25078, 25085, 25086, 25087, 25088, 25096, 25095, 25094, 25093, 25092, 25091, 25090, 25089, 25080, 25079, 25077, 25075, 25073, 25076, 25074, 25067, 25066, 25065].freeze unless const_defined?(:COURTYARD)
+    COURTYARD = [25104, 25103, 25101, 25100, 25105, 25102, 25106, 25107, 25108, 25099, 25098, 25097, 25069, 25068, 25070, 25071, 25072, 25082, 25084, 25083, 25081, 25078, 25085, 25086, 25087, 25088, 25096, 25095, 25094, 25093, 25092, 25091, 25090, 25089, 25080, 25079, 25077, 25075, 25073, 25076, 25074, 25067, 25066, 25065].freeze unless const_defined?(:COURTYARD, false)
     # @return [Array<Integer>] room ids for the Servant Quarters stage
-    SERVANT   = [25113, 25114, 25115, 25119, 25118, 25117, 25116, 25112, 25111, 25110, 25109].freeze unless const_defined?(:SERVANT)
+    SERVANT   = [25113, 25114, 25115, 25119, 25118, 25117, 25116, 25112, 25111, 25110, 25109].freeze unless const_defined?(:SERVANT, false)
     # @return [Array<Integer>] room ids for the Visitor's Quarters stage
-    VISITOR   = [25125, 25124, 25123, 25129, 25128, 25127, 25126, 25122, 25121, 25120].freeze unless const_defined?(:VISITOR)
+    VISITOR   = [25125, 25124, 25123, 25129, 25128, 25127, 25126, 25122, 25121, 25120].freeze unless const_defined?(:VISITOR, false)
     # @return [Array<Integer>] room ids for the Royal Quarters stage
-    ROYAL     = [25141, 25140, 25132, 25134, 25136, 25135, 25137, 25138, 25139, 25133, 25131, 25130].freeze unless const_defined?(:ROYAL)
+    ROYAL     = [25141, 25140, 25132, 25134, 25136, 25135, 25137, 25138, 25139, 25133, 25131, 25130].freeze unless const_defined?(:ROYAL, false)
     # @return [Array<Integer>] room ids outside the main stage progression
     #   that are still considered "in REIM" (e.g. the entry room)
-    MISC_AREAS = [24965].freeze unless const_defined?(:MISC_AREAS)
+    MISC_AREAS = [24965].freeze unless const_defined?(:MISC_AREAS, false)
 
     # @return [Integer] room id of the throne room, where the script idles
     #   between runs
-    THRONE_ROOM_ID = 25142 unless const_defined?(:THRONE_ROOM_ID)
+    THRONE_ROOM_ID = 25142 unless const_defined?(:THRONE_ROOM_ID, false)
     # @return [Integer] room id the character lands in when REIM ends,
     #   which triggers {Treim::Runner#finish}
-    EXIT_ROOM_ID   = 25143 unless const_defined?(:EXIT_ROOM_ID)
+    EXIT_ROOM_ID   = 25143 unless const_defined?(:EXIT_ROOM_ID, false)
 
     # @return [Array<Stage>] every stage in clear-order, village through royal
     STAGES = [
@@ -251,11 +284,11 @@ module Treim
       Stage.new(name: "servant",   rooms: SERVANT,   next_stage: "visitor",   pause_before_next: true),
       Stage.new(name: "visitor",   rooms: VISITOR,   next_stage: "royal",     pause_before_next: true),
       Stage.new(name: "royal",     rooms: ROYAL,     next_stage: "throne",    pause_before_next: true)
-    ].freeze unless const_defined?(:STAGES)
+    ].freeze unless const_defined?(:STAGES, false)
 
     # @return [Array<Integer>] every room id considered "in REIM", sorted;
     #   the union of every stage's rooms plus {MISC_AREAS}
-    ALL_ROOMS = (STAGES.flat_map(&:rooms) | MISC_AREAS).sort.freeze unless const_defined?(:ALL_ROOMS)
+    ALL_ROOMS = (STAGES.flat_map(&:rooms) | MISC_AREAS).sort.freeze unless const_defined?(:ALL_ROOMS, false)
 
     module_function
 
@@ -292,15 +325,15 @@ module Treim
     COMMON_NOUNS = %w[
       commoner denizen guard guardsman guardswoman inmate lunatic madman madwoman peasant prisoner
       squire swordsman swordswoman traveller townsman townswoman villager bandit highwayman
-      highwaywoma marauder waylayer guest maid noble knight servant slave steward visitor dancer
-      juggler nomad traveller
-    ].freeze unless const_defined?(:COMMON_NOUNS)
+      highwaywoman marauder waylayer guest maid noble knight servant slave steward visitor dancer
+      juggler nomad
+    ].freeze unless const_defined?(:COMMON_NOUNS, false)
 
     # @return [Array<String>] `GameObj#noun` values for rare/boss REIM NPCs
     BOSS_NOUNS = %w[
-      Cook Shopkeeper Innkeeper Bartender Leader Lord Lady Queen King Captain Captain Sergeant
-      Hostler Master Torturer Butler ook Captain Dignitary Prince Princess Jester Emperor Empress
-    ].freeze unless const_defined?(:BOSS_NOUNS)
+      Cook Shopkeeper Innkeeper Bartender Leader Lord Lady Queen King Captain Sergeant
+      Hostler Master Torturer Butler Dignitary Prince Princess Jester Emperor Empress
+    ].freeze unless const_defined?(:BOSS_NOUNS, false)
 
     # @return [Regexp] matches the full `GameObj#name` (ethereal-flavor
     #   prefix plus noun, or a bare boss name) of any REIM NPC, common or
@@ -314,14 +347,14 @@ module Treim
       Guard\ Captain|Wall\ Captain|Drill\ Sergeant|Stable\ Hostler|Dungeon\ Master|Master\ Torturer|
       Butler|Cook|Knight\ Captain|Foreign\ Dignitary|Royal\ Prince|Royal\ Princess|Royal\ Jester|
       Royal\ Emperor|Royal\ Empress
-    /x unless const_defined?(:NPC_NAME_REGEX)
+    /x unless const_defined?(:NPC_NAME_REGEX, false)
   end
 
   # Fixed-size ring buffer of already-seen NPC ids, so a wave's mobs are
   # only announced/attacked once even as GameObj.npcs gets rescanned.
   class SeenIds
     # @return [Integer] default capacity when none is given to {#initialize}
-    DEFAULT_MAX_SIZE = 200 unless const_defined?(:DEFAULT_MAX_SIZE)
+    DEFAULT_MAX_SIZE = 200 unless const_defined?(:DEFAULT_MAX_SIZE, false)
 
     # @param max_size [Integer] how many ids to retain before the oldest
     #   are evicted
@@ -356,7 +389,7 @@ module Treim
   module Config
     # @return [Regexp] characters that get rares announced by default when
     #   {UserVars.treim}[:announce_rares] hasn't been set yet
-    DEFAULT_ANNOUNCER_NAMES = /Tysong|Durakar|Siierra|Ragz|Nairdin|Ylandra|Gharr|Ordim/ unless const_defined?(:DEFAULT_ANNOUNCER_NAMES)
+    DEFAULT_ANNOUNCER_NAMES = /Tysong|Durakar|Siierra|Ragz|Nairdin|Ylandra|Gharr|Ordim/ unless const_defined?(:DEFAULT_ANNOUNCER_NAMES, false)
 
     module_function
 
@@ -499,7 +532,7 @@ module Treim
     # @param incant [String] the incant argument, e.g. "1030 open"
     # @return [true]
     def spell_then_mstrike(spell_number, incant)
-      return physical("mstrike") unless Spell[spell_number].affordable?
+      return physical("mstrike") unless affordable?(spell_number)
 
       waitrt?
       waitcastrt?
@@ -521,7 +554,7 @@ module Treim
     #   roundtime/cast-roundtime have cleared
     # @return [true]
     def cast_only(spell_number, incant, pause_before: 0)
-      return true unless Spell[spell_number].affordable?
+      return true unless affordable?(spell_number)
 
       waitrt?
       waitcastrt?
@@ -537,7 +570,7 @@ module Treim
     # @param release_command [String] the follow-up command, e.g. "stop 709"
     # @return [true]
     def cast_and_release(spell_number, release_command)
-      return true unless Spell[spell_number].affordable?
+      return true unless affordable?(spell_number)
 
       waitrt?
       waitcastrt?
@@ -554,7 +587,7 @@ module Treim
     #   affordability/cast
     # @return [true]
     def cast_generic(spell_number)
-      return true unless Spell[spell_number].affordable?
+      return true unless affordable?(spell_number)
 
       waitrt?
       waitcastrt?
@@ -562,6 +595,20 @@ module Treim
       put "incant #{spell_number}"
       defensive_stance! if Config.stance_dance?
       true
+    end
+
+    # Whether spell_number names a spell the character both knows and can
+    # currently afford. Guards against an unrecognized spell number (e.g. a
+    # typo'd `;treim 9999`), which `Spell[]` reports as nil rather than
+    # raising, so calling `.affordable?` directly on it would crash.
+    #
+    # @param spell_number [Integer, String] the spell to check
+    # @return [Boolean]
+    def affordable?(spell_number)
+      spell = Spell[spell_number]
+      return false unless spell
+
+      spell.affordable?
     end
 
     # Switches to offensive stance if not already there.
@@ -586,19 +633,24 @@ module Treim
   module ClearProgress
     # @return [Regexp] matches the first line of the REIM INFO response, so
     #   `issue_command` starts capturing immediately
-    START_PATTERN = /\S/ unless const_defined?(:START_PATTERN)
+    START_PATTERN = /\S/ unless const_defined?(:START_PATTERN, false)
     # @return [Regexp] matches the final line of the REIM INFO response,
     #   ending capture
-    END_PATTERN   = /You have slain a total of/ unless const_defined?(:END_PATTERN)
+    END_PATTERN   = /You have slain a total of/ unless const_defined?(:END_PATTERN, false)
 
     # @return [Regexp] captures the stage name the group is cleared through
-    CLEAR_TO_PATTERN = /currently flagged for entry for up to the(.*)\./ unless const_defined?(:CLEAR_TO_PATTERN)
+    CLEAR_TO_PATTERN = /currently flagged for entry for up to the(.*)\./ unless const_defined?(:CLEAR_TO_PATTERN, false)
     # @return [Regexp] captures the ethereal scrip earned this run
-    SCRIP_PATTERN    = %r{Total Ethereal Scrip for this run: (.*)/} unless const_defined?(:SCRIP_PATTERN)
+    SCRIP_PATTERN    = %r{Total Ethereal Scrip for this run: (.*)/} unless const_defined?(:SCRIP_PATTERN, false)
     # @return [Regexp] captures "H hour(s) and M minute(s) remaining"
-    HOURS_PATTERN    = /You have (.*) hour and (.*) minutes? remaining/ unless const_defined?(:HOURS_PATTERN)
+    HOURS_PATTERN    = /You have (.*) hours? and (.*) minutes? remaining/ unless const_defined?(:HOURS_PATTERN, false)
     # @return [Regexp] captures "M minute(s) remaining" (under an hour left)
-    MINUTES_PATTERN  = /You have ([0-9]{1,2}) minutes? remaining\./ unless const_defined?(:MINUTES_PATTERN)
+    MINUTES_PATTERN  = /You have ([0-9]{1,2}) minutes? remaining\./ unless const_defined?(:MINUTES_PATTERN, false)
+
+    # @return [Numeric] max seconds {.wait_for_death} blocks for a target
+    #   that never dies (e.g. one the caller never actually attacked)
+    #   before giving up and checking REIM INFO anyway
+    DEATH_WAIT_TIMEOUT = 30 unless const_defined?(:DEATH_WAIT_TIMEOUT, false)
 
     # @!attribute [r] clear_to
     #   @return [String, nil] stage name the group is cleared through
@@ -607,7 +659,7 @@ module Treim
     #   @return [Integer, nil] ethereal scrip earned this run
     # @!attribute [r] time_left
     #   @return [String, nil] remaining time as "XH YM" or "YM"
-    Result = Data.define(:clear_to, :scrip, :time_left) unless const_defined?(:Result)
+    Result = Data.define(:clear_to, :scrip, :time_left) unless const_defined?(:Result, false)
 
     module_function
 
@@ -639,12 +691,21 @@ module Treim
       Result.new(clear_to: clear_to, scrip: scrip, time_left: time_left)
     end
 
-    # Blocks until the given NPC is confirmed dead (or was never alive).
+    # Blocks until the given NPC is confirmed dead (or was never alive), up
+    # to {DEATH_WAIT_TIMEOUT} seconds. Bounded rather than unconditional so a
+    # target that's alive but was never actually attacked -- e.g. one seen
+    # only while holding a stage the group already cleared past -- can't
+    # wedge this (and a caller like the clearcheck whisper handler) forever.
     #
     # @param target_id [String, Integer] id of the NPC to wait on
     # @return [void]
     def wait_for_death(target_id)
-      pause 0.5 while GameObj.npcs.any? { |npc| npc.id == target_id && !npc.status.include?("dead") }
+      deadline = Time.now + DEATH_WAIT_TIMEOUT
+      while GameObj.npcs.any? { |npc| npc.id == target_id && !npc.status.include?("dead") }
+        return if Time.now > deadline
+
+        pause 0.5
+      end
     end
   end
 
@@ -677,13 +738,13 @@ module Treim
   # support it, falling back to the legacy GSe/GSf tags.
   module FamiliarWindow
     # @return [String] opening tag for the modern pushStream-based familiar window
-    STREAM_BEGIN = "<pushStream id=\"familiar\" ifClosedStyle=\"watching\"/>" unless const_defined?(:STREAM_BEGIN)
+    STREAM_BEGIN = "<pushStream id=\"familiar\" ifClosedStyle=\"watching\"/>" unless const_defined?(:STREAM_BEGIN, false)
     # @return [String] closing tag for the modern pushStream-based familiar window
-    STREAM_END   = "<popStream/>\r\n" unless const_defined?(:STREAM_END)
+    STREAM_END   = "<popStream/>\r\n" unless const_defined?(:STREAM_END, false)
     # @return [String] opening escape sequence for the legacy familiar window
-    LEGACY_BEGIN = "\034GSe\r\n" unless const_defined?(:LEGACY_BEGIN)
+    LEGACY_BEGIN = "\034GSe\r\n" unless const_defined?(:LEGACY_BEGIN, false)
     # @return [String] closing escape sequence for the legacy familiar window
-    LEGACY_END   = "\034GSf\r\n" unless const_defined?(:LEGACY_END)
+    LEGACY_END   = "\034GSf\r\n" unless const_defined?(:LEGACY_END, false)
 
     module_function
 
@@ -707,7 +768,7 @@ module Treim
   KILL_NOUNS = [
     "Murder", "Kill", "Slaughter", "Abolish", "Exterminate", "Wreck", "Demolish", "Massacre",
     "Obliterate", "Crush", "Tickley tickle", "Kiss", "Hug"
-  ].freeze unless const_defined?(:KILL_NOUNS)
+  ].freeze unless const_defined?(:KILL_NOUNS, false)
 
   # @return [Array<String>] script names killed when
   #   {Treim::Config.lag_control?} is enabled, before combat brief/no-numbers
@@ -715,17 +776,17 @@ module Treim
   LAG_SCRIPTS = %w[
     rnum duskruin_watch prettiernum killcounter title sorter inspectweight inspectarmor uberbounty
     autovote chatfail enchantnotes
-  ].freeze unless const_defined?(:LAG_SCRIPTS)
+  ].freeze unless const_defined?(:LAG_SCRIPTS, false)
 
   # @return [Array<String>] spam-filter script names auto-started (if
   #   installed) when {Treim::Config.spam_control?} is enabled, and killed
   #   on shutdown
-  SPAM_SCRIPTS = %w[briefcombat spellmerge].freeze unless const_defined?(:SPAM_SCRIPTS)
+  SPAM_SCRIPTS = %w[briefcombat spellmerge].freeze unless const_defined?(:SPAM_SCRIPTS, false)
 
   # @return [Array<String>] characters excluded from running this script.
   #   Empty by default; edit locally if you need to keep a specific
   #   character off of it.
-  BLACKLIST = [].freeze unless const_defined?(:BLACKLIST)
+  BLACKLIST = [].freeze unless const_defined?(:BLACKLIST, false)
 
   # @return [Hash{String => String}] exact REIM trap warning lines mapped
   #   to the command that dodges them
@@ -735,10 +796,10 @@ module Treim
     "A pair of ethereal hands shoot up from the ground, straight for your legs!"       => "jump",
     "An ethereal chain lashes out from the shadows straight for your head!"            => "duck",
     "An ethereal chain lashes out from the shadows straight for your legs!"            => "jump"
-  }.freeze unless const_defined?(:TRAP_RESPONSES)
+  }.freeze unless const_defined?(:TRAP_RESPONSES, false)
 
   # @return [String] the `;treim help` / no-argument-and-unconfigured usage text
-  HELP_TEXT = <<~HELP unless const_defined?(:HELP_TEXT)
+  HELP_TEXT = <<~HELP unless const_defined?(:HELP_TEXT, false)
     SYNTAX - ;treim <ATTACKOPTION>
     Will remember last used attack option if none given.
 
@@ -939,6 +1000,12 @@ module Treim
     # holds (if the group has already cleared past this stage) or fights
     # one sampled boss and rechecks clear progress afterward.
     #
+    # @current_boss_id is only set once a boss is actually about to be
+    # fought, not merely detected: setting it during a stage-hold would
+    # point a later clearcheck whisper at an NPC this run never attacks,
+    # and {ClearProgress.wait_for_death} would burn its whole timeout
+    # waiting on it every time.
+    #
     # @param bosses [Array<GameObj>] unseen boss/rare NPCs from this spawn
     # @param clear_to [String, nil] the current known clear-to stage name
     # @return [String, nil] the (possibly updated) clear-to stage name
@@ -949,15 +1016,14 @@ module Treim
         @seen_ids << boss.id
       end
 
-      boss = bosses.sample
-      @current_boss_id = boss.id
-
       stage = Geography.stage_holding(Room.current.id, clear_to)
       if stage
         pause 2 if stage.pause_before_next
         return clear_to
       end
 
+      boss = bosses.sample
+      @current_boss_id = boss.id
       echo boss.noun if Char.name =~ /Tysong/
       until Attack.perform; end
 
@@ -1255,7 +1321,10 @@ module Treim
   #   nil if there wasn't one
   def capture_title_prename
     lines = Lich::Util.issue_command("title show", /#{Regexp.escape(Char.name)}/, silent: true, quiet: true, timeout: 5)
-    match = lines.first&.match(/(.*?) #{Regexp.escape(Char.name)}/)
+    # "title show" responds e.g. "Your current TITLE display is: High Lady
+    # <name> the Runemaster." -- capture only what's between the label's
+    # trailing colon and the character's name, not the label text itself.
+    match = lines.first&.match(/:\s*(.*?)\s+#{Regexp.escape(Char.name)}\b/)
     match && match[1]
   end
 end

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../spec_helper'
+
 # RSpec for ELoot::Loot.pool_full_recovery? (the sell-and-return recovery decision).
 #
 # Run: rspec pool_full_recovery_spec.rb
@@ -10,7 +12,8 @@
 # the real method body from eloot.lic and evaluates it into a bare module. The predicate
 # is pure -- all state is passed as arguments -- so it needs no Lich runtime to exercise.
 # If the source or method cannot be found, the spec fails loudly instead of passing on a
-# stale copy.
+# stale copy. Path lookup and extraction use the shared helpers in spec/spec_helper.rb;
+# nothing else from there is needed since this predicate takes no Lich globals at all.
 
 RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
   # Extract only the pure predicate from eloot.lic and eval it into an isolated module.
@@ -19,17 +22,9 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
   # Sourcing the real method keeps this spec from drifting from the shipped code; if the
   # source or method cannot be found, it fails loudly rather than passing on a stale copy.
   let(:predicate) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    body = File.read(path)[/^ {4}def self\.pool_full_recovery\?[\s\S]*?^ {4}end$/]
-    raise "pool_full_recovery? could not be extracted from #{path}" unless body
+    path = find_lic_source('eloot.lic', from: __dir__)
+    body = extract_from_source(File.read(path), /^ {4}def self\.pool_full_recovery\?[\s\S]*?^ {4}end$/,
+                               label: 'pool_full_recovery?', source_path: path)
 
     Module.new { module_eval(body) }
   end
@@ -105,24 +100,11 @@ end
 # or method cannot be found the spec fails loudly rather than passing on a stale copy.
 
 RSpec.describe 'ELoot::Loot.loot_specials' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:method_body) do
-    body = File.read(eloot_path)[/^ {4}def self\.loot_specials\b[\s\S]*?^ {4}end$/]
-    raise "loot_specials could not be extracted from #{eloot_path}" unless body
-
-    body
+    extract_from_source(File.read(eloot_path), /^ {4}def self\.loot_specials\b[\s\S]*?^ {4}end$/,
+                        label: 'loot_specials', source_path: eloot_path)
   end
 
   # A minimal GameObj stand-in -- only the readers loot_specials touches.

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
   # source or method cannot be found, it fails loudly rather than passing on a stale copy.
   let(:predicate) do
     path = find_lic_source('eloot.lic', from: __dir__)
-    body = extract_from_source(File.read(path), /^ {4}def self\.pool_full_recovery\?[\s\S]*?^ {4}end$/,
-                               label: 'pool_full_recovery?', source_path: path)
+    body = extract_lic_method(File.read(path), 'pool_full_recovery?', source_path: path)
 
     Module.new { module_eval(body) }
   end
@@ -102,10 +101,7 @@ end
 RSpec.describe 'ELoot::Loot.loot_specials' do
   let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
-  let(:method_body) do
-    extract_from_source(File.read(eloot_path), /^ {4}def self\.loot_specials\b[\s\S]*?^ {4}end$/,
-                        label: 'loot_specials', source_path: eloot_path)
-  end
+  let(:method_body) { extract_lic_method(File.read(eloot_path), 'loot_specials', source_path: eloot_path) }
 
   # A minimal GameObj stand-in -- only the readers loot_specials touches.
   let(:obj_class) { Struct.new(:name, :type, :id) }
@@ -266,30 +262,12 @@ end
 # the shipped source.
 
 RSpec.describe 'ELoot box-looting call sites' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  def method_body(source, name)
-    body = source[/^ {4}def self\.#{Regexp.escape(name)}\b[\s\S]*?^ {4}end$/]
-    raise "#{name} could not be extracted from eloot.lic" unless body
-
-    body
-  end
-
-  let(:box_loot) { method_body(source, 'box_loot') }
-  let(:box_loot_ground) { method_body(source, 'box_loot_ground') }
+  let(:box_loot) { extract_lic_method(source, 'box_loot', source_path: eloot_path) }
+  let(:box_loot_ground) { extract_lic_method(source, 'box_loot_ground', source_path: eloot_path) }
 
   it 'box_loot hands the box to loot_specials so a full-container stow can recover' do
     expect(box_loot).to match(/Loot\.loot_specials\([^)]*\bbox:\s*box\b/)
@@ -340,7 +318,7 @@ RSpec.describe 'ELoot box-looting call sites' do
     end
 
     it 'loot_regular actually returns the :recovered it documents, not nil' do
-      loot_regular = method_body(source, 'loot_regular')
+      loot_regular = extract_lic_method(source, 'loot_regular', source_path: eloot_path)
 
       expect(loot_regular).to match(/return :recovered if/)
       expect(loot_regular).not_to match(/^ +return if .*== :recovered$/)
@@ -356,18 +334,7 @@ end
 # never opens, so the predicate and the routing are pinned here.
 
 RSpec.describe 'ELoot::Sell.town_openable?' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -462,31 +429,13 @@ RSpec.describe 'ELoot::Sell.town_openable?' do
 end
 
 RSpec.describe 'ELoot::Sell.process_boxes routing' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  def method_body(source, name)
-    body = source[/^ {4}def self\.#{Regexp.escape(name)}\b[\s\S]*?^ {4}end$/]
-    raise "#{name} could not be extracted from eloot.lic" unless body
-
-    body
-  end
-
-  let(:process_boxes) { method_body(source, 'process_boxes') }
-  let(:locksmith) { method_body(source, 'locksmith') }
-  let(:locksmith_open) { method_body(source, 'locksmith_open') }
+  let(:process_boxes) { extract_lic_method(source, 'process_boxes', source_path: eloot_path) }
+  let(:locksmith) { extract_lic_method(source, 'locksmith', source_path: eloot_path) }
+  let(:locksmith_open) { extract_lic_method(source, 'locksmith_open', source_path: eloot_path) }
 
   # process_boxes cannot be exercised without the Lich runtime, so the routing invariants
   # are asserted against the shipped source.
@@ -529,30 +478,12 @@ end
 # of its own, though, so it is exercised for real against a small stand-in for Sell/ELoot.
 
 RSpec.describe 'ELoot::Sell locksmith_priority routing' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  def method_body(source, name)
-    body = source[/^ {4}def self\.#{Regexp.escape(name)}\b[\s\S]*?^ {4}end$/]
-    raise "#{name} could not be extracted from eloot.lic" unless body
-
-    body
-  end
-
-  let(:process_boxes) { method_body(source, 'process_boxes') }
-  let(:route_town_then_pool_body) { method_body(source, 'route_town_then_pool') }
+  let(:process_boxes) { extract_lic_method(source, 'process_boxes', source_path: eloot_path) }
+  let(:route_town_then_pool_body) { extract_lic_method(source, 'route_town_then_pool', source_path: eloot_path) }
 
   it 'defaults locksmith_priority to pool, so existing setups keep their current behavior' do
     line = source[/^\s*locksmith_priority: \{ default: '(\w+)' \},$/, 1]
@@ -711,27 +642,11 @@ end
 # the spec fails loudly rather than passing on a stale copy.
 
 RSpec.describe 'ELoot.marked_unsellable?' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  let(:method_body) do
-    body = source[/^ {2}def self\.marked_unsellable\?[\s\S]*?^ {2}end$/]
-    raise "marked_unsellable? could not be extracted from #{eloot_path}" unless body
-
-    body
-  end
+  let(:method_body) { extract_lic_method(source, 'marked_unsellable?', source_path: eloot_path) }
 
   let(:obj_class) { Struct.new(:name, :id) }
 
@@ -812,27 +727,11 @@ RSpec.describe 'ELoot.marked_unsellable?' do
 end
 
 RSpec.describe 'ELoot.toss' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  let(:method_body) do
-    body = source[/^ {2}def self\.toss\b[\s\S]*?^ {2}end$/]
-    raise "toss could not be extracted from #{eloot_path}" unless body
-
-    body
-  end
+  let(:method_body) { extract_lic_method(source, 'toss', source_path: eloot_path) }
 
   let(:obj_class) { Struct.new(:name, :id) }
   let(:item) { obj_class.new('a rusty dagger', '12345') }
@@ -1002,34 +901,16 @@ end
 # source, the same way the box-looting call sites above are pinned.
 
 RSpec.describe 'ELoot trash/drop call sites' do
-  let(:eloot_path) do
-    path = [
-      File.expand_path('eloot.lic', __dir__), # delivered alongside the spec
-      File.expand_path('../eloot.lic', __dir__),
-      File.expand_path('../../eloot.lic', __dir__),
-      File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
-    ].find { |p| File.exist?(p) }
-    raise "eloot.lic not found (looked relative to #{__dir__})" unless path
-
-    path
-  end
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
 
   let(:source) { File.read(eloot_path) }
 
-  # Indent-agnostic: box_loot_ground/save_trash_box/dump_herbs_junk sit at different
-  # nesting depths (Loot vs Sell vs top-level ELoot), unlike the fixed-indent helper
-  # used elsewhere in this file.
-  def method_body(source, name)
-    match = source.match(/^( +)def self\.#{Regexp.escape(name)}\b[\s\S]*?\n\1end$/)
-    raise "#{name} could not be extracted from eloot.lic" unless match
-
-    match[0]
-  end
-
-  let(:box_loot_ground) { method_body(source, 'box_loot_ground') }
-  let(:save_trash_box) { method_body(source, 'save_trash_box') }
-  let(:dump_herbs_junk) { method_body(source, 'dump_herbs_junk') }
+  # box_loot_ground/save_trash_box/dump_herbs_junk sit at different nesting
+  # depths (Loot vs Sell vs top-level ELoot); extract_lic_method matches
+  # whatever indentation each is actually written at.
+  let(:box_loot_ground) { extract_lic_method(source, 'box_loot_ground', source_path: eloot_path) }
+  let(:save_trash_box) { extract_lic_method(source, 'save_trash_box', source_path: eloot_path) }
+  let(:dump_herbs_junk) { extract_lic_method(source, 'dump_herbs_junk', source_path: eloot_path) }
 
   it 'routes every trash/drop call site through the shared helper' do
     expect(source.scan(/ELoot\.toss\(/).length).to eq(5)

--- a/spec/scripts/ledger_spec.rb
+++ b/spec/scripts/ledger_spec.rb
@@ -4,24 +4,24 @@
 # needs the whole Lich runtime (Settings, XMLData, Char, Script, DATA_DIR ...).
 # Instead the real method bodies are extracted from scripts/ledger.lic and
 # evaluated against stubs, so these specs exercise production code and fail if
-# that code changes shape.
+# that code changes shape. Path lookup and extraction use the shared helpers
+# in spec/spec_helper.rb; the stubs below are ledger-specific (Ledger::Settings,
+# Query, ...) rather than generic Lich globals, so they stay local here.
 #
 # Every stub lives inside LedgerRollingSpec::Harness rather than at top level, so
 # running the whole suite in one process cannot collide with constants other
 # specs define. In particular Harness::Ledger shadows any top level Ledger, which
 # is what the extracted bodies resolve when they say Ledger::Settings.
 
+require_relative '../spec_helper'
 require 'date'
 
 module LedgerRollingSpec
-  SOURCE_PATH = File.expand_path('../../scripts/ledger.lic', __dir__)
+  SOURCE_PATH = find_lic_source('ledger.lic', from: __dir__)
   SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
 
   def self.extract(pattern, label)
-    found = SOURCE[pattern]
-    raise "could not extract #{label} from ledger.lic" unless found
-
-    found
+    extract_from_source(SOURCE, pattern, label: label, source_path: SOURCE_PATH)
   end
 
   WINDOW_SRC = extract(/^  module Window\n.*?^  end$/m, 'Window module')
@@ -336,10 +336,10 @@ RSpec.describe 'ledger.lic rolling windows' do
       before { rolling_setting.rolling = false }
 
       {
-        hourly:  :hourly_gain_loss,
-        daily:   :daily_gain_loss,
+        hourly: :hourly_gain_loss,
+        daily: :daily_gain_loss,
         monthly: :monthly_gain_loss,
-        yearly:  :yearly_gain_loss
+        yearly: :yearly_gain_loss
       }.each do |period, expected|
         it "routes #{period} to #{expected}" do
           query.current_gain_loss(period, type: 'silver')

--- a/spec/scripts/treim_spec.rb
+++ b/spec/scripts/treim_spec.rb
@@ -1,0 +1,664 @@
+# frozen_string_literal: true
+
+# Spec for the pure/near-pure Treim:: modules in treim.lic (REIM reactive
+# script). treim.lic cannot be required standalone -- it needs the whole
+# Lich runtime and runs `Treim.start` on load. Instead each nested
+# module/class body is extracted verbatim from scripts/treim.lic and
+# module_eval'd into a shared Harness namespace, so these specs exercise the
+# production code (and fail if it changes shape) without needing a live
+# game session.
+#
+# Extracting every piece into ONE shared Harness namespace (rather than
+# isolated namespaces per piece, as spec/scripts/ledger_spec.rb does) matters
+# here: treim.lic's modules refer to each other by bare constant (Attack
+# calls Config.stance_dance?, ClearProgress reaches for GameObj, Party uses
+# ::Group, ...). Evaluating them all under Harness reproduces the same
+# lexical nesting they have under `module Treim` in the real file, so those
+# bare references resolve the same way.
+#
+# A handful of game-command methods (waitrt?, waitcastrt?, fput, put, pause,
+# checkstance) are called with an implicit receiver from inside those
+# module_function methods. Ruby resolves implicit-receiver calls via the
+# *method* lookup chain, not lexical nesting, so nesting them under Harness
+# does not make them reachable there -- they have to exist somewhere every
+# object's method lookup bottoms out at. The real Lich runtime solves this
+# by defining them at the true top level (lib/global_defs.rb), which is
+# exactly why they're callable unqualified from arbitrarily-nested .lic
+# script code in the first place; these specs stub them the same way, kept
+# to the minimal set the modules under test actually call.
+#
+# Runner (the main reactive loop) is deliberately not covered here: it's a
+# thin dispatcher over live game state (GameObj.npcs, Room.current, get,
+# XMLData) that would need a much larger integration-style harness to
+# exercise meaningfully, and the review that requested this coverage called
+# out the same tradeoff for the two `Lich::Util.issue_command`/`Group`-based
+# call sites -- those need a live session, not more stubbing.
+
+# -- Extraction --------------------------------------------------------
+
+SOURCE_PATH = [
+  File.expand_path('treim.lic', __dir__),
+  File.expand_path('../treim.lic', __dir__),
+  File.expand_path('../../treim.lic', __dir__),
+  File.expand_path('../scripts/treim.lic', __dir__),
+  File.expand_path('../../scripts/treim.lic', __dir__)
+].find { |p| File.exist?(p) }
+raise 'treim.lic not found' unless SOURCE_PATH
+
+SOURCE = File.read(SOURCE_PATH)
+
+def self.extract(name, kind)
+  pattern = /^  #{kind} #{name}\n.*?\n  end\n/m
+  found = SOURCE[pattern]
+  raise "could not extract #{kind} #{name} from treim.lic" unless found
+
+  found
+end
+
+GEOGRAPHY_SRC       = extract('Geography', 'module')
+BOSSES_SRC          = extract('Bosses', 'module')
+SEEN_IDS_SRC        = extract('SeenIds', 'class')
+CONFIG_SRC          = extract('Config', 'module')
+ATTACK_SRC          = extract('Attack', 'module')
+CLEAR_PROGRESS_SRC  = extract('ClearProgress', 'module')
+PARTY_SRC           = extract('Party', 'module')
+FAMILIAR_WINDOW_SRC = extract('FamiliarWindow', 'module')
+
+# -- Minimal Lich runtime stand-ins -------------------------------------
+#
+# Every constant here is a bare-bones stand-in for a real Lich global.
+# State is exposed via plain accessors so examples can set up exactly the
+# scenario they need; the shared `before` block below resets it between
+# examples.
+
+class UserVars
+  class << self
+    attr_accessor :treim
+  end
+end
+
+class Char
+  class << self
+    attr_accessor :name
+  end
+end
+
+FakeNpc = Struct.new(:id, :noun, :name, :status)
+
+class GameObj
+  class << self
+    attr_accessor :npcs
+  end
+end
+
+class Spell
+  class << self
+    attr_accessor :affordable
+
+    def [](number)
+      new(number)
+    end
+  end
+
+  def initialize(number)
+    @number = number
+  end
+
+  def affordable?
+    Spell.affordable.nil? || Spell.affordable
+  end
+end
+
+class Script
+  class << self
+    def reset!
+      @started = []
+      @running = []
+    end
+
+    attr_reader :started
+
+    def start(name, args = nil)
+      @started << [name, args]
+    end
+
+    def running?(name)
+      @running.include?(name)
+    end
+
+    def mark_running!(name)
+      @running << name
+    end
+  end
+end
+
+module Group
+  class << self
+    attr_accessor :leader, :members
+
+    def leader?
+      leader == :self
+    end
+  end
+end
+
+module Lich
+  module Util
+    class << self
+      attr_accessor :issue_command_result
+
+      def issue_command(*)
+        issue_command_result || []
+      end
+    end
+  end
+
+  module Common
+    module Frontend
+      class << self
+        attr_accessor :xml_supported
+
+        def supports_xml?
+          !!xml_supported
+        end
+      end
+    end
+  end
+end
+
+# Records of/controls for the bare game-command calls the extracted
+# module_function methods make with an implicit receiver.
+module GameStub
+  class << self
+    attr_accessor :stance, :on_pause
+
+    def calls
+      @calls ||= []
+    end
+
+    def reset!
+      @calls = []
+      @stance = 'defensive'
+      @on_pause = nil
+    end
+  end
+end
+
+# Defined at the true top level (not inside RSpec.describe, whose body is
+# class_eval'd into an example-group subclass) so implicit-receiver calls
+# from the eval'd Harness modules below can find them -- see the file
+# header comment for why that placement matters.
+def waitrt?
+  GameStub.calls << [:waitrt?]
+  false
+end
+
+def waitcastrt?
+  GameStub.calls << [:waitcastrt?]
+  false
+end
+
+def fput(command)
+  GameStub.calls << [:fput, command]
+  GameStub.stance = 'offensive' if command == 'stance offensive'
+  GameStub.stance = 'defensive' if command == 'stance defensive'
+  command
+end
+
+def put(command)
+  GameStub.calls << [:put, command]
+  command
+end
+
+def pause(seconds = 1)
+  GameStub.calls << [:pause, seconds]
+  GameStub.on_pause&.call
+end
+
+def checkstance
+  GameStub.stance
+end
+
+# -- Harness: the extracted Treim modules, sharing one namespace --------
+
+module Harness
+  module_eval(GEOGRAPHY_SRC, SOURCE_PATH)
+  module_eval(BOSSES_SRC, SOURCE_PATH)
+  module_eval(SEEN_IDS_SRC, SOURCE_PATH)
+  module_eval(CONFIG_SRC, SOURCE_PATH)
+  module_eval(ATTACK_SRC, SOURCE_PATH)
+  module_eval(CLEAR_PROGRESS_SRC, SOURCE_PATH)
+  module_eval(PARTY_SRC, SOURCE_PATH)
+  module_eval(FAMILIAR_WINDOW_SRC, SOURCE_PATH)
+end
+
+RSpec.describe 'Treim' do
+  before do
+    UserVars.treim = nil
+    Char.name = 'Tysong'
+    GameObj.npcs = []
+    Spell.affordable = nil
+    Script.reset!
+    Group.leader = nil
+    Group.members = []
+    Lich::Util.issue_command_result = nil
+    Lich::Common::Frontend.xml_supported = nil
+    GameStub.reset!
+  end
+
+  # -- Geography -----------------------------------------------------------
+
+  describe 'Geography' do
+    it 'recognizes every stage room as in REIM' do
+      Harness::Geography::STAGES.each do |stage|
+        stage.rooms.each do |room_id|
+          expect(Harness::Geography.in_reim?(room_id)).to be true
+        end
+      end
+    end
+
+    it 'recognizes misc-area rooms as in REIM' do
+      expect(Harness::Geography.in_reim?(Harness::Geography::MISC_AREAS.first)).to be true
+    end
+
+    it 'does not recognize an unrelated room as in REIM' do
+      expect(Harness::Geography.in_reim?(1)).to be false
+    end
+
+    it 'holds at a stage whose next_stage matches the reported clear-to' do
+      village_room = Harness::Geography::VILLAGE.first
+      stage = Harness::Geography.stage_holding(village_room, 'road')
+      expect(stage.name).to eq('village')
+    end
+
+    it 'does not hold when clear-to has not reached the next stage' do
+      village_room = Harness::Geography::VILLAGE.first
+      expect(Harness::Geography.stage_holding(village_room, 'village')).to be_nil
+    end
+
+    it 'does not hold when clear-to is nil (progress unknown)' do
+      village_room = Harness::Geography::VILLAGE.first
+      expect(Harness::Geography.stage_holding(village_room, nil)).to be_nil
+    end
+
+    it 'only the village stage skips the pause before continuing' do
+      village = Harness::Geography::STAGES.find { |s| s.name == 'village' }
+      others = Harness::Geography::STAGES.reject { |s| s.name == 'village' }
+
+      expect(village.pause_before_next).to be false
+      expect(others.map(&:pause_before_next)).to all(be true)
+    end
+  end
+
+  # -- Bosses ----------------------------------------------------------------
+
+  describe 'Bosses' do
+    it 'matches common ethereal-flavor NPC names' do
+      expect('ethereal commoner').to match(Harness::Bosses::NPC_NAME_REGEX)
+      expect('an ethereal commoner').to match(Harness::Bosses::NPC_NAME_REGEX)
+    end
+
+    it 'matches multi-word boss names' do
+      expect('Patrol Leader').to match(Harness::Bosses::NPC_NAME_REGEX)
+      expect('Royal Empress').to match(Harness::Bosses::NPC_NAME_REGEX)
+    end
+
+    it 'does not match unrelated text' do
+      expect('a wild boar').not_to match(Harness::Bosses::NPC_NAME_REGEX)
+    end
+
+    it 'lists boss nouns used to classify GameObj#noun' do
+      expect(Harness::Bosses::BOSS_NOUNS).to include('Captain', 'Emperor', 'Empress')
+    end
+
+    it 'lists common nouns used to classify GameObj#noun' do
+      expect(Harness::Bosses::COMMON_NOUNS).to include('commoner', 'guard', 'bandit')
+    end
+  end
+
+  # -- SeenIds -----------------------------------------------------------
+
+  describe 'SeenIds' do
+    it 'reports ids that have been recorded' do
+      seen = Harness::SeenIds.new
+      seen << 'abc'
+      expect(seen.include?('abc')).to be true
+    end
+
+    it 'does not report unrecorded ids' do
+      seen = Harness::SeenIds.new
+      expect(seen.include?('abc')).to be false
+    end
+
+    it 'evicts the oldest id once past max_size' do
+      seen = Harness::SeenIds.new(max_size: 2)
+      seen << 'a'
+      seen << 'b'
+      seen << 'c'
+      expect(seen.include?('a')).to be false
+      expect(seen.include?('b')).to be true
+      expect(seen.include?('c')).to be true
+    end
+
+    it 'returns self from << for chaining' do
+      seen = Harness::SeenIds.new
+      expect(seen << 'a').to be(seen)
+    end
+  end
+
+  # -- Config --------------------------------------------------------------
+
+  describe 'Config' do
+    it 'fills in every default on first setup' do
+      Harness::Config.setup!
+
+      expect(Harness::Config.stance_dance?).to be true
+      expect(Harness::Config.attack_type).to eq('')
+      expect(Harness::Config.active_scripts).to eq([])
+      expect(Harness::Config.clear_title?).to be false
+      expect(Harness::Config.spam_control?).to be true
+      expect(Harness::Config.lag_control?).to be false
+      expect(Harness::Config.toggle_ambients?).to be false
+    end
+
+    it 'defaults announce_rares to true for a known announcer name' do
+      Char.name = 'Tysong'
+      Harness::Config.setup!
+      expect(Harness::Config.announce_rares?).to be true
+    end
+
+    it 'defaults announce_rares to false for an unknown character' do
+      Char.name = 'SomeoneElse'
+      Harness::Config.setup!
+      expect(Harness::Config.announce_rares?).to be false
+    end
+
+    it 'does not overwrite an already-configured value on a later setup! call' do
+      Harness::Config.setup!
+      Harness::Config.attack_type = 'mstrike'
+
+      Harness::Config.setup!
+
+      expect(Harness::Config.attack_type).to eq('mstrike')
+    end
+
+    it 'defaults script_args lookups to an empty string' do
+      Harness::Config.setup!
+      expect(Harness::Config.script_args_for('nonexistent')).to eq('')
+    end
+  end
+
+  # -- Attack dispatch -------------------------------------------------------
+
+  describe 'Attack.perform dispatch' do
+    before { Harness::Config.setup! }
+
+    def dispatch(attack_type)
+      Harness::Config.attack_type = attack_type
+      Harness::Attack.perform
+    end
+
+    it 'dispatches mstrike/physical to physical("mstrike")' do
+      expect(Harness::Attack).to receive(:physical).with('mstrike')
+      dispatch('mstrike')
+    end
+
+    it 'dispatches attack to physical("attack")' do
+      expect(Harness::Attack).to receive(:physical).with('attack')
+      dispatch('attack')
+    end
+
+    it 'dispatches fire/ranged to physical("fire")' do
+      expect(Harness::Attack).to receive(:physical).with('fire')
+      dispatch('fire')
+    end
+
+    it 'dispatches jab/punch/grapple/kick to physical(type)' do
+      expect(Harness::Attack).to receive(:physical).with('kick')
+      dispatch('kick')
+    end
+
+    it 'dispatches uac to physical("mstrike punch")' do
+      expect(Harness::Attack).to receive(:physical).with('mstrike punch')
+      dispatch('uac')
+    end
+
+    it 'dispatches sleep to cast_sleep' do
+      expect(Harness::Attack).to receive(:cast_sleep)
+      dispatch('sleep')
+    end
+
+    it 'dispatches scrub to spell_then_mstrike(435, "435")' do
+      expect(Harness::Attack).to receive(:spell_then_mstrike).with(435, '435')
+      dispatch('scrub')
+    end
+
+    it 'dispatches bardass to spell_then_mstrike(1030, "1030 open")' do
+      expect(Harness::Attack).to receive(:spell_then_mstrike).with(1030, '1030 open')
+      dispatch('bardass')
+    end
+
+    it 'dispatches dredd to spell_then_mstrike(1630, "1630 open")' do
+      expect(Harness::Attack).to receive(:spell_then_mstrike).with(1630, '1630 open')
+      dispatch('dredd')
+    end
+
+    it 'dispatches the bare "1030" attack type to cast_only(1030, "1030 open", pause_before: 2)' do
+      expect(Harness::Attack).to receive(:cast_only).with(1030, '1030 open', pause_before: 2)
+      dispatch('1030')
+    end
+
+    it 'dispatches 709 to cast_and_release(709, "stop 709")' do
+      expect(Harness::Attack).to receive(:cast_and_release).with(709, 'stop 709')
+      dispatch('709')
+    end
+
+    it 'dispatches bare 435/635 to cast_only(type, type, pause_before: 2)' do
+      expect(Harness::Attack).to receive(:cast_only).with('435', '435', pause_before: 2)
+      dispatch('435')
+    end
+
+    it 'dispatches a custom ".lic" attack type to run_custom_script' do
+      expect(Harness::Attack).to receive(:run_custom_script).with('duskattack.lic')
+      dispatch('duskattack.lic')
+    end
+
+    it 'dispatches an unrecognized spell number to cast_generic' do
+      expect(Harness::Attack).to receive(:cast_generic).with('908')
+      dispatch('908')
+    end
+
+    it 'returns true (a no-op) for attack type "none" without touching the game' do
+      expect(dispatch('none')).to be true
+      expect(GameStub.calls).to eq([])
+    end
+  end
+
+  # -- Attack handler bodies -------------------------------------------------
+
+  describe 'Attack handler bodies' do
+    before { Harness::Config.setup! }
+
+    it 'physical stance-dances to offensive, sends the command, then back to defensive' do
+      Harness::Attack.physical('mstrike')
+
+      expect(GameStub.calls).to eq([
+                                     [:waitrt?],
+                                     [:fput, 'stance offensive'],
+                                     [:fput, 'mstrike'],
+                                     [:pause, 1],
+                                     [:waitrt?],
+                                     [:fput, 'stance defensive']
+                                   ])
+    end
+
+    it 'physical skips stance dancing when disabled' do
+      Harness::Config.setup!
+      UserVars.treim[:stance_dance] = false
+
+      Harness::Attack.physical('mstrike')
+
+      expect(GameStub.calls).to eq([[:waitrt?], [:fput, 'mstrike']])
+    end
+
+    it 'physical does not re-issue "stance offensive" when already offensive' do
+      GameStub.stance = 'offensive'
+
+      Harness::Attack.physical('mstrike')
+
+      expect(GameStub.calls.first(2)).to eq([[:waitrt?], [:fput, 'mstrike']])
+    end
+
+    it 'cast_only does nothing but return true when the spell is unaffordable' do
+      Spell.affordable = false
+
+      expect(Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)).to be true
+      expect(GameStub.calls).to eq([])
+    end
+
+    it 'cast_only casts the spell when affordable' do
+      Spell.affordable = true
+
+      Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)
+
+      expect(GameStub.calls).to eq([
+                                     [:waitrt?],
+                                     [:waitcastrt?],
+                                     [:pause, 2],
+                                     [:put, 'incant 1030 open']
+                                   ])
+    end
+
+    it 'spell_then_mstrike falls back to a plain mstrike when unaffordable' do
+      Spell.affordable = false
+
+      Harness::Attack.spell_then_mstrike(1030, '1030 open')
+
+      expect(GameStub.calls).to eq([
+                                     [:waitrt?],
+                                     [:fput, 'stance offensive'],
+                                     [:fput, 'mstrike'],
+                                     [:pause, 1],
+                                     [:waitrt?],
+                                     [:fput, 'stance defensive']
+                                   ])
+    end
+
+    it 'run_custom_script starts the script with ".lic" stripped, case-insensitively' do
+      Harness::Attack.run_custom_script('DuskAttack.LIC')
+      expect(Script.started).to eq([['DuskAttack', nil]])
+    end
+
+    it 'run_custom_script does not restart an already-running script' do
+      Script.mark_running!('duskattack')
+      Harness::Attack.run_custom_script('duskattack.lic')
+      expect(Script.started).to eq([])
+    end
+  end
+
+  # -- ClearProgress ---------------------------------------------------------
+
+  describe 'ClearProgress.check' do
+    it 'parses clear-to stage, scrip, and hours+minutes remaining' do
+      Lich::Util.issue_command_result = [
+        'You are currently flagged for entry for up to the road.',
+        'Total Ethereal Scrip for this run: 500/1000',
+        'You have 1 hour and 30 minutes remaining in the Settlement of Reim.'
+      ]
+
+      result = Harness::ClearProgress.check
+
+      expect(result.clear_to).to eq('road')
+      expect(result.scrip).to eq(500)
+      expect(result.time_left).to eq('1H 30M')
+    end
+
+    it 'parses a bare minutes-remaining line when under an hour is left' do
+      Lich::Util.issue_command_result = ['You have 45 minutes remaining.']
+
+      result = Harness::ClearProgress.check
+
+      expect(result.time_left).to eq('45M')
+    end
+
+    it 'returns nils for fields REIM INFO did not report' do
+      Lich::Util.issue_command_result = []
+
+      result = Harness::ClearProgress.check
+
+      expect(result.clear_to).to be_nil
+      expect(result.scrip).to be_nil
+      expect(result.time_left).to be_nil
+    end
+
+    it 'waits for a given target id to no longer be alive before checking' do
+      # check itself unconditionally does one `pause 0.5` after the wait, so
+      # a live target (which makes wait_for_death's loop run at least once)
+      # is distinguished from an already-dead one by an *extra* pause call,
+      # not by whether pause was called at all.
+      npc = FakeNpc.new('123', 'captain', 'The Captain', 'alive')
+      GameObj.npcs = [npc]
+      GameStub.on_pause = -> { npc.status = 'dead' }
+
+      Harness::ClearProgress.check(target_id: '123')
+
+      expect(GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(2)
+    end
+
+    it 'does not wait when the target is already dead' do
+      GameObj.npcs = [FakeNpc.new('123', 'captain', 'The Captain', 'dead')]
+
+      Harness::ClearProgress.check(target_id: '123')
+
+      expect(GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(1)
+    end
+  end
+
+  # -- Party -----------------------------------------------------------------
+
+  describe 'Party' do
+    it "reports the character's own name as leader when leading" do
+      Group.leader = :self
+      Char.name = 'Tysong'
+      expect(Harness::Party.leader_name).to eq('Tysong')
+    end
+
+    it "reports the leader's noun when someone else is leading" do
+      Group.leader = FakeNpc.new('1', 'Durakar', nil, nil)
+      expect(Harness::Party.leader_name).to eq('Durakar')
+    end
+
+    it 'returns nil for leader_name when the leader is unknown' do
+      Group.leader = nil
+      expect(Harness::Party.leader_name).to be_nil
+    end
+
+    it "includes the character's own name in member_names" do
+      Char.name = 'Tysong'
+      Group.leader = :self
+      Group.members = [FakeNpc.new('1', 'Durakar', nil, nil)]
+
+      expect(Harness::Party.member_names).to contain_exactly('Tysong', 'Durakar')
+    end
+  end
+
+  # -- FamiliarWindow ----------------------------------------------------
+
+  describe 'FamiliarWindow.wrap' do
+    it 'uses pushStream tags on an XML-capable frontend' do
+      Lich::Common::Frontend.xml_supported = true
+      expect(Harness::FamiliarWindow.wrap('hi')).to include('pushStream').and include('popStream')
+    end
+
+    it 'uses the legacy GSe/GSf escape sequence otherwise' do
+      Lich::Common::Frontend.xml_supported = false
+      wrapped = Harness::FamiliarWindow.wrap('hi')
+      expect(wrapped).to include("\034GSe\r\n").and include("\034GSf\r\n")
+    end
+
+    it 'includes the given message either way' do
+      Lich::Common::Frontend.xml_supported = true
+      expect(Harness::FamiliarWindow.wrap('Mob Count: 5')).to include('Mob Count: 5')
+    end
+  end
+end

--- a/spec/scripts/treim_spec.rb
+++ b/spec/scripts/treim_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../spec_helper'
+
 # Spec for the pure/near-pure Treim:: modules in treim.lic (REIM reactive
 # script). treim.lic cannot be required standalone -- it needs the whole
 # Lich runtime and runs `Treim.start` on load. Instead each nested
@@ -8,24 +10,34 @@
 # production code (and fail if it changes shape) without needing a live
 # game session.
 #
-# Extracting every piece into ONE shared Harness namespace (rather than
-# isolated namespaces per piece, as spec/scripts/ledger_spec.rb does) matters
-# here: treim.lic's modules refer to each other by bare constant (Attack
-# calls Config.stance_dance?, ClearProgress reaches for GameObj, Party uses
-# ::Group, ...). Evaluating them all under Harness reproduces the same
-# lexical nesting they have under `module Treim` in the real file, so those
-# bare references resolve the same way.
+# Most of the Lich runtime stand-ins these extracted modules need
+# (UserVars, Char, Script, Spell, Lich::Util, Lich::Common::Frontend, plus
+# the bare waitrt?/fput/put/pause/checkstance game-command methods) come
+# from spec/spec_helper.rb, shared with the rest of this repo's .lic-script
+# specs. Two things stay local to this file:
 #
-# A handful of game-command methods (waitrt?, waitcastrt?, fput, put, pause,
-# checkstance) are called with an implicit receiver from inside those
-# module_function methods. Ruby resolves implicit-receiver calls via the
-# *method* lookup chain, not lexical nesting, so nesting them under Harness
-# does not make them reachable there -- they have to exist somewhere every
-# object's method lookup bottoms out at. The real Lich runtime solves this
-# by defining them at the true top level (lib/global_defs.rb), which is
-# exactly why they're callable unqualified from arbitrarily-nested .lic
-# script code in the first place; these specs stub them the same way, kept
-# to the minimal set the modules under test actually call.
+# - GameObj: spec_helper.rb deliberately does not provide one (see its own
+#   header comment) because lib/lich/gameobj.rb defines a real, top-level
+#   GameObj class that spec/gameobj-data exercises directly, and a shared
+#   top-level stub would silently corrupt it for every spec file loaded in
+#   the same rspec process. This file's GameObj lives nested inside Harness
+#   instead, matching spec/bigshot/priority_spec.rb's precedent.
+# - Group: spec_helper.rb's Group stub *is* defined at the true top level,
+#   unlike everything else there -- because treim.lic's Party module reaches
+#   for it via an explicitly absolute `::Group`, not a bare `Group`, so only
+#   a genuine top-level constant satisfies that reference. Nothing else in
+#   this repo defines a top-level Group, so it's safe to share; no local
+#   alias is needed here since `::Group` bypasses lexical nesting entirely.
+#
+# Extracting every treim.lic piece into ONE shared Harness namespace (rather
+# than isolated namespaces per piece, as spec/scripts/ledger_spec.rb does)
+# matters here: treim.lic's modules refer to each other by bare constant
+# (Attack calls Config.stance_dance?, ClearProgress reaches for GameObj,
+# ...). Evaluating them all under Harness reproduces the same lexical
+# nesting they have under `module Treim` in the real file, so those bare
+# references resolve the same way -- which is also why the shared stand-ins
+# above are aliased into Harness below rather than left as bare
+# `LichStub::` constants: treim.lic's own code never says `LichStub::`.
 #
 # Runner (the main reactive loop) is deliberately not covered here: it's a
 # thin dispatcher over live game state (GameObj.npcs, Room.current, get,
@@ -34,194 +46,34 @@
 # out the same tradeoff for the two `Lich::Util.issue_command`/`Group`-based
 # call sites -- those need a live session, not more stubbing.
 
-# -- Extraction --------------------------------------------------------
-
-SOURCE_PATH = [
-  File.expand_path('treim.lic', __dir__),
-  File.expand_path('../treim.lic', __dir__),
-  File.expand_path('../../treim.lic', __dir__),
-  File.expand_path('../scripts/treim.lic', __dir__),
-  File.expand_path('../../scripts/treim.lic', __dir__)
-].find { |p| File.exist?(p) }
-raise 'treim.lic not found' unless SOURCE_PATH
-
+SOURCE_PATH = find_lic_source('treim.lic', from: __dir__)
 SOURCE = File.read(SOURCE_PATH)
 
-def self.extract(name, kind)
-  pattern = /^  #{kind} #{name}\n.*?\n  end\n/m
-  found = SOURCE[pattern]
-  raise "could not extract #{kind} #{name} from treim.lic" unless found
+GEOGRAPHY_SRC       = extract_lic_module(SOURCE, 'Geography', source_path: SOURCE_PATH)
+BOSSES_SRC          = extract_lic_module(SOURCE, 'Bosses', source_path: SOURCE_PATH)
+SEEN_IDS_SRC        = extract_lic_module(SOURCE, 'SeenIds', kind: 'class', source_path: SOURCE_PATH)
+CONFIG_SRC          = extract_lic_module(SOURCE, 'Config', source_path: SOURCE_PATH)
+ATTACK_SRC          = extract_lic_module(SOURCE, 'Attack', source_path: SOURCE_PATH)
+CLEAR_PROGRESS_SRC  = extract_lic_module(SOURCE, 'ClearProgress', source_path: SOURCE_PATH)
+PARTY_SRC           = extract_lic_module(SOURCE, 'Party', source_path: SOURCE_PATH)
+FAMILIAR_WINDOW_SRC = extract_lic_module(SOURCE, 'FamiliarWindow', source_path: SOURCE_PATH)
 
-  found
-end
-
-GEOGRAPHY_SRC       = extract('Geography', 'module')
-BOSSES_SRC          = extract('Bosses', 'module')
-SEEN_IDS_SRC        = extract('SeenIds', 'class')
-CONFIG_SRC          = extract('Config', 'module')
-ATTACK_SRC          = extract('Attack', 'module')
-CLEAR_PROGRESS_SRC  = extract('ClearProgress', 'module')
-PARTY_SRC           = extract('Party', 'module')
-FAMILIAR_WINDOW_SRC = extract('FamiliarWindow', 'module')
-
-# -- Minimal Lich runtime stand-ins -------------------------------------
-#
-# Every constant here is a bare-bones stand-in for a real Lich global.
-# State is exposed via plain accessors so examples can set up exactly the
-# scenario they need; the shared `before` block below resets it between
-# examples.
-
-class UserVars
-  class << self
-    attr_accessor :treim
-  end
-end
-
-class Char
-  class << self
-    attr_accessor :name
-  end
-end
-
-FakeNpc = Struct.new(:id, :noun, :name, :status)
-
-class GameObj
-  class << self
-    attr_accessor :npcs
-  end
-end
-
-class Spell
-  class << self
-    attr_accessor :affordable
-
-    def [](number)
-      new(number)
-    end
-  end
-
-  def initialize(number)
-    @number = number
-  end
-
-  def affordable?
-    Spell.affordable.nil? || Spell.affordable
-  end
-end
-
-class Script
-  class << self
-    def reset!
-      @started = []
-      @running = []
-    end
-
-    attr_reader :started
-
-    def start(name, args = nil)
-      @started << [name, args]
-    end
-
-    def running?(name)
-      @running.include?(name)
-    end
-
-    def mark_running!(name)
-      @running << name
-    end
-  end
-end
-
-module Group
-  class << self
-    attr_accessor :leader, :members
-
-    def leader?
-      leader == :self
-    end
-  end
-end
-
-module Lich
-  module Util
-    class << self
-      attr_accessor :issue_command_result
-
-      def issue_command(*)
-        issue_command_result || []
-      end
-    end
-  end
-
-  module Common
-    module Frontend
-      class << self
-        attr_accessor :xml_supported
-
-        def supports_xml?
-          !!xml_supported
-        end
-      end
-    end
-  end
-end
-
-# Records of/controls for the bare game-command calls the extracted
-# module_function methods make with an implicit receiver.
-module GameStub
-  class << self
-    attr_accessor :stance, :on_pause
-
-    def calls
-      @calls ||= []
-    end
-
-    def reset!
-      @calls = []
-      @stance = 'defensive'
-      @on_pause = nil
-    end
-  end
-end
-
-# Defined at the true top level (not inside RSpec.describe, whose body is
-# class_eval'd into an example-group subclass) so implicit-receiver calls
-# from the eval'd Harness modules below can find them -- see the file
-# header comment for why that placement matters.
-def waitrt?
-  GameStub.calls << [:waitrt?]
-  false
-end
-
-def waitcastrt?
-  GameStub.calls << [:waitcastrt?]
-  false
-end
-
-def fput(command)
-  GameStub.calls << [:fput, command]
-  GameStub.stance = 'offensive' if command == 'stance offensive'
-  GameStub.stance = 'defensive' if command == 'stance defensive'
-  command
-end
-
-def put(command)
-  GameStub.calls << [:put, command]
-  command
-end
-
-def pause(seconds = 1)
-  GameStub.calls << [:pause, seconds]
-  GameStub.on_pause&.call
-end
-
-def checkstance
-  GameStub.stance
-end
-
-# -- Harness: the extracted Treim modules, sharing one namespace --------
+FakeNpc = LichStub::FakeNpc
 
 module Harness
+  # Nested here, not shared via spec_helper.rb -- see the file header.
+  class GameObj
+    class << self
+      attr_accessor :npcs
+    end
+  end
+
+  UserVars = LichStub::UserVars
+  Char = LichStub::Char
+  Script = LichStub::Script
+  Spell = LichStub::Spell
+  Lich = LichStub::Lich
+
   module_eval(GEOGRAPHY_SRC, SOURCE_PATH)
   module_eval(BOSSES_SRC, SOURCE_PATH)
   module_eval(SEEN_IDS_SRC, SOURCE_PATH)
@@ -234,16 +86,8 @@ end
 
 RSpec.describe 'Treim' do
   before do
-    UserVars.treim = nil
-    Char.name = 'Tysong'
-    GameObj.npcs = []
-    Spell.affordable = nil
-    Script.reset!
-    Group.leader = nil
-    Group.members = []
-    Lich::Util.issue_command_result = nil
-    Lich::Common::Frontend.xml_supported = nil
-    GameStub.reset!
+    Harness::Char.name = 'Tysong'
+    Harness::GameObj.npcs = []
   end
 
   # -- Geography -----------------------------------------------------------
@@ -362,13 +206,13 @@ RSpec.describe 'Treim' do
     end
 
     it 'defaults announce_rares to true for a known announcer name' do
-      Char.name = 'Tysong'
+      Harness::Char.name = 'Tysong'
       Harness::Config.setup!
       expect(Harness::Config.announce_rares?).to be true
     end
 
     it 'defaults announce_rares to false for an unknown character' do
-      Char.name = 'SomeoneElse'
+      Harness::Char.name = 'SomeoneElse'
       Harness::Config.setup!
       expect(Harness::Config.announce_rares?).to be false
     end
@@ -470,7 +314,7 @@ RSpec.describe 'Treim' do
 
     it 'returns true (a no-op) for attack type "none" without touching the game' do
       expect(dispatch('none')).to be true
-      expect(GameStub.calls).to eq([])
+      expect(LichStub::GameStub.calls).to eq([])
     end
   end
 
@@ -482,77 +326,77 @@ RSpec.describe 'Treim' do
     it 'physical stance-dances to offensive, sends the command, then back to defensive' do
       Harness::Attack.physical('mstrike')
 
-      expect(GameStub.calls).to eq([
-                                     [:waitrt?],
-                                     [:fput, 'stance offensive'],
-                                     [:fput, 'mstrike'],
-                                     [:pause, 1],
-                                     [:waitrt?],
-                                     [:fput, 'stance defensive']
-                                   ])
+      expect(LichStub::GameStub.calls).to eq([
+                                               [:waitrt?],
+                                               [:fput, 'stance offensive'],
+                                               [:fput, 'mstrike'],
+                                               [:pause, 1],
+                                               [:waitrt?],
+                                               [:fput, 'stance defensive']
+                                             ])
     end
 
     it 'physical skips stance dancing when disabled' do
       Harness::Config.setup!
-      UserVars.treim[:stance_dance] = false
+      Harness::UserVars.treim[:stance_dance] = false
 
       Harness::Attack.physical('mstrike')
 
-      expect(GameStub.calls).to eq([[:waitrt?], [:fput, 'mstrike']])
+      expect(LichStub::GameStub.calls).to eq([[:waitrt?], [:fput, 'mstrike']])
     end
 
     it 'physical does not re-issue "stance offensive" when already offensive' do
-      GameStub.stance = 'offensive'
+      LichStub::GameStub.stance = 'offensive'
 
       Harness::Attack.physical('mstrike')
 
-      expect(GameStub.calls.first(2)).to eq([[:waitrt?], [:fput, 'mstrike']])
+      expect(LichStub::GameStub.calls.first(2)).to eq([[:waitrt?], [:fput, 'mstrike']])
     end
 
     it 'cast_only does nothing but return true when the spell is unaffordable' do
-      Spell.affordable = false
+      Harness::Spell.affordable = false
 
       expect(Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)).to be true
-      expect(GameStub.calls).to eq([])
+      expect(LichStub::GameStub.calls).to eq([])
     end
 
     it 'cast_only casts the spell when affordable' do
-      Spell.affordable = true
+      Harness::Spell.affordable = true
 
       Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)
 
-      expect(GameStub.calls).to eq([
-                                     [:waitrt?],
-                                     [:waitcastrt?],
-                                     [:pause, 2],
-                                     [:put, 'incant 1030 open']
-                                   ])
+      expect(LichStub::GameStub.calls).to eq([
+                                               [:waitrt?],
+                                               [:waitcastrt?],
+                                               [:pause, 2],
+                                               [:put, 'incant 1030 open']
+                                             ])
     end
 
     it 'spell_then_mstrike falls back to a plain mstrike when unaffordable' do
-      Spell.affordable = false
+      Harness::Spell.affordable = false
 
       Harness::Attack.spell_then_mstrike(1030, '1030 open')
 
-      expect(GameStub.calls).to eq([
-                                     [:waitrt?],
-                                     [:fput, 'stance offensive'],
-                                     [:fput, 'mstrike'],
-                                     [:pause, 1],
-                                     [:waitrt?],
-                                     [:fput, 'stance defensive']
-                                   ])
+      expect(LichStub::GameStub.calls).to eq([
+                                               [:waitrt?],
+                                               [:fput, 'stance offensive'],
+                                               [:fput, 'mstrike'],
+                                               [:pause, 1],
+                                               [:waitrt?],
+                                               [:fput, 'stance defensive']
+                                             ])
     end
 
     it 'run_custom_script starts the script with ".lic" stripped, case-insensitively' do
       Harness::Attack.run_custom_script('DuskAttack.LIC')
-      expect(Script.started).to eq([['DuskAttack', nil]])
+      expect(Harness::Script.started).to eq([['DuskAttack', nil]])
     end
 
     it 'run_custom_script does not restart an already-running script' do
-      Script.mark_running!('duskattack')
+      Harness::Script.mark_running!('duskattack')
       Harness::Attack.run_custom_script('duskattack.lic')
-      expect(Script.started).to eq([])
+      expect(Harness::Script.started).to eq([])
     end
   end
 
@@ -560,7 +404,7 @@ RSpec.describe 'Treim' do
 
   describe 'ClearProgress.check' do
     it 'parses clear-to stage, scrip, and hours+minutes remaining' do
-      Lich::Util.issue_command_result = [
+      Harness::Lich::Util.issue_command_result = [
         'You are currently flagged for entry for up to the road.',
         'Total Ethereal Scrip for this run: 500/1000',
         'You have 1 hour and 30 minutes remaining in the Settlement of Reim.'
@@ -574,7 +418,7 @@ RSpec.describe 'Treim' do
     end
 
     it 'parses a bare minutes-remaining line when under an hour is left' do
-      Lich::Util.issue_command_result = ['You have 45 minutes remaining.']
+      Harness::Lich::Util.issue_command_result = ['You have 45 minutes remaining.']
 
       result = Harness::ClearProgress.check
 
@@ -582,7 +426,7 @@ RSpec.describe 'Treim' do
     end
 
     it 'returns nils for fields REIM INFO did not report' do
-      Lich::Util.issue_command_result = []
+      Harness::Lich::Util.issue_command_result = []
 
       result = Harness::ClearProgress.check
 
@@ -597,20 +441,20 @@ RSpec.describe 'Treim' do
       # is distinguished from an already-dead one by an *extra* pause call,
       # not by whether pause was called at all.
       npc = FakeNpc.new('123', 'captain', 'The Captain', 'alive')
-      GameObj.npcs = [npc]
-      GameStub.on_pause = -> { npc.status = 'dead' }
+      Harness::GameObj.npcs = [npc]
+      LichStub::GameStub.on_pause = -> { npc.status = 'dead' }
 
       Harness::ClearProgress.check(target_id: '123')
 
-      expect(GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(2)
+      expect(LichStub::GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(2)
     end
 
     it 'does not wait when the target is already dead' do
-      GameObj.npcs = [FakeNpc.new('123', 'captain', 'The Captain', 'dead')]
+      Harness::GameObj.npcs = [FakeNpc.new('123', 'captain', 'The Captain', 'dead')]
 
       Harness::ClearProgress.check(target_id: '123')
 
-      expect(GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(1)
+      expect(LichStub::GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(1)
     end
   end
 
@@ -619,7 +463,7 @@ RSpec.describe 'Treim' do
   describe 'Party' do
     it "reports the character's own name as leader when leading" do
       Group.leader = :self
-      Char.name = 'Tysong'
+      Harness::Char.name = 'Tysong'
       expect(Harness::Party.leader_name).to eq('Tysong')
     end
 
@@ -634,7 +478,7 @@ RSpec.describe 'Treim' do
     end
 
     it "includes the character's own name in member_names" do
-      Char.name = 'Tysong'
+      Harness::Char.name = 'Tysong'
       Group.leader = :self
       Group.members = [FakeNpc.new('1', 'Durakar', nil, nil)]
 
@@ -646,18 +490,18 @@ RSpec.describe 'Treim' do
 
   describe 'FamiliarWindow.wrap' do
     it 'uses pushStream tags on an XML-capable frontend' do
-      Lich::Common::Frontend.xml_supported = true
+      Harness::Lich::Common::Frontend.xml_supported = true
       expect(Harness::FamiliarWindow.wrap('hi')).to include('pushStream').and include('popStream')
     end
 
     it 'uses the legacy GSe/GSf escape sequence otherwise' do
-      Lich::Common::Frontend.xml_supported = false
+      Harness::Lich::Common::Frontend.xml_supported = false
       wrapped = Harness::FamiliarWindow.wrap('hi')
       expect(wrapped).to include("\034GSe\r\n").and include("\034GSf\r\n")
     end
 
     it 'includes the given message either way' do
-      Lich::Common::Frontend.xml_supported = true
+      Harness::Lich::Common::Frontend.xml_supported = true
       expect(Harness::FamiliarWindow.wrap('Mob Count: 5')).to include('Mob Count: 5')
     end
   end

--- a/spec/scripts/treim_spec.rb
+++ b/spec/scripts/treim_spec.rb
@@ -46,88 +46,96 @@ require_relative '../spec_helper'
 # out the same tradeoff for the two `Lich::Util.issue_command`/`Group`-based
 # call sites -- those need a live session, not more stubbing.
 
-SOURCE_PATH = find_lic_source('treim.lic', from: __dir__)
-SOURCE = File.read(SOURCE_PATH)
+# Everything extraction-related is namespaced under TreimSpec, not left at
+# the true top level, so this file can't collide with another spec's
+# SOURCE/SOURCE_PATH/Harness/FakeNpc -- the same collision class the header
+# above describes for GameObj, and the reason ledger_spec.rb and
+# bigshot/priority_spec.rb both nest their own SOURCE_PATH/Harness under a
+# spec-specific module rather than defining them bare.
+module TreimSpec
+  SOURCE_PATH = find_lic_source('treim.lic', from: __dir__)
+  SOURCE = File.read(SOURCE_PATH)
 
-GEOGRAPHY_SRC       = extract_lic_module(SOURCE, 'Geography', source_path: SOURCE_PATH)
-BOSSES_SRC          = extract_lic_module(SOURCE, 'Bosses', source_path: SOURCE_PATH)
-SEEN_IDS_SRC        = extract_lic_module(SOURCE, 'SeenIds', kind: 'class', source_path: SOURCE_PATH)
-CONFIG_SRC          = extract_lic_module(SOURCE, 'Config', source_path: SOURCE_PATH)
-ATTACK_SRC          = extract_lic_module(SOURCE, 'Attack', source_path: SOURCE_PATH)
-CLEAR_PROGRESS_SRC  = extract_lic_module(SOURCE, 'ClearProgress', source_path: SOURCE_PATH)
-PARTY_SRC           = extract_lic_module(SOURCE, 'Party', source_path: SOURCE_PATH)
-FAMILIAR_WINDOW_SRC = extract_lic_module(SOURCE, 'FamiliarWindow', source_path: SOURCE_PATH)
+  GEOGRAPHY_SRC       = extract_lic_module(SOURCE, 'Geography', source_path: SOURCE_PATH)
+  BOSSES_SRC          = extract_lic_module(SOURCE, 'Bosses', source_path: SOURCE_PATH)
+  SEEN_IDS_SRC        = extract_lic_module(SOURCE, 'SeenIds', kind: 'class', source_path: SOURCE_PATH)
+  CONFIG_SRC          = extract_lic_module(SOURCE, 'Config', source_path: SOURCE_PATH)
+  ATTACK_SRC          = extract_lic_module(SOURCE, 'Attack', source_path: SOURCE_PATH)
+  CLEAR_PROGRESS_SRC  = extract_lic_module(SOURCE, 'ClearProgress', source_path: SOURCE_PATH)
+  PARTY_SRC           = extract_lic_module(SOURCE, 'Party', source_path: SOURCE_PATH)
+  FAMILIAR_WINDOW_SRC = extract_lic_module(SOURCE, 'FamiliarWindow', source_path: SOURCE_PATH)
 
-FakeNpc = LichStub::FakeNpc
+  FakeNpc = LichStub::FakeNpc
 
-module Harness
-  # Nested here, not shared via spec_helper.rb -- see the file header.
-  class GameObj
-    class << self
-      attr_accessor :npcs
+  module Harness
+    # Nested here, not shared via spec_helper.rb -- see the file header.
+    class GameObj
+      class << self
+        attr_accessor :npcs
+      end
     end
+
+    UserVars = LichStub::UserVars
+    Char = LichStub::Char
+    Script = LichStub::Script
+    Spell = LichStub::Spell
+    Lich = LichStub::Lich
+
+    module_eval(GEOGRAPHY_SRC, SOURCE_PATH)
+    module_eval(BOSSES_SRC, SOURCE_PATH)
+    module_eval(SEEN_IDS_SRC, SOURCE_PATH)
+    module_eval(CONFIG_SRC, SOURCE_PATH)
+    module_eval(ATTACK_SRC, SOURCE_PATH)
+    module_eval(CLEAR_PROGRESS_SRC, SOURCE_PATH)
+    module_eval(PARTY_SRC, SOURCE_PATH)
+    module_eval(FAMILIAR_WINDOW_SRC, SOURCE_PATH)
   end
-
-  UserVars = LichStub::UserVars
-  Char = LichStub::Char
-  Script = LichStub::Script
-  Spell = LichStub::Spell
-  Lich = LichStub::Lich
-
-  module_eval(GEOGRAPHY_SRC, SOURCE_PATH)
-  module_eval(BOSSES_SRC, SOURCE_PATH)
-  module_eval(SEEN_IDS_SRC, SOURCE_PATH)
-  module_eval(CONFIG_SRC, SOURCE_PATH)
-  module_eval(ATTACK_SRC, SOURCE_PATH)
-  module_eval(CLEAR_PROGRESS_SRC, SOURCE_PATH)
-  module_eval(PARTY_SRC, SOURCE_PATH)
-  module_eval(FAMILIAR_WINDOW_SRC, SOURCE_PATH)
 end
 
 RSpec.describe 'Treim' do
   before do
-    Harness::Char.name = 'Tysong'
-    Harness::GameObj.npcs = []
+    TreimSpec::Harness::Char.name = 'Tysong'
+    TreimSpec::Harness::GameObj.npcs = []
   end
 
   # -- Geography -----------------------------------------------------------
 
   describe 'Geography' do
     it 'recognizes every stage room as in REIM' do
-      Harness::Geography::STAGES.each do |stage|
+      TreimSpec::Harness::Geography::STAGES.each do |stage|
         stage.rooms.each do |room_id|
-          expect(Harness::Geography.in_reim?(room_id)).to be true
+          expect(TreimSpec::Harness::Geography.in_reim?(room_id)).to be true
         end
       end
     end
 
     it 'recognizes misc-area rooms as in REIM' do
-      expect(Harness::Geography.in_reim?(Harness::Geography::MISC_AREAS.first)).to be true
+      expect(TreimSpec::Harness::Geography.in_reim?(TreimSpec::Harness::Geography::MISC_AREAS.first)).to be true
     end
 
     it 'does not recognize an unrelated room as in REIM' do
-      expect(Harness::Geography.in_reim?(1)).to be false
+      expect(TreimSpec::Harness::Geography.in_reim?(1)).to be false
     end
 
     it 'holds at a stage whose next_stage matches the reported clear-to' do
-      village_room = Harness::Geography::VILLAGE.first
-      stage = Harness::Geography.stage_holding(village_room, 'road')
+      village_room = TreimSpec::Harness::Geography::VILLAGE.first
+      stage = TreimSpec::Harness::Geography.stage_holding(village_room, 'road')
       expect(stage.name).to eq('village')
     end
 
     it 'does not hold when clear-to has not reached the next stage' do
-      village_room = Harness::Geography::VILLAGE.first
-      expect(Harness::Geography.stage_holding(village_room, 'village')).to be_nil
+      village_room = TreimSpec::Harness::Geography::VILLAGE.first
+      expect(TreimSpec::Harness::Geography.stage_holding(village_room, 'village')).to be_nil
     end
 
     it 'does not hold when clear-to is nil (progress unknown)' do
-      village_room = Harness::Geography::VILLAGE.first
-      expect(Harness::Geography.stage_holding(village_room, nil)).to be_nil
+      village_room = TreimSpec::Harness::Geography::VILLAGE.first
+      expect(TreimSpec::Harness::Geography.stage_holding(village_room, nil)).to be_nil
     end
 
     it 'only the village stage skips the pause before continuing' do
-      village = Harness::Geography::STAGES.find { |s| s.name == 'village' }
-      others = Harness::Geography::STAGES.reject { |s| s.name == 'village' }
+      village = TreimSpec::Harness::Geography::STAGES.find { |s| s.name == 'village' }
+      others = TreimSpec::Harness::Geography::STAGES.reject { |s| s.name == 'village' }
 
       expect(village.pause_before_next).to be false
       expect(others.map(&:pause_before_next)).to all(be true)
@@ -138,25 +146,25 @@ RSpec.describe 'Treim' do
 
   describe 'Bosses' do
     it 'matches common ethereal-flavor NPC names' do
-      expect('ethereal commoner').to match(Harness::Bosses::NPC_NAME_REGEX)
-      expect('an ethereal commoner').to match(Harness::Bosses::NPC_NAME_REGEX)
+      expect('ethereal commoner').to match(TreimSpec::Harness::Bosses::NPC_NAME_REGEX)
+      expect('an ethereal commoner').to match(TreimSpec::Harness::Bosses::NPC_NAME_REGEX)
     end
 
     it 'matches multi-word boss names' do
-      expect('Patrol Leader').to match(Harness::Bosses::NPC_NAME_REGEX)
-      expect('Royal Empress').to match(Harness::Bosses::NPC_NAME_REGEX)
+      expect('Patrol Leader').to match(TreimSpec::Harness::Bosses::NPC_NAME_REGEX)
+      expect('Royal Empress').to match(TreimSpec::Harness::Bosses::NPC_NAME_REGEX)
     end
 
     it 'does not match unrelated text' do
-      expect('a wild boar').not_to match(Harness::Bosses::NPC_NAME_REGEX)
+      expect('a wild boar').not_to match(TreimSpec::Harness::Bosses::NPC_NAME_REGEX)
     end
 
     it 'lists boss nouns used to classify GameObj#noun' do
-      expect(Harness::Bosses::BOSS_NOUNS).to include('Captain', 'Emperor', 'Empress')
+      expect(TreimSpec::Harness::Bosses::BOSS_NOUNS).to include('Captain', 'Emperor', 'Empress')
     end
 
     it 'lists common nouns used to classify GameObj#noun' do
-      expect(Harness::Bosses::COMMON_NOUNS).to include('commoner', 'guard', 'bandit')
+      expect(TreimSpec::Harness::Bosses::COMMON_NOUNS).to include('commoner', 'guard', 'bandit')
     end
   end
 
@@ -164,18 +172,18 @@ RSpec.describe 'Treim' do
 
   describe 'SeenIds' do
     it 'reports ids that have been recorded' do
-      seen = Harness::SeenIds.new
+      seen = TreimSpec::Harness::SeenIds.new
       seen << 'abc'
       expect(seen.include?('abc')).to be true
     end
 
     it 'does not report unrecorded ids' do
-      seen = Harness::SeenIds.new
+      seen = TreimSpec::Harness::SeenIds.new
       expect(seen.include?('abc')).to be false
     end
 
     it 'evicts the oldest id once past max_size' do
-      seen = Harness::SeenIds.new(max_size: 2)
+      seen = TreimSpec::Harness::SeenIds.new(max_size: 2)
       seen << 'a'
       seen << 'b'
       seen << 'c'
@@ -185,7 +193,7 @@ RSpec.describe 'Treim' do
     end
 
     it 'returns self from << for chaining' do
-      seen = Harness::SeenIds.new
+      seen = TreimSpec::Harness::SeenIds.new
       expect(seen << 'a').to be(seen)
     end
   end
@@ -194,121 +202,121 @@ RSpec.describe 'Treim' do
 
   describe 'Config' do
     it 'fills in every default on first setup' do
-      Harness::Config.setup!
+      TreimSpec::Harness::Config.setup!
 
-      expect(Harness::Config.stance_dance?).to be true
-      expect(Harness::Config.attack_type).to eq('')
-      expect(Harness::Config.active_scripts).to eq([])
-      expect(Harness::Config.clear_title?).to be false
-      expect(Harness::Config.spam_control?).to be true
-      expect(Harness::Config.lag_control?).to be false
-      expect(Harness::Config.toggle_ambients?).to be false
+      expect(TreimSpec::Harness::Config.stance_dance?).to be true
+      expect(TreimSpec::Harness::Config.attack_type).to eq('')
+      expect(TreimSpec::Harness::Config.active_scripts).to eq([])
+      expect(TreimSpec::Harness::Config.clear_title?).to be false
+      expect(TreimSpec::Harness::Config.spam_control?).to be true
+      expect(TreimSpec::Harness::Config.lag_control?).to be false
+      expect(TreimSpec::Harness::Config.toggle_ambients?).to be false
     end
 
     it 'defaults announce_rares to true for a known announcer name' do
-      Harness::Char.name = 'Tysong'
-      Harness::Config.setup!
-      expect(Harness::Config.announce_rares?).to be true
+      TreimSpec::Harness::Char.name = 'Tysong'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.announce_rares?).to be true
     end
 
     it 'defaults announce_rares to false for an unknown character' do
-      Harness::Char.name = 'SomeoneElse'
-      Harness::Config.setup!
-      expect(Harness::Config.announce_rares?).to be false
+      TreimSpec::Harness::Char.name = 'SomeoneElse'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.announce_rares?).to be false
     end
 
     it 'does not overwrite an already-configured value on a later setup! call' do
-      Harness::Config.setup!
-      Harness::Config.attack_type = 'mstrike'
+      TreimSpec::Harness::Config.setup!
+      TreimSpec::Harness::Config.attack_type = 'mstrike'
 
-      Harness::Config.setup!
+      TreimSpec::Harness::Config.setup!
 
-      expect(Harness::Config.attack_type).to eq('mstrike')
+      expect(TreimSpec::Harness::Config.attack_type).to eq('mstrike')
     end
 
     it 'defaults script_args lookups to an empty string' do
-      Harness::Config.setup!
-      expect(Harness::Config.script_args_for('nonexistent')).to eq('')
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.script_args_for('nonexistent')).to eq('')
     end
   end
 
   # -- Attack dispatch -------------------------------------------------------
 
   describe 'Attack.perform dispatch' do
-    before { Harness::Config.setup! }
+    before { TreimSpec::Harness::Config.setup! }
 
     def dispatch(attack_type)
-      Harness::Config.attack_type = attack_type
-      Harness::Attack.perform
+      TreimSpec::Harness::Config.attack_type = attack_type
+      TreimSpec::Harness::Attack.perform
     end
 
     it 'dispatches mstrike/physical to physical("mstrike")' do
-      expect(Harness::Attack).to receive(:physical).with('mstrike')
+      expect(TreimSpec::Harness::Attack).to receive(:physical).with('mstrike')
       dispatch('mstrike')
     end
 
     it 'dispatches attack to physical("attack")' do
-      expect(Harness::Attack).to receive(:physical).with('attack')
+      expect(TreimSpec::Harness::Attack).to receive(:physical).with('attack')
       dispatch('attack')
     end
 
     it 'dispatches fire/ranged to physical("fire")' do
-      expect(Harness::Attack).to receive(:physical).with('fire')
+      expect(TreimSpec::Harness::Attack).to receive(:physical).with('fire')
       dispatch('fire')
     end
 
     it 'dispatches jab/punch/grapple/kick to physical(type)' do
-      expect(Harness::Attack).to receive(:physical).with('kick')
+      expect(TreimSpec::Harness::Attack).to receive(:physical).with('kick')
       dispatch('kick')
     end
 
     it 'dispatches uac to physical("mstrike punch")' do
-      expect(Harness::Attack).to receive(:physical).with('mstrike punch')
+      expect(TreimSpec::Harness::Attack).to receive(:physical).with('mstrike punch')
       dispatch('uac')
     end
 
     it 'dispatches sleep to cast_sleep' do
-      expect(Harness::Attack).to receive(:cast_sleep)
+      expect(TreimSpec::Harness::Attack).to receive(:cast_sleep)
       dispatch('sleep')
     end
 
     it 'dispatches scrub to spell_then_mstrike(435, "435")' do
-      expect(Harness::Attack).to receive(:spell_then_mstrike).with(435, '435')
+      expect(TreimSpec::Harness::Attack).to receive(:spell_then_mstrike).with(435, '435')
       dispatch('scrub')
     end
 
     it 'dispatches bardass to spell_then_mstrike(1030, "1030 open")' do
-      expect(Harness::Attack).to receive(:spell_then_mstrike).with(1030, '1030 open')
+      expect(TreimSpec::Harness::Attack).to receive(:spell_then_mstrike).with(1030, '1030 open')
       dispatch('bardass')
     end
 
     it 'dispatches dredd to spell_then_mstrike(1630, "1630 open")' do
-      expect(Harness::Attack).to receive(:spell_then_mstrike).with(1630, '1630 open')
+      expect(TreimSpec::Harness::Attack).to receive(:spell_then_mstrike).with(1630, '1630 open')
       dispatch('dredd')
     end
 
     it 'dispatches the bare "1030" attack type to cast_only(1030, "1030 open", pause_before: 2)' do
-      expect(Harness::Attack).to receive(:cast_only).with(1030, '1030 open', pause_before: 2)
+      expect(TreimSpec::Harness::Attack).to receive(:cast_only).with(1030, '1030 open', pause_before: 2)
       dispatch('1030')
     end
 
     it 'dispatches 709 to cast_and_release(709, "stop 709")' do
-      expect(Harness::Attack).to receive(:cast_and_release).with(709, 'stop 709')
+      expect(TreimSpec::Harness::Attack).to receive(:cast_and_release).with(709, 'stop 709')
       dispatch('709')
     end
 
     it 'dispatches bare 435/635 to cast_only(type, type, pause_before: 2)' do
-      expect(Harness::Attack).to receive(:cast_only).with('435', '435', pause_before: 2)
+      expect(TreimSpec::Harness::Attack).to receive(:cast_only).with('435', '435', pause_before: 2)
       dispatch('435')
     end
 
     it 'dispatches a custom ".lic" attack type to run_custom_script' do
-      expect(Harness::Attack).to receive(:run_custom_script).with('duskattack.lic')
+      expect(TreimSpec::Harness::Attack).to receive(:run_custom_script).with('duskattack.lic')
       dispatch('duskattack.lic')
     end
 
     it 'dispatches an unrecognized spell number to cast_generic' do
-      expect(Harness::Attack).to receive(:cast_generic).with('908')
+      expect(TreimSpec::Harness::Attack).to receive(:cast_generic).with('908')
       dispatch('908')
     end
 
@@ -321,10 +329,10 @@ RSpec.describe 'Treim' do
   # -- Attack handler bodies -------------------------------------------------
 
   describe 'Attack handler bodies' do
-    before { Harness::Config.setup! }
+    before { TreimSpec::Harness::Config.setup! }
 
     it 'physical stance-dances to offensive, sends the command, then back to defensive' do
-      Harness::Attack.physical('mstrike')
+      TreimSpec::Harness::Attack.physical('mstrike')
 
       expect(LichStub::GameStub.calls).to eq([
                                                [:waitrt?],
@@ -337,10 +345,10 @@ RSpec.describe 'Treim' do
     end
 
     it 'physical skips stance dancing when disabled' do
-      Harness::Config.setup!
-      Harness::UserVars.treim[:stance_dance] = false
+      TreimSpec::Harness::Config.setup!
+      TreimSpec::Harness::UserVars.treim[:stance_dance] = false
 
-      Harness::Attack.physical('mstrike')
+      TreimSpec::Harness::Attack.physical('mstrike')
 
       expect(LichStub::GameStub.calls).to eq([[:waitrt?], [:fput, 'mstrike']])
     end
@@ -348,22 +356,22 @@ RSpec.describe 'Treim' do
     it 'physical does not re-issue "stance offensive" when already offensive' do
       LichStub::GameStub.stance = 'offensive'
 
-      Harness::Attack.physical('mstrike')
+      TreimSpec::Harness::Attack.physical('mstrike')
 
       expect(LichStub::GameStub.calls.first(2)).to eq([[:waitrt?], [:fput, 'mstrike']])
     end
 
     it 'cast_only does nothing but return true when the spell is unaffordable' do
-      Harness::Spell.affordable = false
+      TreimSpec::Harness::Spell.affordable = false
 
-      expect(Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)).to be true
+      expect(TreimSpec::Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)).to be true
       expect(LichStub::GameStub.calls).to eq([])
     end
 
     it 'cast_only casts the spell when affordable' do
-      Harness::Spell.affordable = true
+      TreimSpec::Harness::Spell.affordable = true
 
-      Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)
+      TreimSpec::Harness::Attack.cast_only(1030, '1030 open', pause_before: 2)
 
       expect(LichStub::GameStub.calls).to eq([
                                                [:waitrt?],
@@ -374,9 +382,9 @@ RSpec.describe 'Treim' do
     end
 
     it 'spell_then_mstrike falls back to a plain mstrike when unaffordable' do
-      Harness::Spell.affordable = false
+      TreimSpec::Harness::Spell.affordable = false
 
-      Harness::Attack.spell_then_mstrike(1030, '1030 open')
+      TreimSpec::Harness::Attack.spell_then_mstrike(1030, '1030 open')
 
       expect(LichStub::GameStub.calls).to eq([
                                                [:waitrt?],
@@ -389,14 +397,27 @@ RSpec.describe 'Treim' do
     end
 
     it 'run_custom_script starts the script with ".lic" stripped, case-insensitively' do
-      Harness::Attack.run_custom_script('DuskAttack.LIC')
-      expect(Harness::Script.started).to eq([['DuskAttack', nil]])
+      TreimSpec::Harness::Attack.run_custom_script('DuskAttack.LIC')
+      expect(TreimSpec::Harness::Script.started).to eq([['DuskAttack', nil]])
     end
 
     it 'run_custom_script does not restart an already-running script' do
-      Harness::Script.mark_running!('duskattack')
-      Harness::Attack.run_custom_script('duskattack.lic')
-      expect(Harness::Script.started).to eq([])
+      TreimSpec::Harness::Script.mark_running!('duskattack')
+      TreimSpec::Harness::Attack.run_custom_script('duskattack.lic')
+      expect(TreimSpec::Harness::Script.started).to eq([])
+    end
+
+    it 'affordable? is false, not a crash, for an unrecognized spell number' do
+      TreimSpec::Harness::Spell.known = false
+
+      expect(TreimSpec::Harness::Attack.affordable?(9999)).to be false
+    end
+
+    it 'cast_generic does nothing but return true for an unrecognized spell number' do
+      TreimSpec::Harness::Spell.known = false
+
+      expect(TreimSpec::Harness::Attack.cast_generic(9999)).to be true
+      expect(LichStub::GameStub.calls).to eq([])
     end
   end
 
@@ -404,31 +425,41 @@ RSpec.describe 'Treim' do
 
   describe 'ClearProgress.check' do
     it 'parses clear-to stage, scrip, and hours+minutes remaining' do
-      Harness::Lich::Util.issue_command_result = [
+      TreimSpec::Harness::Lich::Util.issue_command_result = [
         'You are currently flagged for entry for up to the road.',
         'Total Ethereal Scrip for this run: 500/1000',
         'You have 1 hour and 30 minutes remaining in the Settlement of Reim.'
       ]
 
-      result = Harness::ClearProgress.check
+      result = TreimSpec::Harness::ClearProgress.check
 
       expect(result.clear_to).to eq('road')
       expect(result.scrip).to eq(500)
       expect(result.time_left).to eq('1H 30M')
     end
 
-    it 'parses a bare minutes-remaining line when under an hour is left' do
-      Harness::Lich::Util.issue_command_result = ['You have 45 minutes remaining.']
+    it 'parses plural hours remaining (2+ hours left)' do
+      TreimSpec::Harness::Lich::Util.issue_command_result = [
+        'You have 2 hours and 15 minutes remaining in the Settlement of Reim.'
+      ]
 
-      result = Harness::ClearProgress.check
+      result = TreimSpec::Harness::ClearProgress.check
+
+      expect(result.time_left).to eq('2H 15M')
+    end
+
+    it 'parses a bare minutes-remaining line when under an hour is left' do
+      TreimSpec::Harness::Lich::Util.issue_command_result = ['You have 45 minutes remaining.']
+
+      result = TreimSpec::Harness::ClearProgress.check
 
       expect(result.time_left).to eq('45M')
     end
 
     it 'returns nils for fields REIM INFO did not report' do
-      Harness::Lich::Util.issue_command_result = []
+      TreimSpec::Harness::Lich::Util.issue_command_result = []
 
-      result = Harness::ClearProgress.check
+      result = TreimSpec::Harness::ClearProgress.check
 
       expect(result.clear_to).to be_nil
       expect(result.scrip).to be_nil
@@ -440,19 +471,19 @@ RSpec.describe 'Treim' do
       # a live target (which makes wait_for_death's loop run at least once)
       # is distinguished from an already-dead one by an *extra* pause call,
       # not by whether pause was called at all.
-      npc = FakeNpc.new('123', 'captain', 'The Captain', 'alive')
-      Harness::GameObj.npcs = [npc]
+      npc = TreimSpec::FakeNpc.new('123', 'captain', 'The Captain', 'alive')
+      TreimSpec::Harness::GameObj.npcs = [npc]
       LichStub::GameStub.on_pause = -> { npc.status = 'dead' }
 
-      Harness::ClearProgress.check(target_id: '123')
+      TreimSpec::Harness::ClearProgress.check(target_id: '123')
 
       expect(LichStub::GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(2)
     end
 
     it 'does not wait when the target is already dead' do
-      Harness::GameObj.npcs = [FakeNpc.new('123', 'captain', 'The Captain', 'dead')]
+      TreimSpec::Harness::GameObj.npcs = [TreimSpec::FakeNpc.new('123', 'captain', 'The Captain', 'dead')]
 
-      Harness::ClearProgress.check(target_id: '123')
+      TreimSpec::Harness::ClearProgress.check(target_id: '123')
 
       expect(LichStub::GameStub.calls.count { |call| call == [:pause, 0.5] }).to eq(1)
     end
@@ -463,26 +494,26 @@ RSpec.describe 'Treim' do
   describe 'Party' do
     it "reports the character's own name as leader when leading" do
       Group.leader = :self
-      Harness::Char.name = 'Tysong'
-      expect(Harness::Party.leader_name).to eq('Tysong')
+      TreimSpec::Harness::Char.name = 'Tysong'
+      expect(TreimSpec::Harness::Party.leader_name).to eq('Tysong')
     end
 
     it "reports the leader's noun when someone else is leading" do
-      Group.leader = FakeNpc.new('1', 'Durakar', nil, nil)
-      expect(Harness::Party.leader_name).to eq('Durakar')
+      Group.leader = TreimSpec::FakeNpc.new('1', 'Durakar', nil, nil)
+      expect(TreimSpec::Harness::Party.leader_name).to eq('Durakar')
     end
 
     it 'returns nil for leader_name when the leader is unknown' do
       Group.leader = nil
-      expect(Harness::Party.leader_name).to be_nil
+      expect(TreimSpec::Harness::Party.leader_name).to be_nil
     end
 
     it "includes the character's own name in member_names" do
-      Harness::Char.name = 'Tysong'
+      TreimSpec::Harness::Char.name = 'Tysong'
       Group.leader = :self
-      Group.members = [FakeNpc.new('1', 'Durakar', nil, nil)]
+      Group.members = [TreimSpec::FakeNpc.new('1', 'Durakar', nil, nil)]
 
-      expect(Harness::Party.member_names).to contain_exactly('Tysong', 'Durakar')
+      expect(TreimSpec::Harness::Party.member_names).to contain_exactly('Tysong', 'Durakar')
     end
   end
 
@@ -490,19 +521,19 @@ RSpec.describe 'Treim' do
 
   describe 'FamiliarWindow.wrap' do
     it 'uses pushStream tags on an XML-capable frontend' do
-      Harness::Lich::Common::Frontend.xml_supported = true
-      expect(Harness::FamiliarWindow.wrap('hi')).to include('pushStream').and include('popStream')
+      TreimSpec::Harness::Lich::Common::Frontend.xml_supported = true
+      expect(TreimSpec::Harness::FamiliarWindow.wrap('hi')).to include('pushStream').and include('popStream')
     end
 
     it 'uses the legacy GSe/GSf escape sequence otherwise' do
-      Harness::Lich::Common::Frontend.xml_supported = false
-      wrapped = Harness::FamiliarWindow.wrap('hi')
+      TreimSpec::Harness::Lich::Common::Frontend.xml_supported = false
+      wrapped = TreimSpec::Harness::FamiliarWindow.wrap('hi')
       expect(wrapped).to include("\034GSe\r\n").and include("\034GSf\r\n")
     end
 
     it 'includes the given message either way' do
-      Harness::Lich::Common::Frontend.xml_supported = true
-      expect(Harness::FamiliarWindow.wrap('Mob Count: 5')).to include('Mob Count: 5')
+      TreimSpec::Harness::Lich::Common::Frontend.xml_supported = true
+      expect(TreimSpec::Harness::FamiliarWindow.wrap('Mob Count: 5')).to include('Mob Count: 5')
     end
   end
 end

--- a/spec/scripts/treim_spec.rb
+++ b/spec/scripts/treim_spec.rb
@@ -225,6 +225,28 @@ RSpec.describe 'Treim' do
       expect(TreimSpec::Harness::Config.announce_rares?).to be false
     end
 
+    it 'defaults debug_echo to true for a known debug name, false otherwise' do
+      TreimSpec::Harness::Char.name = 'Tysong'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.debug_echo?).to be true
+
+      TreimSpec::Harness::UserVars.reset!
+      TreimSpec::Harness::Char.name = 'SomeoneElse'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.debug_echo?).to be false
+    end
+
+    it 'defaults mob_count_window to true for a known name, false otherwise' do
+      TreimSpec::Harness::Char.name = 'Rasko'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.mob_count_window?).to be true
+
+      TreimSpec::Harness::UserVars.reset!
+      TreimSpec::Harness::Char.name = 'SomeoneElse'
+      TreimSpec::Harness::Config.setup!
+      expect(TreimSpec::Harness::Config.mob_count_window?).to be false
+    end
+
     it 'does not overwrite an already-configured value on a later setup! call' do
       TreimSpec::Harness::Config.setup!
       TreimSpec::Harness::Config.attack_type = 'mstrike'
@@ -514,6 +536,11 @@ RSpec.describe 'Treim' do
       Group.members = [TreimSpec::FakeNpc.new('1', 'Durakar', nil, nil)]
 
       expect(TreimSpec::Harness::Party.member_names).to contain_exactly('Tysong', 'Durakar')
+    end
+
+    it 'refresh! forces a synchronous Group.check' do
+      TreimSpec::Harness::Party.refresh!
+      expect(Group.check_count).to eq(1)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+# spec/spec_helper.rb - shared scaffolding for this repo's ".lic script"
+# specs (spec/scripts, and any future spec that extracts a script's real
+# module/method bodies and evaluates them against stubs).
+#
+# Modeled on lich-5's spec/spec_helper.rb, but much narrower in scope: this
+# repo's specs are about individual *scripts*, not the runtime itself, so
+# this file only centralizes what genuinely repeats across them --
+#   1. path/extraction helpers for pulling real code out of a `.lic` file
+#      (every existing spec/scripts/*_spec.rb duplicated some version of
+#      this "search a few candidate paths, then regex out a def/module/
+#      class body, raising loudly if either step fails" boilerplate), and
+#   2. generic Lich runtime stand-ins that are safe to share process-wide
+#      (UserVars, Char, Script, Spell, Group, Lich::Util,
+#      Lich::Common::Frontend) plus the handful of bare game-command
+#      methods (waitrt?, waitcastrt?, fput, put, pause, checkstance) that
+#      extracted module_function methods call with an implicit receiver.
+#
+# What this deliberately does NOT provide: a shared GameObj stub.
+# lib/lich/gameobj.rb defines a real, TOP-LEVEL `GameObj` class that
+# spec/gameobj-data loads and exercises directly; defining another
+# top-level `GameObj` here -- even a stub -- would reopen and corrupt that
+# class for every other spec file loaded in the same rspec process (Ruby
+# happily merges reopened class bodies, silently overwriting methods like
+# `GameObj.npcs`). Existing specs already avoid this by nesting their own
+# GameObj stub inside a private Harness namespace instead of defining it at
+# top level (see spec/bigshot/priority_spec.rb's comment on the same
+# constraint); do the same in yours if you need one.
+#
+# Usage: `require_relative '../spec_helper'` (adjust the relative depth to
+# your file's location under spec/), then reference LichStub::UserVars,
+# LichStub::Char, etc. directly, or alias them into your own Harness
+# namespace -- the same way spec/scripts/ledger_spec.rb already aliases its
+# extracted Window module into Harness::Ledger::Window -- if your extracted
+# code needs to find them via lexical constant lookup rather than an
+# explicit `LichStub::` prefix.
+
+require 'rspec'
+
+SPEC_ROOT = File.expand_path(__dir__) unless defined?(SPEC_ROOT)
+REPO_ROOT = File.expand_path('..', SPEC_ROOT) unless defined?(REPO_ROOT)
+
+# -- .lic extraction helpers -------------------------------------------
+
+# Locates a `.lic` file by name, checking a few likely locations relative to
+# the calling spec's own directory. Mirrors the multi-candidate search list
+# every existing extraction-style spec in this repo already duplicated.
+#
+# @param lic_name [String] e.g. "treim.lic"
+# @param from [String] the calling spec file's own `__dir__`
+# @return [String] absolute path to the found file
+# @raise [RuntimeError] if lic_name isn't found anywhere in the search path
+def find_lic_source(lic_name, from:)
+  path = [
+    File.expand_path(lic_name, from),
+    File.expand_path("../#{lic_name}", from),
+    File.expand_path("../../#{lic_name}", from),
+    File.expand_path("../scripts/#{lic_name}", from),
+    File.expand_path("../../scripts/#{lic_name}", from)
+  ].find { |p| File.exist?(p) }
+  raise "#{lic_name} not found (searched relative to #{from})" unless path
+
+  path
+end
+
+# Pulls the first substring of source matching pattern, raising loudly
+# instead of silently testing against a stale/absent extraction if the
+# source no longer contains what the spec expects.
+#
+# @param source [String] full file contents to search
+# @param pattern [Regexp] must be anchored precisely enough to match once
+# @param label [String] used only in the raised error message
+# @param source_path [String, nil] used only in the raised error message
+# @return [String] the matched substring
+# @raise [RuntimeError] if pattern does not match anywhere in source
+def extract_from_source(source, pattern, label:, source_path: nil)
+  found = source[pattern]
+  raise "could not extract #{label} from #{source_path || 'source'}" unless found
+
+  found
+end
+
+# Extracts one `module Name ... end` / `class Name ... end` body, indented
+# two spaces (i.e. nested exactly one level under a script's outer
+# namespace module), for module_eval'ing into a spec's own harness.
+#
+# @param source [String] full `.lic` file contents
+# @param name [String] the module/class name, e.g. "Geography"
+# @param kind ["module", "class"]
+# @param source_path [String, nil] used only in the raised error message
+# @return [String] the extracted source, including the module/class wrapper
+# @raise [RuntimeError] if no matching, two-space-indented body is found
+def extract_lic_module(source, name, kind: 'module', source_path: nil)
+  extract_from_source(source, /^  #{kind} #{name}\n.*?\n  end\n/m, label: "#{kind} #{name}", source_path: source_path)
+end
+
+# -- Generic Lich runtime stand-ins --------------------------------------
+#
+# Every constant here is a bare-bones stand-in for a real Lich global,
+# reset between examples by the RSpec.configure block below. They're
+# namespaced under LichStub rather than defined at top level so a spec can
+# choose exactly which ones it needs (aliasing them into its own Harness)
+# instead of silently inheriting all of them.
+
+module LichStub
+  FakeNpc = Struct.new(:id, :noun, :name, :status)
+
+  # Stand-in for Lich's UserVars: any character variable name works as a
+  # getter/setter (`UserVars.treim`, `UserVars.treim = {}`, ...), backed by
+  # a plain Hash, the same way the real thing is backed by a settings store.
+  module UserVars
+    class << self
+      def reset!
+        @store = {}
+      end
+
+      def method_missing(name, *args)
+        key = name.to_s.delete_suffix('=').to_sym
+        name.to_s.end_with?('=') ? (store[key] = args.first) : store[key]
+      end
+
+      def respond_to_missing?(*) = true
+
+      private
+
+      def store
+        @store ||= {}
+      end
+    end
+  end
+
+  module Char
+    class << self
+      attr_accessor :name
+    end
+  end
+
+  module Script
+    class << self
+      def reset!
+        @started = []
+        @running = []
+      end
+
+      attr_reader :started
+
+      def start(name, args = nil)
+        @started << [name, args]
+      end
+
+      def running?(name)
+        @running.include?(name)
+      end
+
+      def mark_running!(name)
+        @running << name
+      end
+
+      def kill(name)
+        @running.delete(name)
+      end
+
+      def pause(_name) = nil
+      def unpause(_name) = nil
+      def exists?(_name) = true
+    end
+  end
+
+  class Spell
+    class << self
+      attr_accessor :affordable
+
+      def [](number)
+        new(number)
+      end
+    end
+
+    def initialize(number)
+      @number = number
+    end
+
+    def affordable?
+      Spell.affordable.nil? || Spell.affordable
+    end
+  end
+
+  module Lich
+    module Util
+      class << self
+        attr_accessor :issue_command_result
+
+        def issue_command(*)
+          issue_command_result || []
+        end
+      end
+    end
+
+    module Common
+      module Frontend
+        class << self
+          attr_accessor :xml_supported
+
+          def supports_xml?
+            !!xml_supported
+          end
+        end
+      end
+    end
+  end
+
+  # Records of/controls for the bare game-command calls extracted
+  # module_function methods make with an implicit receiver (see the
+  # top-level waitrt?/fput/put/pause/checkstance stubs below).
+  module GameStub
+    class << self
+      attr_accessor :stance, :on_pause
+
+      def calls
+        @calls ||= []
+      end
+
+      def reset!
+        @calls = []
+        @stance = 'defensive'
+        @on_pause = nil
+      end
+    end
+  end
+
+  def self.reset_all!
+    UserVars.reset!
+    Script.reset!
+    Spell.affordable = nil
+    ::Group.leader = nil
+    ::Group.members = []
+    Lich::Util.issue_command_result = nil
+    Lich::Common::Frontend.xml_supported = nil
+    GameStub.reset!
+  end
+end
+
+# Defined at the true top level (not nested, and not inside an RSpec.describe
+# block, whose body is class_eval'd into an example-group subclass) so
+# implicit-receiver calls from eval'd module_function methods -- whatever
+# namespace they were module_eval'd into -- can find them. Ruby resolves an
+# implicit-receiver call via the *receiver's* method lookup chain, not
+# lexical nesting, and every object's chain bottoms out at Object/Kernel;
+# that's also exactly why Lich's own equivalents are defined at the top
+# level of lib/global_defs.rb, making them callable unqualified from
+# arbitrarily-nested .lic script code in the first place.
+def waitrt?
+  LichStub::GameStub.calls << [:waitrt?]
+  false
+end
+
+def waitcastrt?
+  LichStub::GameStub.calls << [:waitcastrt?]
+  false
+end
+
+def fput(command)
+  LichStub::GameStub.calls << [:fput, command]
+  LichStub::GameStub.stance = 'offensive' if command == 'stance offensive'
+  LichStub::GameStub.stance = 'defensive' if command == 'stance defensive'
+  command
+end
+
+def put(command)
+  LichStub::GameStub.calls << [:put, command]
+  command
+end
+
+def pause(seconds = 1)
+  LichStub::GameStub.calls << [:pause, seconds]
+  LichStub::GameStub.on_pause&.call
+end
+
+def checkstance
+  LichStub::GameStub.stance
+end
+
+# Also defined at the true top level, but for a different reason than the
+# game-command methods above: production script code reaches for the native
+# Group API via an explicitly absolute `::Group` (see treim.lic), not a bare
+# `Group`, specifically so it always resolves to the real top-level class
+# regardless of what namespace the calling code is nested in. That means a
+# nested LichStub::Group would never be found here -- only a genuine
+# top-level one satisfies `::Group`. Confirmed safe: nothing else in this
+# repo's lib/ defines a top-level Group.
+module Group
+  class << self
+    attr_accessor :leader, :members
+
+    def leader?
+      leader == :self
+    end
+  end
+end
+
+# -- RSpec configuration --------------------------------------------------
+
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = File.join(SPEC_ROOT, '.rspec_status')
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # Reset shared LichStub state before each example so specs that use it
+  # can't leak configuration or call logs into one another.
+  config.before do
+    LichStub.reset_all!
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,7 +92,50 @@ end
 # @return [String] the extracted source, including the module/class wrapper
 # @raise [RuntimeError] if no matching, two-space-indented body is found
 def extract_lic_module(source, name, kind: 'module', source_path: nil)
-  extract_from_source(source, /^  #{kind} #{name}\n.*?\n  end\n/m, label: "#{kind} #{name}", source_path: source_path)
+  body = extract_from_source(source, /^  #{kind} #{name}\n.*?\n  end\n/m, label: "#{kind} #{name}", source_path: source_path)
+  assert_parses!(body, label: "#{kind} #{name}", source_path: source_path)
+  body
+end
+
+# Extracts a `def self.name ... end` method body, matching whatever
+# indentation depth it's actually written at (unlike extract_lic_module,
+# which assumes a fixed two-space module/class nesting level) -- so it works
+# for methods nested at different depths within the same `.lic` file.
+#
+# @param source [String] full `.lic` file contents
+# @param name [String] the method name, e.g. "box_loot"
+# @param source_path [String, nil] used only in the raised error message
+# @return [String] the extracted method body, including `def`/`end`
+# @raise [RuntimeError] if no `def self.name ... end` is found, or if what
+#   was found isn't complete, parseable Ruby (a truncated extraction)
+def extract_lic_method(source, name, source_path: nil)
+  # (?![\w?!]) rather than \b: name may itself end in ?/! (pool_full_recovery?),
+  # and \b does not match between two non-word characters (e.g. "?" then "("),
+  # so it would fail to find methods whose signature has no space before "(".
+  match = source.match(/^( +)def self\.#{Regexp.escape(name)}(?![\w?!])[\s\S]*?\n\1end$/)
+  raise "could not extract #{name} from #{source_path || 'source'}" unless match
+
+  assert_parses!(match[0], label: name, source_path: source_path)
+  match[0]
+end
+
+# Guards every generic .lic extraction helper above against a regex that
+# matched too little (or too much): a non-greedy `.*?end` can stop at the
+# first same-indent `end` it finds, which is usually the real boundary but
+# would silently return a truncated, invalid body if a nested construct or
+# heredoc ever produced a same-indent `end` of its own. Parsing catches that
+# case loudly instead of handing a spec broken Ruby to module_eval.
+#
+# @param body [String] extracted source expected to be complete Ruby
+# @param label [String] used only in the raised error message
+# @param source_path [String, nil] used only in the raised error message
+# @return [void]
+# @raise [RuntimeError] if body is not syntactically complete Ruby
+def assert_parses!(body, label:, source_path: nil)
+  RubyVM::AbstractSyntaxTree.parse(body)
+rescue SyntaxError => e
+  raise "extracted #{label} from #{source_path || 'source'} is not valid, complete Ruby " \
+        "(likely truncated by the extraction regex): #{e.message}"
 end
 
 # -- Generic Lich runtime stand-ins --------------------------------------
@@ -241,6 +284,7 @@ module LichStub
     Spell.known = nil
     ::Group.leader = nil
     ::Group.members = []
+    ::Group.instance_variable_set(:@check_count, 0)
     Lich::Util.issue_command_result = nil
     Lich::Common::Frontend.xml_supported = nil
     GameStub.reset!
@@ -301,6 +345,17 @@ module Group
 
     def leader?
       leader == :self
+    end
+
+    # No-op stand-in for the real Group.check (which sends the GROUP
+    # command and blocks for a response); just counts calls so a spec can
+    # confirm something like Party.refresh! actually reaches for it.
+    def check
+      @check_count = (@check_count || 0) + 1
+    end
+
+    def check_count
+      @check_count || 0
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,9 +169,14 @@ module LichStub
 
   class Spell
     class << self
-      attr_accessor :affordable
+      attr_accessor :affordable, :known
 
+      # @param number [Integer, String]
+      # @return [Spell, nil] nil simulates an unrecognized spell number, the
+      #   same as the real Spell[] for a number matching no known spell
       def [](number)
+        return nil if known == false
+
         new(number)
       end
     end
@@ -230,8 +235,10 @@ module LichStub
 
   def self.reset_all!
     UserVars.reset!
+    Char.name = nil
     Script.reset!
     Spell.affordable = nil
+    Spell.known = nil
     ::Group.leader = nil
     ::Group.members = []
     Lich::Util.issue_command_result = nil


### PR DESCRIPTION
## Summary
- Full rewrite of `treim.lic` from a flat 789-line procedural script into a namespaced, YARD-documented `Treim` module (`Geography`, `Bosses`, `Attack`, `ClearProgress`, `Party`, `Runner`), following the same modernization pattern established in `dailyvote.lic`.
- Every constant is guarded with `unless const_defined?` so repeated `;treim` invocations in the same Lich process never redefine/warn.
- Adopts current Lich5 API surface: the native `Group` API replaces manual `GROUP` command text-parsing, `Lich::Util.issue_command` replaces the hand-rolled `silence` proc + `DownstreamHook` pairs, and `Frontend.supports_xml?` replaces the `$frontend` regex check.
- Boss-wave stage progression (Village → Road → … → Royal) is now data-driven (`Geography::STAGES`) instead of five copy-pasted `elsif` branches, and the ~10 near-identical stance-dance/attack blocks in the old `attack_routine` collapse into shared helpers behind a `case` dispatch in `Attack`.
- Fixes two real crash bugs found during the rewrite: `variable[2].downcase` and the help/reuse-attack-type check both called `.downcase` on `nil` in very common invocation paths (any run without a second argument; any no-arg rerun after an attack type was already configured) — both raised `NoMethodError`.
- Behavior is otherwise preserved 1:1 against the original, including a couple of intentionally-kept legacy quirks (documented inline) where "fixing" them wasn't this PR's call to make.
- Adds `spec/scripts/treim_spec.rb`, extracting the pure/near-pure modules (`Geography`, `Bosses`, `SeenIds`, `Config`, `Attack` dispatch + handler bodies, `ClearProgress`, `Party`, `FamiliarWindow`) from the shipped source the same way `ledger_spec.rb`/`eloot_spec.rb` do, so the specs fail if the production code drifts.

## Test plan
- [x] `ruby -c scripts/treim.lic` — syntax OK
- [x] `rubocop scripts/treim.lic spec/scripts/treim_spec.rb` — zero offenses
- [x] `rspec spec/scripts/treim_spec.rb` — 56 examples, 0 failures
- [x] `rspec spec/scripts` (full suite) — 204 examples, 0 failures
- [ ] Live REIM run to confirm `Lich::Util.issue_command`-based REIM INFO/title-show parsing and native `Group` API behavior against real game output (not exercised by the spec suite; noted as an open item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automated REIM navigation, wave handling, combat actions, progress tracking, party coordination, trap responses, and familiar-window messages.
  - Added improved configuration options for attack styles, stance control, lag and spam controls, ambient toggles, and rare-item announcements.

- **Bug Fixes**
  - Improved handling for missing arguments, leader detection, floods, bosses, stage transitions, and shutdown cleanup.

- **Tests**
  - Expanded automated coverage for navigation, combat, progress reporting, party status, configuration, and message formatting.
  - Added shared testing utilities for more consistent script validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->