### PR TITLE
feat(messaging.lic): v1.2.0 Saga UTF emoji support and additional messaging support

### DIFF
--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -168,225 +168,225 @@ end
 def messaging_transform(server_string)
   server_string = " #{server_string}" if server_string =~ /\A\*\s/
   result = if server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just bit the dust\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just bit the dust\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just got squashed\!\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just got squashed\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) has gone to feed the fishes\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just turned (?:.*) last page\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just turned (?:.*) last page\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) was just put on ice\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) was just put on ice\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just punched a one-way ticket\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just punched a one-way ticket\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is going home on (?:.*) shield\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is going home on (?:.*) shield\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just took a long walk off of a short pier\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just took a long walk off of a short pier\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is dust in the wind\!(.*)$/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is dust in the wind\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is six hundred feet under\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is six hundred feet under\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just lost (?:.*) way somewhere in the Settlement of Reim\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just perished defending a fortress within Reim\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just gave up the ghost\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Trail to Icemule or Solhaven #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) may just be going home on (?:.*) shield\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Red Forest/Aradhul Road #{$3}\n"
-    elsif server_string =~ /(.*) \* The death cry of (.*) echoes in your mind\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Rift #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) flame just burnt out in the Sea of Fire\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Sanctum of Scales #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just sank to the bottom of the Tenebrous Cauldron\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Open Sea Adventures #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just (?:.*) the Elemental Confluence\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is going home from the Elemental Confluence on (?:.*) shield\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is dust in the winds of the Elemental Confluence\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes in the Elemental Confluence\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) failed to bring a shrubbery to the Night at the Academy\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Night at the Academy #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) failed within the Bank at Bloodriven\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Heist #{$3}\n"
-    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Swarm Duskruin Arena\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Swarm #{$4}\n"
-    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Duskruin Arena\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Endless #{$4}\n"
-    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Duskruin Arena\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Arena #{$4}\n"
-    elsif server_string =~ /(.*) \* (.*) was just defeated in Duskruin Arena\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Arena #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) hopes just sank in Sailor\'s Grief\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Sailor's Grief #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just got iced in the Hinterwilds\!(.*)/
-      "#{$1} * #{$2} - #{DEATH_MARKER} Hinterwilds #{$3}\n"
+             "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just bit the dust\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just got squashed\!\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just got squashed\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) has gone to feed the fishes\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just turned (?:.*) last page\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just turned (?:.*) last page\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) was just put on ice\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) was just put on ice\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just punched a one-way ticket\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just punched a one-way ticket\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is going home on (?:.*) shield\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is going home on (?:.*) shield\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just took a long walk off of a short pier\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just took a long walk off of a short pier\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is dust in the wind\!(.*)$/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is dust in the wind\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is six hundred feet under\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is six hundred feet under\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just lost (?:.*) way somewhere in the Settlement of Reim\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just perished defending a fortress within Reim\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just gave up the ghost\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Trail to Icemule or Solhaven #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) may just be going home on (?:.*) shield\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Red Forest/Aradhul Road #{$3}\n"
+           elsif server_string =~ /(.*) \* The death cry of (.*) echoes in your mind\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Rift #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) flame just burnt out in the Sea of Fire\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Sanctum of Scales #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just sank to the bottom of the Tenebrous Cauldron\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Open Sea Adventures #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just (?:.*) the Elemental Confluence\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is going home from the Elemental Confluence on (?:.*) shield\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is dust in the winds of the Elemental Confluence\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes in the Elemental Confluence\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) failed to bring a shrubbery to the Night at the Academy\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Night at the Academy #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) failed within the Bank at Bloodriven\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Heist #{$3}\n"
+           elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Swarm Duskruin Arena\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Swarm #{$4}\n"
+           elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Duskruin Arena\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Endless #{$4}\n"
+           elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Duskruin Arena\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Arena #{$4}\n"
+           elsif server_string =~ /(.*) \* (.*) was just defeated in Duskruin Arena\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Arena #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) hopes just sank in Sailor\'s Grief\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Sailor's Grief #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just got iced in the Hinterwilds\!(.*)/
+             "#{$1} * #{$2} - #{DEATH_MARKER} Hinterwilds #{$3}\n"
 =begin
 BEGIN LOGIN/LOGOUT MESSAGING
 =end
-    elsif server_string =~ /(.*) \* (.*) joins the adventure\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) rises from (?:.*) grave!  There was much rejoicing\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) takes off (?:.*) lobster bib and gets ready for action\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Looks like (.*) is awake.  Good morning, Elanthia\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A warhorn's clarion call rings out, heralding the return of (.*)\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A cloud of deep shadow coalesces, then fades to reveal (.*)\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Pour some coffee, (.*) has arrived\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A snowy white owl grasping a silver dagger soars in, heralding the sudden arrival of (.*)\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A trio of blaring horns broadcasts (.*) arrival\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Got jasmine\?  (.*) does\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* The reverberating sound of a gong announces the arrival of (.*)\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has arrived, munching the last bite of a big pickle\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has arrived to save the day\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) arrives, in search of mines and tunnels\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) arranges (?:.*) quills and parchments, ready to begin\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) arrives, proudly displaying (?:.*) papers\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A chorus of squawking penguins signals the arrival of (.*)\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) hops off the turnip wagon, ready to defend the town\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) hits the cobblestones running\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Rejoice, peasants! (.*) has arrived and the adventure can truly begin\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) returns for more merrymaking\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has decided to drop anchor in this fine port of call\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A troop of minstrels sings, their voices in perfect harmony, crooning the arrival of (.*)\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has come out of a rabbit hole, and is ready for adventure\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Hey, what's that smell? Oh, it's (.*)\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* A deep-voiced announcer loudly proclaims, "Heeeere's (.*)\!"(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) arrives, accompanied by a fanfare of trumpets\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* Roaring applause accompanies the arrival of (.*)\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* The POP of a cork accompanies the arrival of (.*)\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just sneaked back in\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has arrived, as gorgeous as ever\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) returns from the wild\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* The level of empathy and common decency ceases to exist upon (.*)'s arrival\.(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has arrived to replenish (?:.*) stockpile of reagents\!(.*)/
-      "#{$1}#{$2} On #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) returns home from a hard day of adventuring\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has disconnected\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) just got knocked over the head and dragged down a dark alley.  Good night, (?:.*)\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* Encroaching dark shadows swallow (.*) and then dissolves, leaving nothing behind\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* The ground trembles briefly as (.*) heads off\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) grabs a crystal amulet and heads off, looking for a boot\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) puts away (?:.*) shovel and heads for the nearest tavern\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) returns home, closing t(?:.*) chapter of (?:.*) book\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) calls a halt to (?:.*) campaign for the day\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) packs up (?:.*) tarts and heads home\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) retires before losing any more deeds\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) hits the road\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* With a heavy heart, (.*) trudges away. Life will simply not be the same without him\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) shall return to the merriment, anon\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is out like a trout\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as he wanders off\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) is late for a very important date and jumps back down a rabbit hole\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) departs, vowing to fight another day\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has gone home. Someone spray the disinfectant\!(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* A deep-voiced announcer loudly declares, "(.*) has left the realms\!"(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* Worn out from (?:.*) heroic adventures, (.*) shuffles out of Elanthia\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* A sad trombone refrain bids farewell to (.*)\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* The faint sound of weeping signifies (.*)'s departure\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as (?:.*) wanders off\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) goes home to sleep it off\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* The jasmine supply has been gravely diminished, so (.*) is going home\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) has had enough of t(?:.*) for the time being\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) goes off to primp and preen\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \*  Gathering the folds of (?:.*), (.*) tiredly climbs a nearby tree for a nap\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) leaves to heed the call of nature\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* (.*) returns to the workshop\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
-    else
-      server_string
-  end
+           elsif server_string =~ /(.*) \* (.*) joins the adventure\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) rises from (?:.*) grave!  There was much rejoicing\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) takes off (?:.*) lobster bib and gets ready for action\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Looks like (.*) is awake.  Good morning, Elanthia\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A warhorn's clarion call rings out, heralding the return of (.*)\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A cloud of deep shadow coalesces, then fades to reveal (.*)\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Pour some coffee, (.*) has arrived\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A snowy white owl grasping a silver dagger soars in, heralding the sudden arrival of (.*)\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A trio of blaring horns broadcasts (.*) arrival\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Got jasmine\?  (.*) does\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* The reverberating sound of a gong announces the arrival of (.*)\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has arrived, munching the last bite of a big pickle\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has arrived to save the day\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) arrives, in search of mines and tunnels\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) arranges (?:.*) quills and parchments, ready to begin\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) arrives, proudly displaying (?:.*) papers\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A chorus of squawking penguins signals the arrival of (.*)\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) hops off the turnip wagon, ready to defend the town\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) hits the cobblestones running\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Rejoice, peasants! (.*) has arrived and the adventure can truly begin\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) returns for more merrymaking\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has decided to drop anchor in this fine port of call\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A troop of minstrels sings, their voices in perfect harmony, crooning the arrival of (.*)\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has come out of a rabbit hole, and is ready for adventure\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Hey, what's that smell? Oh, it's (.*)\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* A deep-voiced announcer loudly proclaims, "Heeeere's (.*)\!"(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) arrives, accompanied by a fanfare of trumpets\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* Roaring applause accompanies the arrival of (.*)\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* The POP of a cork accompanies the arrival of (.*)\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just sneaked back in\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has arrived, as gorgeous as ever\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) returns from the wild\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* The level of empathy and common decency ceases to exist upon (.*)'s arrival\.(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has arrived to replenish (?:.*) stockpile of reagents\!(.*)/
+             "#{$1}#{$2} On #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) returns home from a hard day of adventuring\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has disconnected\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) just got knocked over the head and dragged down a dark alley.  Good night, (?:.*)\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* Encroaching dark shadows swallow (.*) and then dissolves, leaving nothing behind\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* The ground trembles briefly as (.*) heads off\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) grabs a crystal amulet and heads off, looking for a boot\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) puts away (?:.*) shovel and heads for the nearest tavern\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) returns home, closing t(?:.*) chapter of (?:.*) book\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) calls a halt to (?:.*) campaign for the day\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) packs up (?:.*) tarts and heads home\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) retires before losing any more deeds\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) hits the road\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* With a heavy heart, (.*) trudges away. Life will simply not be the same without him\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) shall return to the merriment, anon\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is out like a trout\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as he wanders off\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) is late for a very important date and jumps back down a rabbit hole\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) departs, vowing to fight another day\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has gone home. Someone spray the disinfectant\!(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* A deep-voiced announcer loudly declares, "(.*) has left the realms\!"(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* Worn out from (?:.*) heroic adventures, (.*) shuffles out of Elanthia\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* A sad trombone refrain bids farewell to (.*)\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* The faint sound of weeping signifies (.*)'s departure\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as (?:.*) wanders off\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) goes home to sleep it off\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* The jasmine supply has been gravely diminished, so (.*) is going home\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) has had enough of t(?:.*) for the time being\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) goes off to primp and preen\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \*  Gathering the folds of (?:.*), (.*) tiredly climbs a nearby tree for a nap\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) leaves to heed the call of nature\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           elsif server_string =~ /(.*) \* (.*) returns to the workshop\.(.*)/
+             "#{$1}#{$2} Off #{$3}\n"
+           else
+             server_string
+           end
 
   CHANNEL_ICONS_UTF8.each do |channel, icon|
     result = result.gsub(/\[#{Regexp.escape(channel)}\]/i, icon) if result

--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -417,8 +417,10 @@ BEGIN LOGIN/LOGOUT MESSAGING
   result
 end
 
-DEATH_STREAM_GSL_OPEN  = "GSw00003\r\n" unless defined?(DEATH_STREAM_GSL_OPEN)
-DEATH_STREAM_GSL_CLOSE = "GSw00004\r\n" unless defined?(DEATH_STREAM_GSL_CLOSE)
+Object.send(:remove_const, :DEATH_STREAM_GSL_OPEN) if Object.const_defined?(:DEATH_STREAM_GSL_OPEN, false)
+Object.send(:remove_const, :DEATH_STREAM_GSL_CLOSE) if Object.const_defined?(:DEATH_STREAM_GSL_CLOSE, false)
+DEATH_STREAM_GSL_OPEN  = "\034GSw00003\r\n"
+DEATH_STREAM_GSL_CLOSE = "\034GSw00004\r\n"
 
 Object.send(:remove_const, :MESSAGING_GSL_FRONTEND) if Object.const_defined?(:MESSAGING_GSL_FRONTEND, false)
 MESSAGING_GSL_FRONTEND = Frontend.supports_gsl?
@@ -662,6 +664,8 @@ if command == "help"
   respond "       RIFT  - Pinerfar/Rift"
   respond "       SOS   - Sanctum of Scales"
   respond "       EC    - Elemental Confluence"
+  respond "       KF    - Kraken's Fall"
+  respond "       OSA   - Open Sea Adventures"
   respond "       HW    - Hinterwilds"
   respond ""
   Script.self.kill

--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -90,9 +90,10 @@ no_kill_all
 
 Object.send(:remove_const, :DEATH_MARKER_UTF8) if Object.const_defined?(:DEATH_MARKER_UTF8, false)
 Object.send(:remove_const, :DEATH_MARKER_XML) if Object.const_defined?(:DEATH_MARKER_XML, false)
+Object.send(:remove_const, :DEATH_MARKER_ASCII) if Object.const_defined?(:DEATH_MARKER_ASCII, false)
 Object.send(:remove_const, :DEATH_MARKER) if Object.const_defined?(:DEATH_MARKER, false)
 
-DEATH_MARKER_UTF8 = "\u{1FAA6}"
+DEATH_MARKER_UTF8 = [0x1FAA6].pack("U*")
 DEATH_MARKER_XML = "&#x1FAA6;"
 DEATH_MARKER_ASCII = "[RIP]"
 DEATH_MARKER = DEATH_MARKER_UTF8
@@ -105,7 +106,7 @@ Object.send(:remove_const, :ANNOUNCEMENT_MARKER_ASCII) if Object.const_defined?(
 # stream (<pushStream id="announcements"/> -- server broadcasts, SEND[]
 # REPORTs, event notices, etc), same dual-representation approach as
 # DEATH_MARKER.
-ANNOUNCEMENT_MARKER_UTF8 = "\u{1F4E2}"
+ANNOUNCEMENT_MARKER_UTF8 = [0x1F4E2].pack("U*")
 ANNOUNCEMENT_MARKER_XML = "&#x1F4E2;"
 ANNOUNCEMENT_MARKER_ASCII = "[Announcement]"
 
@@ -115,14 +116,17 @@ ANNOUNCEMENT_MARKER_ASCII = "[Announcement]"
 # below converts it to the XML numeric-character-reference form on Saga
 # specifically, where raw UTF8 embedded in dialog-control content doesn't
 # render reliably. Every other frontend gets a plain ASCII fallback.
+Object.send(:remove_const, :CHANNEL_ICONS_UTF8) if Object.const_defined?(:CHANNEL_ICONS_UTF8, false)
+Object.send(:remove_const, :CHANNEL_ICONS_XML) if Object.const_defined?(:CHANNEL_ICONS_XML, false)
+
 CHANNEL_ICONS_UTF8 = {
-  'Merchant'   => "\u{1F4B0}",
-  'General'    => "\u{1F4DC}",
-  'Help'       => "\u{2753}",
-  'Wyrmwatch'  => "\u{1F432}",
-  'Onslaughts' => "\u{1F6F8}",
-  'Realm'      => "\u{1F3F0}",
-  'Invoker'    => "\u{1F9D9}\u{200D}\u{2642}\u{FE0F}"
+  'Merchant'   => [0x1F4B0].pack("U*"),
+  'General'    => [0x1F4DC].pack("U*"),
+  'Help'       => [0x2753].pack("U*"),
+  'Wyrmwatch'  => [0x1F432].pack("U*"),
+  'Onslaughts' => [0x1F6F8].pack("U*"),
+  'Realm'      => [0x1F3F0].pack("U*"),
+  'Invoker'    => [0x1F9D9, 0x200D, 0x2642, 0xFE0F].pack("U*")
 }.freeze
 
 CHANNEL_ICONS_XML = {
@@ -389,7 +393,7 @@ BEGIN LOGIN/LOGOUT MESSAGING
            end
 
   CHANNEL_ICONS_UTF8.each do |channel, icon|
-    result = result.gsub(/\[#{Regexp.escape(channel)}\]/i, icon) if result
+    result = result.gsub(/\[#{Regexp.escape(channel)}\]/, icon) if result
   end
 
   # Anything routed to the Announcements stream (<pushStream
@@ -404,7 +408,10 @@ BEGIN LOGIN/LOGOUT MESSAGING
   # this content, so result is still just the untouched original line at
   # this point every time this fires.
   if result
-    result = result.sub(/(<pushStream id=['"]announcements['"]\s*\/?>)/i) { "#{$1}#{ANNOUNCEMENT_MARKER_UTF8} " }
+    announcement_stream = /(<pushStream id=['"]announcements['"]\s*\/?>)(.*?)(<popStream[^>]*\/>|\z)/m
+    result = result.sub(announcement_stream) do
+      "#{$1}#{ANNOUNCEMENT_MARKER_UTF8} #{$2}#{$3}"
+    end
   end
 
   result
@@ -417,7 +424,7 @@ Object.send(:remove_const, :MESSAGING_GSL_FRONTEND) if Object.const_defined?(:ME
 MESSAGING_GSL_FRONTEND = Frontend.supports_gsl?
 
 Object.send(:remove_const, :MESSAGING_SENTINEL_FRONTEND) if Object.const_defined?(:MESSAGING_SENTINEL_FRONTEND, false)
-MESSAGING_SENTINEL_FRONTEND = Frontend.supports_sentinel?
+MESSAGING_SENTINEL_FRONTEND = Frontend.respond_to?(:supports_sentinel?) && Frontend.supports_sentinel?
 
 # Real downstream game text always gets run through Game.process_downstream_
 # hooks, which -- on frontends that support it (Saga) -- prefixes every
@@ -587,7 +594,7 @@ def messaging_announcement_test
     respond "#{ANNOUNCEMENT_MARKER_UTF8} Messaging announcement test (#{label}):"
     respond "  input:  #{input}"
     respond "  output: #{actual.strip}"
-    if actual =~ /<pushStream id=['"]announcements['"]\s*\/?>#{Regexp.escape(ANNOUNCEMENT_MARKER_UTF8)}/i
+    if actual =~ /<pushStream id=['"]announcements['"]\s*\/?>#{Regexp.escape(ANNOUNCEMENT_MARKER_UTF8)}/
       respond "  PASS: #{ANNOUNCEMENT_MARKER_UTF8} announcement marker inserted right after the tag."
     else
       respond '  FAIL: announcement marker missing or not immediately after the tag.'

--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -57,6 +57,7 @@
        todo: add additional confluence messaging
      author: Tysong (horibu on PC), Claude Code
        name: messaging
+      required: Lich >= 5.20.0
        tags: death, messaging, login, logout, saga, announcements
     version: 1.2.0
 
@@ -165,8 +166,8 @@ def messaging_frontend_text(text)
 end
 
 def messaging_transform(server_string)
-    server_string = " #{server_string}" if server_string =~ /\A\*\s/
-    result = if server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just bit the dust\!(.*)/
+  server_string = " #{server_string}" if server_string =~ /\A\*\s/
+  result = if server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just bit the dust\!(.*)/
       "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
     elsif server_string =~ /(.*) \* (.*) just bit the dust\!(.*)/
       "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
@@ -385,7 +386,7 @@ BEGIN LOGIN/LOGOUT MESSAGING
       "#{$1}#{$2} Off #{$3}\n"
     else
       server_string
-    end
+  end
 
   CHANNEL_ICONS_UTF8.each do |channel, icon|
     result = result.gsub(/\[#{Regexp.escape(channel)}\]/i, icon) if result
@@ -478,32 +479,32 @@ end
 
 def messaging_self_test
   tests = {
-    "Wehnimer's Landing" => '* Testperson just bit the dust!',
-    'Cysaegir' => '* Testperson just got squashed!',
-    "River's Rest" => '* Testperson has gone to feed the fishes!',
-    "Ta'Illistim" => '* Testperson just turned her last page!',
-    'Icemule Trace' => '* Testperson was just put on ice!',
-    'Teras Isle' => '* Testperson just punched a one-way ticket!',
-    "Ta'Vaalor" => '* Testperson is going home on her shield!',
-    'Solhaven' => '* Testperson just took a long walk off of a short pier!',
-    'Four Winds Isle' => '* Testperson is dust in the wind!',
-    'Zul Logoth' => '* Testperson is six hundred feet under!',
-    'Reim' => '* Testperson just lost her way somewhere in the Settlement of Reim!',
+    "Wehnimer's Landing"           => '* Testperson just bit the dust!',
+    'Cysaegir'                     => '* Testperson just got squashed!',
+    "River's Rest"                 => '* Testperson has gone to feed the fishes!',
+    "Ta'Illistim"                  => '* Testperson just turned her last page!',
+    'Icemule Trace'                => '* Testperson was just put on ice!',
+    'Teras Isle'                   => '* Testperson just punched a one-way ticket!',
+    "Ta'Vaalor"                    => '* Testperson is going home on her shield!',
+    'Solhaven'                     => '* Testperson just took a long walk off of a short pier!',
+    'Four Winds Isle'              => '* Testperson is dust in the wind!',
+    'Zul Logoth'                   => '* Testperson is six hundred feet under!',
+    'Reim'                         => '* Testperson just lost her way somewhere in the Settlement of Reim!',
     'Trail to Icemule or Solhaven' => '* Testperson just gave up the ghost!',
-    'Red Forest/Aradhul Road' => '* Testperson may just be going home on her shield!',
-    'Rift' => '* The death cry of Testperson echoes in your mind!',
-    'Sanctum of Scales' => '* Testperson flame just burnt out in the Sea of Fire!',
-    "Kraken's Fall" => "* Testperson life on land appears to be as rough as her life at sea.",
-    'Open Sea Adventures' => '* Testperson just sank to the bottom of the Tenebrous Cauldron!',
-    'Elemental Confluence' => '* Testperson is dust in the winds of the Elemental Confluence!',
-    'Night at the Academy' => '* Testperson failed to bring a shrubbery to the Night at the Academy!',
-    'Duskruin Heist' => '* Testperson failed within the Bank at Bloodriven!',
-    'Round 25 Arena' => '* Testperson was just defeated during round 25 in Duskruin Arena!',
-    'Round 42 Endless' => '* Testperson was just defeated during round 42 in Endless Duskruin Arena!',
-    'Round 32 Swarm' => '* Testperson was just defeated during round 32 in Endless Swarm Duskruin Arena!',
-    'Duskruin Arena' => '* Testperson was just defeated in Duskruin Arena!',
-    "Sailor's Grief" => "* Testperson's hopes just sank in Sailor's Grief!",
-    'Hinterwilds' => '* Testperson just got iced in the Hinterwilds!'
+    'Red Forest/Aradhul Road'      => '* Testperson may just be going home on her shield!',
+    'Rift'                         => '* The death cry of Testperson echoes in your mind!',
+    'Sanctum of Scales'            => '* Testperson flame just burnt out in the Sea of Fire!',
+    "Kraken's Fall"                => "* Testperson life on land appears to be as rough as her life at sea.",
+    'Open Sea Adventures'          => '* Testperson just sank to the bottom of the Tenebrous Cauldron!',
+    'Elemental Confluence'         => '* Testperson is dust in the winds of the Elemental Confluence!',
+    'Night at the Academy'         => '* Testperson failed to bring a shrubbery to the Night at the Academy!',
+    'Duskruin Heist'               => '* Testperson failed within the Bank at Bloodriven!',
+    'Round 25 Arena'               => '* Testperson was just defeated during round 25 in Duskruin Arena!',
+    'Round 42 Endless'             => '* Testperson was just defeated during round 42 in Endless Duskruin Arena!',
+    'Round 32 Swarm'               => '* Testperson was just defeated during round 32 in Endless Swarm Duskruin Arena!',
+    'Duskruin Arena'               => '* Testperson was just defeated in Duskruin Arena!',
+    "Sailor's Grief"               => "* Testperson's hopes just sank in Sailor's Grief!",
+    'Hinterwilds'                  => '* Testperson just got iced in the Hinterwilds!'
   }
 
   area, input = tests.to_a.sample
@@ -573,7 +574,7 @@ def messaging_announcement_test
   # often does -- both need the marker landing inside the Announcements
   # routing, not pushed out into the ambient stream after a <popStream/>.
   samples = {
-    "no popStream (real-world shape)" => "<pushStream id='announcements'/>Testperson announces: This is a test announcement.",
+    "no popStream (real-world shape)"       => "<pushStream id='announcements'/>Testperson announces: This is a test announcement.",
     "with popStream (manual ;e test shape)" => "<pushStream id='announcements'/>Testperson announces: This is a test announcement.<popStream/>"
   }
 

--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -383,8 +383,6 @@ BEGIN LOGIN/LOGOUT MESSAGING
       "#{$1}#{$2} Off #{$3}\n"
     elsif server_string =~ /(.*) \* (.*) returns to the workshop\.(.*)/
       "#{$1}#{$2} Off #{$3}\n"
-    elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
-      "#{$1}#{$2} Off #{$3}\n"
     else
       server_string
     end

--- a/scripts/messaging.lic
+++ b/scripts/messaging.lic
@@ -1,11 +1,38 @@
 =begin
     Changes Deaths and Arrivals window messaging
-    Replaces normal death messaging with specific town instead.
-    Replaces normal/RP login and logout messagins with generic messaging
-    Works in Stormfront, not sure if works in Wizard.
-	
+    Replaces normal death messaging with specific town instead (tagged with
+    a tombstone marker). Replaces normal/RP login and logout messagins with
+    generic messaging. Also replaces official channel tags ([Merchant],
+    [General], [Help], [Wyrmwatch], [Onslaughts], [Realm], [Invoker]) with
+    an icon in the Thoughts panel. Prefixes a loudspeaker marker onto
+    anything routed to the Announcements panel (server broadcasts, SEND[]
+    REPORTs, event notices, merchant visits, etc). Works in Stormfront/
+    Wrayth/Saga and Wizard/Avalon; the death marker, channel icons, and
+    announcement marker only render as actual emoji on Saga specifically --
+    every other frontend gets a plain ASCII fallback ("[RIP]" / the
+    untouched "[Channel]" tag / "[Announcement]") instead.
+
     SYNTAX - ;messaging
-	
+             ;messaging test         - Runs one random death-message
+                                       conversion and pushes it through the
+                                       real Deaths and Arrivals stream (not
+                                       just the main window), so you can
+                                       confirm the tombstone marker actually
+                                       renders in that panel.
+             ;messaging esptest      - Runs all 7 channel icons at once
+                                       ([Merchant]/[General]/[Help]/
+                                       [Wyrmwatch]/[Onslaughts]/[Realm]/
+                                       [Invoker]) and pushes them through
+                                       the real Thoughts stream, so you can
+                                       confirm every icon renders correctly
+                                       in one shot.
+             ;messaging anntest      - Runs a sample announcement through
+                                       messaging_transform and pushes it
+                                       through the real Announcements
+                                       stream, so you can confirm the
+                                       loudspeaker marker actually renders
+                                       in that panel.
+
     Abbreviations:
         WL    - Wehnimer's Landing
         CY    - Cysaegir
@@ -23,276 +50,619 @@
         RIFT  - Rift
         SOS   - Sanctum of Scales
         EC    - Elemental Confluence
-		KF    - Kraken's Fall
-		OSA   - Open Sea Adventures
-		
+        KF    - Kraken's Fall
+        OSA   - Open Sea Adventures
+        HW    - Hinterwilds
+
        todo: add additional confluence messaging
-     author: Tysong (horibu on PC)
+     author: Tysong (horibu on PC), Claude Code
        name: messaging
-       tags: death, messaging, login, logout
-    version: 1.1.0
+       tags: death, messaging, login, logout, saga, announcements
+    version: 1.2.0
 
     changelog:
+        1.2.0 (2026-08-23)
+            Added channel-name icon replacement in the Thoughts panel
+            ([Merchant]/[General]/[Help]/[Wyrmwatch]/[Onslaughts]/[Realm]/
+            [Invoker], each swapped for an icon) and a new marker for
+            anything routed to the Announcements panel (server broadcasts,
+            SEND[] REPORTs, event notices, merchant visits, etc). Both
+            follow the same approach as the existing death marker: a real
+            emoji on Saga, a plain ASCII fallback ("[Channel]" tag /
+            "[Announcement]") on every other frontend, since raw UTF8
+            isn't reliably supported outside Saga. Death marker itself
+            switched from plain text to a tombstone emoji, and ;messaging
+            test/esptest/anntest were added to verify the death marker,
+            channel icons, and announcement marker each render correctly
+            in their real panel. Also fixed a few Saga-specific rendering
+            issues along the way (dimmed/normal text occasionally bleeding
+            together, an extra blank line between Deaths/Arrivals entries,
+            a script-lifecycle bug where running a one-shot test could
+            disable the live hook until the script was restarted).
         1.1.0 (2021-08-03)
             Updates from Virtuousin
         1.0 (2017-03-26)
             Initial Release
 =end
 
-messaging = proc {
-	action = proc { |server_string|
-#		if server_string.strip.length == 0
-#			nil
-#			next
-#		end
-		if server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just bit the dust\!(.*)/
-			"#{$1} * #{$2} - Wehnimer's Landing #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just bit the dust\!(.*)/
-			"#{$1} * #{$2} - Wehnimer's Landing #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just got squashed\!\!(.*)/
-			"#{$1} * #{$2} - Cysaegir #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just got squashed\!(.*)/
-			"#{$1} * #{$2} - Cysaegir #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) has gone to feed the fishes\!(.*)/
-			"#{$1} * #{$2} - River's Rest #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes\!(.*)/
-			"#{$1} * #{$2} - River's Rest #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just turned (?:.*) last page\!(.*)$/
-			"#{$1} * #{$2} - Ta'Illistim #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just turned (?:.*) last page\!(.*)/
-			"#{$1} * #{$2} - Ta'Illistim #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) was just put on ice\!(.*)$/
-			"#{$1} * #{$2} - Icemule Trace #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) was just put on ice\!(.*)$/
-			"#{$1} * #{$2} - Icemule Trace #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just punched a one-way ticket\!(.*)$/
-			"#{$1} * #{$2} - Teras Isle #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just punched a one-way ticket\!(.*)/
-			"#{$1} * #{$2} - Teras Isle #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is going home on (?:.*) shield\!(.*)/
-			"#{$1} * #{$2} - Ta'Vaalor #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is going home on (?:.*) shield\!(.*)/
-			"#{$1} * #{$2} - Ta'Vaalor #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just took a long walk off of a short pier\!(.*)$/
-			"#{$1} * #{$2} - Solhaven #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just took a long walk off of a short pier\!(.*)/
-			"#{$1} * #{$2} - Solhaven #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is dust in the wind\!(.*)$/
-			"#{$1} * #{$2} - Four Winds Isle #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is dust in the wind\!(.*)/
-			"#{$1} * #{$2} - Four Winds Isle #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is six hundred feet under\!(.*)/
-			"#{$1} * #{$2} - Zul Logoth #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is six hundred feet under\!(.*)/
-			"#{$1} * #{$2} - Zul Logoth #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just lost (?:.*) way somewhere in the Settlement of Reim\!(.*)/
-			"#{$1} * #{$2} - Reim #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just perished defending a fortress within Reim\!(.*)/
-			"#{$1} * #{$2} - Reim #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just gave up the ghost\!(.*)/
-			"#{$1} * #{$2} - Trail to Icemule or Solhaven #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) may just be going home on (?:.*) shield\!(.*)/
-			"#{$1} * #{$2} - Red Forest/Aradhul Road #{$3}\n"
-		elsif server_string =~ /(.*) \* The death cry of (.*) echoes in your mind\!(.*)/
-			"#{$1} * #{$2} - Rift #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) flame just burnt out in the Sea of Fire\!(.*)/
-			"#{$1} * #{$2} - Sanctum of Scales #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
-			"#{$1} * #{$2} - Kraken's Fall #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
-			"#{$1} * #{$2} - Kraken's Fall #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just sank to the bottom of the Tenebrous Cauldron\!(.*)/
-			"#{$1} * #{$2} - Open Sea Adventures #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just (?:.*) the Elemental Confluence\!(.*)/
-			"#{$1} * #{$2} - Elemental Confluence #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is going home from the Elemental Confluence on (?:.*) shield\!(.*)/
-			"#{$1} * #{$2} - Elemental Confluence #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is dust in the winds of the Elemental Confluence\!(.*)/
-			"#{$1} * #{$2} - Elemental Confluence #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes in the Elemental Confluence\!(.*)/
-			"#{$1} * #{$2} - Elemental Confluence #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) failed to bring a shrubbery to the Night at the Academy\!(.*)/
-			"#{$1} * #{$2} - Night at the Academy #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) failed within the Bank at Bloodriven\!(.*)/
-			"#{$1} * #{$2} - Duskruin Heist #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) was just defeated in Duskruin Arena\!(.*)/
-			"#{$1} * #{$2} - Duskruin Arena #{$3}\n"
+no_kill_all
+
+Object.send(:remove_const, :DEATH_MARKER_UTF8) if Object.const_defined?(:DEATH_MARKER_UTF8, false)
+Object.send(:remove_const, :DEATH_MARKER_XML) if Object.const_defined?(:DEATH_MARKER_XML, false)
+Object.send(:remove_const, :DEATH_MARKER) if Object.const_defined?(:DEATH_MARKER, false)
+
+DEATH_MARKER_UTF8 = "\u{1FAA6}"
+DEATH_MARKER_XML = "&#x1FAA6;"
+DEATH_MARKER_ASCII = "[RIP]"
+DEATH_MARKER = DEATH_MARKER_UTF8
+
+Object.send(:remove_const, :ANNOUNCEMENT_MARKER_UTF8) if Object.const_defined?(:ANNOUNCEMENT_MARKER_UTF8, false)
+Object.send(:remove_const, :ANNOUNCEMENT_MARKER_XML) if Object.const_defined?(:ANNOUNCEMENT_MARKER_XML, false)
+Object.send(:remove_const, :ANNOUNCEMENT_MARKER_ASCII) if Object.const_defined?(:ANNOUNCEMENT_MARKER_ASCII, false)
+
+# Inserted right after the tag for anything routed to the Announcements
+# stream (<pushStream id="announcements"/> -- server broadcasts, SEND[]
+# REPORTs, event notices, etc), same dual-representation approach as
+# DEATH_MARKER.
+ANNOUNCEMENT_MARKER_UTF8 = "\u{1F4E2}"
+ANNOUNCEMENT_MARKER_XML = "&#x1F4E2;"
+ANNOUNCEMENT_MARKER_ASCII = "[Announcement]"
+
+# Channel-name icons: replaces "[Merchant]" etc with an icon in the
+# transformed text. Same dual-representation approach as DEATH_MARKER --
+# messaging_transform inserts the UTF8 form, and messaging_frontend_text
+# below converts it to the XML numeric-character-reference form on Saga
+# specifically, where raw UTF8 embedded in dialog-control content doesn't
+# render reliably. Every other frontend gets a plain ASCII fallback.
+CHANNEL_ICONS_UTF8 = {
+  'Merchant'   => "\u{1F4B0}",
+  'General'    => "\u{1F4DC}",
+  'Help'       => "\u{2753}",
+  'Wyrmwatch'  => "\u{1F432}",
+  'Onslaughts' => "\u{1F6F8}",
+  'Realm'      => "\u{1F3F0}",
+  'Invoker'    => "\u{1F9D9}\u{200D}\u{2642}\u{FE0F}"
+}.freeze
+
+CHANNEL_ICONS_XML = {
+  'Merchant'   => "&#x1F4B0;",
+  'General'    => "&#x1F4DC;",
+  'Help'       => "&#x2753;",
+  'Wyrmwatch'  => "&#x1F432;",
+  'Onslaughts' => "&#x1F6F8;",
+  'Realm'      => "&#x1F3F0;",
+  'Invoker'    => "&#x1F9D9;&#x200D;&#x2642;&#xFE0F;"
+}.freeze
+
+# Cached once at script start rather than re-checked on every call --
+# querying it fresh per line risked an inconsistent answer within the same
+# session (some messages getting the safe XML-entity form, others getting
+# raw UTF8 bytes that can arrive mojibake'd depending on how they're
+# ultimately relayed).
+Object.send(:remove_const, :MESSAGING_SAGA_FRONTEND) if Object.const_defined?(:MESSAGING_SAGA_FRONTEND, false)
+MESSAGING_SAGA_FRONTEND = ($frontend == 'saga')
+
+# messaging_transform always inserts the raw UTF8 marker/icon forms; this
+# converts them to whatever's actually safe for the connected frontend.
+# Emoji substitution is Saga-only (via the XML numeric-character-reference
+# form). Every other frontend -- Wrayth, GSL (Wizard/Avalon), etc. -- gets
+# a plain ASCII fallback instead: neither Lich's own transport nor the
+# server itself reliably supports non-ASCII for those clients (per horibu),
+# so raw UTF8 is never sent to them. The death marker becomes "[RIP]", and
+# channel icons revert to the plain "[Channel]" tag the game itself sent.
+def messaging_frontend_text(text)
+  result = text.to_s
+  if MESSAGING_SAGA_FRONTEND
+    result = result.gsub(DEATH_MARKER_UTF8, DEATH_MARKER_XML)
+    result = result.gsub(ANNOUNCEMENT_MARKER_UTF8, ANNOUNCEMENT_MARKER_XML)
+    CHANNEL_ICONS_UTF8.each { |channel, utf8| result = result.gsub(utf8, CHANNEL_ICONS_XML[channel]) }
+  else
+    result = result.gsub(DEATH_MARKER_UTF8, DEATH_MARKER_ASCII)
+    result = result.gsub(ANNOUNCEMENT_MARKER_UTF8, ANNOUNCEMENT_MARKER_ASCII)
+    CHANNEL_ICONS_UTF8.each { |channel, utf8| result = result.gsub(utf8, "[#{channel}]") }
+  end
+  result
+end
+
+def messaging_transform(server_string)
+    server_string = " #{server_string}" if server_string =~ /\A\*\s/
+    result = if server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just bit the dust\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just bit the dust\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Wehnimer's Landing #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just got squashed\!\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just got squashed\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Cysaegir #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) has gone to feed the fishes\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} River's Rest #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just turned (?:.*) last page\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just turned (?:.*) last page\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Illistim #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) was just put on ice\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) was just put on ice\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Icemule Trace #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just punched a one-way ticket\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just punched a one-way ticket\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Teras Isle #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is going home on (?:.*) shield\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is going home on (?:.*) shield\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Ta'Vaalor #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) just took a long walk off of a short pier\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just took a long walk off of a short pier\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Solhaven #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is dust in the wind\!(.*)$/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is dust in the wind\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Four Winds Isle #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) is six hundred feet under\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is six hundred feet under\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Zul Logoth #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just lost (?:.*) way somewhere in the Settlement of Reim\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just perished defending a fortress within Reim\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Reim #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just gave up the ghost\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Trail to Icemule or Solhaven #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) may just be going home on (?:.*) shield\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Red Forest/Aradhul Road #{$3}\n"
+    elsif server_string =~ /(.*) \* The death cry of (.*) echoes in your mind\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Rift #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) flame just burnt out in the Sea of Fire\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Sanctum of Scales #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is off to a rough start\!  (?:.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) life on land appears to be as rough as (?:.*) life at sea\.(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Kraken's Fall #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just sank to the bottom of the Tenebrous Cauldron\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Open Sea Adventures #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just (?:.*) the Elemental Confluence\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is going home from the Elemental Confluence on (?:.*) shield\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is dust in the winds of the Elemental Confluence\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has gone to feed the fishes in the Elemental Confluence\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Elemental Confluence #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) failed to bring a shrubbery to the Night at the Academy\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Night at the Academy #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) failed within the Bank at Bloodriven\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Heist #{$3}\n"
+    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Swarm Duskruin Arena\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Swarm #{$4}\n"
+    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Endless Duskruin Arena\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Endless #{$4}\n"
+    elsif server_string =~ /(.*?)\s*\*\s+(.*) was just defeated during round (\d+) in Duskruin Arena\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Round #{$3} Arena #{$4}\n"
+    elsif server_string =~ /(.*) \* (.*) was just defeated in Duskruin Arena\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Duskruin Arena #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) hopes just sank in Sailor\'s Grief\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Sailor's Grief #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just got iced in the Hinterwilds\!(.*)/
+      "#{$1} * #{$2} - #{DEATH_MARKER} Hinterwilds #{$3}\n"
 =begin
 BEGIN LOGIN/LOGOUT MESSAGING
 =end
-		elsif server_string =~ /(.*) \* (.*) joins the adventure\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) rises from (?:.*) grave!  There was much rejoicing\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) takes off (?:.*) lobster bib and gets ready for action\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Looks like (.*) is awake.  Good morning, Elanthia\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A warhorn's clarion call rings out, heralding the return of (.*)\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A cloud of deep shadow coalesces, then fades to reveal (.*)\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Pour some coffee, (.*) has arrived\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A snowy white owl grasping a silver dagger soars in, heralding the sudden arrival of (.*)\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A trio of blaring horns broadcasts (.*) arrival\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Got jasmine\?  (.*) does\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* The reverberating sound of a gong announces the arrival of (.*)\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has arrived, munching the last bite of a big pickle\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has arrived to save the day\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) arrives, in search of mines and tunnels\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) arranges (?:.*) quills and parchments, ready to begin\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) arrives, proudly displaying (?:.*) papers\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A chorus of squawking penguins signals the arrival of (.*)\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) hops off the turnip wagon, ready to defend the town\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) hits the cobblestones running\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Rejoice, peasants! (.*) has arrived and the adventure can truly begin\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) returns for more merrymaking\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has decided to drop anchor in this fine port of call\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A troop of minstrels sings, their voices in perfect harmony, crooning the arrival of (.*)\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has come out of a rabbit hole, and is ready for adventure\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Hey, what's that smell? Oh, it's (.*)\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* A deep-voiced announcer loudly proclaims, "Heeeere's (.*)\!"(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) arrives, accompanied by a fanfare of trumpets\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* Roaring applause accompanies the arrival of (.*)\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* The POP of a cork accompanies the arrival of (.*)\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just sneaked back in\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has arrived, as gorgeous as ever\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) returns from the wild\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* The level of empathy and common decency ceases to exist upon (.*)'s arrival\.(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has arrived to replenish (?:.*) stockpile of reagents\!(.*)/
-			"#{$1}#{$2} On #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) returns home from a hard day of adventuring\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has disconnected\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) just got knocked over the head and dragged down a dark alley.  Good night, (?:.*)\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* Encroaching dark shadows swallow (.*) and then dissolves, leaving nothing behind\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* The ground trembles briefly as (.*) heads off\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) grabs a crystal amulet and heads off, looking for a boot\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) puts away (?:.*) shovel and heads for the nearest tavern\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) returns home, closing t(?:.*) chapter of (?:.*) book\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) calls a halt to (?:.*) campaign for the day\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) packs up (?:.*) tarts and heads home\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) retires before losing any more deeds\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) hits the road\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* With a heavy heart, (.*) trudges away. Life will simply not be the same without him\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) shall return to the merriment, anon\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is out like a trout\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as he wanders off\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) is late for a very important date and jumps back down a rabbit hole\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) departs, vowing to fight another day\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has gone home. Someone spray the disinfectant\!(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* A deep-voiced announcer loudly declares, "(.*) has left the realms\!"(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* Worn out from (?:.*) heroic adventures, (.*) shuffles out of Elanthia\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* A sad trombone refrain bids farewell to (.*)\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* The faint sound of weeping signifies (.*)'s departure\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as (?:.*) wanders off\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) goes home to sleep it off\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* The jasmine supply has been gravely diminished, so (.*) is going home\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) has had enough of t(?:.*) for the time being\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) goes off to primp and preen\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \*  Gathering the folds of (?:.*), (.*) tiredly climbs a nearby tree for a nap\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) leaves to heed the call of nature\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* (.*) returns to the workshop\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
-			"#{$1}#{$2} Off #{$3}\n"
-		else
-			server_string
-		end
-	}
-	DownstreamHook.add("#{script.name}_messaging", action)
+    elsif server_string =~ /(.*) \* (.*) joins the adventure\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) rises from (?:.*) grave!  There was much rejoicing\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) takes off (?:.*) lobster bib and gets ready for action\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Looks like (.*) is awake.  Good morning, Elanthia\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A warhorn's clarion call rings out, heralding the return of (.*)\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A cloud of deep shadow coalesces, then fades to reveal (.*)\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Pour some coffee, (.*) has arrived\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A snowy white owl grasping a silver dagger soars in, heralding the sudden arrival of (.*)\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A trio of blaring horns broadcasts (.*) arrival\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Got jasmine\?  (.*) does\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* The reverberating sound of a gong announces the arrival of (.*)\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has arrived, munching the last bite of a big pickle\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has arrived to save the day\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) arrives, in search of mines and tunnels\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) arranges (?:.*) quills and parchments, ready to begin\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) arrives, proudly displaying (?:.*) papers\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A chorus of squawking penguins signals the arrival of (.*)\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) hops off the turnip wagon, ready to defend the town\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) hits the cobblestones running\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Rejoice, peasants! (.*) has arrived and the adventure can truly begin\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) returns for more merrymaking\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has decided to drop anchor in this fine port of call\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A troop of minstrels sings, their voices in perfect harmony, crooning the arrival of (.*)\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has come out of a rabbit hole, and is ready for adventure\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Hey, what's that smell? Oh, it's (.*)\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* A deep-voiced announcer loudly proclaims, "Heeeere's (.*)\!"(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) arrives, accompanied by a fanfare of trumpets\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* Roaring applause accompanies the arrival of (.*)\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* The POP of a cork accompanies the arrival of (.*)\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just sneaked back in\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has arrived, as gorgeous as ever\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) returns from the wild\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* The level of empathy and common decency ceases to exist upon (.*)'s arrival\.(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has arrived to replenish (?:.*) stockpile of reagents\!(.*)/
+      "#{$1}#{$2} On #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) returns home from a hard day of adventuring\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has disconnected\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) just got knocked over the head and dragged down a dark alley.  Good night, (?:.*)\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* Encroaching dark shadows swallow (.*) and then dissolves, leaving nothing behind\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* The ground trembles briefly as (.*) heads off\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) grabs a crystal amulet and heads off, looking for a boot\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) puts away (?:.*) shovel and heads for the nearest tavern\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) returns home, closing t(?:.*) chapter of (?:.*) book\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) calls a halt to (?:.*) campaign for the day\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) packs up (?:.*) tarts and heads home\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) retires before losing any more deeds\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) hits the road\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* With a heavy heart, (.*) trudges away. Life will simply not be the same without him\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) shall return to the merriment, anon\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is out like a trout\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as he wanders off\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) is late for a very important date and jumps back down a rabbit hole\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) departs, vowing to fight another day\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has gone home. Someone spray the disinfectant\!(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* A deep-voiced announcer loudly declares, "(.*) has left the realms\!"(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* Worn out from (?:.*) heroic adventures, (.*) shuffles out of Elanthia\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* A sad trombone refrain bids farewell to (.*)\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* The faint sound of weeping signifies (.*)'s departure\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* With skill and remarkable flair, (.*) delivers a memorable farewell serenade as (?:.*) wanders off\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) goes home to sleep it off\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* The jasmine supply has been gravely diminished, so (.*) is going home\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) has had enough of t(?:.*) for the time being\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) goes off to primp and preen\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \*  Gathering the folds of (?:.*), (.*) tiredly climbs a nearby tree for a nap\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) leaves to heed the call of nature\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* (.*) returns to the workshop\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    elsif server_string =~ /(.*) \* Pounding hoofbeats build, and (.*) appears to ride off on a snowy white horse\.(.*)/
+      "#{$1}#{$2} Off #{$3}\n"
+    else
+      server_string
+    end
+
+  CHANNEL_ICONS_UTF8.each do |channel, icon|
+    result = result.gsub(/\[#{Regexp.escape(channel)}\]/i, icon) if result
+  end
+
+  # Anything routed to the Announcements stream (<pushStream
+  # id="announcements"/> -- server broadcasts, SEND[] REPORTs, event
+  # notices, merchant visits, etc) gets the marker inserted right after
+  # the tag, at the start of the message text, rather than at the end of
+  # the line -- sidesteps needing to know whether a <popStream/> shows up
+  # later on the same line (real announcements never carry one; a
+  # manually-built test string sometimes does) since the marker always
+  # lands inside the routing either way, immediately after the tag that
+  # opens it. None of the death/login/logout patterns above ever match
+  # this content, so result is still just the untouched original line at
+  # this point every time this fires.
+  if result
+    result = result.sub(/(<pushStream id=['"]announcements['"]\s*\/?>)/i) { "#{$1}#{ANNOUNCEMENT_MARKER_UTF8} " }
+  end
+
+  result
+end
+
+DEATH_STREAM_GSL_OPEN  = "GSw00003\r\n" unless defined?(DEATH_STREAM_GSL_OPEN)
+DEATH_STREAM_GSL_CLOSE = "GSw00004\r\n" unless defined?(DEATH_STREAM_GSL_CLOSE)
+
+Object.send(:remove_const, :MESSAGING_GSL_FRONTEND) if Object.const_defined?(:MESSAGING_GSL_FRONTEND, false)
+MESSAGING_GSL_FRONTEND = Frontend.supports_gsl?
+
+Object.send(:remove_const, :MESSAGING_SENTINEL_FRONTEND) if Object.const_defined?(:MESSAGING_SENTINEL_FRONTEND, false)
+MESSAGING_SENTINEL_FRONTEND = Frontend.supports_sentinel?
+
+# Real downstream game text always gets run through Game.process_downstream_
+# hooks, which -- on frontends that support it (Saga) -- prefixes every
+# line with Frontend::ORIGIN_SENTINEL (a leading \x1f) before it reaches
+# the client. That's how Saga knows a line is Lich-touched and should get
+# its dimmed "line-lich" treatment, and critically it's also what tells
+# Saga's parser "this Lich-marked stretch is now over" so it stops dimming
+# unrelated lines that come after.
+#
+# _respond() bypasses that whole pipeline -- it writes straight to the
+# client, so nothing we _respond() ever gets the sentinel automatically.
+# Once *anything* elsewhere trips Saga's dimming state (which ordinary
+# gameplay does constantly), our un-prefixed _respond() output reads as
+# "not part of that Lich-marked stretch" and can get pulled into the wrong
+# font/opacity, or leave the dimming stuck on for whatever comes next.
+# Applying the same sentinel ourselves, the same way core does, keeps our
+# output consistent with however the rest of the stream is currently
+# classified instead of fighting it.
+def messaging_apply_sentinel(text)
+  return text unless MESSAGING_SENTINEL_FRONTEND && defined?(Game) && Game.respond_to?(:prefix_origin_sentinel)
+
+  Game.prefix_origin_sentinel(text)
+end
+
+# Wraps text in the same stream tags the game itself uses for the Deaths
+# and Arrivals panel, so sending it through _respond lands it in that
+# panel specifically instead of the main story window. XML frontends
+# (Saga/Wrayth) get the real <pushStream id="death"/>...<popStream/> pair;
+# Wizard/Avalon get the raw GSw00003/GSw00004 markers Lich's own GSL
+# conversion (lib/global_defs.rb) produces for this same stream. text is
+# chomped first -- every messaging_transform branch already ends its
+# output with "\n", and leaving that in place before adding our own
+# trailing line ending doubled up into an extra blank line/gap in the
+# panel between entries.
+def messaging_death_window(text)
+  text = text.to_s.chomp
+  if MESSAGING_GSL_FRONTEND
+    "#{DEATH_STREAM_GSL_OPEN}#{text}\r\n#{DEATH_STREAM_GSL_CLOSE}"
+  else
+    "<pushStream id=\"death\"/>#{text}<popStream/>\r\n"
+  end
+end
+
+# Wraps text in the same stream tags the game itself uses for the Thoughts
+# panel (where official channel messages -- Merchant, General, etc. --
+# normally land), so *esptest can confirm the channel icons render there.
+# XML frontends get the real <pushStream id="thoughts"/>...<popStream/>
+# pair; GSL frontends have no simple marker pair for this stream (see
+# lib/messaging.rb's stream_window), so it's phrased the same way Lich's
+# own core ESP helper already does for GSL clients.
+def messaging_thoughts_window(text)
+  text = text.to_s.chomp
+  if MESSAGING_GSL_FRONTEND
+    "You hear the faint thoughts of LICH-MESSAGE echo in your mind:\r\n#{text}\r\n"
+  else
+    "<pushStream id=\"thoughts\"/>#{text}<popStream/>\r\n"
+  end
+end
+
+def messaging_self_test
+  tests = {
+    "Wehnimer's Landing" => '* Testperson just bit the dust!',
+    'Cysaegir' => '* Testperson just got squashed!',
+    "River's Rest" => '* Testperson has gone to feed the fishes!',
+    "Ta'Illistim" => '* Testperson just turned her last page!',
+    'Icemule Trace' => '* Testperson was just put on ice!',
+    'Teras Isle' => '* Testperson just punched a one-way ticket!',
+    "Ta'Vaalor" => '* Testperson is going home on her shield!',
+    'Solhaven' => '* Testperson just took a long walk off of a short pier!',
+    'Four Winds Isle' => '* Testperson is dust in the wind!',
+    'Zul Logoth' => '* Testperson is six hundred feet under!',
+    'Reim' => '* Testperson just lost her way somewhere in the Settlement of Reim!',
+    'Trail to Icemule or Solhaven' => '* Testperson just gave up the ghost!',
+    'Red Forest/Aradhul Road' => '* Testperson may just be going home on her shield!',
+    'Rift' => '* The death cry of Testperson echoes in your mind!',
+    'Sanctum of Scales' => '* Testperson flame just burnt out in the Sea of Fire!',
+    "Kraken's Fall" => "* Testperson life on land appears to be as rough as her life at sea.",
+    'Open Sea Adventures' => '* Testperson just sank to the bottom of the Tenebrous Cauldron!',
+    'Elemental Confluence' => '* Testperson is dust in the winds of the Elemental Confluence!',
+    'Night at the Academy' => '* Testperson failed to bring a shrubbery to the Night at the Academy!',
+    'Duskruin Heist' => '* Testperson failed within the Bank at Bloodriven!',
+    'Round 25 Arena' => '* Testperson was just defeated during round 25 in Duskruin Arena!',
+    'Round 42 Endless' => '* Testperson was just defeated during round 42 in Endless Duskruin Arena!',
+    'Round 32 Swarm' => '* Testperson was just defeated during round 32 in Endless Swarm Duskruin Arena!',
+    'Duskruin Arena' => '* Testperson was just defeated in Duskruin Arena!',
+    "Sailor's Grief" => "* Testperson's hopes just sank in Sailor's Grief!",
+    'Hinterwilds' => '* Testperson just got iced in the Hinterwilds!'
+  }
+
+  area, input = tests.to_a.sample
+  actual = messaging_transform(input).to_s.strip
+  frontend_actual = messaging_frontend_text(actual)
+
+  respond ''
+  respond "#{DEATH_MARKER} Messaging random death test: #{area}"
+  respond "  input:  #{input}"
+  respond "  output: #{actual}"
+  if actual == input
+    respond '  FAIL: message was not transformed.'
+  elsif actual.include?(DEATH_MARKER)
+    respond "  PASS: #{DEATH_MARKER} death marker displayed and message transformed."
+  else
+    respond '  FAIL: message transformed without death marker.'
+  end
+  respond ''
+
+  _respond(messaging_apply_sentinel(messaging_death_window(frontend_actual))) unless frontend_actual.empty?
+end
+
+# Runs every channel through messaging_transform at once and pushes the
+# results into the Thoughts panel as a single block, so all seven icons
+# can be visually checked in one shot instead of relying on random sampling
+# the way the death test does.
+def messaging_esp_test
+  respond ''
+  respond "Messaging ESP/channel icon test (#{CHANNEL_ICONS_UTF8.size} channels):"
+
+  panel_lines = []
+  CHANNEL_ICONS_UTF8.each do |channel, icon|
+    input = "[#{channel}]-Testperson: \"This is a test message.\""
+    actual = messaging_transform(input).to_s
+    passed = actual.include?(icon) && !actual.include?("[#{channel}]")
+
+    respond "  #{channel.ljust(10)} input:  #{input}"
+    respond "  #{' ' * 10} output: #{actual}"
+    respond "  #{' ' * 10} #{passed ? 'PASS' : 'FAIL: channel tag was not replaced.'}"
+
+    panel_lines << messaging_frontend_text(actual)
+  end
+  respond ''
+
+  combined = panel_lines.join("\r\n")
+  _respond(messaging_apply_sentinel(messaging_thoughts_window(combined))) unless combined.empty?
+end
+
+# Wraps text in the same stream tag the game itself uses for the
+# Announcements panel, so *anntest can confirm the marker renders there.
+# XML frontends get the real <pushStream id="announcements"/>...
+# <popStream/> pair; GSL frontends have no dedicated marker pair for this
+# stream (there's nothing in lib/messaging.rb for it), so it's just sent
+# as plain text, same fallback approach messaging_thoughts_window uses.
+def messaging_announcement_window(text)
+  text = text.to_s.chomp
+  if MESSAGING_GSL_FRONTEND
+    "#{text}\r\n"
+  else
+    "<pushStream id=\"announcements\"/>#{text}<popStream/>\r\n"
+  end
+end
+
+def messaging_announcement_test
+  # Two shapes: real game announcements never carry an explicit
+  # <popStream/> (routing just stays open), but a hand-typed ;e test
+  # often does -- both need the marker landing inside the Announcements
+  # routing, not pushed out into the ambient stream after a <popStream/>.
+  samples = {
+    "no popStream (real-world shape)" => "<pushStream id='announcements'/>Testperson announces: This is a test announcement.",
+    "with popStream (manual ;e test shape)" => "<pushStream id='announcements'/>Testperson announces: This is a test announcement.<popStream/>"
+  }
+
+  respond ''
+  last_frontend_actual = nil
+  samples.each do |label, input|
+    actual = messaging_transform(input).to_s
+    last_frontend_actual = messaging_frontend_text(actual)
+
+    respond "#{ANNOUNCEMENT_MARKER_UTF8} Messaging announcement test (#{label}):"
+    respond "  input:  #{input}"
+    respond "  output: #{actual.strip}"
+    if actual =~ /<pushStream id=['"]announcements['"]\s*\/?>#{Regexp.escape(ANNOUNCEMENT_MARKER_UTF8)}/i
+      respond "  PASS: #{ANNOUNCEMENT_MARKER_UTF8} announcement marker inserted right after the tag."
+    else
+      respond '  FAIL: announcement marker missing or not immediately after the tag.'
+    end
+    respond ''
+  end
+
+  _respond(messaging_apply_sentinel(messaging_announcement_window(last_frontend_actual))) unless last_frontend_actual.to_s.strip.empty?
+end
+
+messaging = proc {
+  action = proc { |server_string| messaging_frontend_text(messaging_transform(server_string)) }
+  DownstreamHook.add("#{script.name}_messaging", action)
+  before_dying {
+    DownstreamHook.remove("#{script.name}_messaging")
+  }
 }
 
-before_dying { 
-	DownstreamHook.remove("#{script.name}_messaging")
-}
+command = (variable[1] || '').downcase
 
-if variable[1].downcase == "help"
-	respond ""
-    respond "    SYNTAX - ;messaging"
-	respond ""
-    respond "    Abbreviations:"
-	respond "       WL    - Wehnimer's Landing"
-	respond "       CY    - Cysaegir"
-	respond "       RR    - River's Rest"
-	respond "       TI    - Ta'Illistim"
-	respond "       IMT   - Icemule Trace"
-	respond "       KD    - Kharam Dzu (Teras Isle)"
-	respond "       TV    - Ta'Vaalor"
-	respond "       SOL   - Solhaven"
-	respond "       FWI   - Four Winds Isle"
-	respond "       ZUL   - Zul Logoth"
-	respond "       REIM  - Settlement of REIM"
-	respond "       TRAIL - Trail to Solhaven/Icemule, Castle Varunar"
-	respond "       RED   - Red Forest & Aradhul Road"
-	respond "       RIFT  - Pinerfar/Rift"
-	respond "       SOS   - Sanctum of Scales"
-	respond "       EC    - Elemental Confluence"
-	respond ""
-	Script.self.kill
-	exit
+if command == 'test'
+  messaging_self_test
+  Script.self.kill
+  exit
+end
+
+if command == 'esptest'
+  messaging_esp_test
+  Script.self.kill
+  exit
+end
+
+if command == 'anntest'
+  messaging_announcement_test
+  Script.self.kill
+  exit
+end
+
+if command == "help"
+  respond ""
+  respond "    SYNTAX - ;messaging"
+  respond "             ;messaging test"
+  respond "             ;messaging esptest"
+  respond "             ;messaging anntest"
+  respond ""
+  respond "    Test:"
+  respond "       test     - Show one random death-message conversion"
+  respond "       esptest  - Show all 7 channel icon conversions at once"
+  respond "       anntest  - Show the announcement marker conversion"
+  respond ""
+  respond "    Abbreviations:"
+  respond "       WL    - Wehnimer's Landing"
+  respond "       CY    - Cysaegir"
+  respond "       RR    - River's Rest"
+  respond "       TI    - Ta'Illistim"
+  respond "       IMT   - Icemule Trace"
+  respond "       KD    - Kharam Dzu (Teras Isle)"
+  respond "       TV    - Ta'Vaalor"
+  respond "       SOL   - Solhaven"
+  respond "       FWI   - Four Winds Isle"
+  respond "       ZUL   - Zul Logoth"
+  respond "       REIM  - Settlement of REIM"
+  respond "       TRAIL - Trail to Solhaven/Icemule, Castle Varunar"
+  respond "       RED   - Red Forest & Aradhul Road"
+  respond "       RIFT  - Pinerfar/Rift"
+  respond "       SOS   - Sanctum of Scales"
+  respond "       EC    - Elemental Confluence"
+  respond "       HW    - Hinterwilds"
+  respond ""
+  Script.self.kill
+  exit
 end
 
 messaging.call
 loop {
-	
-	sleep 1
+  sleep 1
 }


### PR DESCRIPTION
I added a bunch of emoji stuff for saga and updated with newer messaging for duskruin and sailor's grief. Will still work on older frontends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Saga-specific message rendering with emoji/XML formatting and readable ASCII fallbacks.
  - Death messages now display a tombstone marker.
  - Official channel tags use channel icons, and announcement messages include a loudspeaker marker.
  - Added dedicated Deaths, Thoughts, and Announcements message panels.
  - Added messaging self-test commands for general, ESP, and announcement displays.
- **Improvements**
  - Improved message formatting, sentinel handling, and newline cleanup across supported frontends.
  - Expanded command help and metadata for the new messaging tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->