### PR TITLE
feat(resource.lic): v1.13.0 Add read-only FIXSKILLS service bonus planner

### DIFF
--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -5,6 +5,10 @@
 
   OPTION Selections Include:
     BONUS <PROFESSION> - Show's profession success bonus formula
+    MAX                - Show the read-only maximum profession-service bonus possible
+                         with FIXSKILLS for the logged-in character
+      Professions supported: Wizard, Sorcerer, Cleric, Empath, Bard, Paladin, Monk, Ranger
+      Not yet supported: Rogue, Warrior
     ALL                - Show's all known bonuses from previous BONUS checks
     CHART <PROFESSION> - Prints off cost chart for each increase
       If no profession given, will use current character profession
@@ -24,20 +28,24 @@
     ROLLS  - Numeric Values For Roll Descriptions
     MATS   - Material Difficulty Modifiers
 
-        todo: none
+        todo: Add FIXSKILLS maximum planning models for Rogue and Warrior
       author: elanthia-online
 contributors: Tysong, FFNG, Xanlin, Rinualdo, Maodan
         name: resource
         game: gemstone
         tags: resource, tears, 330, santify, grit, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic, grit, wps, devotion, jesus juice, sanctify, 330, permabless, 620, ranger, druid fluid, grace, luck inspiration, paladin, empath, bloodstone, 1135
     requires: Lich > 5.5.0
-     version: 1.12.1
+     version: 1.13.0
 
   changelog:
-    1.12.1 (2026-07-13)
-      Add Battle Standard (B1-B6) difficulty calculation
-      Fix Bloodstone Jewelry (J1-J5) to use the same correct formula
-      Add Paladin to auto-bonus profession detection
+    1.13.0 (2026-08-31)
+      Added ;resource max, a read-only FIXSKILLS profession-service planner
+      Reconstructs lifetime and post-cap training points while excluding Ascension experience
+      Preserves PTP/MTP conversion behavior, rank caps, escalating costs, and automatic unconversion
+      Uses exact service formulas and bounded optimization for Wizard, Sorcerer, Cleric, Empath,
+        Bard, Paladin, Monk, and Ranger
+      Added hypothetical training, TP accounting, assumptions, and formula-breakdown output
+      Rogue and Warrior FIXSKILLS maximum models are not yet implemented
     1.12.0 (2025-05-01)
       Added option to run silently to update the saved data (for autostarting/autoupdating)
       Updated header version requirement to match tested version
@@ -272,6 +280,732 @@ class Resource
     ["Something doesn't seem right...         ", "Fumble"]
   ]
 
+  STAT_NAMES ||= %w[Strength Constitution Dexterity Agility Discipline Aura Logic Intuition Wisdom Influence]
+  STAT_ABBREVIATIONS ||= {
+    "Strength" => :str, "Constitution" => :con, "Dexterity" => :dex, "Agility" => :agi,
+    "Discipline" => :dis, "Aura" => :aur, "Logic" => :log, "Intuition" => :int,
+    "Wisdom" => :wis, "Influence" => :inf
+  }
+  PROFESSION_GROWTH ||= {
+    "Bard"     => [[25, 20, 25, 20, 15, 25, 10, 15, 20, 30], %w[Influence Aura]],
+    "Cleric"   => [[20, 20, 10, 15, 25, 15, 25, 25, 30, 20], %w[Wisdom Intuition]],
+    "Empath"   => [[10, 20, 15, 15, 25, 20, 25, 20, 30, 25], %w[Wisdom Influence]],
+    "Monk"     => [[25, 25, 20, 30, 25, 15, 20, 20, 15, 10], %w[Agility Strength]],
+    "Paladin"  => [[30, 25, 20, 20, 25, 15, 10, 15, 25, 20], %w[Wisdom Strength]],
+    "Ranger"   => [[25, 20, 30, 20, 20, 15, 15, 25, 25, 10], %w[Dexterity Intuition]],
+    "Sorcerer" => [[10, 15, 20, 15, 25, 30, 25, 20, 25, 20], %w[Aura Wisdom]],
+    "Wizard"   => [[10, 15, 25, 15, 20, 30, 25, 25, 20, 20], %w[Aura Logic]]
+  }
+  RACE_GROWTH ||= {
+    "Aelotoi"       => [0, -2, 3, 3, 2, 0, 0, 2, 0, -2],
+    "Burghal Gnome" => [-5, 0, 3, 3, -3, -2, 5, 5, 0, 0],
+    "Dark Elf"      => [0, -2, 5, 5, -2, 0, 0, 0, 0, 0],
+    "Dwarf"         => [5, 5, -3, -5, 3, 0, 0, 0, 3, -2],
+    "Elf"           => [0, -5, 5, 3, -5, 5, 0, 0, 0, 3],
+    "Erithian"      => [-2, 0, 0, 0, 3, 0, 2, 0, 0, 3],
+    "Forest Gnome"  => [-3, 2, 2, 3, 2, 0, 0, 0, 0, 0],
+    "Giantman"      => [5, 3, -2, -2, 0, 0, 0, 2, 0, 0],
+    "Half-Elf"      => [2, 0, 2, 2, -2, 0, 0, 0, 0, 2],
+    "Half-Krolvin"  => [3, 5, 2, 2, 0, -2, -2, 0, 0, -2],
+    "Halfling"      => [-5, 5, 5, 5, -2, 0, -2, 0, 0, 0],
+    "Human"         => [2, 2, 0, 0, 0, 0, 0, 2, 0, 0],
+    "Sylvankind"    => [-3, -2, 5, 5, -5, 3, 0, 0, 0, 3]
+  }
+  SERVICE_NAMES ||= {
+    "Wizard" => "Enchanting", "Sorcerer" => "Ensorcell", "Cleric" => "Sanctify",
+    "Empath" => "Bloodstone Jewelry", "Bard" => "Luck's Reverberation",
+    "Paladin" => "Battle Standard", "Monk" => "Tattoos", "Ranger" => "Resist Nature"
+  }
+  TRAINING ||= {
+    "Wizard" => {
+      "Harness Power" => [0, 4, 3], "Physical Fitness" => [8, 0, 1],
+      "Arcane Symbols" => [0, 2, 2], "Magic Item Use" => [0, 1, 2],
+      "Elemental Mana Control" => [0, 3, 3], "Wizard" => [0, 8, 3]
+    },
+    "Sorcerer" => {
+      "Harness Power" => [0, 4, 3], "Physical Fitness" => [8, 0, 1],
+      "Arcane Symbols" => [0, 1, 2], "Magic Item Use" => [0, 2, 2],
+      "Elemental Mana Control" => [0, 3, 2], "Spirit Mana Control" => [0, 3, 2],
+      "Sorcerer" => [0, 8, 3]
+    },
+    "Cleric" => {
+      "Harness Power" => [0, 4, 3], "Physical Fitness" => [8, 0, 1],
+      "Arcane Symbols" => [0, 2, 2], "Magic Item Use" => [0, 2, 2],
+      "Spirit Mana Control" => [0, 3, 3], "Cleric" => [0, 8, 3]
+    },
+    "Empath" => {
+      "Harness Power" => [0, 4, 3], "Physical Fitness" => [2, 0, 3],
+      "First Aid" => [1, 0, 3], "Arcane Symbols" => [0, 2, 2],
+      "Magic Item Use" => [0, 2, 2], "Spirit Mana Control" => [0, 3, 2],
+      "Mental Mana Control" => [0, 3, 2], "Empath" => [0, 8, 3]
+    },
+    "Bard" => {
+      "Harness Power" => [0, 5, 2], "Physical Fitness" => [4, 0, 2],
+      "Magic Item Use" => [0, 4, 2], "Elemental Mana Control" => [0, 5, 1],
+      "Mental Mana Control" => [0, 5, 1], "Bard" => [0, 17, 2]
+    },
+    "Paladin" => {
+      "Harness Power" => [0, 5, 2], "Physical Fitness" => [3, 0, 2],
+      "Arcane Symbols" => [0, 5, 1], "Magic Item Use" => [0, 5, 1],
+      "Spirit Mana Control" => [0, 5, 1], "Paladin" => [0, 17, 2]
+    },
+    "Monk" => {
+      "Harness Power" => [0, 6, 1], "Physical Fitness" => [2, 0, 3],
+      "First Aid" => [1, 2, 2], "Arcane Symbols" => [0, 6, 1],
+      "Mental Mana Control" => [0, 8, 1], "Spirit Mana Control" => [0, 8, 1],
+      "Mental Lore - Transformation" => [0, 12, 1], "Mental Lore - Telepathy" => [0, 12, 1],
+      "Minor Mental" => [0, 38, 1], "Minor Spiritual" => [0, 38, 1]
+    },
+    "Ranger" => {
+      "Harness Power" => [0, 5, 2], "Physical Fitness" => [4, 0, 2],
+      "Survival" => [1, 1, 3], "Magic Item Use" => [0, 5, 1],
+      "Spirit Mana Control" => [0, 5, 1], "Spiritual Lore - Blessings" => [0, 10, 1],
+      "Ranger" => [0, 17, 2]
+    }
+  }
+  TRAINING.each_value { |skills|
+    skills.each { |skill, metadata|
+      next if metadata.is_a?(Hash)
+      skills[skill] = { :ptp => metadata[0], :mtp => metadata[1], :max_per_level => metadata[2] }
+    }
+  }
+  SERVICE_SKILLS ||= {
+    "Wizard" => ["Arcane Symbols", "Magic Item Use", "Elemental Mana Control", "Wizard"],
+    "Sorcerer" => ["Arcane Symbols", "Magic Item Use", "Elemental Mana Control", "Spirit Mana Control", "Sorcerer"],
+    "Cleric" => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Cleric"],
+    "Empath" => ["Physical Fitness", "First Aid", "Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Mental Mana Control", "Empath"],
+    "Bard" => ["Magic Item Use", "Elemental Mana Control", "Mental Mana Control", "Bard"],
+    "Paladin" => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Paladin"],
+    "Monk" => ["Physical Fitness", "First Aid", "Arcane Symbols", "Mental Mana Control", "Spirit Mana Control", "Mental Lore - Transformation", "Mental Lore - Telepathy", "Minor Mental", "Minor Spiritual"],
+    "Ranger" => ["Harness Power", "Survival", "Magic Item Use", "Spirit Mana Control", "Spiritual Lore - Blessings", "Ranger"]
+  }
+  CAP_EXPERIENCE ||= 7_572_500
+
+  def self.clean_xml(line)
+    line.to_s.gsub(/<[^>]*>/, '').gsub('&gt;', '>').gsub('&lt;', '<').gsub('&amp;', '&')
+  end
+
+  def self.skill_bonus(ranks)
+    remaining = ranks.to_i
+    bonus = 0
+    [[10, 5], [10, 4], [10, 3], [10, 2]].each { |count, value|
+      used = [remaining, count].min
+      bonus += used * value
+      remaining -= used
+      break if remaining <= 0
+    }
+    bonus + [remaining, 0].max
+  end
+
+  def self.formula_skill_bonus(data, skill)
+    bonuses = data[:skill_bonuses]
+    return bonuses[skill] if bonuses && bonuses.key?(skill)
+    skill_bonus(data[:ranks][skill])
+  end
+
+  def self.spell_contribution(ranks, threshold)
+    ranks > threshold ? threshold * 2 + ranks - threshold : ranks * 2
+  end
+
+  def self.service_score(profession, data)
+    r = data[:ranks]
+    s = data[:stats]
+    level = data[:level]
+    location = data[:location_bonus].to_i
+    case profession
+    when "Wizard"
+      level + s[:log] + s[:int] + r["Magic Item Use"] / 10 + r["Arcane Symbols"] / 10 + r["Elemental Mana Control"] / 2 + spell_contribution(r["Wizard"], level + 1) + 25 + location
+    when "Sorcerer"
+      controls = [r["Elemental Mana Control"], r["Spirit Mana Control"]].sort.reverse
+      level + s[:wis] + s[:int] + r["Magic Item Use"] / 10 + r["Arcane Symbols"] / 10 + controls[0] / 2 + controls[1] / 4 + spell_contribution(r["Sorcerer"], level + 1) + location
+    when "Cleric"
+      level + s[:wis] + s[:inf] + r["Magic Item Use"] / 10 + r["Arcane Symbols"] / 10 + r["Spirit Mana Control"] / 2 + spell_contribution(r["Cleric"], level + 1) + location
+    when "Empath"
+      controls = [r["Spirit Mana Control"], r["Mental Mana Control"]].sort.reverse
+      level + s[:con] + s[:inf] + spell_contribution(r["Empath"], level) + controls[0] / 2 + controls[1] / 4 + r["Arcane Symbols"] / 10 + r["Magic Item Use"] / 10 + r["Physical Fitness"] / 20 + r["First Aid"] / 20
+    when "Bard"
+      level + s[:int] + s[:inf] + spell_contribution(r["Bard"], level) + r["Mental Mana Control"] + r["Elemental Mana Control"] + r["Magic Item Use"] + location
+    when "Paladin"
+      level + s[:wis] + s[:inf] + (r["Magic Item Use"] * 1.5).truncate + (r["Arcane Symbols"] * 1.5).truncate + r["Spirit Mana Control"] + spell_contribution(r["Paladin"], level + 1) + location
+    when "Monk"
+      shared = level + s[:dex] * 2 + s[:dis] * 2 + (r["Physical Fitness"] * 0.75).truncate + r["First Aid"] / 2 + (r["Minor Mental"] + r["Minor Spiritual"]) * 2 + r["Arcane Symbols"] + r["Mental Mana Control"] + r["Spirit Mana Control"]
+      [shared + formula_skill_bonus(data, "Mental Lore - Transformation"), shared + formula_skill_bonus(data, "Mental Lore - Telepathy")]
+    when "Ranger"
+      level + s[:wis] * 2 + s[:int] * 2 + (r["Survival"] * 0.75).truncate + r["Magic Item Use"] + r["Harness Power"] + r["Spirit Mana Control"] + r["Spiritual Lore - Blessings"] + (r["Ranger"] * 1.5).truncate + location
+    end
+  end
+
+  def self.respond_formula_rows(rows, total, title = nil)
+    respond title if title
+    rows.each_with_index { |row, index|
+      respond "#{index.zero? ? '  ' : '+ '}#{row[0].to_s.rjust(4)} : #{row[1]}"
+    }
+    respond "  ======"
+    respond "  #{total.to_s.rjust(4)} : Total"
+  end
+
+  def self.show_maximum_formula(profession, data)
+    ranks = data[:ranks]
+    stats = data[:stats]
+    level = data[:level]
+    location = data[:location_bonus].to_i
+    respond ""
+    respond "FIXSKILLS maximum formula:"
+    case profession
+    when "Wizard"
+      rows = [[level, "Level"], [stats[:log], "LOG Bonus"], [stats[:int], "INT Bonus"],
+              [ranks["Magic Item Use"] / 10, "trunc(MIU ranks / 10)"],
+              [ranks["Arcane Symbols"] / 10, "trunc(AS ranks / 10)"],
+              [ranks["Elemental Mana Control"] / 2, "trunc(EMC ranks / 2)"],
+              [spell_contribution(ranks["Wizard"], level + 1), "Wizard Spells"],
+              [25, "Familiar Bonus"], [location, "Public Workshop Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Sorcerer"
+      larger, smaller = ["Elemental Mana Control", "Spirit Mana Control"].sort_by { |skill| -ranks[skill] }
+      rows = [[level, "Level"], [stats[:wis], "WIS Bonus"], [stats[:int], "INT Bonus"],
+              [ranks["Magic Item Use"] / 10, "trunc(MIU ranks / 10)"],
+              [ranks["Arcane Symbols"] / 10, "trunc(AS ranks / 10)"],
+              [ranks[larger] / 2, "trunc(#{larger} ranks / 2)"],
+              [ranks[smaller] / 4, "trunc(#{smaller} ranks / 4)"],
+              [spell_contribution(ranks["Sorcerer"], level + 1), "Sorcerer Spells"],
+              [location, "Public Workshop Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Cleric"
+      rows = [[level, "Level"], [stats[:wis], "WIS Bonus"], [stats[:inf], "INF Bonus"],
+              [ranks["Magic Item Use"] / 10, "trunc(MIU ranks / 10)"],
+              [ranks["Arcane Symbols"] / 10, "trunc(AS ranks / 10)"],
+              [ranks["Spirit Mana Control"] / 2, "trunc(SMC ranks / 2)"],
+              [spell_contribution(ranks["Cleric"], level + 1), "Cleric Spells"],
+              [location, "Shrine Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Empath"
+      larger, smaller = ["Spirit Mana Control", "Mental Mana Control"].sort_by { |skill| -ranks[skill] }
+      rows = [[level, "Level"], [stats[:con], "CON Bonus"], [stats[:inf], "INF Bonus"],
+              [spell_contribution(ranks["Empath"], level), "Empath Spells"],
+              [ranks[larger] / 2, "trunc(#{larger} ranks / 2)"],
+              [ranks[smaller] / 4, "trunc(#{smaller} ranks / 4)"],
+              [ranks["Arcane Symbols"] / 10, "trunc(AS ranks / 10)"],
+              [ranks["Magic Item Use"] / 10, "trunc(MIU ranks / 10)"],
+              [ranks["Physical Fitness"] / 20, "trunc(PF ranks / 20)"],
+              [ranks["First Aid"] / 20, "trunc(First Aid ranks / 20)"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Bard"
+      rows = [[level, "Level"], [stats[:int], "INT Bonus"], [stats[:inf], "INF Bonus"],
+              [spell_contribution(ranks["Bard"], level), "Bard Spells"],
+              [ranks["Mental Mana Control"], "MMC ranks"],
+              [ranks["Elemental Mana Control"], "EMC ranks"],
+              [ranks["Magic Item Use"], "MIU ranks"], [location, "Tavern/Shrine Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Paladin"
+      rows = [[level, "Level"], [stats[:wis], "WIS Bonus"], [stats[:inf], "INF Bonus"],
+              [(ranks["Magic Item Use"] * 1.5).truncate, "trunc(MIU ranks * 1.5)"],
+              [(ranks["Arcane Symbols"] * 1.5).truncate, "trunc(AS ranks * 1.5)"],
+              [ranks["Spirit Mana Control"], "SMC ranks"],
+              [spell_contribution(ranks["Paladin"], level + 1), "Paladin Spells"],
+              [location, "Shrine Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    when "Monk"
+      shared = [[level, "Level"], [stats[:dex] * 2, "DEX Bonus * 2"], [stats[:dis] * 2, "DIS Bonus * 2"],
+                [(ranks["Physical Fitness"] * 0.75).truncate, "trunc(PF ranks * 0.75)"],
+                [ranks["First Aid"] / 2, "trunc(First Aid ranks / 2)"],
+                [(ranks["Minor Mental"] + ranks["Minor Spiritual"]) * 2, "Minor spell ranks * 2"],
+                [ranks["Arcane Symbols"], "AS ranks"], [ranks["Mental Mana Control"], "MMC ranks"],
+                [ranks["Spirit Mana Control"], "SMC ranks"]]
+      totals = service_score(profession, data)
+      respond_formula_rows(shared + [[formula_skill_bonus(data, "Mental Lore - Transformation"), "ML:Transformation Bonus"]], totals[0], "Self Tattoo:")
+      respond ""
+      respond_formula_rows(shared + [[formula_skill_bonus(data, "Mental Lore - Telepathy"), "ML:Telepathy Bonus"]], totals[1], "Other Tattoo:")
+    when "Ranger"
+      rows = [[level, "Level"], [stats[:wis] * 2, "WIS Bonus * 2"], [stats[:int] * 2, "INT Bonus * 2"],
+              [(ranks["Survival"] * 0.75).truncate, "trunc(Survival ranks * 0.75)"],
+              [ranks["Magic Item Use"], "MIU ranks"], [ranks["Harness Power"], "Harness Power ranks"],
+              [ranks["Spirit Mana Control"], "SMC ranks"],
+              [ranks["Spiritual Lore - Blessings"], "SL:Blessings ranks"],
+              [(ranks["Ranger"] * 1.5).truncate, "trunc(Ranger spell ranks * 1.5)"],
+              [location, location == 20 ? "Outdoors Bonus" : "Indoors Bonus"]]
+      respond_formula_rows(rows, service_score(profession, data))
+    end
+  end
+
+  def self.score_objective(score)
+    score.is_a?(Array) ? [[score[0], score[1]].min, score[0] + score[1], score[0]] : [score]
+  end
+
+  def self.resource_value(ptp, mtp, direction)
+    return ptp + mtp * 2 if direction == :physical_to_mental
+    return ptp * 2 + mtp if direction == :mental_to_physical
+    ptp + mtp
+  end
+
+  def self.rank_cost(profession, skill, rank, cycles)
+    metadata = TRAINING[profession][skill]
+    ptp = metadata[:ptp]
+    mtp = metadata[:mtp]
+    max_per_level = metadata[:max_per_level]
+    tier = (rank - 1) / cycles
+    return nil if tier >= max_per_level
+    multiplier = 2**tier
+    [ptp * multiplier, mtp * multiplier]
+  end
+
+  def self.pay_cost(ptp, mtp, cost, conversion)
+    ptp_cost, mtp_cost = cost
+    conversion_remaining = conversion[:remaining]
+    if conversion[:direction] == :physical_to_mental
+      if ptp < ptp_cost
+        units = (ptp_cost - ptp + 1) / 2
+        return nil if units > conversion_remaining / 2 || mtp < units
+        ptp += units * 2
+        mtp -= units
+        conversion_remaining -= units * 2
+      end
+      if mtp < mtp_cost
+        units = mtp_cost - mtp
+        return nil if ptp - ptp_cost < units * 2
+        ptp -= units * 2
+        mtp += units
+        conversion_remaining += units * 2
+      end
+    elsif conversion[:direction] == :mental_to_physical
+      if mtp < mtp_cost
+        units = (mtp_cost - mtp + 1) / 2
+        return nil if units > conversion_remaining / 2 || ptp < units
+        mtp += units * 2
+        ptp -= units
+        conversion_remaining -= units * 2
+      end
+      if ptp < ptp_cost
+        units = ptp_cost - ptp
+        return nil if mtp - mtp_cost < units * 2
+        mtp -= units * 2
+        ptp += units
+        conversion_remaining += units * 2
+      end
+    end
+    return nil if ptp < ptp_cost || mtp < mtp_cost
+    [ptp - ptp_cost, mtp - mtp_cost, conversion_remaining]
+  end
+
+  def self.replay_training_points(profession, race, level, starting_stats)
+    profession_data = PROFESSION_GROWTH[profession]
+    race_data = RACE_GROWTH[race]
+    return nil unless profession_data && race_data
+    stats = STAT_NAMES.map { |name| starting_stats[STAT_ABBREVIATIONS[name]] }
+    return nil if stats.any?(&:nil?)
+    intervals = profession_data[0].each_with_index.map { |value, index| value + race_data[index] }
+    primes = profession_data[1]
+    totals = [0, 0]
+    (0..level).each { |cycle|
+      if cycle > 0
+        stats.each_with_index { |value, index|
+          interval = [value / intervals[index], 1].max
+          stats[index] = [value + (cycle % interval == 0 ? 1 : 0), 100].min
+        }
+      end
+      values = {}
+      STAT_NAMES.each_with_index { |name, index| values[name] = stats[index] }
+      weight = lambda { |name| primes.include?(name) ? 2 : 1 }
+      physical = %w[Strength Constitution Dexterity Agility].sum { |name| values[name] * weight.call(name) }
+      physical += (values["Aura"] * weight.call("Aura") + values["Discipline"] * weight.call("Discipline")) / 2
+      mental = %w[Logic Intuition Wisdom Influence].sum { |name| values[name] * weight.call(name) }
+      mental += (values["Aura"] * weight.call("Aura") + values["Discipline"] * weight.call("Discipline")) / 2
+      totals[0] += 25 + physical / 20
+      totals[1] += 25 + mental / 20
+    }
+    totals
+  end
+
+  def self.parse_snapshot(exp_lines, info_lines, start_lines, skill_lines)
+    snapshot = { :stats => {}, :starting_stats => {}, :ranks => Hash.new(0), :unspent => nil, :conversion => nil }
+    info_lines.each { |raw|
+      line = clean_xml(raw)
+      if line =~ /Race:\s*(.+?)\s+Profession:\s*(Wizard|Sorcerer|Cleric|Empath|Bard|Paladin|Monk|Ranger|Rogue|Warrior)\b/i
+        snapshot[:race] = $1.strip
+        snapshot[:profession] = $2.capitalize
+      end
+      if line =~ /Level:\s*(\d+)/
+        snapshot[:level] = $1.to_i
+      end
+      STAT_ABBREVIATIONS.each { |name, key|
+        if line =~ /#{Regexp.escape(name)}(?:\s+\([A-Z]{3}\))?:\s*(\d+)\s+\((-?\d+)\)/
+          snapshot[:stats][key] = $2.to_i
+        elsif line =~ /#{Regexp.escape(name)}.*?\((-?\d+)\)\s*$/
+          snapshot[:stats][key] = $1.to_i
+        end
+      }
+    }
+    start_lines.each { |raw|
+      line = clean_xml(raw)
+      if line =~ /Level 0 Stats for .*,\s*(.+)\s+(Wizard|Sorcerer|Cleric|Empath|Bard|Paladin|Monk|Ranger|Rogue|Warrior)\s*$/i
+        snapshot[:race] ||= $1.strip
+        snapshot[:profession] ||= $2.capitalize
+      end
+      STAT_ABBREVIATIONS.each { |name, key| snapshot[:starting_stats][key] = $1.to_i if line =~ /#{Regexp.escape(name)}(?:\s+\([A-Z]{3}\))?:\s*(\d+)/ }
+    }
+    exp_lines.each { |raw|
+      line = clean_xml(raw)
+      snapshot[:normal_experience] = $1.delete(',').to_i if line !~ /(?:Total|Ascension) Exp/ && line =~ /\bExperience:\s*([\d,]+)/
+      snapshot[:total_experience] = $1.delete(',').to_i if line =~ /^\s*Total Exp(?:erience)?:\s*([\d,]+)/
+      snapshot[:ascension_experience] = $1.delete(',').to_i if line =~ /^\s*Ascension Exp(?:erience)?:\s*([\d,]+)/
+      snapshot[:unspent] = [$1.to_i, $2.to_i] if line =~ /PTPs\/MTPs:\s*(\d+)\s*\/\s*(\d+)/
+      snapshot[:unspent] = [$1.to_i, $2.to_i] if line =~ /Training Points:\s*(\d+)\s+Phy\s+(\d+)\s+Mnt/
+      if line =~ /\(([\d,]+)\s+Phy converted to Mnt\)/
+        snapshot[:conversion] = { :direction => :physical_to_mental, :amount => $1.delete(',').to_i }
+      elsif line =~ /\(([\d,]+)\s+Mnt converted to Phy\)/
+        snapshot[:conversion] = { :direction => :mental_to_physical, :amount => $1.delete(',').to_i }
+      end
+    }
+    skill_lines.each { |raw|
+      line = clean_xml(raw)
+      snapshot[:unspent] = [$1.to_i, $2.to_i] if line =~ /Training Points:\s*(\d+)\s+Phy\s+(\d+)\s+Mnt/
+      if line =~ /\(([\d,]+)\s+Phy converted to Mnt\)/
+        snapshot[:conversion] = { :direction => :physical_to_mental, :amount => $1.delete(',').to_i }
+      elsif line =~ /\(([\d,]+)\s+Mnt converted to Phy\)/
+        snapshot[:conversion] = { :direction => :mental_to_physical, :amount => $1.delete(',').to_i }
+      end
+      TRAINING.values.each { |table| table.keys.each { |skill|
+        pattern = Regexp.escape(skill).gsub('\\ ', '\\s+')
+        if line =~ /^\s*#{pattern}(?:\.{2,}|\s+\|).*?(\d+)\s*(?:\d+\s*)?$/i
+          numbers = line.scan(/\d+/).map(&:to_i)
+          spell_skill = %w[Wizard Sorcerer Cleric Empath Bard Paladin Ranger].include?(skill) || skill =~ /^Minor /
+          snapshot[:ranks][skill] = spell_skill ? numbers[0] : numbers[1] if numbers.length >= (spell_skill ? 1 : 2)
+        end
+      } }
+    }
+    snapshot[:normal_experience] ||= snapshot[:total_experience] - snapshot[:ascension_experience].to_i if snapshot[:total_experience] && snapshot.key?(:ascension_experience)
+    snapshot[:conversion] ||= { :direction => :none, :amount => 0 } if snapshot[:unspent]
+    snapshot
+  end
+
+  def self.ranger_mental_capacity(ptp, mtp, conversion)
+    case conversion[:direction]
+    when :physical_to_mental
+      mtp + ptp / 2
+    when :mental_to_physical
+      mtp + 2 * [conversion[:remaining] / 2, ptp].min
+    else
+      mtp
+    end
+  end
+
+  def self.optimize_ranger(data, ptp, mtp, conversion)
+    profession = "Ranger"
+    cycles = data[:level] + 1
+    base_ranks = Hash.new(0)
+    base_ranks["Harness Power"] = 6
+    mental_skills = ["Harness Power", "Magic Item Use", "Spirit Mana Control", "Spiritual Lore - Blessings", "Ranger"]
+    maximum_capacity = ranger_mental_capacity(ptp, mtp, conversion)
+    base_score = service_score(profession, data.merge(:ranks => base_ranks))
+    dp = { 0 => { :gain => 0, :ranks => base_ranks } }
+
+    mental_skills.each { |skill|
+      starting_rank = skill == "Harness Power" ? 6 : 0
+      options = []
+      running_cost = 0
+      last_gain = nil
+      rank = starting_rank
+      loop do
+        option_ranks = base_ranks.dup
+        option_ranks[skill] = rank
+        gain = service_score(profession, data.merge(:ranks => option_ranks)) - base_score
+        if last_gain.nil? || gain != last_gain
+          options << [running_cost, gain, rank]
+          last_gain = gain
+        end
+        next_cost = rank_cost(profession, skill, rank + 1, cycles)
+        break unless next_cost
+        running_cost += next_cost[1]
+        break if running_cost > maximum_capacity
+        rank += 1
+      end
+
+      next_dp = {}
+      dp.each { |spent, state|
+        options.each { |option_cost, gain, option_rank|
+          total_cost = spent + option_cost
+          next if total_cost > maximum_capacity
+          candidate_gain = state[:gain] + gain
+          old = next_dp[total_cost]
+          if old.nil? || candidate_gain > old[:gain]
+            option_plan = state[:ranks].dup
+            option_plan[skill] = option_rank
+            next_dp[total_cost] = { :gain => candidate_gain, :ranks => option_plan }
+          end
+        }
+      }
+      dp = next_dp
+    }
+
+    best_for_capacity = Array.new(maximum_capacity + 1)
+    best = nil
+    (0..maximum_capacity).each { |capacity|
+      exact = dp[capacity]
+      if exact && (best.nil? || exact[:gain] > best[:gain])
+        best = exact.merge(:cost => capacity)
+      end
+      best_for_capacity[capacity] = best
+    }
+
+    best_result = nil
+    survival_cost = [0, 0]
+    survival_rank = 0
+    loop do
+      after_survival = pay_cost(ptp, mtp, survival_cost, conversion)
+      break unless after_survival
+      capacity = ranger_mental_capacity(after_survival[0], after_survival[1], conversion.merge(:remaining => after_survival[2]))
+      mental = best_for_capacity[[capacity, maximum_capacity].min]
+      if mental
+        ranks = mental[:ranks].dup
+        ranks["Survival"] = survival_rank
+        total_cost = [survival_cost[0], survival_cost[1] + mental[:cost]]
+        remaining = pay_cost(ptp, mtp, total_cost, conversion)
+        if remaining
+          score = service_score(profession, data.merge(:ranks => ranks))
+          candidate = {
+            :ptp => remaining[0], :mtp => remaining[1], :conversion_remaining => remaining[2],
+            :spent => total_cost, :ranks => ranks, :score => score
+          }
+          if best_result.nil? || (score_objective(score) + [remaining[0] + remaining[1]] <=> score_objective(best_result[:score]) + [best_result[:ptp] + best_result[:mtp]]) == 1
+            best_result = candidate
+          end
+        end
+      end
+      next_cost = rank_cost(profession, "Survival", survival_rank + 1, cycles)
+      break unless next_cost
+      survival_cost[0] += next_cost[0]
+      survival_cost[1] += next_cost[1]
+      survival_rank += 1
+    end
+    best_result
+  end
+
+  def self.optimize_service(profession, data, ptp, mtp, conversion)
+    return optimize_ranger(data, ptp, mtp, conversion) if profession == "Ranger"
+    cycles = data[:level] + 1
+    ranks = Hash.new(0)
+    ranks["Harness Power"] = 6
+    initial = { :ptp => ptp, :mtp => mtp, :conversion_remaining => conversion[:remaining], :spent => [0, 0], :ranks => ranks, :score => service_score(profession, data.merge(:ranks => ranks)) }
+    best = { [ptp, mtp, conversion[:remaining]] => initial }
+    priority = resource_value(ptp, mtp, conversion[:direction])
+    buckets = Hash.new { |hash, key| hash[key] = [] }
+    buckets[priority] << initial
+    terminal = []
+    while priority >= 0
+      if buckets[priority].empty?
+        priority -= 1
+        next
+      end
+      state = buckets[priority].pop
+      next unless best[[state[:ptp], state[:mtp], state[:conversion_remaining]]].equal?(state)
+      advanced = false
+      SERVICE_SKILLS[profession].each { |skill|
+        next_ranks = state[:ranks].dup
+        cost = [0, 0]
+        score = nil
+        loop do
+          next_rank = next_ranks[skill] + 1
+          break if profession == "Monk" && %w[Minor\ Mental Minor\ Spiritual].include?(skill) && next_ranks["Minor Mental"] + next_ranks["Minor Spiritual"] >= cycles
+          cost_rank = next_rank
+          if profession == "Monk" && %w[Minor\ Mental Minor\ Spiritual].include?(skill)
+            cost_rank = next_ranks["Minor Mental"] + next_ranks["Minor Spiritual"] + 1
+          elsif profession == "Monk" && ["Mental Lore - Transformation", "Mental Lore - Telepathy"].include?(skill)
+            cost_rank = next_ranks["Mental Lore - Transformation"] + next_ranks["Mental Lore - Telepathy"] + 1
+          end
+          rank_cost_value = rank_cost(profession, skill, cost_rank, cycles)
+          break unless rank_cost_value
+          cost[0] += rank_cost_value[0]
+          cost[1] += rank_cost_value[1]
+          next_ranks[skill] = next_rank
+          score = service_score(profession, data.merge(:ranks => next_ranks))
+          break if score_objective(score) != score_objective(state[:score])
+          score = nil
+        end
+        next unless score
+        remaining = pay_cost(state[:ptp], state[:mtp], cost, conversion.merge(:remaining => state[:conversion_remaining]))
+        next unless remaining
+        advanced = true
+        candidate = {
+          :ptp => remaining[0], :mtp => remaining[1], :conversion_remaining => remaining[2],
+          :spent => [state[:spent][0] + cost[0], state[:spent][1] + cost[1]],
+          :ranks => next_ranks, :score => score
+        }
+        key = remaining
+        old = best[key]
+        if old.nil? || (score_objective(score) <=> score_objective(old[:score])) == 1
+          best[key] = candidate
+          candidate_priority = resource_value(candidate[:ptp], candidate[:mtp], conversion[:direction])
+          buckets[candidate_priority] << candidate
+        end
+      }
+      terminal << state unless advanced
+    end
+    terminal.max_by { |state| score_objective(state[:score]) + [state[:ptp] + state[:mtp]] }
+  end
+
+  def self.maximum
+    profession = Stats.prof.to_s
+    if %w[Rogue Warrior].include?(profession)
+      respond "No FIXSKILLS maximum model exists for #{profession} yet."
+      respond ";resource max is not yet supported for #{profession}; no estimate was produced."
+      return
+    end
+    unless TRAINING.key?(profession)
+      respond "No FIXSKILLS maximum model exists for #{profession.empty? ? 'this profession' : profession} yet."
+      return
+    end
+
+    exp_lines = Lich::Util.quiet_command_xml("exp", /Level:|Experience:/, /Your mind/, 8)
+    info_lines = Lich::Util.quiet_command_xml("info", /^Name: /)
+    start_lines = Lich::Util.quiet_command_xml("info start", /Level 0 Stats for/, /This character was created/, 8)
+    skill_lines = Lich::Util.quiet_command_xml("skills base full", /base skill bonuses, ranks and goals|base skill bonuses and ranks/, /Further information can be found/, 8)
+    snapshot = parse_snapshot(exp_lines, info_lines, start_lines, skill_lines)
+    snapshot[:profession] ||= profession
+    required_stats = STAT_ABBREVIATIONS.values
+    if snapshot[:level].nil? || snapshot[:race].nil? || required_stats.any? { |key| snapshot[:stats][key].nil? }
+      respond ";resource max could not parse INFO; no estimate was produced."
+      return
+    end
+    if required_stats.any? { |key| snapshot[:starting_stats][key].nil? }
+      respond ";resource max requires INFO START to read level-0 stats."
+      return
+    end
+    if snapshot[:normal_experience].nil?
+      respond "Could not parse normal experience; no estimate was produced."
+      return
+    end
+    if snapshot[:conversion].nil?
+      respond "Could not determine current PTP/MTP conversion state."
+      return
+    end
+
+    lifetime = replay_training_points(profession, snapshot[:race], snapshot[:level], snapshot[:starting_stats])
+    unless lifetime
+      respond "Could not replay stat growth for #{snapshot[:race]} #{profession}; no estimate was produced."
+      return
+    end
+    normal_post_cap = [snapshot[:normal_experience] - CAP_EXPERIENCE, 0].max
+    post_cap_pairs = normal_post_cap / 2500
+    post_cap = [post_cap_pairs, post_cap_pairs]
+    available = [lifetime[0] + post_cap[0], lifetime[1] + post_cap[1]]
+    conversion = snapshot[:conversion]
+    if conversion[:direction] == :physical_to_mental
+      if conversion[:amount] > available[0] || conversion[:amount].odd?
+        respond "Could not safely apply the reported PTP-to-MTP conversion; no estimate was produced."
+        return
+      end
+      available[0] -= conversion[:amount]
+      available[1] += conversion[:amount] / 2
+    elsif conversion[:direction] == :mental_to_physical
+      if conversion[:amount] > available[1] || conversion[:amount].odd?
+        respond "Could not safely apply the reported MTP-to-PTP conversion; no estimate was produced."
+        return
+      end
+      available[1] -= conversion[:amount]
+      available[0] += conversion[:amount] / 2
+    end
+    conversion_state = { :direction => conversion[:direction], :remaining => conversion[:amount] }
+    cycles = snapshot[:level] + 1
+    reserve_cost = [0, 0]
+    (1..6).each { |rank|
+      cost = rank_cost(profession, "Harness Power", rank, cycles)
+      unless cost
+        respond "Six Harness Power ranks exceed the level-based rank cap; no estimate was produced."
+        return
+      end
+      reserve_cost[0] += cost[0]
+      reserve_cost[1] += cost[1]
+    }
+    after_reserve = pay_cost(available[0], available[1], reserve_cost, conversion_state)
+    unless after_reserve
+      respond "The lifetime training-point budget cannot reserve six Harness Power ranks; no estimate was produced."
+      return
+    end
+    location_bonus = case profession
+                     when "Wizard" then 50
+                     when "Sorcerer", "Cleric", "Bard", "Paladin" then 20
+                     when "Ranger" then outside? ? 20 : 0
+                     else 0
+                     end
+    formula_data = { :level => snapshot[:level], :stats => snapshot[:stats], :location_bonus => location_bonus }
+    current_score = service_score(profession, formula_data.merge(:ranks => snapshot[:ranks]))
+    optimized = optimize_service(profession, formula_data, after_reserve[0], after_reserve[1], conversion_state.merge(:remaining => after_reserve[2]))
+    unless optimized
+      respond "No legal service-training plan could be evaluated; no estimate was produced."
+      return
+    end
+    service_ranks = optimized[:ranks]
+    service_spent = optimized[:spent]
+    survivability_ranks = 0
+    survivability_spent = [0, 0]
+    remaining = [optimized[:ptp], optimized[:mtp]]
+    unless %w[Empath Monk].include?(profession)
+      loop do
+        next_rank = survivability_ranks + 1
+        cost = rank_cost(profession, "Physical Fitness", next_rank, cycles)
+        break unless cost
+        paid = pay_cost(remaining[0], remaining[1], cost, conversion_state.merge(:remaining => optimized[:conversion_remaining]))
+        break unless paid
+        survivability_ranks = next_rank
+        survivability_spent[0] += cost[0]
+        survivability_spent[1] += cost[1]
+        optimized[:conversion_remaining] = paid[2]
+        remaining = paid[0, 2]
+      end
+    end
+
+    respond "With Fixskills — #{profession} #{SERVICE_NAMES[profession]}"
+    respond ""
+    if profession == "Monk"
+      respond "Current service bonus:"
+      respond "  Self Tattoo: #{current_score[0]}"
+      respond "  Other Tattoo: #{current_score[1]}"
+      respond "FIXSKILLS maximum:"
+      respond "  Self Tattoo: #{optimized[:score][0]}"
+      respond "  Other Tattoo: #{optimized[:score][1]}"
+    else
+      respond "Current service bonus: #{current_score}"
+      respond "FIXSKILLS maximum: #{optimized[:score]}"
+    end
+    respond ""
+    respond "Lifetime PTP/MTP earned: #{lifetime[0]} / #{lifetime[1]}"
+    respond "Post-cap PTP/MTP earned: #{post_cap[0]} / #{post_cap[1]}"
+    respond "Reserved PTP/MTP: #{reserve_cost[0]} / #{reserve_cost[1]}"
+    respond "Service PTP/MTP spent: #{service_spent[0]} / #{service_spent[1]}"
+    respond "Survivability PTP/MTP spent: #{survivability_spent[0]} / #{survivability_spent[1]}"
+    respond "Unspent PTP/MTP: #{remaining[0]} / #{remaining[1]}"
+    respond ""
+    respond "Required training:"
+    respond "  Harness Power: 6"
+    respond ""
+    respond "Service training:"
+    SERVICE_SKILLS[profession].each { |skill|
+      ranks = service_ranks[skill]
+      respond "  #{skill}: #{ranks}" unless skill == "Harness Power" && ranks == 6
+    }
+    respond ""
+    respond "Survivability training:"
+    respond "  Physical Fitness: #{%w[Empath Monk].include?(profession) ? service_ranks['Physical Fitness'] : survivability_ranks}"
+    respond ""
+    respond "Assumptions:"
+    case profession
+    when "Wizard" then respond "  Public workshop: +50 (private workshop not assumed)"; respond "  Familiar present: +25"
+    when "Sorcerer" then respond "  Public workshop: +20"
+    when "Cleric" then respond "  Maximum matching-deity shrine: +20"
+    when "Bard" then respond "  Tavern or qualifying shrine: +20"
+    when "Paladin" then respond "  Matching-deity shrine: +20"
+    when "Ranger" then respond "  Current location: #{location_bonus == 20 ? 'outdoors (+20)' : 'indoors (+0)'}"
+    else respond "  No non-skill location bonus assumed"
+    end
+    respond "  Ascension experience excluded from training points"
+    if conversion[:direction] == :none
+      respond "  Conversion direction: none"
+    else
+      respond "  Conversion direction: #{conversion[:direction].to_s.tr('_', ' ')}"
+      respond "  Reported/planned converted source points: #{conversion[:amount]} / #{optimized[:conversion_remaining]}"
+    end
+    show_maximum_formula(profession, formula_data.merge(:ranks => service_ranks))
+  end
+
   def self.load_bonuses()
     dir = File.join(DATA_DIR, "resource")
     filename = File.join(dir, "bonuses.yaml")
@@ -466,7 +1200,7 @@ class Resource
   end
 
   def self.chance(item_difficulty, type, bonus)
-    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath|Paladin$/)
+    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath$/)
       unless type =~ /^(e(?:50|[1-4][0-9]|[0-9])|[tmj](?:[1-5])|[slb](?:[1-6])|[ra](?:2[0-5]|1[0-9]|[1-9]))$/i
         respond "Need to provide an item difficulty and bonus type too use advanced chance option."
         respond "  ;resource chance <ItemDifficulty> <BonusType> <SkillBonus>"
@@ -479,8 +1213,8 @@ class Resource
         respond "    Resistance         - R1 to R25"
         respond "    Covert Arts        - A1 to A25"
         respond "    Luck               - L1 to L6"
-        respond "    Battle Standard    - B1 to B6"
-        respond "    Bloodstone Jewelry - J1 to J5"
+        respond "    Battle Standard    - B1 to B6 (not implemented)"
+        respond "    Bloodstone Jewelry - J1 to J5 (not implemented)"
         respond ""
         respond "  Will attempt to be smart if no SkillBonus given."
         return
@@ -498,12 +1232,8 @@ class Resource
         penalty = (($1.to_i == 6) ? 50 : 20)
       when /l([1-6])/i
         penalty = (($1.to_i == 1) ? 150 : 75)
-      when /b([1-6])/i
-        penalty = 75 + ($1.to_i * 75)
-        item_difficulty = 0
       when /j([1-5])/i
-        penalty = 75 + ($1.to_i * 75)
-        item_difficulty = 0
+        penalty = (($1.to_i == 1) ? 150 : 75)
       when /r(2[0-5]|1[0-9]|[1-9])/i
         penalty = $1.to_i
         item_difficulty = 0
@@ -927,6 +1657,30 @@ class Resource
       echo gritSkills
     end
 
+    formula_data = {
+      :level => level,
+      :stats => {
+        :str => strength, :con => constitution, :dex => dexterity, :agi => agility, :dis => discipline,
+        :aur => aura, :log => logic, :int => intuition, :wis => wisdom, :inf => influence
+      },
+      :ranks => Hash.new(0).merge(
+        "Arcane Symbols" => arcanesymbols, "Magic Item Use" => magicitemuse,
+        "Physical Fitness" => physicalfitness, "First Aid" => firstaid,
+        "Elemental Mana Control" => elementalmanacontrol, "Spirit Mana Control" => spiritmanacontrol,
+        "Mental Mana Control" => mentalmanacontrol, "Mental Lore - Telepathy" => mentalloretelepathy,
+        "Mental Lore - Transformation" => mentalloretransformation,
+        "Spiritual Lore - Blessings" => spiritloreblessings, "Survival" => survival,
+        "Harness Power" => harnesspower, "Bard" => bardranks, "Sorcerer" => sorcererranks,
+        "Wizard" => wizardranks, "Cleric" => clericranks, "Ranger" => rangerranks,
+        "Empath" => empathranks, "Paladin" => paladinranks, "Minor Mental" => minormentalranks,
+        "Minor Spiritual" => minorspiritranks
+      ),
+      :skill_bonuses => {
+        "Mental Lore - Telepathy" => mentalloretelepathybonus,
+        "Mental Lore - Transformation" => mentalloretransformationbonus
+      }
+    }
+
     if (Stats.prof == "Wizard" && profession.nil?) || profession =~ /^wiz/i
       if show_chart
         respond "Enchanting Success Formula"
@@ -943,7 +1697,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + logic + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (elementalmanacontrol / 2).truncate + (wizardranks > (level + 1) ? (level + 1) * 2 + (wizardranks - (level + 1)) : wizardranks * 2) + 25 + (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50)}"
       end
-      bonus = (level + logic + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (elementalmanacontrol / 2).truncate + (wizardranks > (level + 1) ? (level + 1) * 2 + (wizardranks - (level + 1)) : wizardranks * 2) + 25 + (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50))
+      bonus = Resource.service_score("Wizard", formula_data.merge(:location_bonus => (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50)))
       Resource.save_bonuses(bonus) if Stats.prof == "Wizard"
       return bonus
     elsif (Stats.prof == "Sorcerer" && profession.nil?) || profession =~ /^sorc/i
@@ -962,7 +1716,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + ((elementalmanacontrol >= spiritmanacontrol) ? (elementalmanacontrol / 2).truncate : (elementalmanacontrol / 4).truncate) + ((spiritmanacontrol > elementalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + (sorcererranks > (level + 1) ? (level + 1) * 2 + (sorcererranks - (level + 1)) : sorcererranks * 2) + 20}"
       end
-      bonus = (level + wisdom + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + ((elementalmanacontrol >= spiritmanacontrol) ? (elementalmanacontrol / 2).truncate : (elementalmanacontrol / 4).truncate) + ((spiritmanacontrol > elementalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + (sorcererranks > (level + 1) ? (level + 1) * 2 + (sorcererranks - (level + 1)) : sorcererranks * 2) + 20)
+      bonus = Resource.service_score("Sorcerer", formula_data.merge(:location_bonus => 20))
       Resource.save_bonuses(bonus) if Stats.prof == "Sorcerer"
       return bonus
     elsif (Stats.prof == "Bard" && profession.nil?) || profession =~ /^bard/i
@@ -980,7 +1734,7 @@ class Resource
         respond "=========================================="
         respond "Total of #{level + (intuition) + (influence) + (magicitemuse) + (elementalmanacontrol) + (mentalmanacontrol) + (20) + ((bardranks > level) ? (level * 2) + (bardranks - level) : bardranks * 2).truncate}"
       end
-      bonus = (level + (intuition) + (influence) + (magicitemuse) + (elementalmanacontrol) + (mentalmanacontrol) + (20) + ((bardranks > level) ? (level * 2) + (bardranks - level) : bardranks * 2).truncate)
+      bonus = Resource.service_score("Bard", formula_data.merge(:location_bonus => 20))
       Resource.save_bonuses(bonus) if Stats.prof == "Bard"
       return bonus
     elsif (Stats.prof == "Cleric" && profession.nil?) || profession =~ /^cleric/i
@@ -998,7 +1752,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + influence + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (spiritmanacontrol / 2).truncate + (clericranks > (level + 1) ? (level + 1) * 2 + (clericranks - (level + 1)) : clericranks * 2) + 20}"
       end
-      bonus = (level + wisdom + influence + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (spiritmanacontrol / 2).truncate + (clericranks > (level + 1) ? (level + 1) * 2 + (clericranks - (level + 1)) : clericranks * 2) + 20)
+      bonus = Resource.service_score("Cleric", formula_data.merge(:location_bonus => 20))
       Resource.save_bonuses(bonus) if Stats.prof == "Cleric"
       return bonus
     elsif (Stats.prof == "Paladin" && profession.nil?) || profession =~ /^Paladin/i
@@ -1016,7 +1770,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + influence + (magicitemuse * 1.5).truncate + (arcanesymbols * 1.5).truncate + spiritmanacontrol + (paladinranks > (level + 1) ? (level + 1) * 2 + (paladinranks - (level + 1)) : paladinranks * 2) + 20}"
       end
-      bonus = (level + wisdom + influence + (magicitemuse * 1.5).truncate + (arcanesymbols * 1.5).truncate + spiritmanacontrol + (paladinranks > (level + 1) ? (level + 1) * 2 + (paladinranks - (level + 1)) : paladinranks * 2) + 20)
+      bonus = Resource.service_score("Paladin", formula_data.merge(:location_bonus => 20))
       Resource.save_bonuses(bonus) if Stats.prof == "Paladin"
       return bonus
     elsif (Stats.prof == "Warrior" && profession.nil?) || profession =~ /^warrior/i
@@ -1066,10 +1820,7 @@ class Resource
         respond "Self-Tattoo Total of #{level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretransformationbonus}"
         respond "Other-Tattoo Total of #{level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretelepathybonus}"
       end
-      bonus = [
-        (level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretransformationbonus),
-        (level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretelepathybonus)
-      ]
+      bonus = Resource.service_score("Monk", formula_data.merge(:location_bonus => 0))
       Resource.save_bonuses(bonus) if Stats.prof == "Monk"
       return bonus
     elsif (Stats.prof == "Ranger" && profession.nil?) || profession =~ /^ranger/i
@@ -1089,7 +1840,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + (wisdom * 2) + (intuition * 2) + (survival * 0.75).truncate + magicitemuse + harnesspower + spiritmanacontrol + spiritloreblessings + (rangerranks * 1.5).truncate + (outside? ? 20 : 0)}"
       end
-      bonus = (level + (wisdom * 2) + (intuition * 2) + (survival * 0.75).truncate + magicitemuse + harnesspower + spiritmanacontrol + spiritloreblessings + (rangerranks * 1.5).truncate + (outside? ? 20 : 0))
+      bonus = Resource.service_score("Ranger", formula_data.merge(:location_bonus => (outside? ? 20 : 0)))
       Resource.save_bonuses(bonus) if Stats.prof == "Ranger"
       return bonus
     elsif (Stats.prof == "Empath" && profession.nil?) || profession =~ /^emp/i
@@ -1109,7 +1860,7 @@ class Resource
         respond "=================================="
         respond "Total of #{level + (constitution) + (influence) + ((empathranks > level) ? (level * 2) + (empathranks - level) : empathranks * 2) + ((spiritmanacontrol >= mentalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + ((mentalmanacontrol > spiritmanacontrol) ? (mentalmanacontrol / 2).truncate : (mentalmanacontrol / 4).truncate) + ((arcanesymbols / 10).truncate) + ((magicitemuse / 10).truncate) + ((physicalfitness / 20).truncate) + ((firstaid / 20).truncate)}"
       end
-      bonus = (level + (constitution) + (influence) + ((empathranks > level) ? (level * 2) + (empathranks - level) : empathranks * 2) + ((spiritmanacontrol >= mentalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + ((mentalmanacontrol > spiritmanacontrol) ? (mentalmanacontrol / 2).truncate : (mentalmanacontrol / 4).truncate) + ((arcanesymbols / 10).truncate) + ((magicitemuse / 10).truncate) + ((physicalfitness / 20).truncate) + ((firstaid / 20).truncate))
+      bonus = Resource.service_score("Empath", formula_data.merge(:location_bonus => 0))
       Resource.save_bonuses(bonus) if Stats.prof == "Empath"
       return bonus
     elsif (Stats.prof == "Rogue" && profession.nil?) || profession =~ /^rogue/i
@@ -1269,6 +2020,9 @@ class Resource
     respond "You need to give an option. See below:"
     respond ""
     respond "   ;resource bonus <PROFESSION> - Show's profession success bonus formula"
+    respond "   ;resource max — Show the maximum profession-service bonus possible with FIXSKILLS"
+    respond "                   Read-only; uses current character, stats, experience, and training-point conversion"
+    respond "                   Not yet supported: Rogue, Warrior"
     respond "   ;resource all                - Show's all known bonuses from previous BONUS checks"
     respond "   ;resource chart <PROFESSION> - Prints off cost chart for each increase"
     respond "       If no profession given, will use current character profession"
@@ -1281,8 +2035,7 @@ class Resource
     respond "       Professions supported: wizard, sorcerer, cleric"
     respond "   ;resource chance <DIFFICULTY> <TYPE> <BONUS> - Will calculate the chance to succeed"
     respond "       Supports Enchant(E1-E50), Ensorcell(T1-T5), Sanctify(S1-S6), Tattooing(M1-M5),"
-    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Battle Standard(B1-B6),"
-    respond "                Bloodstone Jewelry(J1-J5)"
+    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Bloodstone Jewelry(J1-J5)"
     respond ""
     respond "   ;resource chance - Description Of Test CASTs And Chance To Succeed"
     respond "   ;resource rolls  - Numeric Values For Roll Descriptions"
@@ -1309,6 +2062,8 @@ when /^chart/i
   Resource.chart
 when /^bonus/i
   Resource.bonus(true, variable[2])
+when /^max$/i
+  Resource.maximum
 when /^item/i
   Resource.item(variable[2])
 when /^character|^all$/i

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -2020,7 +2020,7 @@ class Resource
     respond "You need to give an option. See below:"
     respond ""
     respond "   ;resource bonus <PROFESSION> - Show's profession success bonus formula"
-    respond "   ;resource max — Show the maximum profession-service bonus possible with FIXSKILLS"
+    respond "   ;resource max - Show the maximum profession-service bonus possible with FIXSKILLS"
     respond "                   Read-only; uses current character, stats, experience, and training-point conversion"
     respond "                   Not yet supported: Rogue, Warrior"
     respond "   ;resource all                - Show's all known bonuses from previous BONUS checks"

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -46,6 +46,10 @@ contributors: Tysong, FFNG, Xanlin, Rinualdo, Maodan
         Bard, Paladin, Monk, and Ranger
       Added hypothetical training, TP accounting, assumptions, and formula-breakdown output
       Rogue and Warrior FIXSKILLS maximum models are not yet implemented
+    1.12.1 (2026-07-13)
+      Add Battle Standard (B1-B6) difficulty calculation
+      Fix Bloodstone Jewelry (J1-J5) to use the same correct formula
+      Add Paladin to auto-bonus profession detection
     1.12.0 (2025-05-01)
       Added option to run silently to update the saved data (for autostarting/autoupdating)
       Updated header version requirement to match tested version
@@ -317,7 +321,7 @@ class Resource
     "Paladin" => "Battle Standard", "Monk" => "Tattoos", "Ranger" => "Resist Nature"
   }
   TRAINING ||= {
-    "Wizard" => {
+    "Wizard"   => {
       "Harness Power" => [0, 4, 3], "Physical Fitness" => [8, 0, 1],
       "Arcane Symbols" => [0, 2, 2], "Magic Item Use" => [0, 1, 2],
       "Elemental Mana Control" => [0, 3, 3], "Wizard" => [0, 8, 3]
@@ -328,35 +332,35 @@ class Resource
       "Elemental Mana Control" => [0, 3, 2], "Spirit Mana Control" => [0, 3, 2],
       "Sorcerer" => [0, 8, 3]
     },
-    "Cleric" => {
+    "Cleric"   => {
       "Harness Power" => [0, 4, 3], "Physical Fitness" => [8, 0, 1],
       "Arcane Symbols" => [0, 2, 2], "Magic Item Use" => [0, 2, 2],
       "Spirit Mana Control" => [0, 3, 3], "Cleric" => [0, 8, 3]
     },
-    "Empath" => {
+    "Empath"   => {
       "Harness Power" => [0, 4, 3], "Physical Fitness" => [2, 0, 3],
       "First Aid" => [1, 0, 3], "Arcane Symbols" => [0, 2, 2],
       "Magic Item Use" => [0, 2, 2], "Spirit Mana Control" => [0, 3, 2],
       "Mental Mana Control" => [0, 3, 2], "Empath" => [0, 8, 3]
     },
-    "Bard" => {
+    "Bard"     => {
       "Harness Power" => [0, 5, 2], "Physical Fitness" => [4, 0, 2],
       "Magic Item Use" => [0, 4, 2], "Elemental Mana Control" => [0, 5, 1],
       "Mental Mana Control" => [0, 5, 1], "Bard" => [0, 17, 2]
     },
-    "Paladin" => {
+    "Paladin"  => {
       "Harness Power" => [0, 5, 2], "Physical Fitness" => [3, 0, 2],
       "Arcane Symbols" => [0, 5, 1], "Magic Item Use" => [0, 5, 1],
       "Spirit Mana Control" => [0, 5, 1], "Paladin" => [0, 17, 2]
     },
-    "Monk" => {
+    "Monk"     => {
       "Harness Power" => [0, 6, 1], "Physical Fitness" => [2, 0, 3],
       "First Aid" => [1, 2, 2], "Arcane Symbols" => [0, 6, 1],
       "Mental Mana Control" => [0, 8, 1], "Spirit Mana Control" => [0, 8, 1],
       "Mental Lore - Transformation" => [0, 12, 1], "Mental Lore - Telepathy" => [0, 12, 1],
       "Minor Mental" => [0, 38, 1], "Minor Spiritual" => [0, 38, 1]
     },
-    "Ranger" => {
+    "Ranger"   => {
       "Harness Power" => [0, 5, 2], "Physical Fitness" => [4, 0, 2],
       "Survival" => [1, 1, 3], "Magic Item Use" => [0, 5, 1],
       "Spirit Mana Control" => [0, 5, 1], "Spiritual Lore - Blessings" => [0, 10, 1],
@@ -370,14 +374,14 @@ class Resource
     }
   }
   SERVICE_SKILLS ||= {
-    "Wizard" => ["Arcane Symbols", "Magic Item Use", "Elemental Mana Control", "Wizard"],
+    "Wizard"   => ["Arcane Symbols", "Magic Item Use", "Elemental Mana Control", "Wizard"],
     "Sorcerer" => ["Arcane Symbols", "Magic Item Use", "Elemental Mana Control", "Spirit Mana Control", "Sorcerer"],
-    "Cleric" => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Cleric"],
-    "Empath" => ["Physical Fitness", "First Aid", "Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Mental Mana Control", "Empath"],
-    "Bard" => ["Magic Item Use", "Elemental Mana Control", "Mental Mana Control", "Bard"],
-    "Paladin" => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Paladin"],
-    "Monk" => ["Physical Fitness", "First Aid", "Arcane Symbols", "Mental Mana Control", "Spirit Mana Control", "Mental Lore - Transformation", "Mental Lore - Telepathy", "Minor Mental", "Minor Spiritual"],
-    "Ranger" => ["Harness Power", "Survival", "Magic Item Use", "Spirit Mana Control", "Spiritual Lore - Blessings", "Ranger"]
+    "Cleric"   => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Cleric"],
+    "Empath"   => ["Physical Fitness", "First Aid", "Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Mental Mana Control", "Empath"],
+    "Bard"     => ["Magic Item Use", "Elemental Mana Control", "Mental Mana Control", "Bard"],
+    "Paladin"  => ["Arcane Symbols", "Magic Item Use", "Spirit Mana Control", "Paladin"],
+    "Monk"     => ["Physical Fitness", "First Aid", "Arcane Symbols", "Mental Mana Control", "Spirit Mana Control", "Mental Lore - Transformation", "Mental Lore - Telepathy", "Minor Mental", "Minor Spiritual"],
+    "Ranger"   => ["Harness Power", "Survival", "Magic Item Use", "Spirit Mana Control", "Spiritual Lore - Blessings", "Ranger"]
   }
   CAP_EXPERIENCE ||= 7_572_500
 
@@ -663,14 +667,16 @@ class Resource
       elsif line =~ /\(([\d,]+)\s+Mnt converted to Phy\)/
         snapshot[:conversion] = { :direction => :mental_to_physical, :amount => $1.delete(',').to_i }
       end
-      TRAINING.values.each { |table| table.keys.each { |skill|
-        pattern = Regexp.escape(skill).gsub('\\ ', '\\s+')
-        if line =~ /^\s*#{pattern}(?:\.{2,}|\s+\|).*?(\d+)\s*(?:\d+\s*)?$/i
-          numbers = line.scan(/\d+/).map(&:to_i)
-          spell_skill = %w[Wizard Sorcerer Cleric Empath Bard Paladin Ranger].include?(skill) || skill =~ /^Minor /
-          snapshot[:ranks][skill] = spell_skill ? numbers[0] : numbers[1] if numbers.length >= (spell_skill ? 1 : 2)
-        end
-      } }
+      TRAINING.values.each { |table|
+        table.keys.each { |skill|
+          pattern = Regexp.escape(skill).gsub('\\ ', '\\s+')
+          if line =~ /^\s*#{pattern}(?:\.{2,}|\s+\|).*?(\d+)\s*(?:\d+\s*)?$/i
+            numbers = line.scan(/\d+/).map(&:to_i)
+            spell_skill = %w[Wizard Sorcerer Cleric Empath Bard Paladin Ranger].include?(skill) || skill =~ /^Minor /
+            snapshot[:ranks][skill] = spell_skill ? numbers[0] : numbers[1] if numbers.length >= (spell_skill ? 1 : 2)
+          end
+        }
+      }
     }
     snapshot[:normal_experience] ||= snapshot[:total_experience] - snapshot[:ascension_experience].to_i if snapshot[:total_experience] && snapshot.key?(:ascension_experience)
     snapshot[:conversion] ||= { :direction => :none, :amount => 0 } if snapshot[:unspent]
@@ -906,7 +912,8 @@ class Resource
     conversion_state = { :direction => conversion[:direction], :remaining => conversion[:amount] }
     cycles = snapshot[:level] + 1
     reserve_cost = [0, 0]
-    (1..6).each { |rank|
+    rank = 1
+    while rank <= 6
       cost = rank_cost(profession, "Harness Power", rank, cycles)
       unless cost
         respond "Six Harness Power ranks exceed the level-based rank cap; no estimate was produced."
@@ -914,7 +921,8 @@ class Resource
       end
       reserve_cost[0] += cost[0]
       reserve_cost[1] += cost[1]
-    }
+      rank += 1
+    end
     after_reserve = pay_cost(available[0], available[1], reserve_cost, conversion_state)
     unless after_reserve
       respond "The lifetime training-point budget cannot reserve six Harness Power ranks; no estimate was produced."
@@ -1200,7 +1208,7 @@ class Resource
   end
 
   def self.chance(item_difficulty, type, bonus)
-    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath$/)
+    if !item_difficulty.nil? && (!bonus.nil? || Stats.prof =~ /^Wizard|Sorcerer|Monk|Cleric|Ranger|Rogue|Bard|Empath|Paladin$/)
       unless type =~ /^(e(?:50|[1-4][0-9]|[0-9])|[tmj](?:[1-5])|[slb](?:[1-6])|[ra](?:2[0-5]|1[0-9]|[1-9]))$/i
         respond "Need to provide an item difficulty and bonus type too use advanced chance option."
         respond "  ;resource chance <ItemDifficulty> <BonusType> <SkillBonus>"
@@ -1213,8 +1221,8 @@ class Resource
         respond "    Resistance         - R1 to R25"
         respond "    Covert Arts        - A1 to A25"
         respond "    Luck               - L1 to L6"
-        respond "    Battle Standard    - B1 to B6 (not implemented)"
-        respond "    Bloodstone Jewelry - J1 to J5 (not implemented)"
+        respond "    Battle Standard    - B1 to B6"
+        respond "    Bloodstone Jewelry - J1 to J5"
         respond ""
         respond "  Will attempt to be smart if no SkillBonus given."
         return
@@ -1232,8 +1240,12 @@ class Resource
         penalty = (($1.to_i == 6) ? 50 : 20)
       when /l([1-6])/i
         penalty = (($1.to_i == 1) ? 150 : 75)
+      when /b([1-6])/i
+        penalty = 75 + ($1.to_i * 75)
+        item_difficulty = 0
       when /j([1-5])/i
-        penalty = (($1.to_i == 1) ? 150 : 75)
+        penalty = 75 + ($1.to_i * 75)
+        item_difficulty = 0
       when /r(2[0-5]|1[0-9]|[1-9])/i
         penalty = $1.to_i
         item_difficulty = 0
@@ -1658,12 +1670,12 @@ class Resource
     end
 
     formula_data = {
-      :level => level,
-      :stats => {
+      :level         => level,
+      :stats         => {
         :str => strength, :con => constitution, :dex => dexterity, :agi => agility, :dis => discipline,
         :aur => aura, :log => logic, :int => intuition, :wis => wisdom, :inf => influence
       },
-      :ranks => Hash.new(0).merge(
+      :ranks         => Hash.new(0).merge(
         "Arcane Symbols" => arcanesymbols, "Magic Item Use" => magicitemuse,
         "Physical Fitness" => physicalfitness, "First Aid" => firstaid,
         "Elemental Mana Control" => elementalmanacontrol, "Spirit Mana Control" => spiritmanacontrol,
@@ -1676,7 +1688,7 @@ class Resource
         "Minor Spiritual" => minorspiritranks
       ),
       :skill_bonuses => {
-        "Mental Lore - Telepathy" => mentalloretelepathybonus,
+        "Mental Lore - Telepathy"      => mentalloretelepathybonus,
         "Mental Lore - Transformation" => mentalloretransformationbonus
       }
     }
@@ -2035,7 +2047,8 @@ class Resource
     respond "       Professions supported: wizard, sorcerer, cleric"
     respond "   ;resource chance <DIFFICULTY> <TYPE> <BONUS> - Will calculate the chance to succeed"
     respond "       Supports Enchant(E1-E50), Ensorcell(T1-T5), Sanctify(S1-S6), Tattooing(M1-M5),"
-    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Bloodstone Jewelry(J1-J5)"
+    respond "                Resistance(R1-R25), Arts(A1-A25), Luck(L1-L6), Battle Standard(B1-B6),"
+    respond "                Bloodstone Jewelry(J1-J5)"
     respond ""
     respond "   ;resource chance - Description Of Test CASTs And Chance To Succeed"
     respond "   ;resource rolls  - Numeric Values For Roll Descriptions"

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -30,7 +30,7 @@
 
         todo: Add FIXSKILLS maximum planning models for Rogue and Warrior
       author: elanthia-online
-contributors: Tysong, FFNG, Xanlin, Rinualdo, Maodan
+contributors: Tysong, FFNG, Xanlin, Rinualdo, Maodan, Lucullan
         name: resource
         game: gemstone
         tags: resource, tears, 330, santify, grit, essence, enchant, enchanting, 925, recall, loresinging, bard, lkp, unlocking, murderverse, murder, juice, necrojuice, ensorcell, ensorcelling, 735, mystic tattoo, tattoo, mystic, grit, wps, devotion, jesus juice, sanctify, 330, permabless, 620, ranger, druid fluid, grace, luck inspiration, paladin, empath, bloodstone, 1135
@@ -1669,30 +1669,6 @@ class Resource
       echo gritSkills
     end
 
-    formula_data = {
-      :level         => level,
-      :stats         => {
-        :str => strength, :con => constitution, :dex => dexterity, :agi => agility, :dis => discipline,
-        :aur => aura, :log => logic, :int => intuition, :wis => wisdom, :inf => influence
-      },
-      :ranks         => Hash.new(0).merge(
-        "Arcane Symbols" => arcanesymbols, "Magic Item Use" => magicitemuse,
-        "Physical Fitness" => physicalfitness, "First Aid" => firstaid,
-        "Elemental Mana Control" => elementalmanacontrol, "Spirit Mana Control" => spiritmanacontrol,
-        "Mental Mana Control" => mentalmanacontrol, "Mental Lore - Telepathy" => mentalloretelepathy,
-        "Mental Lore - Transformation" => mentalloretransformation,
-        "Spiritual Lore - Blessings" => spiritloreblessings, "Survival" => survival,
-        "Harness Power" => harnesspower, "Bard" => bardranks, "Sorcerer" => sorcererranks,
-        "Wizard" => wizardranks, "Cleric" => clericranks, "Ranger" => rangerranks,
-        "Empath" => empathranks, "Paladin" => paladinranks, "Minor Mental" => minormentalranks,
-        "Minor Spiritual" => minorspiritranks
-      ),
-      :skill_bonuses => {
-        "Mental Lore - Telepathy"      => mentalloretelepathybonus,
-        "Mental Lore - Transformation" => mentalloretransformationbonus
-      }
-    }
-
     if (Stats.prof == "Wizard" && profession.nil?) || profession =~ /^wiz/i
       if show_chart
         respond "Enchanting Success Formula"
@@ -1709,7 +1685,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + logic + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (elementalmanacontrol / 2).truncate + (wizardranks > (level + 1) ? (level + 1) * 2 + (wizardranks - (level + 1)) : wizardranks * 2) + 25 + (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50)}"
       end
-      bonus = Resource.service_score("Wizard", formula_data.merge(:location_bonus => (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50)))
+      bonus = (level + logic + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (elementalmanacontrol / 2).truncate + (wizardranks > (level + 1) ? (level + 1) * 2 + (wizardranks - (level + 1)) : wizardranks * 2) + 25 + (PRIVATE_WORKSHOP.include?(Char.name) ? 75 : 50))
       Resource.save_bonuses(bonus) if Stats.prof == "Wizard"
       return bonus
     elsif (Stats.prof == "Sorcerer" && profession.nil?) || profession =~ /^sorc/i
@@ -1728,7 +1704,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + ((elementalmanacontrol >= spiritmanacontrol) ? (elementalmanacontrol / 2).truncate : (elementalmanacontrol / 4).truncate) + ((spiritmanacontrol > elementalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + (sorcererranks > (level + 1) ? (level + 1) * 2 + (sorcererranks - (level + 1)) : sorcererranks * 2) + 20}"
       end
-      bonus = Resource.service_score("Sorcerer", formula_data.merge(:location_bonus => 20))
+      bonus = (level + wisdom + intuition + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + ((elementalmanacontrol >= spiritmanacontrol) ? (elementalmanacontrol / 2).truncate : (elementalmanacontrol / 4).truncate) + ((spiritmanacontrol > elementalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + (sorcererranks > (level + 1) ? (level + 1) * 2 + (sorcererranks - (level + 1)) : sorcererranks * 2) + 20)
       Resource.save_bonuses(bonus) if Stats.prof == "Sorcerer"
       return bonus
     elsif (Stats.prof == "Bard" && profession.nil?) || profession =~ /^bard/i
@@ -1746,7 +1722,7 @@ class Resource
         respond "=========================================="
         respond "Total of #{level + (intuition) + (influence) + (magicitemuse) + (elementalmanacontrol) + (mentalmanacontrol) + (20) + ((bardranks > level) ? (level * 2) + (bardranks - level) : bardranks * 2).truncate}"
       end
-      bonus = Resource.service_score("Bard", formula_data.merge(:location_bonus => 20))
+      bonus = (level + (intuition) + (influence) + (magicitemuse) + (elementalmanacontrol) + (mentalmanacontrol) + (20) + ((bardranks > level) ? (level * 2) + (bardranks - level) : bardranks * 2).truncate)
       Resource.save_bonuses(bonus) if Stats.prof == "Bard"
       return bonus
     elsif (Stats.prof == "Cleric" && profession.nil?) || profession =~ /^cleric/i
@@ -1764,7 +1740,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + influence + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (spiritmanacontrol / 2).truncate + (clericranks > (level + 1) ? (level + 1) * 2 + (clericranks - (level + 1)) : clericranks * 2) + 20}"
       end
-      bonus = Resource.service_score("Cleric", formula_data.merge(:location_bonus => 20))
+      bonus = (level + wisdom + influence + (magicitemuse / 10).truncate + (arcanesymbols / 10).truncate + (spiritmanacontrol / 2).truncate + (clericranks > (level + 1) ? (level + 1) * 2 + (clericranks - (level + 1)) : clericranks * 2) + 20)
       Resource.save_bonuses(bonus) if Stats.prof == "Cleric"
       return bonus
     elsif (Stats.prof == "Paladin" && profession.nil?) || profession =~ /^Paladin/i
@@ -1782,7 +1758,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + wisdom + influence + (magicitemuse * 1.5).truncate + (arcanesymbols * 1.5).truncate + spiritmanacontrol + (paladinranks > (level + 1) ? (level + 1) * 2 + (paladinranks - (level + 1)) : paladinranks * 2) + 20}"
       end
-      bonus = Resource.service_score("Paladin", formula_data.merge(:location_bonus => 20))
+      bonus = (level + wisdom + influence + (magicitemuse * 1.5).truncate + (arcanesymbols * 1.5).truncate + spiritmanacontrol + (paladinranks > (level + 1) ? (level + 1) * 2 + (paladinranks - (level + 1)) : paladinranks * 2) + 20)
       Resource.save_bonuses(bonus) if Stats.prof == "Paladin"
       return bonus
     elsif (Stats.prof == "Warrior" && profession.nil?) || profession =~ /^warrior/i
@@ -1832,7 +1808,10 @@ class Resource
         respond "Self-Tattoo Total of #{level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretransformationbonus}"
         respond "Other-Tattoo Total of #{level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretelepathybonus}"
       end
-      bonus = Resource.service_score("Monk", formula_data.merge(:location_bonus => 0))
+      bonus = [
+        (level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretransformationbonus),
+        (level + (dexterity * 2) + (discipline * 2) + (physicalfitness * (0.75)).truncate + (firstaid / 2).truncate + ((minormentalranks + minorspiritranks) * 2) + arcanesymbols + mentalmanacontrol + spiritmanacontrol + mentalloretelepathybonus)
+      ]
       Resource.save_bonuses(bonus) if Stats.prof == "Monk"
       return bonus
     elsif (Stats.prof == "Ranger" && profession.nil?) || profession =~ /^ranger/i
@@ -1852,7 +1831,7 @@ class Resource
         respond "==========================="
         respond "Total of #{level + (wisdom * 2) + (intuition * 2) + (survival * 0.75).truncate + magicitemuse + harnesspower + spiritmanacontrol + spiritloreblessings + (rangerranks * 1.5).truncate + (outside? ? 20 : 0)}"
       end
-      bonus = Resource.service_score("Ranger", formula_data.merge(:location_bonus => (outside? ? 20 : 0)))
+      bonus = (level + (wisdom * 2) + (intuition * 2) + (survival * 0.75).truncate + magicitemuse + harnesspower + spiritmanacontrol + spiritloreblessings + (rangerranks * 1.5).truncate + (outside? ? 20 : 0))
       Resource.save_bonuses(bonus) if Stats.prof == "Ranger"
       return bonus
     elsif (Stats.prof == "Empath" && profession.nil?) || profession =~ /^emp/i
@@ -1872,7 +1851,7 @@ class Resource
         respond "=================================="
         respond "Total of #{level + (constitution) + (influence) + ((empathranks > level) ? (level * 2) + (empathranks - level) : empathranks * 2) + ((spiritmanacontrol >= mentalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + ((mentalmanacontrol > spiritmanacontrol) ? (mentalmanacontrol / 2).truncate : (mentalmanacontrol / 4).truncate) + ((arcanesymbols / 10).truncate) + ((magicitemuse / 10).truncate) + ((physicalfitness / 20).truncate) + ((firstaid / 20).truncate)}"
       end
-      bonus = Resource.service_score("Empath", formula_data.merge(:location_bonus => 0))
+      bonus = (level + (constitution) + (influence) + ((empathranks > level) ? (level * 2) + (empathranks - level) : empathranks * 2) + ((spiritmanacontrol >= mentalmanacontrol) ? (spiritmanacontrol / 2).truncate : (spiritmanacontrol / 4).truncate) + ((mentalmanacontrol > spiritmanacontrol) ? (mentalmanacontrol / 2).truncate : (mentalmanacontrol / 4).truncate) + ((arcanesymbols / 10).truncate) + ((magicitemuse / 10).truncate) + ((physicalfitness / 20).truncate) + ((firstaid / 20).truncate))
       Resource.save_bonuses(bonus) if Stats.prof == "Empath"
       return bonus
     elsif (Stats.prof == "Rogue" && profession.nil?) || profession =~ /^rogue/i

--- a/scripts/resource.lic
+++ b/scripts/resource.lic
@@ -953,7 +953,7 @@ class Resource
       end
     end
 
-    respond "With Fixskills — #{profession} #{SERVICE_NAMES[profession]}"
+    respond "With Fixskills - #{profession} #{SERVICE_NAMES[profession]}"
     respond ""
     if profession == "Monk"
       respond "Current service bonus:"


### PR DESCRIPTION
## Summary

Adds `;resource max`, a read-only planner that calculates the maximum profession-service bonus a character could achieve by using FIXSKILLS and retraining solely for service performance.

Supported professions:

- Wizard
- Sorcerer
- Cleric
- Empath
- Bard
- Paladin
- Monk
- Ranger

Rogue and Warrior are explicitly unsupported and receive a clear message without an estimate.

## Implementation

- Collects a single snapshot using `EXP`, `INFO`, `INFO START`, and `SKILLS BASE FULL`.
- Reconstructs lifetime PTP/MTP earnings from level 0 through the current level.
- Adds post-cap training points while excluding Ascension experience.
- Models PTP/MTP conversion, additional conversion, and automatic unconversion.
- Enforces profession training costs, escalating multi-training costs, and level-based rank caps.
- Reserves exactly six Harness Power ranks.
- Uses bounded integer optimization rather than a global greedy ratio.
- Uses a specialized exact Ranger optimizer to avoid excessive runtime.
- Allocates remaining points to Physical Fitness only after service training is exhausted.
- Leaves any remaining points unspent.
- Does not send `GOALS`, `FIXSKILLS`, `FIXSKILL CONFIRM`, `CHECK IN`, or `CMAN`.
- Does not update the existing resource bonus YAML data.

## Formula changes

The existing live bonus calculations and the FIXSKILLS planner now share pure profession formula helpers, preventing the displayed current formula and hypothetical maximum from diverging.

The maximum report includes:

- Current and maximum service bonuses
- Lifetime and post-cap TP earnings
- Reserved, service, survivability, and unspent TPs
- Exact hypothetical skill ranks
- Location and workshop assumptions
- Reported and planned conversion amounts
- A full `;resource bonus`-style formula breakdown

Monks receive separate Self Tattoo and Other Tattoo results using the required lexicographic optimization objective.

Rangers use the character’s current indoor/outdoor state.

## Unsupported professions

`Rogue` and `Warrior` do not yet have FIXSKILLS maximum models. Running `;resource max` for either profession prints an explicit unsupported message and produces no estimate. Their existing `;resource bonus` behavior is unchanged.

## Documentation

- Adds `MAX` to the script header and help output.
- Updates the version to `1.13.0`.
- Adds a `1.13.0` changelog entry while preserving all previous history.
- Records Rogue and Warrior maximum planning as remaining TODO work.

## Validation

- `ruby -c C:\Ruby4Lich5\Lich5\scripts\resource.lic`
- Targeted rank-cap, stat-growth, conversion, and formula assertions
- Simulated end-to-end Wizard and Ranger runs
- Rogue and Warrior unsupported-path tests
- Formula-breakdown tests for all supported professions
- `git diff --check`
- In game black box testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only `;resource max` command to calculate the highest achievable profession-service bonus with FIXSKILLS.
  - Displays current and maximum bonuses, required training, training-point accounting, assumptions, and formula details.
  - Supports Ranger-specific optimization and accounts for skill limits, training costs, and point conversions.

- **Documentation**
  - Updated command help, header documentation, and changelog information.
  - Rogue and Warrior professions are not currently supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->