### PR TITLE
feat(kswole): add moulis spell prep flavor text for maaghara tower

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -20,12 +20,14 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.7
+       version: 1.1.8
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.8 (2026-08-31)
+    - Added preps for Maaghara Tower
   v1.1.7 (2026-05-28)
     - Added preps for Onslaughts
   v1.1.6 (2026-02-03)
@@ -282,6 +284,9 @@ class KSwole
     /^An? (?:.*)\bmonk utters an arcane incantation\./, # Frenzied Monk, Lunule Weald
     /^An? (?:.*)\bwood sprite utters an eerie sound\./, # Lesser Wood Sprite, Sorcerer's Isle
     /^An? (?:.*)\bspectre glows faintly as a spectral mist begins to swirl around (?:her|him)\./, # Bog Spectre, Faethyl Bog
+
+    # Maaghara Tower
+    /^An? (?:.*)\bmoulis draws its smaller appendages inward, forming itself into a more compact mass\./, # Moulis, Maaghara Tower
   )
 
   @dispelable_debuffs = [


### PR DESCRIPTION
Adds the creature spell prep regex for Moulis (Maaghara Tower) to @creature_spell_preps, following the existing per-area convention.
Bumps version to 1.1.8 and updates the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spell preparation support for Maaghara Tower encounters.
  * Added recognition for the Moulis creature’s compact-form spell preparation.

* **Chores**
  * Updated the script version to 1.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->