### PR TITLE
feat(kswole): add dhu goleras and shrickhen preps, document maaghara tower

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -8,7 +8,7 @@
   Hunting areas currently supported:
     Atoll/Nelemar, Bonespear (partial), Bowels, Citadel, Confluence, Crawling Shore, Den of Rot,
     Duskruin Arena, Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, Onslaughts, OSA (partial), OTF (incl. Aqueducts),
-    Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), The Hive
+    Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), The Hive, Maaghara Tower
 
     USAGE:
     ;kswole
@@ -20,12 +20,15 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.8
+       version: 1.1.9
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.9 (2026-08-31)
+    - Added preps for Dhu Goleras and Shrickhen, Maaghara Tower
+    - Documented Maaghara Tower in the supported hunting areas lists
   v1.1.8 (2026-08-31)
     - Added preps for Maaghara Tower
   v1.1.7 (2026-05-28)
@@ -287,6 +290,8 @@ class KSwole
 
     # Maaghara Tower
     /^An? (?:.*)\bmoulis draws its smaller appendages inward, forming itself into a more compact mass\./, # Moulis, Maaghara Tower
+    /^An? (?:.*)\bdhu goleras contorts his fingers into near impossible positions as he utters some indecipherable sounds\./, # Dhu Goleras, Maaghara Tower
+    /^An? (?:.*)\bshrickhen drums her hands on her head and a ring of cold blue fire springs up around her\./, # Shrickhen, Maaghara Tower
   )
 
   @dispelable_debuffs = [
@@ -361,7 +366,7 @@ class KSwole
     Lich::Messaging.msg('teal', '| Hunting areas currently supported:')
     Lich::Messaging.msg('teal', '|   Atoll/Nelemar, Bonespear, Bowels, Citadel, Confluence, Crawling Shore, Den of Rot, Duskruin Arena,')
     Lich::Messaging.msg('teal', '|   Grimswarm, Hidden Plateau, Hinterwilds, Moonsedge, Onslaughts, OSA (partial), OTF (incl. Aqueducts),')
-    Lich::Messaging.msg('teal', '|   Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), Ta\'Vaalor (partial).')
+    Lich::Messaging.msg('teal', '|   Red Forest, Reim, Rift/Scatter, Sanctum of Scales, Icemule Trace (partial), Ta\'Vaalor (partial), Maaghara Tower.')
     Lich::Messaging.msg('teal', '|')
     Lich::Messaging.msg('teal', '| Usage:')
     Lich::Messaging.msg('teal', '|   ;kswole')


### PR DESCRIPTION
Adds creature spell prep regexes for Dhu Goleras and Shrickhen
(Maaghara Tower) to @creature_spell_preps. Also adds Maaghara Tower
to the header's supported-area list and the ;kswole help output,
per CodeRabbit feedback on #2437. Bumps version to 1.1.9 and updates
the changelog.