### PR TITLE
fix(eloot): v2.11.4 fix Vars.needed_reagents check to be String compatible

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -6519,7 +6519,10 @@ module ELoot # Sells the loot
       # Collect items to dump
       dump_items = ELoot.set_selling_containers.flat_map(&:contents).select do |item|
         next false unless dump_stuff.any? { |type| item.type =~ /#{type}/ } || (ELoot.data.alchemy_mode && item.name =~ alchemy_regex)
-        next false if ELoot.data.alchemy_mode && item.name =~ /#{Vars.needed_reagents}/ && Vars.needed_reagents.length.to_i > 0
+        next false if ELoot.data.alchemy_mode &&
+                      Vars.needed_reagents.is_a?(String) &&
+                      !Vars.needed_reagents.empty? &&
+                      item.name =~ /#{Vars.needed_reagents}/
         next false if item.name.match?(ELoot.data.sell_exclude_regex)
         next false if ELoot.data.settings[:keep_transmogs] && Inventory.is_transmog?(item)
         true

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,11 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.3
+           version: 2.11.4
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.4 (2026-08-31)
+    - fix: bugfix for Vars.needed_reagents being a String
   v2.11.3 (2026-08-21)
     - fix: boxes that ran out of silver mid-open at the town locksmith could end up
       getting sent to the locksmith pool instead of actually being opened. This is fixed.
@@ -6517,7 +6519,7 @@ module ELoot # Sells the loot
       # Collect items to dump
       dump_items = ELoot.set_selling_containers.flat_map(&:contents).select do |item|
         next false unless dump_stuff.any? { |type| item.type =~ /#{type}/ } || (ELoot.data.alchemy_mode && item.name =~ alchemy_regex)
-        next false if ELoot.data.alchemy_mode && Vars.needed_reagents.any? { |r| item.name =~ /#{r}/ }
+        next false if ELoot.data.alchemy_mode && item.name =~ /#{Vars.needed_reagents}/ && Vars.needed_reagents.length.to_i > 0
         next false if item.name.match?(ELoot.data.sell_exclude_regex)
         next false if ELoot.data.settings[:keep_transmogs] && Inventory.is_transmog?(item)
         true


### PR DESCRIPTION
When ELoot was updated in v2.7.0 the `Vars.needed_reagents` was compared with an `.any?` check. But `Vars.needed_reagents` is a String.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alchemy-mode item handling when the needed reagents value is provided as text.
  * Prevented errors when checking whether herbs or junk should be skipped during selling.

* **Chores**
  * Updated the script version to 2.11.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->