### PR TITLE
fix(ecleanse): v2.3.5 enhance recovery logic for being moved away

### DIFF
--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -859,9 +859,9 @@ module Ecleanse
     end
 
     def self.go2(place)
-      fput('unhide') if (hidden? || invisible?)
-
       return if Room.current.id == place
+
+      fput('unhide') if (hidden? || invisible?)
 
       if Room.current.id.nil?
         respond "Currently in an unmapped room - Need to go to #{place}"

--- a/scripts/ecleanse.lic
+++ b/scripts/ecleanse.lic
@@ -6,9 +6,11 @@
           game: Gemstone
           tags: dispel, unpoison, undisease, disarmed, effects
       required: Lich >= 5.12.10
-       version: 2.3.4
+       version: 2.3.5
 
   Improvements:
+  v2.3.5  (2026-09-01)
+    - on recover attempts, always attempt to go to room_id between attempts incase somehow moved away from room (group movement?)
   v2.3.4  (2026-08-18)
     - fixed a case where the script could wrongly think a disarmed weapon
       was already back in hand (if another script, like eloot, briefly put
@@ -1188,6 +1190,9 @@ module Ecleanse
 
         search_count = 0
         until search_count.eql?(10)
+
+          # Move to the disarm room incase somehow moved away while attempting to search
+          Action.go2(room_id)
 
           until kneeling?
             dothistimeout("kneel", 2, /You kneel|You are already/i)


### PR DESCRIPTION
Updated version to 2.3.5 and added improvements for recovery attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weapon recovery by returning to the disarm room before each search attempt.
  * Increased reliability when the character has moved away between recovery attempts.

* **Chores**
  * Updated the script version to 2.3.5 and added a changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->