### PR TITLE
fix(kswole): match either pronoun for dhu goleras and shrickhen preps

### DIFF
--- a/scripts/kswole.lic
+++ b/scripts/kswole.lic
@@ -20,12 +20,14 @@
           name: kswole
           game: Gemstone
           tags: kroderine soul, feat absorb, feat dispel
-       version: 1.1.9
+       version: 1.1.10
 
  Help Contribute: https://github.com/elanthia-online/scripts
 
   Version Control:
     Major_change.feature_addition.bugfix
+  v1.1.10 (2026-09-01)
+    - Fixed Dhu Goleras and Shrickhen preps to match either pronoun (Maaghara Tower)
   v1.1.9 (2026-08-31)
     - Added preps for Dhu Goleras and Shrickhen, Maaghara Tower
     - Documented Maaghara Tower in the supported hunting areas lists
@@ -290,8 +292,8 @@ class KSwole
 
     # Maaghara Tower
     /^An? (?:.*)\bmoulis draws its smaller appendages inward, forming itself into a more compact mass\./, # Moulis, Maaghara Tower
-    /^An? (?:.*)\bdhu goleras contorts his fingers into near impossible positions as he utters some indecipherable sounds\./, # Dhu Goleras, Maaghara Tower
-    /^An? (?:.*)\bshrickhen drums her hands on her head and a ring of cold blue fire springs up around her\./, # Shrickhen, Maaghara Tower
+    /^An? (?:.*)\bdhu goleras contorts (?:his|her) fingers into near impossible positions as (?:he|she) utters some indecipherable sounds\./, # Dhu Goleras, Maaghara Tower
+    /^An? (?:.*)\bshrickhen drums (?:his|her) hands on (?:his|her) head and a ring of cold blue fire springs up around (?:her|him)\./, # Shrickhen, Maaghara Tower
   )
 
   @dispelable_debuffs = [


### PR DESCRIPTION
Updates the Dhu Goleras and Shrickhen spell prep regexes (Maaghara
Tower) to accept either he/she and his/her pronoun forms, since the
creatures can spawn as either. Bumps version to 1.1.10 and updates
the changelog.