### PR TITLE
fix(eherbs): refresh authoritative herb scans

### DIFF
--- a/scripts/eherbs.lic
+++ b/scripts/eherbs.lic
@@ -14,7 +14,10 @@
               game: Gemstone
               tags: healing, herbs
           requires: Lich >= 5.9.0
-           version: 2.2.0
+           version: 2.2.1
+  2.2.1 (2026-09-02)
+    - fix authoritative herb scans using a previously cached container snapshot instead
+      of refreshing the container before making healing and stocking decisions
   2.2.0 (2026-07-13)
     - add --splitblood option to count and stock major blood separately from acantha; off by default
     - fix check blood count to total every matching herb across all containers, not just the last item found
@@ -2310,7 +2313,7 @@ module EHerbs
       # If it's a GameObj
       if container.instance_of?(GameObj) && GameObj.inv.find { |obj| obj.id =~ /#{container.id}/ }
         EHerbs.data[:herb_sack] = container
-        Inventory.open_single_container(container)
+        Inventory.open_single_container(container, refresh: true)
         Utility.determine_survival_kit(container) if EHerbs.data[:survival_kit].nil?
 
         if EHerbs.data[:survival_kit]
@@ -2368,7 +2371,7 @@ module EHerbs
               break
             end
 
-            result = Inventory.open_single_container(EHerbs.data[:herb_sack])
+            result = Inventory.open_single_container(EHerbs.data[:herb_sack], refresh: true)
             if result == 'locked'
               _respond Msg.monsterbold(" Not able to look in #{container}. It's locked. Exiting...")
               exit
@@ -2420,11 +2423,12 @@ module EHerbs
       return items
     end
 
-    def self.open_single_container(sack)
+    def self.open_single_container(sack, refresh: false)
       return if sack.nil? || sack.empty?
 
-      # If its in the game obj and contents.is_a?(Array) return
-      return if GameObj.containers.keys.include?(sack.id) && sack.contents.is_a?(Array)
+      # Keep the cached fast path for routine opens. Callers making decisions
+      # from the contents can request an authoritative OPEN + LOOK IN scan.
+      return if !refresh && GameObj.containers.keys.include?(sack.id) && sack.contents.is_a?(Array)
 
       # Still here? Assume the sack is closed and open it
       result = Utility.get_lines("open ##{sack.id}", EHerbs.data[:open_regex])

--- a/spec/scripts/eherbs_spec.rb
+++ b/spec/scripts/eherbs_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'EHerbs authoritative container scans' do
+  let(:source_path) { find_lic_source('eherbs.lic', from: __dir__) }
+  let(:source) { File.read(source_path) }
+
+  def build_harness(source, source_path)
+    game_obj = Class.new do
+      class << self
+        attr_accessor :containers, :inv
+      end
+
+      attr_accessor :id, :contents
+
+      def initialize(id, contents)
+        @id = id
+        @contents = contents
+      end
+
+      def empty? = false
+    end
+
+    container = game_obj.new('101', [])
+    game_obj.containers = { container.id => container }
+    game_obj.inv = [container]
+
+    data = {
+      herb_sack: nil,
+      survival_kit: false,
+      open_regex: /./,
+      needs_closed: /never matches/,
+      look_regex: /./,
+      close_herbsack: false,
+      drinkable: /potion/
+    }
+
+    eherbs = Module.new
+    eherbs.define_singleton_method(:data) { data }
+    eherbs.define_singleton_method(:known_herbs) { [] }
+
+    commands = []
+    utility = Module.new
+    utility.define_singleton_method(:get_lines) do |command, _regex|
+      commands << command
+      command.start_with?('open ') ? ['That is already open.'] : ['In the sack you see an herb.']
+    end
+    utility.define_singleton_method(:determine_survival_kit) { |_container| nil }
+
+    inventory = Module.new
+    inventory.const_set(:GameObj, game_obj)
+    inventory.const_set(:EHerbs, eherbs)
+    inventory.const_set(:Utility, utility)
+    inventory.const_set(:Inventory, inventory)
+    inventory.module_eval(extract_lic_method(source, 'open_single_container', source_path: source_path))
+    inventory.module_eval(extract_lic_method(source, 'herb_container_contents_load', source_path: source_path))
+
+    [inventory, container, commands]
+  end
+
+  it 'refreshes a cached herb sack before an authoritative contents load' do
+    inventory, container, commands = build_harness(source, source_path)
+
+    inventory.herb_container_contents_load(container)
+
+    expect(commands).to eq(['open #101', 'look in #101'])
+  end
+
+  it 'keeps the cached fast path for a non-authoritative open request' do
+    inventory, container, commands = build_harness(source, source_path)
+
+    inventory.open_single_container(container)
+
+    expect(commands).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary

Prevent `eherbs` from making healing and stocking decisions from an older cached container snapshot.

- add an opt-in `refresh:` path to `Inventory.open_single_container`
- use it at the central authoritative herb-contents loader
- use it when an explicit `LOOK` has already established that a non-inventory herb container is closed
- retain the existing cached fast path for routine open requests

## Root cause

`open_single_container` treated `contents.is_a?(Array)` as proof that the contents were current. That only establishes that the container has been inspected before. If the published snapshot is older than the inventory state, an authoritative herb scan returns without issuing `OPEN` or `LOOK IN`, and `eherbs` can conclude that a needed herb is missing.

The refresh is centralized in `herb_container_contents_load` rather than added to every high-level healing or stocking action, avoiding duplicate scans while keeping the decision point authoritative.

This was also checked against the suspected Lich core regression. Lich's staged container refresh retains the last complete snapshot until the prompt commits a replacement by design, its focused core specs pass, and the relevant published-cache behavior is unchanged between Lich 5.19.1 and 5.20.1. This patch corrects the script's freshness assumption without weakening atomic `GameObj` publication.

## Testing

- Added a behavioral regression test that starts with an array-shaped stale cache and verifies the authoritative loader issues `OPEN` plus `LOOK IN`.
- Added a control test proving routine opens retain the cached fast path.
- `rspec spec/scripts/eherbs_spec.rb` — 2 examples, 0 failures
- `ruby -c scripts/eherbs.lic` — syntax OK
- `rubocop scripts/eherbs.lic spec/scripts/eherbs_spec.rb` — no offenses
