### PR TITLE
fix(ebounty): refresh authoritative bounty scans

### DIFF
--- a/scripts/ebounty.lic
+++ b/scripts/ebounty.lic
@@ -10,10 +10,13 @@
           game: Gemstone
           tags: bounty, adventure's guild, advguild, bounties
       required: Lich >= 5.19.0
-       version: 1.12.3
+       version: 1.12.4
 
   Version Control:
   Major_change.feature_addition.bugfix
+  v1.12.4 (2026-09-02)
+    - fix authoritative bounty inventory scans using previously cached container
+      snapshots when checking for heirlooms, herbs, gems, and skins
   v1.12.3 (2026-08-17)
     - fix rgambit usage when not hidden to just put away instead
     - fix to grab new bounty when available instead of waiting for should_hunt? to be true
@@ -648,15 +651,16 @@ module EBounty
     return data[/version: (\d+\.\d+\.\d+)/i, 1]
   end
 
-  def self.open_container(container)
+  def self.open_container(container, refresh: false)
     EBounty.msg("debug", " #{__method__} | caller: #{caller[0]} | container: #{container.inspect}")
 
-    return if GameObj.containers.keys.include?(container.id) && container.contents.is_a?(Array)
     return if container.name =~ /keyring/
+    return if !refresh && GameObj.containers.keys.include?(container.id) && container.contents.is_a?(Array)
 
     # Still here? Assume the container is closed and open it
     lines = EBounty.get_command("open ##{container.id}", /You|<exposeContainer|The shard is open already|You must remove|You can't do that|That is already open|<container|There doesn't seem to be any way to do that.|You open|An <a exist=".*?" noun=".*?">.*?<\/a>.*?is already open.|You press your hand against your|You wave a hand across/i, silent: true, quiet: true)
-    return if lines.any? { |l| l =~ /There doesn't seem to be any way to do that|That is already open|is open already|You can't do that|You must remove|You wave a hand across|You glance/ }
+    already_open = lines.any? { |l| l =~ /That is already open|is open already|You glance/ }
+    return if lines.any? { |l| l =~ /There doesn't seem to be any way to do that|You can't do that|You must remove|You wave a hand across/ }
 
     # check out whats inside
     lines = EBounty.get_command("look in ##{container.id}", /<exposeContainer|<dialogData|<container|you glance|There is nothing|This <a exist=".*?" noun=".*?">.*?<\/a>.*?inside./i, silent: true, quiet: true)
@@ -672,7 +676,9 @@ module EBounty
     }
 
     # If we open it, lets close it before script dies
-    EBounty.data.close_containers.push(container.id) unless EBounty.data.close_containers.include?(container.id)
+    unless already_open || EBounty.data.close_containers.include?(container.id)
+      EBounty.data.close_containers.push(container.id)
+    end
   end
 
   def self.regroup
@@ -2738,7 +2744,7 @@ module EBounty
           found_item = nil
 
           EBounty.data.containers.each do |container|
-            EBounty.open_container(container)
+            EBounty.open_container(container, refresh: true)
 
             found_item = container.contents.find { |item| item.name.match?(/#{requested_item}/) }
             break if found_item
@@ -3287,7 +3293,7 @@ module EBounty
 
       herb = herb.gsub(/^some /, "")
 
-      EBounty.open_container(StowList.stow_list[:default])
+      EBounty.open_container(StowList.stow_list[:default], refresh: true)
       herbs = find_herb_stow_list(herb)
 
       if herbs.length.positive?
@@ -3333,7 +3339,7 @@ module EBounty
 
       herb = herb.gsub(/^some /, "")
 
-      EBounty.open_container(StowList.stow_list[:default])
+      EBounty.open_container(StowList.stow_list[:default], refresh: true)
       herbs = find_herb_stow_list(herb)
 
       if herbs.length.positive?
@@ -3407,7 +3413,7 @@ module EBounty
       # Lets check if we have enough gems to turn in already
       count = 0
       EBounty.data.containers.each { |container|
-        EBounty.open_container(container)
+        EBounty.open_container(container, refresh: true)
         container.contents.each { |item|
           if item.name =~ /#{EBounty.data.gem}$/
             count += 1
@@ -3594,7 +3600,7 @@ module EBounty
       # Lets check if we have enough skins to turn in already
       count = 0
       EBounty.data.containers.each { |container|
-        EBounty.open_container(container)
+        EBounty.open_container(container, refresh: true)
         container.contents.each { |item|
           if item.name =~ /bundle of #{EBounty.data.bundle_skin}/
             lines = EBounty.get_command("measure ##{item.id}", /You glance through/)

--- a/spec/scripts/ebounty_spec.rb
+++ b/spec/scripts/ebounty_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'ostruct'
+
+RSpec.describe 'EBounty authoritative container scans' do
+  let(:source_path) { find_lic_source('ebounty.lic', from: __dir__) }
+  let(:source) { File.read(source_path) }
+
+  def build_harness(source, source_path, open_result: 'That is already open.')
+    item = Struct.new(:name).new('a ruby')
+    container = Struct.new(:id, :name, :contents).new('201', 'a gem pouch', [])
+
+    game_obj = Module.new
+    game_obj.define_singleton_method(:containers) { { container.id => container } }
+
+    task = Module.new
+    task.singleton_class.attr_accessor :prepped
+    task.prepped = false
+    task.define_singleton_method(:prep) { |no_check:| self.prepped = no_check }
+
+    hunting = Module.new
+    hunting.singleton_class.attr_accessor :started
+    hunting.started = false
+    hunting.define_singleton_method(:go_hunting) { self.started = true }
+
+    data = OpenStruct.new(
+      close_containers: [],
+      containers: [container],
+      settings: { hording_script: '' },
+      loot_script: 'none'
+    )
+
+    commands = []
+    ebounty = Module.new
+    ebounty.const_set(:EBounty, ebounty)
+    ebounty.const_set(:GameObj, game_obj)
+    ebounty.const_set(:Task, task)
+    ebounty.const_set(:Hunting, hunting)
+    ebounty.define_singleton_method(:data) { data }
+    ebounty.define_singleton_method(:msg) { |*| nil }
+    ebounty.define_singleton_method(:checkbounty) { 'You have been tasked with collecting gems.' }
+    ebounty.define_singleton_method(:load_default_profile) { nil }
+    ebounty.define_singleton_method(:get_command) do |command, *_args, **_kwargs|
+      commands << command
+      if command.start_with?('open ')
+        [open_result]
+      else
+        container.contents = [item]
+        ['<container id="201">']
+      end
+    end
+    ebounty.module_eval(extract_lic_method(source, 'open_container', source_path: source_path))
+    ebounty.module_eval(extract_lic_method(source, 'gem_bounty', source_path: source_path))
+
+    [ebounty, container, commands, task, hunting]
+  end
+
+  it 'refreshes cached gem containers before deciding whether to hunt' do
+    ebounty, _container, commands, task, hunting = build_harness(source, source_path)
+
+    ebounty.gem_bounty('ruby', 1)
+
+    expect(commands).to eq(['open #201', 'look in #201'])
+    expect(task.prepped).to be true
+    expect(hunting.started).to be false
+  end
+
+  it 'does not schedule an already-open container for closure after a forced scan' do
+    ebounty, container, _commands, = build_harness(source, source_path)
+
+    if ebounty.method(:open_container).parameters.any? { |_kind, name| name == :refresh }
+      ebounty.open_container(container, refresh: true)
+    else
+      ebounty.open_container(container)
+    end
+
+    expect(ebounty.data.close_containers).to be_empty
+  end
+
+  it 'keeps the cached fast path for a non-authoritative open request' do
+    ebounty, container, commands, = build_harness(source, source_path)
+
+    ebounty.open_container(container)
+
+    expect(commands).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary

Prevent `ebounty` from making bounty decisions from older cached container snapshots.

- add an opt-in `refresh:` path to `EBounty.open_container`
- request authoritative scans before checking held heirlooms, forage herbs, gems, and skins
- preserve the cached fast path for routine open requests
- avoid scheduling a container for closure when it was already open before the forced scan

## Root cause

`open_container` treated `contents.is_a?(Array)` as proof that the contents were current. That only establishes that the container has been inspected before. With an older published snapshot, `ebounty` can skip `OPEN`/`LOOK IN`, miss an item already in the character's containers, and continue hunting unnecessarily.

Forced scans also need to distinguish "already open" from "opened by this script" so cleanup does not close a container the player had left open.

This was checked against the suspected Lich core regression. Lich's staged container refresh retains the last complete snapshot until the prompt commits a replacement by design, its focused core specs pass, and the relevant published-cache behavior is unchanged between Lich 5.19.1 and 5.20.1. This patch corrects the script's freshness assumption without weakening atomic `GameObj` publication.

## Testing

- Added a behavioral gem-bounty regression test: a stale empty snapshot is refreshed, the held gem is found, and the script prepares turn-in instead of hunting.
- Added coverage for already-open cleanup ownership and the routine cached fast path.
- `rspec spec/scripts/ebounty_spec.rb` — 3 examples, 0 failures
- `ruby -c scripts/ebounty.lic` — syntax OK
- `rubocop scripts/ebounty.lic spec/scripts/ebounty_spec.rb` — no offenses
