### PR TITLE
fix(eloot): v2.11.6 gem/reagent hoard reset could come back empty

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.5
+           version: 2.11.6
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.6 (2026-09-04)
+    - fix: gem/reagent hoard reset could come back empty when run before eloot had looted
+      anything yet this session
   v2.11.5 (2026-09-02)
     - feature: add a command to clear the automatically learned unskinnable creature
       list or remove one creature from it without editing the character YAML file
@@ -4177,6 +4180,8 @@ module ELoot # Gem and Reagent hoarding
     end
 
     def self.check_type(item)
+      GameObj.load_data if GameObj.type_data.empty?
+
       obj_type = ELoot.data.hoard_type == 'alchemy' ? 'reagent' : ELoot.data.hoard_type
 
       item = item.gsub(/teeth/, "tooth")


### PR DESCRIPTION
## Summary
- `;eloot reset gem` (and `;eloot reset alchemy`) built an empty inventory when run cold, before eloot had looted anything in that session -- confirmed via a user-supplied debug log where 150 premium-locker gem items were parsed and normalized but zero made it into the final inventory (only the empty-jar count showed up).
- `Hoard.check_type` reads `GameObj.type_data[obj_type]` directly. That class-level accessor does **not** trigger the lazy `GameObj.load_data` -- only the instance methods `GameObj#type`/`#sellable` do, which normally run as a side effect of ordinary looting before hoarding kicks in. A standalone `;eloot reset gem` skips straight to the hoard-reset path, so `@@type_data` is still empty, `GameObj.type_data['gem']` returns `nil`, and the `NilClass` monkeypatch (`nil.method_missing` -> `nil`, `nil.to_s` -> `""`) makes every subsequent match in `check_type` silently evaluate `false` instead of raising -- so every parsed item is rejected with no visible error.
- Fix: force `GameObj.load_data` at the top of `check_type` whenever `GameObj.type_data` is still empty, mirroring the guard already used by `GameObj#type`/`#sellable`.

## Test plan
- [x] `bundle exec rspec spec/scripts/eloot_spec.rb` -- 111 examples, 0 failures
- [x] `rubocop scripts/eloot.lic` -- no offenses
- [ ] Manual: cold `;eloot reset gem` at a premium locker now populates the gem inventory table instead of showing only `*** Empty Jars ***`

🤖 Generated with [Claude Code](https://claude.com/claude-code)