### PR TITLE
feat(pilepull): v1.2.0 new script for Shattered/Prime treasure pile searching

### DIFF
--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -1,0 +1,624 @@
+=begin
+
+  This is for Shattered!
+
+  ;pilepull
+  For use with the treasure pile put out for 1,000,000 silvers per search.
+
+  Start in front of a treasure pile to search.
+  Currently will withdraw 100,000,000 silvers per go (configurable manually in the script)
+  and continue doing so until you have no more room in your STOW container or you are item capped.
+
+  Usage:
+
+      ;pilepull           - will run the normal SEARCH of the pile
+      ;pilepull cleanup   - will attempt to cleanup bundlable items, which include:
+                              * glowing orbs
+                              * potent yellow-green potion
+                              * swirling yellow-green potion
+                              * Elanthian Guilds voucher pack
+                              * Adventurer's Guild voucher pack
+      ;pilepull rewards   - print a summary of items received this character has
+                            gotten during the current/most recent Duskruin event
+                            (broken down by reward tier: common/uncommon/rare/
+                            epic/legendary) and silver spent searching, tracked
+                            in a shared local database so it works correctly
+                            across multiple characters. Duskruin runs twice a
+                            year (Feb/Mar and Aug/Sep); each reward is tagged
+                            with the event it was earned in.
+      ;pilepull rewards all       - same, but combined across every character
+                                    that has used this database (not just you)
+      ;pilepull rewards history   - same, but shows every Duskruin event on
+                                    record instead of just the current one
+      ;pilepull rewards all history  - combine "all" and "history": every
+                                        character, every event
+
+  There's also some variables in the script you can set to true/false
+  All default to false to throw away
+    * @withdraw_amount
+    * @keep_spoon
+    * @keep_wisp  (not yet implemented)
+    * @keep_nexus
+
+            author: Tysong
+      contributors: everyone in shattered!
+              game: Gemstone
+              tags: loot, mania, treasure, pile, shattered
+          required: Lich >= 5.12.4
+       requirements:
+        - sequel gem
+           version: 1.3.0
+
+  Improvements:
+  Major_change.feature_addition.bugfix
+  v1.3.0 (2026-09-05)
+    - Add ";pilepull rewards all" to combine reward totals across every character
+      that has run this script, instead of just the current one.
+    - Tag every recorded reward with the Duskruin event it was earned in (Feb/Mar
+      or Aug/Sep of that year). ";pilepull rewards" now shows only the current/most
+      recent event by default; add "history" (";pilepull rewards history") to see
+      every event on record, and combine with "all" for every character across
+      every event.
+  v1.2.0 (2026-09-05)
+    - Add reward tracking: items received and silver spent searching are now saved
+      to a local database so they survive between runs. Use ";pilepull rewards" to
+      see a summary broken down by reward tier (common/uncommon/rare/epic/legendary).
+      Safe to run on multiple characters at the same time.
+    - Fix cleanup skipping a single leftover flexing arm token or potion; it only
+      ever cleaned those up when you had two or more.
+    - Fix cleanup sometimes waiting the full timeout to notice a container had
+      already finished being inspected.
+  v1.1.0 (2026-09-04)
+    - ad logic to try to run cleanup if hit too many items
+  v1.0.1 (2026-03-01)
+    - slight fix to retry item handling after prize pulling
+  v1.0.0 (2025-08-31)
+    - initial release
+=end
+
+# Load required gems with safety checks
+gems_to_load = ["sequel"]
+failed_to_load = []
+
+gems_to_load.each do |gem|
+  unless Gem::Dependency.new(gem).matching_specs.max_by(&:version).nil?
+    require gem
+  else
+    failed_to_load.push(gem)
+  end
+end
+
+unless failed_to_load.empty?
+  echo "Requires Ruby gems: #{failed_to_load.join(", ")}"
+  echo "Please install the above gem(s) to run ;pilepull"
+  exit
+end
+
+require 'date'
+
+module PilePull
+  @prize_pile = nil
+  @inventory_quantity = nil
+  @max_inventory = false
+
+  # Set the amount to withdraw each time it goes to the bank
+  @withdraw_amount = 100_000_000
+
+  # Set the following on whether to TRASH them on receiving them
+  @keep_spoon = false
+  @keep_wisp  = false # not yet implemented
+  @keep_nexus = false
+
+  # Tracks rewards (items received) and silver spent searching, persisted to a
+  # local Sequel/SQLite database. Several characters may run this script at the
+  # same time, so a shared YAML/JSON file would risk read/write clobbering;
+  # SQLite handles concurrent inserts from multiple processes safely, and every
+  # row is tagged by character/account/game so totals can be sliced per-character
+  # or across the account. Mirrors the pattern used by ledger.lic.
+  module Rewards
+    @file = File.join(DATA_DIR, "pilepull.db")
+    Self = Sequel.sqlite(@file)
+
+    # Known reward tiers, keyed by the item name pattern the game hands you.
+    # Based on player-observed drop rates: 65% common / 22% uncommon / 10% rare /
+    # 2% epic / 1% legendary, with an even chance for each item inside its tier.
+    # Order matters: checked top to bottom, first match wins.
+    TIER_PATTERNS = [
+      [/larger locker contract/i, 'common'],
+      [/Chronomage rush ticket/i,           'common'],
+      [/locker runner contract/i,           'common'],
+      [/swirling yellow-green potion/i,     'uncommon'],
+      [/Adventurer's Guild voucher pack/i,  'uncommon'],
+      [/Elanthian Guilds voucher pack/i,    'uncommon'],
+      [/\bglowing orb\b/i,                  'rare'],
+      [/swirling nexus orb/i,               'rare'],
+      [/potent yellow-green potion/i,       'rare'],
+      [/creased stamped voucher booklet/i,  'epic'],
+      [/shimmering blue orb/i,              'epic'],
+      [/small locker expansion contract/i,  'epic'],
+      [/shimmering violet orb/i,            'legendary'],
+    ].freeze unless const_defined?(:TIER_PATTERNS, false)
+
+    # Display order for tier breakdowns; also doubles as the set of valid tiers.
+    TIER_ORDER = %w(legendary epic rare uncommon common unknown).freeze unless const_defined?(:TIER_ORDER, false)
+
+    Self.create_table?(:rewards) do
+      primary_key :id
+      String  :character
+      String  :account
+      String  :game
+      String  :type       # 'item' or 'search'
+      String  :item_name  # populated for 'item' rows, nil for 'search' rows
+      String  :tier       # 'common'/'uncommon'/'rare'/'epic'/'legendary'/'unknown', nil for 'search' rows
+      Integer :quantity   # item count for 'item' rows, silver spent for 'search' rows
+      String  :event      # display label for the Duskruin event, e.g. "2026 Duskruin (Aug/Sep)"
+      Integer :event_key  # sortable/filterable form of `event`: year * 10 + (1 for Feb/Mar, 2 for Aug/Sep)
+      Date    :created_at
+      Integer :year
+      Integer :month
+      Integer :day
+      Integer :hour
+    end
+
+    def self.tier_for(item_name)
+      return 'unknown' if item_name.nil?
+      _pattern, tier = TIER_PATTERNS.find { |pattern, _tier| item_name =~ pattern }
+      tier || 'unknown'
+    end
+
+    # Duskruin runs twice a year: Feb/Mar and Aug/Sep. Bucketed by calendar half
+    # (Jan-Jun => Feb/Mar, Jul-Dec => Aug/Sep) since the script is only ever run
+    # during an actual event window, so the half a reward falls in always matches
+    # the event it was earned in.
+    def self.event_half(month)
+      month <= 6 ? 1 : 2
+    end
+
+    def self.event_key_for(year, month)
+      (year * 10) + event_half(month)
+    end
+
+    def self.label_for_key(key)
+      return 'unknown event' if key.nil?
+      year = key / 10
+      half = key % 10
+      "#{year} Duskruin (#{half == 1 ? 'Feb/Mar' : 'Aug/Sep'})"
+    end
+
+    # One-time migration: add `tier`/`event`/`event_key` columns to existing
+    # databases, backfilling from each row's own item_name/year/month.
+    begin
+      existing_columns = Self.schema(:rewards).map(&:first)
+
+      unless existing_columns.include?(:tier)
+        Self.alter_table(:rewards) { add_column :tier, String }
+        Self[:rewards].where(type: 'item').each do |row|
+          Self[:rewards].where(id: row[:id]).update(tier: tier_for(row[:item_name]))
+        end
+      end
+
+      unless existing_columns.include?(:event_key)
+        Self.alter_table(:rewards) do
+          add_column :event, String
+          add_column :event_key, Integer
+        end
+        Self[:rewards].each do |row|
+          key = event_key_for(row[:year], row[:month])
+          Self[:rewards].where(id: row[:id]).update(event: label_for_key(key), event_key: key)
+        end
+      end
+    rescue => e
+      echo "Note: Could not migrate pilepull rewards database: #{e.message}"
+    end
+
+    begin
+      unless Self.indexes(:rewards).key?(:pilepull_rewards_character_type_index)
+        Self.add_index :rewards, [:character, :type], name: :pilepull_rewards_character_type_index
+      end
+      unless Self.indexes(:rewards).key?(:pilepull_rewards_character_tier_index)
+        Self.add_index :rewards, [:character, :tier], name: :pilepull_rewards_character_tier_index
+      end
+      unless Self.indexes(:rewards).key?(:pilepull_rewards_event_key_index)
+        Self.add_index :rewards, [:event_key], name: :pilepull_rewards_event_key_index
+      end
+    rescue => e
+      echo "Note: Could not add pilepull rewards index: #{e.message}"
+    end
+
+    Transactions = Self[:rewards]
+
+    def self.account_name
+      return nil unless Object.const_defined?(:Account)
+      Account.name if Account.name && !Account.name.to_s.empty?
+    end
+
+    def self.record(type:, item_name: nil, tier: nil, quantity: 1)
+      now = Time.now
+      event_key = event_key_for(now.year, now.month)
+      Transactions.insert(
+        character: Char.name,
+        account: account_name,
+        game: XMLData.game,
+        type: type,
+        item_name: item_name,
+        tier: tier,
+        quantity: quantity,
+        event: label_for_key(event_key),
+        event_key: event_key,
+        created_at: now,
+        year: now.year,
+        month: now.month,
+        day: now.day,
+        hour: now.hour
+      )
+    end
+
+    def self.record_item(item_name, quantity: 1)
+      return if item_name.nil? || item_name.to_s.empty?
+      record(type: 'item', item_name: item_name, tier: tier_for(item_name), quantity: quantity)
+    end
+
+    def self.record_search_cost(amount)
+      record(type: 'search', quantity: amount)
+    end
+
+    def self.with_commas(num)
+      num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+    end
+
+    # @param character [String] restrict to this character; ignored when all_characters is true
+    # @param all_characters [Boolean] combine every character in the database instead of just one
+    # @param all_events [Boolean] show every Duskruin event on record instead of just the latest
+    def self.print_summary(character: Char.name, all_characters: false, all_events: false)
+      scope = all_characters ? Transactions : Transactions.where(character: character)
+      scope_desc = all_characters ? "ALL characters" : character
+
+      if all_events
+        event_keys = (scope.select_map(:event_key)).compact.uniq.sort.reverse
+
+        if event_keys.empty?
+          echo("=== PilePull rewards for #{scope_desc} ===")
+          echo("  No rewards recorded yet.")
+          return
+        end
+
+        event_keys.each { |key| print_event_block(scope, key, scope_desc) }
+      else
+        key = scope.max(:event_key) || event_key_for(Time.now.year, Time.now.month)
+        print_event_block(scope, key, scope_desc)
+      end
+    end
+
+    # Prints the tier breakdown and silver spent for a single Duskruin event.
+    #
+    # @param scope [Sequel::Dataset] the character/all-characters filtered dataset to report on
+    # @param key [Integer] the event_key identifying which Duskruin event to report
+    # @param scope_desc [String] human-readable label for who this report covers
+    def self.print_event_block(scope, key, scope_desc)
+      echo("=== PilePull rewards for #{scope_desc} - #{label_for_key(key)} ===")
+
+      event_scope = scope.where(event_key: key)
+
+      rows = event_scope
+             .where(type: 'item')
+             .group_and_count(:tier, :item_name)
+             .order(Sequel.desc(:count))
+             .all
+
+      total_items = rows.sum { |row| row[:count] }
+
+      if rows.empty?
+        echo("  No items recorded yet.")
+      else
+        by_tier = rows.group_by { |row| row[:tier] || 'unknown' }
+
+        TIER_ORDER.each do |tier|
+          tier_rows = by_tier[tier]
+          next if tier_rows.nil? || tier_rows.empty?
+
+          tier_count = tier_rows.sum { |row| row[:count] }
+          tier_pct = total_items.zero? ? 0 : (tier_count * 100.0 / total_items)
+          echo("#{tier.upcase} (#{tier_count}, #{'%.1f' % tier_pct}%)")
+          tier_rows.each do |row|
+            echo("  #{row[:item_name]}: #{row[:count]}")
+          end
+        end
+      end
+
+      total_spent = event_scope.where(type: 'search').sum(:quantity) || 0
+      echo("Total items: #{total_items}")
+      echo("Total silver spent searching: #{with_commas(total_spent)}")
+      echo("")
+    end
+  end
+
+  def self.detect_pile
+    ['pile', 'prizes'].each do |thing|
+      if (found_thing = GameObj.loot.find { |item| item.noun == thing })
+        result = dothistimeout("look ##{found_thing.id}", 2, /SEARCH the \w+ to get something from the \w+!/)
+        if result =~ /SEARCH the \w+ to get something from the \w+!/
+          return @prize_pile = found_thing
+        end
+      end
+    end
+    echo("Could not find a prize pile, be sure to start script in front of a treasure pile! Exiting!")
+    exit
+  end
+
+  def self.silver_check
+    return Lich::Util.silver_count
+  end
+
+  def self.bank_run
+    current_location = Room.current.id
+    Script.run("go2", "u8213023")
+    fput("deposit all")
+    result = dothistimeout("withdraw #{@withdraw_amount} silver", 2, /you don't seem to have that much|hands you [\d,]+ silvers/)
+    if result =~ /you don't seem to have that much/
+      echo("Not enough silver, exiting!")
+      exit
+    end
+    Script.run("go2", "#{current_location}")
+  end
+
+  def self.search_pile
+    loop {
+      result = dothistimeout("search ##{@prize_pile.id}", 2, /In order to search through a pile of mania prizes|You do not have enough silver to SEARCH|You hand over 1,000,000|You've recently searched through|You have too many items to search./)
+      case result
+      when /In order to search through/
+        next
+      when /You've recently searched through/
+        sleep(0.3)
+        next
+      when /You do not have enough silver to SEARCH/
+        return false
+      when /You have too many items to search./
+        if @max_inventory
+          echo("You have too many items! Handle that!")
+          exit
+        else
+          @max_inventory = true
+          return false
+        end
+      when /You hand over 1,000,000/
+        @max_inventory = false
+        Rewards.record_search_cost(1_000_000)
+        sleep(1)
+        waitrt?
+        return true
+      end
+    }
+  end
+
+  def self.handle_loot
+    recorded_id = nil
+    2.times do
+      waitrt?
+      hand = GameObj.right_hand
+      item_name = hand.name
+
+      if hand.id && hand.id != recorded_id
+        Rewards.record_item(item_name)
+        recorded_id = hand.id
+      end
+
+      case item_name
+      when /booklet/
+        fput('redeem booklet')
+      when /steel spoon/
+        if @keep_spoon
+          fput('stow all')
+        else
+          fput('trash my spoon')
+        end
+      when /nexus orb/
+        if @keep_nexus
+          fput('stow all')
+        else
+          fput('trash my orb')
+        end
+      else
+        fput('stow all')
+      end
+
+      30.times {
+        return if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+        sleep(0.1)
+      }
+    end
+
+    echo("Couldn't handle item received, likely full containers, exiting!")
+    exit
+  end
+
+  def self.check_inventory_count
+    waitrt?
+    result = dothistimeout("inventory quantity", 3, /You are carrying ([\d,]+) items\./)
+    if result =~ /You are carrying ([\d,]+) items\./
+      @inventory_quantity = $1.to_i
+      if @inventory_quantity >= 400
+        echo("You have to many items on you, preventing run as you should empty some stuff off your person")
+        echo("Item cap is 500 and you have #{@inventory_quantity}.")
+        exit
+      end
+    else
+      echo("Couldn't detect current inventory quantity, exiting for safety reasons!")
+      exit
+    end
+  end
+
+  def self.populate_inventory
+    GameObj.inv.each do |item|
+      # echo "item: #{item.name} | type: #{item.type}"
+      next if GameObj.containers.keys.include?(item.id.to_s) && item.contents.is_a?(Array)
+      next if item.type =~ /jewelry|weapon|armor|uncommon/
+      next if item.type.nil?
+
+      # check out whats inside
+      lines = Lich::Util.issue_command("look in ##{item.id}", /<exposeContainer|<dialogData|<container|you glance|There is nothing|appears to be a very sturdy and spacious container despite its seemingly small size/i, usexml: true, silent: true, quiet: true)
+      next if lines.any? { |l| l =~ /You glance|There is nothing|appears to be a very sturdy and spacious container despite its seemingly small size/i }
+
+      20.times {
+        break if GameObj.containers.keys.include?(item.id.to_s) && item.contents.is_a?(Array)
+        sleep 0.1
+      }
+    end
+  end
+
+  def self.find_items(item_name)
+    all_items = []
+
+    if StowList.default
+      StowList.default.contents.each do |thing|
+        if thing.name =~ item_name
+          all_items.push(thing)
+        end
+      end
+    else
+      GameObj.inv.each { |container|
+        next unless GameObj.containers.keys.include?(container.id.to_s)
+        next unless container.contents.is_a?(Array)
+
+        container.contents.each do |thing|
+          if thing.name =~ item_name
+            all_items.push(thing)
+          end
+        end
+      }
+    end
+    return all_items
+  end
+
+  def self.cleanup
+    populate_inventory
+
+    # glowing orbs - REIM stuff
+    found_items = find_items(/\bglowing orb\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("bundle ##{item.id}", "bundle ##{item.id}")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # blue feather-shaped charm - Encumbrance reducing (1 use)
+    found_items = find_items(/\bblue feather-shaped charm\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("bundle ##{item.id}")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # flexing arm token - Enhancive Pause (15 uses)
+    found_items = find_items(/\bflexing arm token\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      fput("trash ##{item.id}")
+      fput("trash ##{item.id}") unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+    } if found_items.count > 0
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+=begin
+    # urchin guide contract - 30 days (1 use)
+    found_items = find_items(/\burchin guide contract\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      fput("trash ##{item.id}")
+      fput("trash ##{item.id}") unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+=end
+
+    # potent blue-green potion - SKE enhancive 30min recharge
+    found_items = find_items(/\bpotent blue-green potion\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("pour ##{item.id} in my second potion")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 0
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # potent yellow-green potions - SKE enhancive 30day recharge
+    found_items = find_items(/\bpotent yellow-green potion\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("pour ##{item.id} in my second potion")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 0
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # swirling yellow-green potions - regular enhancive 30day recharge
+    found_items = find_items(/\bswirling yellow-green potion\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("pour ##{item.id} in my second potion")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 0
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # Elanthian Guilds voucher pack - Professional Guild task reassigning
+    found_items = find_items(/\bElanthian Guilds voucher pack\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("bundle ##{item.id}")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # Adventurer's Guild voucher pack - Adv Guild task reassigning
+    found_items = find_items(/\bAdventurer's Guild voucher pack\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("bundle ##{item.id}")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    # Adventurer's Guild task waiver - 30 days of being exempt from a task in the Adv Guild
+    found_items = find_items(/\bAdventurer's Guild task waiver\b/)
+    found_items.each { |item|
+      fput("get ##{item.id}")
+      multifput("bundle ##{item.id}")
+      fput('stow left') unless GameObj.right_hand.id.nil? || GameObj.left_hand.id.nil?
+    } if found_items.count > 1
+    fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+
+    20.times do
+      waitrt?
+      fput('stow all') unless GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+      sleep(0.1)
+    end
+  end
+
+  def self.main
+    detect_pile
+
+    check_inventory_count
+    unless silver_check >= 1_000_000
+      bank_run
+    end
+    loop do
+      if search_pile
+        handle_loot
+      else
+        cleanup
+        check_inventory_count
+        bank_run
+      end
+    end
+  end
+end
+
+case Script.current.vars[1]
+when "cleanup"
+  PilePull.cleanup
+when "rewards"
+  rewards_args = (Script.current.vars[2..-1] || []).map { |arg| arg.to_s.downcase }
+  PilePull::Rewards.print_summary(
+    all_characters: rewards_args.include?("all"),
+    all_events: rewards_args.include?("history") || rewards_args.include?("years")
+  )
+else
+  PilePull.main
+end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -77,6 +77,9 @@
       longer matches items received); a booklet or trashed nexus orb could
       silently vanish from tracking, and add a booklet name fix-up.
     - Render ";pilepull rewards" as a table instead of plain text lines.
+    - Fix a swirling yellow-green potion and a potent yellow-green potion
+      both being tracked as "unknown" tier; the pulled item's full name is
+      now read from the SEARCH result text itself, which tells them apart.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -109,6 +112,7 @@ module PilePull
   @prize_pile = nil
   @inventory_quantity = nil
   @max_inventory = false
+  @last_pull_name = nil
 
   # Set the amount to withdraw each time it goes to the bank
   @withdraw_amount = 100_000_000
@@ -506,6 +510,21 @@ module PilePull
         @max_inventory = false
         dbg("search_pile: search succeeded, recording 1,000,000 silver spent")
         Rewards.record_search_cost(1_000_000)
+
+        # The search response spells out the pulled item's full, unambiguous
+        # name ("You pull a swirling yellow-green potion from within!"),
+        # unlike GameObj.right_hand.name in handle_loot, which can report a
+        # truncated fragment ("yellow-green potion") that's genuinely
+        # ambiguous between the uncommon swirling and the rare potent
+        # variant. Stash it so handle_loot can prefer it over the hand name.
+        if result =~ /You pull (?:a|an) (.+) from within!/i
+          @last_pull_name = $1
+          dbg("search_pile: pulled item name from search text: #{@last_pull_name.inspect}")
+        else
+          @last_pull_name = nil
+          dbg("search_pile: could not parse a pulled item name out of the search result text")
+        end
+
         sleep(1)
         waitrt?
         return true
@@ -533,10 +552,19 @@ module PilePull
       # the reward entirely rather than just mis-tiering it. The pre-action
       # name is always present, and canonical_name_for/tier_for (below)
       # already handle every truncated fragment seen in the wild.
+      #
+      # search_pile already parsed the full, unambiguous name straight out
+      # of the search response text (@last_pull_name) -- prefer that over
+      # the hand name when it's available, since it's the only source that
+      # can tell a swirling yellow-green potion apart from a potent one;
+      # the hand name truncates both to the same ambiguous fragment.
       if hand.id && hand.id != recorded_id
-        dbg("handle_loot[#{attempt}]: recording id=#{hand.id} name=#{item_name.inspect}")
-        Rewards.record_item(item_name)
+        recorded_name = @last_pull_name || item_name
+        dbg("handle_loot[#{attempt}]: recording id=#{hand.id} name=#{recorded_name.inspect} " \
+            "(source=#{@last_pull_name ? 'search text' : 'hand name'})")
+        Rewards.record_item(recorded_name)
         recorded_id = hand.id
+        @last_pull_name = nil
       else
         dbg("handle_loot[#{attempt}]: not recording (hand.id=#{hand.id.inspect}, already recorded=#{recorded_id.inspect})")
       end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -73,6 +73,9 @@
       item name capture, and reward tier/canonicalization decisions.
     - Fix reward tracking never actually recording an item on the normal
       (success) path; it only ever recorded silver spent searching.
+    - Fix reward tracking undercounting items (silver spent searching no
+      longer matches items received); a booklet or trashed nexus orb could
+      silently vanish from tracking, and add a booklet name fix-up.
     - Render ";pilepull rewards" as a table instead of plain text lines.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
@@ -175,21 +178,24 @@ module PilePull
     # Display order for tier breakdowns; also doubles as the set of valid tiers.
     TIER_ORDER = %w(legendary epic rare uncommon common unknown).freeze unless const_defined?(:TIER_ORDER, false)
 
-    # GameObj.right_hand/left_hand can occasionally report a partial/truncated
-    # name for an item before its data has fully settled (see handle_loot,
-    # which now re-reads the name via GameObj[id] after the item leaves your
-    # hands instead of trusting the hand object's name in the moment). These
-    # patterns recover the full item name from a handful of truncated
-    # fragments actually seen in the wild, so both new and already-recorded
-    # rows land in the right tier. Ambiguous fragments (e.g. a bare
-    # "yellow-green potion", which could be the uncommon swirling or the rare
-    # potent variant) are deliberately left unmapped rather than guessed at.
+    # GameObj.right_hand/left_hand can report a partial/truncated name for an
+    # item before its data has fully settled. handle_loot records this
+    # truncated name as-is (attempting to re-resolve it afterward via
+    # GameObj[id] turned out to be worse: that lookup frequently returns nil
+    # once the item has been redeemed/trashed/stowed, which silently dropped
+    # the reward instead of just mis-tiering it). These patterns recover the
+    # full item name from every truncated fragment actually seen in the
+    # wild, so both new and already-recorded rows land in the right tier.
+    # Ambiguous fragments (e.g. a bare "yellow-green potion", which could be
+    # the uncommon swirling or the rare potent variant) are deliberately
+    # left unmapped rather than guessed at.
     FALLBACK_ITEM_FIXUPS = [
-      [/\brunner contract\b/i,     'locker runner contract'],
-      [/\bGuild voucher pack\b/i,  "Adventurer's Guild voucher pack"],
-      [/\bGuilds voucher pack\b/i, 'Elanthian Guilds voucher pack'],
-      [/\bnexus orb\b/i,           'swirling nexus orb'],
-      [/\bblue orb\b/i,            'shimmering blue orb'],
+      [/\brunner contract\b/i,          'locker runner contract'],
+      [/\bGuild voucher pack\b/i,       "Adventurer's Guild voucher pack"],
+      [/\bGuilds voucher pack\b/i,      'Elanthian Guilds voucher pack'],
+      [/\bnexus orb\b/i,                'swirling nexus orb'],
+      [/\bblue orb\b/i,                 'shimmering blue orb'],
+      [/\bstamped voucher booklet\b/i,  'creased stamped voucher booklet'],
     ].freeze unless const_defined?(:FALLBACK_ITEM_FIXUPS, false)
 
     Self.create_table?(:rewards) do
@@ -517,6 +523,24 @@ module PilePull
       item_name = hand.name
       dbg("handle_loot[#{attempt}]: right_hand id=#{hand.id.inspect} name=#{item_name.inspect} left_hand id=#{GameObj.left_hand.id.inspect} name=#{GameObj.left_hand.name.inspect}")
 
+      # Record from the name captured here, before the item is redeemed/
+      # trashed/stowed. A prior version tried re-reading the name via
+      # GameObj[id] after the item left your hands, on the theory that the
+      # hand object's name could be a truncated fragment; in practice
+      # GameObj[id] frequently returns nil afterward instead (always for a
+      # redeemed booklet or trashed orb, since that id no longer exists;
+      # sometimes for an ordinary stowed item too), which silently dropped
+      # the reward entirely rather than just mis-tiering it. The pre-action
+      # name is always present, and canonical_name_for/tier_for (below)
+      # already handle every truncated fragment seen in the wild.
+      if hand.id && hand.id != recorded_id
+        dbg("handle_loot[#{attempt}]: recording id=#{hand.id} name=#{item_name.inspect}")
+        Rewards.record_item(item_name)
+        recorded_id = hand.id
+      else
+        dbg("handle_loot[#{attempt}]: not recording (hand.id=#{hand.id.inspect}, already recorded=#{recorded_id.inspect})")
+      end
+
       case item_name
       when /booklet/
         dbg("handle_loot[#{attempt}]: matched booklet -> redeem")
@@ -540,35 +564,10 @@ module PilePull
         fput('stow all')
       end
 
-      hands_cleared = false
       30.times {
-        if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
-          hands_cleared = true
-          break
-        end
+        return if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
         sleep(0.1)
       }
-      dbg("handle_loot[#{attempt}]: hands_cleared=#{hands_cleared}")
-
-      # Read the name back via GameObj[id] rather than trusting the hand
-      # object's name at the moment the item arrived: GameObj.right_hand/
-      # left_hand can occasionally report a partial/truncated name for the
-      # same item before its data has fully settled.
-      #
-      # This has to happen before the `return` below rather than inside the
-      # 30.times block above: `return` inside a block unwinds the enclosing
-      # method (handle_loot), not just the block, so putting it in the wait
-      # loop would skip this recording step entirely the moment hands clear.
-      if hand.id && hand.id != recorded_id
-        resolved_name = GameObj[hand.id].name
-        dbg("handle_loot[#{attempt}]: recording id=#{hand.id} pre-action name=#{item_name.inspect} resolved name=#{resolved_name.inspect}")
-        Rewards.record_item(resolved_name)
-        recorded_id = hand.id
-      else
-        dbg("handle_loot[#{attempt}]: not recording (hand.id=#{hand.id.inspect}, already recorded=#{recorded_id.inspect})")
-      end
-
-      return if hands_cleared
     end
 
     echo("Couldn't handle item received, likely full containers, exiting!")

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -70,6 +70,8 @@
     - Add a "--debug" flag (usable with any command, e.g. ";pilepull --debug"
       or ";pilepull rewards --debug") for verbose logging of search results,
       item name capture, and reward tier/canonicalization decisions.
+    - Fix reward tracking never actually recording an item on the normal
+      (success) path; it only ever recorded silver spent searching.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -526,15 +528,25 @@ module PilePull
         fput('stow all')
       end
 
+      hands_cleared = false
       30.times {
-        return if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+        if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
+          hands_cleared = true
+          break
+        end
         sleep(0.1)
       }
+      dbg("handle_loot[#{attempt}]: hands_cleared=#{hands_cleared}")
 
       # Read the name back via GameObj[id] rather than trusting the hand
       # object's name at the moment the item arrived: GameObj.right_hand/
       # left_hand can occasionally report a partial/truncated name for the
       # same item before its data has fully settled.
+      #
+      # This has to happen before the `return` below rather than inside the
+      # 30.times block above: `return` inside a block unwinds the enclosing
+      # method (handle_loot), not just the block, so putting it in the wait
+      # loop would skip this recording step entirely the moment hands clear.
       if hand.id && hand.id != recorded_id
         resolved_name = GameObj[hand.id].name
         dbg("handle_loot[#{attempt}]: recording id=#{hand.id} pre-action name=#{item_name.inspect} resolved name=#{resolved_name.inspect}")
@@ -543,6 +555,8 @@ module PilePull
       else
         dbg("handle_loot[#{attempt}]: not recording (hand.id=#{hand.id.inspect}, already recorded=#{recorded_id.inspect})")
       end
+
+      return if hands_cleared
     end
 
     echo("Couldn't handle item received, likely full containers, exiting!")

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -33,6 +33,10 @@
       ;pilepull rewards all history  - combine "all" and "history": every
                                         character, every event
 
+  Add --debug to any of the above (in any position) for verbose logging of
+  search results, item name capture, and reward tier/canonicalization
+  decisions, e.g. ";pilepull --debug" or ";pilepull rewards all --debug".
+
   There's also some variables in the script you can set to true/false
   All default to false to throw away
     * @withdraw_amount
@@ -63,6 +67,9 @@
       usage instead of starting a search.
     - Fix reward tracking leaking a database connection every time the script
       ran, which could leave the database file locked.
+    - Add a "--debug" flag (usable with any command, e.g. ";pilepull --debug"
+      or ";pilepull rewards --debug") for verbose logging of search results,
+      item name capture, and reward tier/canonicalization decisions.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -103,6 +110,25 @@ module PilePull
   @keep_spoon = false
   @keep_wisp  = false # not yet implemented
   @keep_nexus = false
+
+  # --debug can appear anywhere after ";pilepull" (";pilepull --debug",
+  # ";pilepull cleanup --debug", ";pilepull rewards --debug", etc.) and turns
+  # on verbose logging. This is computed here, before Rewards is defined
+  # below, so debug output is available during Rewards' own module-load-time
+  # database migrations too.
+  @debug = (Script.current.vars[1..-1] || []).any? { |arg| arg.to_s.casecmp("--debug").zero? }
+
+  def self.debug?
+    @debug == true
+  end
+
+  # Prints a message only when --debug was passed, prefixed so it's easy to
+  # spot/filter in the game window.
+  def self.dbg(msg)
+    echo("[pilepull-debug] #{msg}") if debug?
+  end
+
+  dbg("debug mode enabled")
 
   # Tracks rewards (items received) and silver spent searching, persisted to a
   # local Sequel/SQLite database. Several characters may run this script at the
@@ -182,16 +208,31 @@ module PilePull
 
     def self.canonical_name_for(item_name)
       return item_name if item_name.nil?
-      _pattern, canonical = FALLBACK_ITEM_FIXUPS.find { |pattern, _canonical| item_name =~ pattern }
-      canonical || item_name
+      pattern, canonical = FALLBACK_ITEM_FIXUPS.find { |candidate, _canonical| item_name =~ candidate }
+      if canonical
+        PilePull.dbg("Rewards.canonical_name_for: #{item_name.inspect} matched fallback #{pattern.inspect} -> #{canonical.inspect}")
+        canonical
+      else
+        item_name
+      end
     end
 
     def self.tier_for(item_name)
       return 'unknown' if item_name.nil?
-      return 'rare' if XMLData.game.eql?("GSF") && item_name =~ /creased stamped voucher booklet/i
 
-      _pattern, tier = TIER_PATTERNS.find { |pattern, _tier| item_name =~ pattern }
-      tier || 'unknown'
+      if XMLData.game.eql?("GSF") && item_name =~ /creased stamped voucher booklet/i
+        PilePull.dbg("Rewards.tier_for: #{item_name.inspect} -> rare (GSF booklet override)")
+        return 'rare'
+      end
+
+      pattern, tier = TIER_PATTERNS.find { |candidate, _tier| item_name =~ candidate }
+      if tier
+        PilePull.dbg("Rewards.tier_for: #{item_name.inspect} matched #{pattern.inspect} -> #{tier}")
+        tier
+      else
+        PilePull.dbg("Rewards.tier_for: #{item_name.inspect} matched no pattern -> unknown")
+        'unknown'
+      end
     end
 
     # Duskruin runs twice a year: Feb/Mar and Aug/Sep. Bucketed by calendar half
@@ -247,6 +288,7 @@ module PilePull
       Self[:rewards].where(type: 'item', tier: 'unknown').each do |row|
         canonical = canonical_name_for(row[:item_name])
         next if canonical == row[:item_name]
+        PilePull.dbg("Rewards migration: row id=#{row[:id]} item_name=#{row[:item_name].inspect} -> #{canonical.inspect}")
         Self[:rewards].where(id: row[:id]).update(item_name: canonical, tier: tier_for(canonical))
       end
     rescue => e
@@ -277,6 +319,7 @@ module PilePull
     def self.record(type:, item_name: nil, tier: nil, quantity: 1)
       now = Time.now
       event_key = event_key_for(now.year, now.month)
+      PilePull.dbg("Rewards.record: type=#{type} item_name=#{item_name.inspect} tier=#{tier.inspect} quantity=#{quantity} event_key=#{event_key} character=#{Char.name}")
       Transactions.insert(
         character: Char.name,
         account: account_name,
@@ -296,12 +339,18 @@ module PilePull
     end
 
     def self.record_item(item_name, quantity: 1)
-      return if item_name.nil? || item_name.to_s.empty?
+      if item_name.nil? || item_name.to_s.empty?
+        PilePull.dbg("Rewards.record_item: ignoring blank/nil item_name (#{item_name.inspect})")
+        return
+      end
       canonical = canonical_name_for(item_name)
-      record(type: 'item', item_name: canonical, tier: tier_for(canonical), quantity: quantity)
+      tier = tier_for(canonical)
+      PilePull.dbg("Rewards.record_item: raw=#{item_name.inspect} canonical=#{canonical.inspect} tier=#{tier}")
+      record(type: 'item', item_name: canonical, tier: tier, quantity: quantity)
     end
 
     def self.record_search_cost(amount)
+      PilePull.dbg("Rewards.record_search_cost: #{amount}")
       record(type: 'search', quantity: amount)
     end
 
@@ -378,12 +427,16 @@ module PilePull
   def self.detect_pile
     ['pile', 'prizes'].each do |thing|
       if (found_thing = GameObj.loot.find { |item| item.noun == thing })
+        dbg("detect_pile: checking noun=#{thing.inspect} id=#{found_thing.id}")
         result = dothistimeout("look ##{found_thing.id}", 2, /SEARCH the \w+ to get something from the \w+!/)
+        dbg("detect_pile: look result=#{result.inspect}")
         if result =~ /SEARCH the \w+ to get something from the \w+!/
+          dbg("detect_pile: using id=#{found_thing.id} as the prize pile")
           return @prize_pile = found_thing
         end
       end
     end
+    dbg("detect_pile: no pile/prizes noun matched in GameObj.loot (#{GameObj.loot.map { |i| "#{i.id}:#{i.noun}" }.join(', ')})")
     echo("Could not find a prize pile, be sure to start script in front of a treasure pile! Exiting!")
     exit
   end
@@ -394,19 +447,23 @@ module PilePull
 
   def self.bank_run
     current_location = Room.current.id
+    dbg("bank_run: leaving room #{current_location} for the bank")
     Script.run("go2", "u8213023")
     fput("deposit all")
     result = dothistimeout("withdraw #{@withdraw_amount} silver", 2, /you don't seem to have that much|hands you [\d,]+ silvers/)
+    dbg("bank_run: withdraw result=#{result.inspect}")
     if result =~ /you don't seem to have that much/
       echo("Not enough silver, exiting!")
       exit
     end
+    dbg("bank_run: returning to room #{current_location}")
     Script.run("go2", "#{current_location}")
   end
 
   def self.search_pile
     loop {
       result = dothistimeout("search ##{@prize_pile.id}", 2, /In order to search through a pile of mania prizes|You do not have enough silver to SEARCH|You hand over 1,000,000|You've recently searched through|You have too many items to search./)
+      dbg("search_pile: result=#{result.inspect}")
       case result
       when /In order to search through/
         next
@@ -414,17 +471,20 @@ module PilePull
         sleep(0.3)
         next
       when /You do not have enough silver to SEARCH/
+        dbg("search_pile: out of silver")
         return false
       when /You have too many items to search./
         if @max_inventory
           echo("You have too many items! Handle that!")
           exit
         else
+          dbg("search_pile: too many items, will attempt cleanup once")
           @max_inventory = true
           return false
         end
       when /You hand over 1,000,000/
         @max_inventory = false
+        dbg("search_pile: search succeeded, recording 1,000,000 silver spent")
         Rewards.record_search_cost(1_000_000)
         sleep(1)
         waitrt?
@@ -435,27 +495,34 @@ module PilePull
 
   def self.handle_loot
     recorded_id = nil
+    attempt = 0
     2.times do
+      attempt += 1
       waitrt?
       hand = GameObj.right_hand
       item_name = hand.name
+      dbg("handle_loot[#{attempt}]: right_hand id=#{hand.id.inspect} name=#{item_name.inspect} left_hand id=#{GameObj.left_hand.id.inspect} name=#{GameObj.left_hand.name.inspect}")
 
       case item_name
       when /booklet/
+        dbg("handle_loot[#{attempt}]: matched booklet -> redeem")
         fput('redeem booklet')
       when /steel spoon/
+        dbg("handle_loot[#{attempt}]: matched steel spoon -> keep_spoon=#{@keep_spoon}")
         if @keep_spoon
           fput('stow all')
         else
           fput('trash my spoon')
         end
       when /nexus orb/
+        dbg("handle_loot[#{attempt}]: matched nexus orb -> keep_nexus=#{@keep_nexus}")
         if @keep_nexus
           fput('stow all')
         else
           fput('trash my orb')
         end
       else
+        dbg("handle_loot[#{attempt}]: no special case matched -> stow all")
         fput('stow all')
       end
 
@@ -469,8 +536,12 @@ module PilePull
       # left_hand can occasionally report a partial/truncated name for the
       # same item before its data has fully settled.
       if hand.id && hand.id != recorded_id
-        Rewards.record_item(GameObj[hand.id].name)
+        resolved_name = GameObj[hand.id].name
+        dbg("handle_loot[#{attempt}]: recording id=#{hand.id} pre-action name=#{item_name.inspect} resolved name=#{resolved_name.inspect}")
+        Rewards.record_item(resolved_name)
         recorded_id = hand.id
+      else
+        dbg("handle_loot[#{attempt}]: not recording (hand.id=#{hand.id.inspect}, already recorded=#{recorded_id.inspect})")
       end
     end
 
@@ -483,12 +554,14 @@ module PilePull
     result = dothistimeout("inventory quantity", 3, /You are carrying ([\d,]+) items\./)
     if result =~ /You are carrying ([\d,]+) items\./
       @inventory_quantity = $1.to_i
+      dbg("check_inventory_count: carrying #{@inventory_quantity} items")
       if @inventory_quantity >= 400
         echo("You have to many items on you, preventing run as you should empty some stuff off your person")
         echo("Item cap is 500 and you have #{@inventory_quantity}.")
         exit
       end
     else
+      dbg("check_inventory_count: result did not match, got #{result.inspect}")
       echo("Couldn't detect current inventory quantity, exiting for safety reasons!")
       exit
     end
@@ -500,6 +573,8 @@ module PilePull
       next if GameObj.containers.keys.include?(item.id.to_s) && item.contents.is_a?(Array)
       next if item.type =~ /jewelry|weapon|armor|uncommon/
       next if item.type.nil?
+
+      dbg("populate_inventory: inspecting container id=#{item.id} name=#{item.name.inspect}")
 
       # check out whats inside
       lines = Lich::Util.issue_command("look in ##{item.id}", /<exposeContainer|<dialogData|<container|you glance|There is nothing|appears to be a very sturdy and spacious container despite its seemingly small size/i, usexml: true, silent: true, quiet: true)
@@ -533,6 +608,7 @@ module PilePull
         end
       }
     end
+    dbg("find_items: pattern=#{item_name.inspect} matched #{all_items.length} item(s): #{all_items.map(&:name).join(', ')}")
     return all_items
   end
 
@@ -657,11 +733,16 @@ module PilePull
   end
 end
 
-case Script.current.vars[1]
+# --debug is stripped out here (rather than being matched as a subcommand)
+# so it can be combined with any of the below, in any position: ";pilepull
+# --debug", ";pilepull cleanup --debug", ";pilepull rewards all --debug", etc.
+pilepull_args = (Script.current.vars[1..-1] || []).reject { |arg| arg.to_s.casecmp("--debug").zero? }
+
+case pilepull_args[0]
 when "cleanup"
   PilePull.cleanup
 when "rewards"
-  rewards_args = (Script.current.vars[2..-1] || []).map { |arg| arg.to_s.downcase }
+  rewards_args = pilepull_args[1..-1].map { |arg| arg.to_s.downcase }
   PilePull::Rewards.print_summary(
     all_characters: rewards_args.include?("all"),
     all_events: rewards_args.include?("history") || rewards_args.include?("years")
@@ -693,5 +774,8 @@ else
                                     record instead of just the current one
       ;pilepull rewards all history  - combine "all" and "history": every
                                         character, every event
+      --debug             - add to any of the above for verbose logging of
+                            search results, item name capture, and reward
+                            tier/canonicalization decisions
   TEXT
 end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -47,32 +47,17 @@
           required: Lich >= 5.12.4
        requirements:
         - sequel gem
-           version: 1.3.1
+           version: 1.2.0
 
   Improvements:
   Major_change.feature_addition.bugfix
-  v1.3.1 (2026-09-05)
-    - Fix reward tier tracking for Shattered's actual prize pile: the booklet is
-      one tier less rare than originally tracked (epic -> rare), and the
-      Chronomage rush ticket isn't in Shattered's pile at all anymore. Any
-      booklet already recorded as epic is automatically corrected.
-  v1.3.0 (2026-09-05)
-    - Add ";pilepull rewards all" to combine reward totals across every character
-      that has run this script, instead of just the current one.
-    - Tag every recorded reward with the Duskruin event it was earned in (Feb/Mar
-      or Aug/Sep of that year). ";pilepull rewards" now shows only the current/most
-      recent event by default; add "history" (";pilepull rewards history") to see
-      every event on record, and combine with "all" for every character across
-      every event.
   v1.2.0 (2026-09-05)
-    - Add reward tracking: items received and silver spent searching are now saved
-      to a local database so they survive between runs. Use ";pilepull rewards" to
-      see a summary broken down by reward tier (common/uncommon/rare/epic/legendary).
-      Safe to run on multiple characters at the same time.
-    - Fix cleanup skipping a single leftover flexing arm token or potion; it only
-      ever cleaned those up when you had two or more.
-    - Fix cleanup sometimes waiting the full timeout to notice a container had
-      already finished being inspected.
+    - Add reward tracking: items received and silver spent searching are saved to
+      a local database. Use ";pilepull rewards" for a tier breakdown of the
+      current Duskruin run, "all" to combine every character, and "history" for
+      every run on record.
+    - Fix cleanup skipping a single leftover flexing arm token or potion.
+    - Fix cleanup sometimes waiting the full timeout on an already-populated container.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -128,14 +113,9 @@ module PilePull
     # Based on player-observed drop rates: 65% common / 22% uncommon / 10% rare /
     # 2% epic / 1% legendary, with an even chance for each item inside its tier.
     # Order matters: checked top to bottom, first match wins.
-    #
-    # Shattered's prize pile was rebuilt from Prime's table (the old one had been
-    # duping in something that was removed from Platinum years ago). Per Wyromzzz
-    # (GM), two Shattered-specific corrections vs. that copied Prime table:
-    #   - the booklet was pushed down a tier (epic -> rare)
-    #   - the Chronomage rush ticket was removed from Shattered's pile entirely
     TIER_PATTERNS = [
       [/larger locker contract/i,           'common'],
+      [/Chronomage rush ticket/i,           'common'],
       [/locker runner contract/i,           'common'],
       [/swirling yellow-green potion/i,     'uncommon'],
       [/Adventurer's Guild voucher pack/i,  'uncommon'],
@@ -143,7 +123,7 @@ module PilePull
       [/\bglowing orb\b/i,                  'rare'],
       [/swirling nexus orb/i,               'rare'],
       [/potent yellow-green potion/i,       'rare'],
-      [/creased stamped voucher booklet/i,  'rare'],
+      [/creased stamped voucher booklet/i,  'epic'],
       [/shimmering blue orb/i,              'epic'],
       [/small locker expansion contract/i,  'epic'],
       [/shimmering violet orb/i,            'legendary'],
@@ -172,6 +152,8 @@ module PilePull
 
     def self.tier_for(item_name)
       return 'unknown' if item_name.nil?
+      return 'rare' if XMLData.game.eql?("GSF") && item_name =~ /creased stamped voucher booklet/i
+
       _pattern, tier = TIER_PATTERNS.find { |pattern, _tier| item_name =~ pattern }
       tier || 'unknown'
     end
@@ -219,19 +201,6 @@ module PilePull
       end
     rescue => e
       echo "Note: Could not migrate pilepull rewards database: #{e.message}"
-    end
-
-    # One-time fix: earlier versions of this script tiered the booklet as
-    # 'epic' before Shattered's prize pile was corrected (booklet moved down
-    # to 'rare', Chronomage rush ticket removed from Shattered entirely).
-    # Re-tier any already-recorded booklet rows so old data matches TIER_PATTERNS.
-    begin
-      Self[:rewards]
-        .where(type: 'item', tier: 'epic')
-        .where(Sequel.like(:item_name, '%booklet%'))
-        .update(tier: 'rare')
-    rescue => e
-      echo "Note: Could not correct pilepull rewards booklet tier: #{e.message}"
     end
 
     begin

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -145,11 +145,11 @@ module PilePull
     # "yellow-green potion", which could be the uncommon swirling or the rare
     # potent variant) are deliberately left unmapped rather than guessed at.
     FALLBACK_ITEM_FIXUPS = [
-      [/\brunner contract\b/i,     'a locker runner contract'],
-      [/\bGuild voucher pack\b/i,  "an Adventurer's Guild voucher pack"],
-      [/\bGuilds voucher pack\b/i, 'an Elanthian Guilds voucher pack'],
-      [/\bnexus orb\b/i,           'a swirling nexus orb'],
-      [/\bblue orb\b/i,            'a shimmering blue orb'],
+      [/\brunner contract\b/i,     'locker runner contract'],
+      [/\bGuild voucher pack\b/i,  "Adventurer's Guild voucher pack"],
+      [/\bGuilds voucher pack\b/i, 'Elanthian Guilds voucher pack'],
+      [/\bnexus orb\b/i,           'swirling nexus orb'],
+      [/\bblue orb\b/i,            'shimmering blue orb'],
     ].freeze unless const_defined?(:FALLBACK_ITEM_FIXUPS, false)
 
     Self.create_table?(:rewards) do

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -47,10 +47,15 @@
           required: Lich >= 5.12.4
        requirements:
         - sequel gem
-           version: 1.3.0
+           version: 1.3.1
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.1 (2026-09-05)
+    - Fix reward tier tracking for Shattered's actual prize pile: the booklet is
+      one tier less rare than originally tracked (epic -> rare), and the
+      Chronomage rush ticket isn't in Shattered's pile at all anymore. Any
+      booklet already recorded as epic is automatically corrected.
   v1.3.0 (2026-09-05)
     - Add ";pilepull rewards all" to combine reward totals across every character
       that has run this script, instead of just the current one.
@@ -123,9 +128,14 @@ module PilePull
     # Based on player-observed drop rates: 65% common / 22% uncommon / 10% rare /
     # 2% epic / 1% legendary, with an even chance for each item inside its tier.
     # Order matters: checked top to bottom, first match wins.
+    #
+    # Shattered's prize pile was rebuilt from Prime's table (the old one had been
+    # duping in something that was removed from Platinum years ago). Per Wyromzzz
+    # (GM), two Shattered-specific corrections vs. that copied Prime table:
+    #   - the booklet was pushed down a tier (epic -> rare)
+    #   - the Chronomage rush ticket was removed from Shattered's pile entirely
     TIER_PATTERNS = [
-      [/larger locker contract/i, 'common'],
-      [/Chronomage rush ticket/i,           'common'],
+      [/larger locker contract/i,           'common'],
       [/locker runner contract/i,           'common'],
       [/swirling yellow-green potion/i,     'uncommon'],
       [/Adventurer's Guild voucher pack/i,  'uncommon'],
@@ -133,7 +143,7 @@ module PilePull
       [/\bglowing orb\b/i,                  'rare'],
       [/swirling nexus orb/i,               'rare'],
       [/potent yellow-green potion/i,       'rare'],
-      [/creased stamped voucher booklet/i,  'epic'],
+      [/creased stamped voucher booklet/i,  'rare'],
       [/shimmering blue orb/i,              'epic'],
       [/small locker expansion contract/i,  'epic'],
       [/shimmering violet orb/i,            'legendary'],
@@ -209,6 +219,19 @@ module PilePull
       end
     rescue => e
       echo "Note: Could not migrate pilepull rewards database: #{e.message}"
+    end
+
+    # One-time fix: earlier versions of this script tiered the booklet as
+    # 'epic' before Shattered's prize pile was corrected (booklet moved down
+    # to 'rare', Chronomage rush ticket removed from Shattered entirely).
+    # Re-tier any already-recorded booklet rows so old data matches TIER_PATTERNS.
+    begin
+      Self[:rewards]
+        .where(type: 'item', tier: 'epic')
+        .where(Sequel.like(:item_name, '%booklet%'))
+        .update(tier: 'rare')
+    rescue => e
+      echo "Note: Could not correct pilepull rewards booklet tier: #{e.message}"
     end
 
     begin

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -51,6 +51,7 @@
           required: Lich >= 5.12.4
        requirements:
         - sequel gem
+        - terminal-table gem
            version: 1.2.0
 
   Improvements:
@@ -72,6 +73,7 @@
       item name capture, and reward tier/canonicalization decisions.
     - Fix reward tracking never actually recording an item on the normal
       (success) path; it only ever recorded silver spent searching.
+    - Render ";pilepull rewards" as a table instead of plain text lines.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -81,7 +83,7 @@
 =end
 
 # Load required gems with safety checks
-gems_to_load = ["sequel"]
+gems_to_load = ["sequel", "terminal-table"]
 failed_to_load = []
 
 gems_to_load.each do |gem|
@@ -371,8 +373,7 @@ module PilePull
         event_keys = (scope.select_map(:event_key)).compact.uniq.sort.reverse
 
         if event_keys.empty?
-          echo("=== PilePull rewards for #{scope_desc} ===")
-          echo("  No rewards recorded yet.")
+          echo("No PilePull rewards recorded yet for #{scope_desc}.")
           return
         end
 
@@ -383,14 +384,13 @@ module PilePull
       end
     end
 
-    # Prints the tier breakdown and silver spent for a single Duskruin event.
+    # Prints the tier breakdown and silver spent for a single Duskruin event
+    # as a Terminal::Table, matching the table style used by ledger.lic.
     #
     # @param scope [Sequel::Dataset] the character/all-characters filtered dataset to report on
     # @param key [Integer] the event_key identifying which Duskruin event to report
     # @param scope_desc [String] human-readable label for who this report covers
     def self.print_event_block(scope, key, scope_desc)
-      echo("=== PilePull rewards for #{scope_desc} - #{label_for_key(key)} ===")
-
       event_scope = scope.where(event_key: key)
 
       rows = event_scope
@@ -401,8 +401,13 @@ module PilePull
 
       total_items = rows.sum { |row| row[:count] }
 
+      table = Terminal::Table.new(
+        title: "PilePull rewards for #{scope_desc} - #{label_for_key(key)}",
+        headings: ['Item', 'Count', '% of Items']
+      )
+
       if rows.empty?
-        echo("  No items recorded yet.")
+        table << [{ value: 'No items recorded yet.', colspan: 3, alignment: :center }]
       else
         by_tier = rows.group_by { |row| row[:tier] || 'unknown' }
 
@@ -412,15 +417,22 @@ module PilePull
 
           tier_count = tier_rows.sum { |row| row[:count] }
           tier_pct = total_items.zero? ? 0 : (tier_count * 100.0 / total_items)
-          echo("#{tier.upcase} (#{tier_count}, #{'%.1f' % tier_pct}%)")
+          table << [{ value: "#{tier.upcase}  -  #{tier_count} (#{'%.1f' % tier_pct}%)", colspan: 3, alignment: :center }]
+          table.add_separator
+
           tier_rows.each do |row|
-            echo("  #{row[:item_name]}: #{row[:count]}")
+            item_pct = total_items.zero? ? 0 : (row[:count] * 100.0 / total_items)
+            table << [row[:item_name], row[:count], "#{'%.1f' % item_pct}%"]
           end
+          table.add_separator
         end
+
+        table << [{ value: 'Total', colspan: 2 }, total_items]
       end
 
+      _respond "<output class=\"mono\"/>\n#{table}\n<output class=\"\"/>"
+
       total_spent = event_scope.where(type: 'search').sum(:quantity) || 0
-      echo("Total items: #{total_items}")
       echo("Total silver spent searching: #{with_commas(total_spent)}")
       echo("")
     end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -61,6 +61,8 @@
     - Fix reward tracking occasionally recording a truncated item name (and
       corrects any already saved); unrecognized ";pilepull" arguments now show
       usage instead of starting a search.
+    - Fix reward tracking leaking a database connection every time the script
+      ran, which could leave the database file locked.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -110,7 +112,15 @@ module PilePull
   # or across the account. Mirrors the pattern used by ledger.lic.
   module Rewards
     @file = File.join(DATA_DIR, "pilepull.db")
-    Self = Sequel.sqlite(@file)
+
+    # Lich re-evaluates a .lic script's top-level code from scratch on every
+    # invocation within the same process, so a bare `Self = Sequel.sqlite(...)`
+    # would open a brand new connection to the same file on each run and
+    # orphan the previous one (nothing ever closes it), leaking a SQLite
+    # connection/file handle every time ";pilepull" is run. Guard it like the
+    # other per-process-lifetime constants below so the existing connection is
+    # reused instead.
+    Self = Sequel.sqlite(@file) unless const_defined?(:Self, false)
 
     # Known reward tiers, keyed by the item name pattern the game hands you.
     # Based on player-observed drop rates: 65% common / 22% uncommon / 10% rare /
@@ -257,7 +267,7 @@ module PilePull
       echo "Note: Could not add pilepull rewards index: #{e.message}"
     end
 
-    Transactions = Self[:rewards]
+    Transactions = Self[:rewards] unless const_defined?(:Transactions, false)
 
     def self.account_name
       return nil unless Object.const_defined?(:Account)

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -58,6 +58,9 @@
       every run on record.
     - Fix cleanup skipping a single leftover flexing arm token or potion.
     - Fix cleanup sometimes waiting the full timeout on an already-populated container.
+    - Fix reward tracking occasionally recording a truncated item name (and
+      corrects any already saved); unrecognized ";pilepull" arguments now show
+      usage instead of starting a search.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -132,6 +135,23 @@ module PilePull
     # Display order for tier breakdowns; also doubles as the set of valid tiers.
     TIER_ORDER = %w(legendary epic rare uncommon common unknown).freeze unless const_defined?(:TIER_ORDER, false)
 
+    # GameObj.right_hand/left_hand can occasionally report a partial/truncated
+    # name for an item before its data has fully settled (see handle_loot,
+    # which now re-reads the name via GameObj[id] after the item leaves your
+    # hands instead of trusting the hand object's name in the moment). These
+    # patterns recover the full item name from a handful of truncated
+    # fragments actually seen in the wild, so both new and already-recorded
+    # rows land in the right tier. Ambiguous fragments (e.g. a bare
+    # "yellow-green potion", which could be the uncommon swirling or the rare
+    # potent variant) are deliberately left unmapped rather than guessed at.
+    FALLBACK_ITEM_FIXUPS = [
+      [/\brunner contract\b/i,     'a locker runner contract'],
+      [/\bGuild voucher pack\b/i,  "an Adventurer's Guild voucher pack"],
+      [/\bGuilds voucher pack\b/i, 'an Elanthian Guilds voucher pack'],
+      [/\bnexus orb\b/i,           'a swirling nexus orb'],
+      [/\bblue orb\b/i,            'a shimmering blue orb'],
+    ].freeze unless const_defined?(:FALLBACK_ITEM_FIXUPS, false)
+
     Self.create_table?(:rewards) do
       primary_key :id
       String  :character
@@ -148,6 +168,12 @@ module PilePull
       Integer :month
       Integer :day
       Integer :hour
+    end
+
+    def self.canonical_name_for(item_name)
+      return item_name if item_name.nil?
+      _pattern, canonical = FALLBACK_ITEM_FIXUPS.find { |pattern, _canonical| item_name =~ pattern }
+      canonical || item_name
     end
 
     def self.tier_for(item_name)
@@ -203,6 +229,20 @@ module PilePull
       echo "Note: Could not migrate pilepull rewards database: #{e.message}"
     end
 
+    # Re-canonicalize and re-tier any rows recorded with one of the truncated
+    # names FALLBACK_ITEM_FIXUPS knows how to resolve. Scoped to tier =
+    # 'unknown' so it's cheap and self-limiting: once a row is fixed it no
+    # longer matches this filter, so this becomes a no-op on later runs.
+    begin
+      Self[:rewards].where(type: 'item', tier: 'unknown').each do |row|
+        canonical = canonical_name_for(row[:item_name])
+        next if canonical == row[:item_name]
+        Self[:rewards].where(id: row[:id]).update(item_name: canonical, tier: tier_for(canonical))
+      end
+    rescue => e
+      echo "Note: Could not canonicalize pilepull rewards item names: #{e.message}"
+    end
+
     begin
       unless Self.indexes(:rewards).key?(:pilepull_rewards_character_type_index)
         Self.add_index :rewards, [:character, :type], name: :pilepull_rewards_character_type_index
@@ -247,7 +287,8 @@ module PilePull
 
     def self.record_item(item_name, quantity: 1)
       return if item_name.nil? || item_name.to_s.empty?
-      record(type: 'item', item_name: item_name, tier: tier_for(item_name), quantity: quantity)
+      canonical = canonical_name_for(item_name)
+      record(type: 'item', item_name: canonical, tier: tier_for(canonical), quantity: quantity)
     end
 
     def self.record_search_cost(amount)
@@ -389,11 +430,6 @@ module PilePull
       hand = GameObj.right_hand
       item_name = hand.name
 
-      if hand.id && hand.id != recorded_id
-        Rewards.record_item(item_name)
-        recorded_id = hand.id
-      end
-
       case item_name
       when /booklet/
         fput('redeem booklet')
@@ -417,6 +453,15 @@ module PilePull
         return if GameObj.right_hand.id.nil? && GameObj.left_hand.id.nil?
         sleep(0.1)
       }
+
+      # Read the name back via GameObj[id] rather than trusting the hand
+      # object's name at the moment the item arrived: GameObj.right_hand/
+      # left_hand can occasionally report a partial/truncated name for the
+      # same item before its data has fully settled.
+      if hand.id && hand.id != recorded_id
+        Rewards.record_item(GameObj[hand.id].name)
+        recorded_id = hand.id
+      end
     end
 
     echo("Couldn't handle item received, likely full containers, exiting!")
@@ -611,6 +656,32 @@ when "rewards"
     all_characters: rewards_args.include?("all"),
     all_events: rewards_args.include?("history") || rewards_args.include?("years")
   )
-else
+when nil
   PilePull.main
+else
+  respond <<-TEXT
+  Usage:
+
+      ;pilepull           - will run the normal SEARCH of the pile
+      ;pilepull cleanup   - will attempt to cleanup bundlable items, which include:
+                              * glowing orbs
+                              * potent yellow-green potion
+                              * swirling yellow-green potion
+                              * Elanthian Guilds voucher pack
+                              * Adventurer's Guild voucher pack
+      ;pilepull rewards   - print a summary of items received this character has
+                            gotten during the current/most recent Duskruin event
+                            (broken down by reward tier: common/uncommon/rare/
+                            epic/legendary) and silver spent searching, tracked
+                            in a shared local database so it works correctly
+                            across multiple characters. Duskruin runs twice a
+                            year (Feb/Mar and Aug/Sep); each reward is tagged
+                            with the event it was earned in.
+      ;pilepull rewards all       - same, but combined across every character
+                                    that has used this database (not just you)
+      ;pilepull rewards history   - same, but shows every Duskruin event on
+                                    record instead of just the current one
+      ;pilepull rewards all history  - combine "all" and "history": every
+                                        character, every event
+  TEXT
 end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -5,57 +5,27 @@
   ;pilepull
   For use with the treasure pile put out for 1,000,000 silvers per search.
 
-  Start in front of a treasure pile to search.
-  Currently will withdraw 100,000,000 silvers per go (configurable, see --withdraw below)
-  and continue doing so until you have no more room in your STOW container or you are item capped.
+  Start in front of a treasure pile to search. Withdraws silver from the bank as
+  needed and keeps searching until your STOW container is full or you're item capped.
 
   Usage:
+      ;pilepull                         - search the pile
+      ;pilepull cleanup                 - bundle up glowing orbs, potions, and voucher packs
+      ;pilepull rewards [all] [history] - tier breakdown of items received + silver spent.
+                                           "all" = every character, "history" = every
+                                           Duskruin event on record (both combine)
 
-      ;pilepull           - will run the normal SEARCH of the pile
-      ;pilepull cleanup   - will attempt to cleanup bundlable items, which include:
-                              * glowing orbs
-                              * potent yellow-green potion
-                              * swirling yellow-green potion
-                              * Elanthian Guilds voucher pack
-                              * Adventurer's Guild voucher pack
-      ;pilepull rewards   - print a summary of items received this character has
-                            gotten during the current/most recent Duskruin event
-                            (broken down by reward tier: common/uncommon/rare/
-                            epic/legendary) and silver spent searching, tracked
-                            in a shared local database so it works correctly
-                            across multiple characters. Duskruin runs twice a
-                            year (Feb/Mar and Aug/Sep); each reward is tagged
-                            with the event it was earned in.
-      ;pilepull rewards all       - same, but combined across every character
-                                    that has used this database (not just you)
-      ;pilepull rewards history   - same, but shows every Duskruin event on
-                                    record instead of just the current one
-      ;pilepull rewards all history  - combine "all" and "history": every
-                                        character, every event
-
-  Add --debug to any of the above (in any position) for verbose logging of
-  search results, item name capture, and reward tier/canonicalization
-  decisions, e.g. ";pilepull --debug" or ";pilepull rewards all --debug".
-
-  The following can also be combined with any of the above, in any position,
-  to change what gets kept vs. trashed and how much silver gets withdrawn
-  per bank run. Each one is saved to CharSettings immediately, so it's
-  remembered on your next run without needing to edit the script:
-
-      ;pilepull --withdraw=<amount>             - silver per bank run
-                                                   (default: 100,000,000)
-      ;pilepull --keep-spoon[=on|off]           - keep a steel spoon instead
-                                                   of trashing it (default: off)
-      ;pilepull --keep-nexus[=on|off]           - keep a swirling nexus orb
-                                                   instead of trashing it (default: off)
-      ;pilepull --keep-runner-contract[=on|off] - keep a locker runner
-                                                   contract instead of trashing it (default: on)
-      ;pilepull --keep-locker-contract[=on|off] - keep a larger locker
-                                                   contract instead of trashing it (default: on)
+  Flags (combine with any command above, in any position; all but --debug are
+  saved to CharSettings and remembered on your next run):
+      --debug                          - verbose logging, for troubleshooting
+      --withdraw=<amount>              - silver withdrawn per bank run (default: 100,000,000)
+      --keep-spoon[=on|off]            - keep a steel spoon instead of trashing it (default: off)
+      --keep-nexus[=on|off]            - keep a nexus orb instead of trashing it (default: off)
+      --keep-runner-contract[=on|off]  - keep a locker runner contract (default: on)
+      --keep-locker-contract[=on|off]  - keep a larger locker contract (default: on)
 
   Examples:
       ;pilepull --withdraw=50000000
-      ;pilepull --keep-nexus=on cleanup
       ;pilepull cleanup --keep-locker-contract=off
 
             author: Tysong
@@ -71,34 +41,15 @@
   Improvements:
   Major_change.feature_addition.bugfix
   v1.2.0 (2026-09-05)
-    - Add reward tracking: items received and silver spent searching are saved to
-      a local database. Use ";pilepull rewards" for a tier breakdown of the
-      current Duskruin run, "all" to combine every character, and "history" for
-      every run on record.
-    - Fix cleanup skipping a single leftover flexing arm token or potion.
-    - Fix cleanup sometimes waiting the full timeout on an already-populated container.
-    - Fix reward tracking occasionally recording a truncated item name (and
-      corrects any already saved); unrecognized ";pilepull" arguments now show
-      usage instead of starting a search.
-    - Fix reward tracking leaking a database connection every time the script
-      ran, which could leave the database file locked.
-    - Add a "--debug" flag (usable with any command, e.g. ";pilepull --debug"
-      or ";pilepull rewards --debug") for verbose logging of search results,
-      item name capture, and reward tier/canonicalization decisions.
-    - Fix reward tracking never actually recording an item on the normal
-      (success) path; it only ever recorded silver spent searching.
-    - Fix reward tracking undercounting items (silver spent searching no
-      longer matches items received); a booklet or trashed nexus orb could
-      silently vanish from tracking, and add a booklet name fix-up.
-    - Render ";pilepull rewards" as a table instead of plain text lines.
-    - Fix a swirling yellow-green potion and a potent yellow-green potion
-      both being tracked as "unknown" tier; the pulled item's full name is
-      now read from the SEARCH result text itself, which tells them apart.
-    - Add options to keep (rather than trash) a locker runner contract or a
-      larger locker contract on receiving one, defaulting to keep for both.
-    - Add "--withdraw"/"--keep-*" CLI flags so the withdrawal amount and
-      every keep/trash choice can be changed without editing the script;
-      each is saved to CharSettings and remembered on your next run.
+    - Add reward tracking: see what you've pulled from the pile and how much
+      silver you've spent with ";pilepull rewards" (shown as a table).
+    - Add options to keep or trash a steel spoon, nexus orb, locker runner
+      contract, or larger locker contract when you receive one.
+    - Add a --withdraw option to change how much silver is withdrawn per bank
+      run. All options are remembered between runs.
+    - Add a --debug option for troubleshooting.
+    - Several accuracy fixes to reward tracking, and a couple of small
+      cleanup fixes (a lone leftover item no longer gets skipped).
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -908,38 +859,19 @@ when nil
 else
   respond <<-TEXT
   Usage:
+      ;pilepull                         - search the pile
+      ;pilepull cleanup                 - bundle up glowing orbs, potions, and voucher packs
+      ;pilepull rewards [all] [history] - tier breakdown of items received + silver spent.
+                                           "all" = every character, "history" = every
+                                           Duskruin event on record (both combine)
 
-      ;pilepull           - will run the normal SEARCH of the pile
-      ;pilepull cleanup   - will attempt to cleanup bundlable items, which include:
-                              * glowing orbs
-                              * potent yellow-green potion
-                              * swirling yellow-green potion
-                              * Elanthian Guilds voucher pack
-                              * Adventurer's Guild voucher pack
-      ;pilepull rewards   - print a summary of items received this character has
-                            gotten during the current/most recent Duskruin event
-                            (broken down by reward tier: common/uncommon/rare/
-                            epic/legendary) and silver spent searching, tracked
-                            in a shared local database so it works correctly
-                            across multiple characters. Duskruin runs twice a
-                            year (Feb/Mar and Aug/Sep); each reward is tagged
-                            with the event it was earned in.
-      ;pilepull rewards all       - same, but combined across every character
-                                    that has used this database (not just you)
-      ;pilepull rewards history   - same, but shows every Duskruin event on
-                                    record instead of just the current one
-      ;pilepull rewards all history  - combine "all" and "history": every
-                                        character, every event
-      --debug             - add to any of the above for verbose logging of
-                            search results, item name capture, and reward
-                            tier/canonicalization decisions
-
-  These can also be combined with any of the above, in any position; each
-  is saved to CharSettings immediately so it's remembered on your next run:
-      --withdraw=<amount>             - silver per bank run (default: 100,000,000)
-      --keep-spoon[=on|off]           - keep instead of trash a steel spoon (default: off)
-      --keep-nexus[=on|off]           - keep instead of trash a swirling nexus orb (default: off)
-      --keep-runner-contract[=on|off] - keep instead of trash a locker runner contract (default: on)
-      --keep-locker-contract[=on|off] - keep instead of trash a larger locker contract (default: on)
+  Flags (combine with any command above, in any position; all but --debug are
+  saved to CharSettings and remembered on your next run):
+      --debug                          - verbose logging, for troubleshooting
+      --withdraw=<amount>              - silver withdrawn per bank run (default: 100,000,000)
+      --keep-spoon[=on|off]            - keep a steel spoon instead of trashing it (default: off)
+      --keep-nexus[=on|off]            - keep a nexus orb instead of trashing it (default: off)
+      --keep-runner-contract[=on|off]  - keep a locker runner contract (default: on)
+      --keep-locker-contract[=on|off]  - keep a larger locker contract (default: on)
   TEXT
 end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -6,7 +6,7 @@
   For use with the treasure pile put out for 1,000,000 silvers per search.
 
   Start in front of a treasure pile to search.
-  Currently will withdraw 100,000,000 silvers per go (configurable manually in the script)
+  Currently will withdraw 100,000,000 silvers per go (configurable, see --withdraw below)
   and continue doing so until you have no more room in your STOW container or you are item capped.
 
   Usage:
@@ -37,12 +37,26 @@
   search results, item name capture, and reward tier/canonicalization
   decisions, e.g. ";pilepull --debug" or ";pilepull rewards all --debug".
 
-  There's also some variables in the script you can set to true/false
-  All default to false to throw away
-    * @withdraw_amount
-    * @keep_spoon
-    * @keep_wisp  (not yet implemented)
-    * @keep_nexus
+  The following can also be combined with any of the above, in any position,
+  to change what gets kept vs. trashed and how much silver gets withdrawn
+  per bank run. Each one is saved to CharSettings immediately, so it's
+  remembered on your next run without needing to edit the script:
+
+      ;pilepull --withdraw=<amount>             - silver per bank run
+                                                   (default: 100,000,000)
+      ;pilepull --keep-spoon[=on|off]           - keep a steel spoon instead
+                                                   of trashing it (default: off)
+      ;pilepull --keep-nexus[=on|off]           - keep a swirling nexus orb
+                                                   instead of trashing it (default: off)
+      ;pilepull --keep-runner-contract[=on|off] - keep a locker runner
+                                                   contract instead of trashing it (default: on)
+      ;pilepull --keep-locker-contract[=on|off] - keep a larger locker
+                                                   contract instead of trashing it (default: on)
+
+  Examples:
+      ;pilepull --withdraw=50000000
+      ;pilepull --keep-nexus=on cleanup
+      ;pilepull cleanup --keep-locker-contract=off
 
             author: Tysong
       contributors: everyone in shattered!
@@ -80,6 +94,11 @@
     - Fix a swirling yellow-green potion and a potent yellow-green potion
       both being tracked as "unknown" tier; the pulled item's full name is
       now read from the SEARCH result text itself, which tells them apart.
+    - Add options to keep (rather than trash) a locker runner contract or a
+      larger locker contract on receiving one, defaulting to keep for both.
+    - Add "--withdraw"/"--keep-*" CLI flags so the withdrawal amount and
+      every keep/trash choice can be changed without editing the script;
+      each is saved to CharSettings and remembered on your next run.
   v1.1.0 (2026-09-04)
     - ad logic to try to run cleanup if hit too many items
   v1.0.1 (2026-03-01)
@@ -114,13 +133,29 @@ module PilePull
   @max_inventory = false
   @last_pull_name = nil
 
-  # Set the amount to withdraw each time it goes to the bank
-  @withdraw_amount = 100_000_000
+  # Reads a per-character setting from CharSettings, seeding it with
+  # `default` (and persisting that) the first time it's read. A bare
+  # `CharSettings[key] ||= default` would work for everything here except
+  # `false` -- once a keep_* flag is legitimately set to `false`, `||=`
+  # would treat that as unset and keep rewriting the default over it.
+  def self.persisted_default(key, default)
+    value = CharSettings[key]
+    return value unless value.nil?
 
-  # Set the following on whether to TRASH them on receiving them
-  @keep_spoon = false
-  @keep_wisp  = false # not yet implemented
-  @keep_nexus = false
+    CharSettings[key] = default
+    default
+  end
+
+  # Configurable behavior, persisted per character via CharSettings so it
+  # survives between script runs without editing the script itself. Change
+  # these with the --withdraw/--keep-* flags (see parse_config_args below,
+  # and the usage block up top) rather than editing the values here directly.
+  @withdraw_amount      = persisted_default('withdraw_amount', 100_000_000)
+  @keep_spoon           = persisted_default('keep_spoon', false)
+  @keep_wisp            = false # not yet implemented
+  @keep_nexus           = persisted_default('keep_nexus', false)
+  @keep_runner_contract = persisted_default('keep_runner_contract', true)
+  @keep_locker_contract = persisted_default('keep_locker_contract', true)
 
   # --debug can appear anywhere after ";pilepull" (";pilepull --debug",
   # ";pilepull cleanup --debug", ";pilepull rewards --debug", etc.) and turns
@@ -140,6 +175,55 @@ module PilePull
   end
 
   dbg("debug mode enabled")
+
+  def self.parse_boolean_flag(value, default_true: true)
+    return default_true if value.nil? || value.to_s.empty?
+
+    case value.to_s.downcase
+    when 'true', 'on', '1', 'yes', 'y'
+      true
+    when 'false', 'off', '0', 'no', 'n'
+      false
+    else
+      echo("pilepull: unrecognized value #{value.inspect}, expected on/off")
+      default_true
+    end
+  end
+
+  # Parses --withdraw=<amount> and --keep-*[=on|off] flags out of `args`,
+  # updating the in-memory setting and persisting it to CharSettings
+  # immediately (no explicit save needed) so it's remembered on the next
+  # run. Returns `args` with every recognized config flag removed, so the
+  # caller can go on to look for a subcommand/--debug/etc. in what's left.
+  def self.parse_config_args(args)
+    args.reject do |arg|
+      case arg
+      when /^--withdraw(?:-amount)?=([\d,]+)$/i
+        amount = $1.delete(',').to_i
+        @withdraw_amount = CharSettings['withdraw_amount'] = amount
+        echo("pilepull: withdraw amount set to #{amount}")
+        true
+      when /^--keep-spoon(?:=(.+))?$/i
+        @keep_spoon = CharSettings['keep_spoon'] = parse_boolean_flag($1)
+        echo("pilepull: keep_spoon set to #{@keep_spoon}")
+        true
+      when /^--keep-nexus(?:=(.+))?$/i
+        @keep_nexus = CharSettings['keep_nexus'] = parse_boolean_flag($1)
+        echo("pilepull: keep_nexus set to #{@keep_nexus}")
+        true
+      when /^--keep-runner-contract(?:=(.+))?$/i
+        @keep_runner_contract = CharSettings['keep_runner_contract'] = parse_boolean_flag($1)
+        echo("pilepull: keep_runner_contract set to #{@keep_runner_contract}")
+        true
+      when /^--keep-locker-contract(?:=(.+))?$/i
+        @keep_locker_contract = CharSettings['keep_locker_contract'] = parse_boolean_flag($1)
+        echo("pilepull: keep_locker_contract set to #{@keep_locker_contract}")
+        true
+      else
+        false
+      end
+    end
+  end
 
   # Tracks rewards (items received) and silver spent searching, persisted to a
   # local Sequel/SQLite database. Several characters may run this script at the
@@ -587,6 +671,23 @@ module PilePull
         else
           fput('trash my orb')
         end
+      # Matches the trailing fragment rather than requiring "locker" up
+      # front: GameObj.right_hand.name can truncate "a locker runner
+      # contract" down to just "runner contract" (see canonical_name_for).
+      when /runner contract/
+        dbg("handle_loot[#{attempt}]: matched locker runner contract -> keep_runner_contract=#{@keep_runner_contract}")
+        if @keep_runner_contract
+          fput('stow all')
+        else
+          fput('trash my contract')
+        end
+      when /larger locker contract/
+        dbg("handle_loot[#{attempt}]: matched larger locker contract -> keep_locker_contract=#{@keep_locker_contract}")
+        if @keep_locker_contract
+          fput('stow all')
+        else
+          fput('trash my contract')
+        end
       else
         dbg("handle_loot[#{attempt}]: no special case matched -> stow all")
         fput('stow all')
@@ -786,10 +887,12 @@ module PilePull
   end
 end
 
-# --debug is stripped out here (rather than being matched as a subcommand)
-# so it can be combined with any of the below, in any position: ";pilepull
-# --debug", ";pilepull cleanup --debug", ";pilepull rewards all --debug", etc.
+# --debug and any --withdraw/--keep-* config flags are stripped out here
+# (rather than being matched as a subcommand) so they can be combined with
+# any of the below, in any position: ";pilepull --debug", ";pilepull cleanup
+# --keep-nexus=on", ";pilepull --withdraw=50000000 rewards all", etc.
 pilepull_args = (Script.current.vars[1..-1] || []).reject { |arg| arg.to_s.casecmp("--debug").zero? }
+pilepull_args = PilePull.parse_config_args(pilepull_args)
 
 case pilepull_args[0]
 when "cleanup"
@@ -830,5 +933,13 @@ else
       --debug             - add to any of the above for verbose logging of
                             search results, item name capture, and reward
                             tier/canonicalization decisions
+
+  These can also be combined with any of the above, in any position; each
+  is saved to CharSettings immediately so it's remembered on your next run:
+      --withdraw=<amount>             - silver per bank run (default: 100,000,000)
+      --keep-spoon[=on|off]           - keep instead of trash a steel spoon (default: off)
+      --keep-nexus[=on|off]           - keep instead of trash a swirling nexus orb (default: off)
+      --keep-runner-contract[=on|off] - keep instead of trash a locker runner contract (default: on)
+      --keep-locker-contract[=on|off] - keep instead of trash a larger locker contract (default: on)
   TEXT
 end

--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -108,6 +108,12 @@ module PilePull
   @keep_runner_contract = persisted_default('keep_runner_contract', true)
   @keep_locker_contract = persisted_default('keep_locker_contract', true)
 
+  # Read-only so the usage/help text (outside this module) can show the
+  # current value of each setting rather than a hardcoded default.
+  class << self
+    attr_reader :withdraw_amount, :keep_spoon, :keep_nexus, :keep_runner_contract, :keep_locker_contract
+  end
+
   # --debug can appear anywhere after ";pilepull" (";pilepull --debug",
   # ";pilepull cleanup --debug", ";pilepull rewards --debug", etc.) and turns
   # on verbose logging. This is computed here, before Rewards is defined
@@ -857,6 +863,9 @@ when "rewards"
 when nil
   PilePull.main
 else
+  on_off = ->(flag) { flag ? 'on' : 'off' }
+  withdraw_display = PilePull::Rewards.with_commas(PilePull.withdraw_amount)
+
   respond <<-TEXT
   Usage:
       ;pilepull                         - search the pile
@@ -868,10 +877,10 @@ else
   Flags (combine with any command above, in any position; all but --debug are
   saved to CharSettings and remembered on your next run):
       --debug                          - verbose logging, for troubleshooting
-      --withdraw=<amount>              - silver withdrawn per bank run (default: 100,000,000)
-      --keep-spoon[=on|off]            - keep a steel spoon instead of trashing it (default: off)
-      --keep-nexus[=on|off]            - keep a nexus orb instead of trashing it (default: off)
-      --keep-runner-contract[=on|off]  - keep a locker runner contract (default: on)
-      --keep-locker-contract[=on|off]  - keep a larger locker contract (default: on)
+      --withdraw=<amount>              - silver withdrawn per bank run (currently: #{withdraw_display})
+      --keep-spoon[=on|off]            - keep a steel spoon instead of trashing it (currently: #{on_off.call(PilePull.keep_spoon)})
+      --keep-nexus[=on|off]            - keep a nexus orb instead of trashing it (currently: #{on_off.call(PilePull.keep_nexus)})
+      --keep-runner-contract[=on|off]  - keep a locker runner contract (currently: #{on_off.call(PilePull.keep_runner_contract)})
+      --keep-locker-contract[=on|off]  - keep a larger locker contract (currently: #{on_off.call(PilePull.keep_locker_contract)})
   TEXT
 end

--- a/spec/scripts/pilepull_spec.rb
+++ b/spec/scripts/pilepull_spec.rb
@@ -1,0 +1,396 @@
+# Spec for pilepull.lic's reward tracking: name canonicalization/tiering and
+# the handle_loot control flow that decides what gets recorded.
+#
+# We do NOT load the .lic file: Rewards opens a SQLite database at
+# module-load time and needs the whole Lich runtime. Instead the real method
+# bodies are extracted from scripts/pilepull.lic and evaluated against
+# stubs, so these specs exercise production code and fail if that code
+# changes shape. Extraction uses the shared helpers in spec/spec_helper.rb.
+#
+# This file exists because of two real bugs that shipped and were only
+# caught by manually diffing search count against item count in --debug
+# output:
+#   1. `return` inside the `30.times { }` wait block in handle_loot unwinds
+#      the whole method, not just the block -- a Rewards.record_item call
+#      placed after that loop was silently skipped every time hands cleared
+#      quickly (i.e. almost always).
+#   2. Re-reading an item's name via GameObj[id] after redeeming/trashing it
+#      returns nil for a consumed/destroyed object (always true for a
+#      redeemed booklet or trashed orb), and record_item's nil guard then
+#      dropped the reward entirely rather than just mis-tiering it.
+# Every example under "handle_loot" is here to make a regression of either
+# bug fail loudly instead of silently undercounting again.
+
+require_relative '../spec_helper'
+
+module PilePullRewardsSpec
+  SOURCE_PATH = find_lic_source('pilepull.lic', from: __dir__)
+  SOURCE = File.read(SOURCE_PATH).gsub("\r\n", "\n")
+
+  def self.extract(pattern, label)
+    extract_from_source(SOURCE, pattern, label: label, source_path: SOURCE_PATH)
+  end
+
+  TIER_PATTERNS_SRC = extract(
+    /^    TIER_PATTERNS = \[.*?\]\.freeze unless const_defined\?\(:TIER_PATTERNS, false\)$/m,
+    'TIER_PATTERNS'
+  )
+  FALLBACK_ITEM_FIXUPS_SRC = extract(
+    /^    FALLBACK_ITEM_FIXUPS = \[.*?\]\.freeze unless const_defined\?\(:FALLBACK_ITEM_FIXUPS, false\)$/m,
+    'FALLBACK_ITEM_FIXUPS'
+  )
+  CANONICAL_NAME_FOR_SRC = extract_lic_method(SOURCE, 'canonical_name_for', source_path: SOURCE_PATH)
+  TIER_FOR_SRC = extract_lic_method(SOURCE, 'tier_for', source_path: SOURCE_PATH)
+  EVENT_HALF_SRC = extract_lic_method(SOURCE, 'event_half', source_path: SOURCE_PATH)
+  EVENT_KEY_FOR_SRC = extract_lic_method(SOURCE, 'event_key_for', source_path: SOURCE_PATH)
+  LABEL_FOR_KEY_SRC = extract_lic_method(SOURCE, 'label_for_key', source_path: SOURCE_PATH)
+  RECORD_ITEM_SRC = extract_lic_method(SOURCE, 'record_item', source_path: SOURCE_PATH)
+  HANDLE_LOOT_SRC = extract_lic_method(SOURCE, 'handle_loot', source_path: SOURCE_PATH)
+
+  # Real tier/canonicalization/event-bucketing logic under test, evaluated so
+  # bare XMLData and PilePull references resolve to the stand-ins nested here.
+  class RewardsLogic
+    module XMLData
+      class << self
+        attr_accessor :game
+      end
+    end
+
+    module PilePull
+      class << self
+        def dbg(_msg); end
+      end
+    end
+
+    module_eval(TIER_PATTERNS_SRC, SOURCE_PATH)
+    module_eval(FALLBACK_ITEM_FIXUPS_SRC, SOURCE_PATH)
+    module_eval(CANONICAL_NAME_FOR_SRC, SOURCE_PATH)
+    module_eval(TIER_FOR_SRC, SOURCE_PATH)
+    module_eval(EVENT_HALF_SRC, SOURCE_PATH)
+    module_eval(EVENT_KEY_FOR_SRC, SOURCE_PATH)
+    module_eval(LABEL_FOR_KEY_SRC, SOURCE_PATH)
+
+    class << self
+      attr_reader :record_calls
+
+      def reset!
+        @record_calls = []
+      end
+
+      # Stands in for Rewards.record (the real Sequel insert) so record_item
+      # can be tested without a database.
+      def record(type:, item_name: nil, tier: nil, quantity: 1)
+        (@record_calls ||= []) << { type: type, item_name: item_name, tier: tier, quantity: quantity }
+      end
+    end
+
+    module_eval(RECORD_ITEM_SRC, SOURCE_PATH)
+  end
+
+  # Real handle_loot control flow under test, with GameObj/Rewards stubbed
+  # locally (never at top level -- see spec_helper.rb's note on GameObj) and
+  # sleep/exit/echo/fput overridden as harness singleton methods so they take
+  # precedence over Kernel's for calls made with an implicit receiver, the
+  # same trick spec_helper documents for its own generic stubs.
+  class HandleLoot
+    FakeHand = Struct.new(:id, :name)
+
+    module GameObj
+      class << self
+        attr_accessor :right_hand, :left_hand
+
+        def clear_hands!
+          self.right_hand = FakeHand.new(nil, nil)
+          self.left_hand = FakeHand.new(nil, nil)
+        end
+      end
+    end
+
+    module Rewards
+      class << self
+        attr_reader :recorded
+
+        def reset!
+          @recorded = []
+        end
+
+        def record_item(item_name, quantity: 1)
+          @recorded << [item_name, quantity]
+        end
+      end
+    end
+
+    class << self
+      attr_accessor :keep_spoon, :keep_nexus, :stuck
+      attr_reader :fput_calls, :sleep_count, :exited, :echoed
+
+      def reset!
+        @keep_spoon = false
+        @keep_nexus = false
+        @stuck = false
+        @fput_calls = []
+        @sleep_count = 0
+        @exited = false
+        @echoed = []
+        GameObj.clear_hands!
+        Rewards.reset!
+      end
+
+      def dbg(_msg); end
+
+      def echo(msg)
+        @echoed << msg
+      end
+
+      # Simulates the action succeeding immediately (hands clear) unless the
+      # test has set `stuck`, matching a real "containers full" run where
+      # the item never leaves your hands no matter what you do with it.
+      def fput(command)
+        @fput_calls << command
+        GameObj.clear_hands! unless stuck
+        command
+      end
+
+      # Overrides Kernel#sleep for the 30.times wait loop's bare sleep(0.1)
+      # so a "stuck" example does not actually block for 3 real seconds.
+      def sleep(*)
+        @sleep_count += 1
+      end
+
+      # Overrides Kernel#exit the same way, turning the real script's
+      # process-ending exit into something a test can observe and unwind
+      # from safely.
+      def exit(*)
+        @exited = true
+        throw :handle_loot_exit
+      end
+    end
+
+    module_eval(HANDLE_LOOT_SRC, SOURCE_PATH)
+
+    def self.run
+      catch(:handle_loot_exit) { handle_loot }
+    end
+  end
+end
+
+RSpec.describe 'pilepull.lic reward tracking' do
+  def rewards_logic
+    PilePullRewardsSpec::RewardsLogic
+  end
+
+  def handle_loot
+    PilePullRewardsSpec::HandleLoot
+  end
+
+  def fake_hand
+    PilePullRewardsSpec::HandleLoot::FakeHand
+  end
+
+  describe 'Rewards.canonical_name_for' do
+    {
+      'runner contract'         => 'locker runner contract',
+      'Guild voucher pack'      => "Adventurer's Guild voucher pack",
+      'Guilds voucher pack'     => 'Elanthian Guilds voucher pack',
+      'nexus orb'               => 'swirling nexus orb',
+      'blue orb'                => 'shimmering blue orb',
+      'stamped voucher booklet' => 'creased stamped voucher booklet'
+    }.each do |truncated, canonical|
+      it "recovers #{truncated.inspect} (a fragment actually seen from GameObj) to #{canonical.inspect}" do
+        expect(rewards_logic.canonical_name_for(truncated)).to eq(canonical)
+      end
+    end
+
+    it 'leaves an already-full name alone' do
+      expect(rewards_logic.canonical_name_for('locker runner contract')).to eq('locker runner contract')
+    end
+
+    it 'does not guess at a genuinely ambiguous fragment' do
+      # Could be the uncommon swirling or the rare potent variant -- guessing
+      # would silently corrupt data rather than fix it.
+      expect(rewards_logic.canonical_name_for('yellow-green potion')).to eq('yellow-green potion')
+    end
+
+    it 'passes nil through without raising' do
+      expect(rewards_logic.canonical_name_for(nil)).to be_nil
+    end
+  end
+
+  describe 'Rewards.tier_for' do
+    after { rewards_logic::XMLData.game = nil }
+
+    {
+      'larger locker contract'          => 'common',
+      'locker runner contract'          => 'common',
+      'swirling yellow-green potion'    => 'uncommon',
+      "Adventurer's Guild voucher pack" => 'uncommon',
+      'Elanthian Guilds voucher pack'   => 'uncommon',
+      'glowing orb'                     => 'rare',
+      'swirling nexus orb'              => 'rare',
+      'potent yellow-green potion'      => 'rare',
+      'shimmering blue orb'             => 'epic',
+      'small locker expansion contract' => 'epic',
+      'shimmering violet orb'           => 'legendary'
+    }.each do |name, tier|
+      it "tiers #{name.inspect} as #{tier}" do
+        rewards_logic::XMLData.game = 'GS'
+        expect(rewards_logic.tier_for(name)).to eq(tier)
+      end
+    end
+
+    it 'tiers the booklet as epic outside Shattered' do
+      rewards_logic::XMLData.game = 'GS'
+      expect(rewards_logic.tier_for('creased stamped voucher booklet')).to eq('epic')
+    end
+
+    it 'tiers the booklet one tier down (rare) specifically on Shattered (GSF)' do
+      rewards_logic::XMLData.game = 'GSF'
+      expect(rewards_logic.tier_for('creased stamped voucher booklet')).to eq('rare')
+    end
+
+    it 'does not apply the GSF booklet override to an unrelated item' do
+      rewards_logic::XMLData.game = 'GSF'
+      expect(rewards_logic.tier_for('glowing orb')).to eq('rare')
+    end
+
+    it 'returns unknown for an unrecognized item rather than raising' do
+      rewards_logic::XMLData.game = 'GS'
+      expect(rewards_logic.tier_for('a mysterious trinket')).to eq('unknown')
+    end
+
+    it 'returns unknown for nil' do
+      expect(rewards_logic.tier_for(nil)).to eq('unknown')
+    end
+  end
+
+  describe 'Rewards.record_item' do
+    before { rewards_logic.reset! }
+
+    it 'canonicalizes and tiers a truncated name before recording' do
+      rewards_logic::XMLData.game = 'GS'
+      rewards_logic.record_item('runner contract')
+      expect(rewards_logic.record_calls).to eq(
+        [{ type: 'item', item_name: 'locker runner contract', tier: 'common', quantity: 1 }]
+      )
+    end
+
+    # This is the exact failure mode of bug #2: a nil name (what
+    # GameObj[id] returned for a redeemed booklet/trashed orb) must not
+    # silently vanish -- it must be visibly refused, not recorded as
+    # anything.
+    it 'refuses to record a nil item name' do
+      rewards_logic.record_item(nil)
+      expect(rewards_logic.record_calls).to be_empty
+    end
+
+    it 'refuses to record a blank item name' do
+      rewards_logic.record_item('')
+      expect(rewards_logic.record_calls).to be_empty
+    end
+
+    after { rewards_logic::XMLData.game = nil }
+  end
+
+  describe 'Rewards event bucketing' do
+    it 'buckets January through June as the Feb/Mar event' do
+      expect(rewards_logic.event_key_for(2026, 1)).to eq(20_261)
+      expect(rewards_logic.event_key_for(2026, 6)).to eq(20_261)
+    end
+
+    it 'buckets July through December as the Aug/Sep event' do
+      expect(rewards_logic.event_key_for(2026, 7)).to eq(20_262)
+      expect(rewards_logic.event_key_for(2026, 12)).to eq(20_262)
+    end
+
+    it 'labels an event key with the year and the correct half' do
+      expect(rewards_logic.label_for_key(20_261)).to eq('2026 Duskruin (Feb/Mar)')
+      expect(rewards_logic.label_for_key(20_262)).to eq('2026 Duskruin (Aug/Sep)')
+    end
+
+    it 'labels a nil key without raising' do
+      expect(rewards_logic.label_for_key(nil)).to eq('unknown event')
+    end
+  end
+
+  describe 'handle_loot' do
+    before { handle_loot.reset! }
+
+    # Regression test for bug #1: `return` inside the 30.times wait block
+    # unwinds handle_loot entirely, not just the block. If Rewards.record_item
+    # were ever moved back below that wait loop, this example would start
+    # failing because hands clearing immediately (the overwhelmingly common
+    # case) would skip recording every time.
+    it 'records the item even when hands clear on the very first check' do
+      handle_loot::GameObj.right_hand = fake_hand.new('111', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['a larger locker contract', 1]])
+    end
+
+    # Regression test for bug #2: recording must not depend on re-reading the
+    # item's name after the action, since that lookup returns nil once the
+    # object has been destroyed (a redeemed booklet, a trashed orb).
+    it 'records a booklet using the name captured before redeeming it' do
+      handle_loot::GameObj.right_hand = fake_hand.new('222', 'a creased stamped voucher booklet')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['a creased stamped voucher booklet', 1]])
+      expect(handle_loot.fput_calls).to include('redeem booklet')
+    end
+
+    it 'records a nexus orb using the name captured before trashing it' do
+      handle_loot::GameObj.right_hand = fake_hand.new('333', 'a swirling nexus orb')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['a swirling nexus orb', 1]])
+      expect(handle_loot.fput_calls).to include('trash my orb')
+    end
+
+    it 'stows a nexus orb instead of trashing it when keep_nexus is set' do
+      handle_loot.keep_nexus = true
+      handle_loot::GameObj.right_hand = fake_hand.new('333', 'a swirling nexus orb')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to include('stow all')
+      expect(handle_loot.fput_calls).not_to include('trash my orb')
+    end
+
+    it 'trashes an unwanted steel spoon' do
+      handle_loot::GameObj.right_hand = fake_hand.new('444', 'a steel spoon')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to include('trash my spoon')
+    end
+
+    it 'stows a steel spoon instead of trashing it when keep_spoon is set' do
+      handle_loot.keep_spoon = true
+      handle_loot::GameObj.right_hand = fake_hand.new('444', 'a steel spoon')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to include('stow all')
+      expect(handle_loot.fput_calls).not_to include('trash my spoon')
+    end
+
+    it 'stows anything else that has no special handling' do
+      handle_loot::GameObj.right_hand = fake_hand.new('555', 'a locker runner contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['stow all'])
+    end
+
+    it 'does not record the same item id twice' do
+      handle_loot.stuck = true
+      handle_loot::GameObj.right_hand = fake_hand.new('666', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['a larger locker contract', 1]])
+    end
+
+    it 'falls back to the "couldn\'t handle" exit path when hands never clear' do
+      handle_loot.stuck = true
+      handle_loot::GameObj.right_hand = fake_hand.new('777', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot.exited).to be true
+      expect(handle_loot.echoed.join).to match(/Couldn't handle item received/)
+    end
+
+    it 'never reaches the exit path when hands do clear' do
+      handle_loot::GameObj.right_hand = fake_hand.new('888', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot.exited).to be false
+      expect(handle_loot.echoed).to be_empty
+    end
+  end
+end

--- a/spec/scripts/pilepull_spec.rb
+++ b/spec/scripts/pilepull_spec.rb
@@ -46,6 +46,7 @@ module PilePullRewardsSpec
   LABEL_FOR_KEY_SRC = extract_lic_method(SOURCE, 'label_for_key', source_path: SOURCE_PATH)
   RECORD_ITEM_SRC = extract_lic_method(SOURCE, 'record_item', source_path: SOURCE_PATH)
   HANDLE_LOOT_SRC = extract_lic_method(SOURCE, 'handle_loot', source_path: SOURCE_PATH)
+  SEARCH_PILE_SRC = extract_lic_method(SOURCE, 'search_pile', source_path: SOURCE_PATH)
 
   # Real tier/canonicalization/event-bucketing logic under test, evaluated so
   # bare XMLData and PilePull references resolve to the stand-ins nested here.
@@ -121,13 +122,14 @@ module PilePullRewardsSpec
     end
 
     class << self
-      attr_accessor :keep_spoon, :keep_nexus, :stuck
+      attr_accessor :keep_spoon, :keep_nexus, :stuck, :last_pull_name
       attr_reader :fput_calls, :sleep_count, :exited, :echoed
 
       def reset!
         @keep_spoon = false
         @keep_nexus = false
         @stuck = false
+        @last_pull_name = nil
         @fput_calls = []
         @sleep_count = 0
         @exited = false
@@ -172,6 +174,82 @@ module PilePullRewardsSpec
       catch(:handle_loot_exit) { handle_loot }
     end
   end
+
+  # Real search_pile control flow under test. The point of this harness is
+  # the @last_pull_name it captures for handle_loot to consume: the search
+  # response text spells out a pulled item's full name, unlike
+  # GameObj.right_hand.name in handle_loot, which truncates a swirling and a
+  # potent yellow-green potion to the exact same ambiguous fragment.
+  class SearchPile
+    Pile = Struct.new(:id)
+
+    module Rewards
+      class << self
+        attr_reader :calls
+
+        def reset!
+          @calls = []
+        end
+
+        def record_search_cost(amount)
+          (@calls ||= []) << amount
+        end
+      end
+    end
+
+    class << self
+      attr_accessor :max_inventory, :last_pull_name
+      attr_reader :dothistimeout_calls, :echoed, :exited, :sleep_calls
+
+      def reset!
+        @prize_pile = Pile.new('50993552')
+        @max_inventory = false
+        @last_pull_name = nil
+        @dothistimeout_calls = []
+        @next_results = []
+        @echoed = []
+        @exited = false
+        @sleep_calls = []
+      end
+
+      # Queues a value dothistimeout should return on its next call --
+      # search_pile's `next`-driven retries can call it more than once in a
+      # single example (e.g. a "search again" retry before it succeeds).
+      def queue_result(value)
+        (@next_results ||= []) << value
+      end
+
+      def dothistimeout(command, _timeout, _pattern)
+        @dothistimeout_calls << command
+        @next_results.shift
+      end
+
+      def dbg(_msg); end
+
+      def echo(msg)
+        @echoed << msg
+      end
+
+      def exit(*)
+        @exited = true
+        throw :search_pile_exit
+      end
+
+      def sleep(seconds)
+        @sleep_calls << seconds
+      end
+
+      def waitrt?
+        false
+      end
+    end
+
+    module_eval(SEARCH_PILE_SRC, SOURCE_PATH)
+
+    def self.run
+      catch(:search_pile_exit) { search_pile }
+    end
+  end
 end
 
 RSpec.describe 'pilepull.lic reward tracking' do
@@ -185,6 +263,10 @@ RSpec.describe 'pilepull.lic reward tracking' do
 
   def fake_hand
     PilePullRewardsSpec::HandleLoot::FakeHand
+  end
+
+  def search_pile
+    PilePullRewardsSpec::SearchPile
   end
 
   describe 'Rewards.canonical_name_for' do
@@ -391,6 +473,127 @@ RSpec.describe 'pilepull.lic reward tracking' do
       handle_loot.run
       expect(handle_loot.exited).to be false
       expect(handle_loot.echoed).to be_empty
+    end
+
+    # GameObj.right_hand.name truncates a swirling and a potent yellow-green
+    # potion to the exact same "yellow-green potion" fragment -- genuinely
+    # ambiguous, and previously always landed as "unknown" tier. search_pile
+    # parses the full name out of the search response text and stashes it in
+    # @last_pull_name for handle_loot to prefer.
+    it 'prefers the full name captured by search_pile over an ambiguous truncated hand name' do
+      handle_loot.last_pull_name = 'swirling yellow-green potion'
+      handle_loot::GameObj.right_hand = fake_hand.new('999', 'yellow-green potion')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['swirling yellow-green potion', 1]])
+    end
+
+    it 'clears last_pull_name after using it, so a later item cannot inherit a stale name' do
+      handle_loot.last_pull_name = 'swirling yellow-green potion'
+      handle_loot::GameObj.right_hand = fake_hand.new('999', 'yellow-green potion')
+      handle_loot.run
+      expect(handle_loot.last_pull_name).to be_nil
+    end
+
+    it 'falls back to the hand name when search_pile did not capture anything' do
+      handle_loot::GameObj.right_hand = fake_hand.new('999', 'a locker runner contract')
+      handle_loot.run
+      expect(handle_loot::Rewards.recorded).to eq([['a locker runner contract', 1]])
+    end
+  end
+
+  describe 'search_pile' do
+    before do
+      search_pile.reset!
+      search_pile::Rewards.reset!
+    end
+
+    it 'records 1,000,000 silver spent on a successful search' do
+      search_pile.queue_result(
+        'You hand over 1,000,000 silver and search through a pile of mania prizes.  ' \
+        'You pull a locker runner contract from within!'
+      )
+      expect(search_pile.run).to be true
+      expect(search_pile::Rewards.calls).to eq([1_000_000])
+    end
+
+    {
+      'swirling yellow-green potion'    => 'a',
+      'potent yellow-green potion'      => 'a',
+      'glowing orb'                     => 'a',
+      'creased stamped voucher booklet' => 'a',
+      "Adventurer's Guild voucher pack" => 'an',
+      'Elanthian Guilds voucher pack'   => 'an'
+    }.each do |pulled, article|
+      it "captures the full pulled item name for #{pulled.inspect} from the search text" do
+        search_pile.queue_result(
+          "You hand over 1,000,000 silver and search through a pile of mania prizes.  " \
+          "You pull #{article} #{pulled} from within!"
+        )
+        search_pile.run
+        expect(search_pile.last_pull_name).to eq(pulled)
+      end
+    end
+
+    # This is the actual bug this whole harness exists to catch: a truncated
+    # GameObj.right_hand.name cannot tell these two apart, but the search
+    # result text always spells out which one it was.
+    it 'tells a swirling yellow-green potion apart from a potent one' do
+      search_pile.queue_result(
+        'You hand over 1,000,000 silver and search through a pile of mania prizes.  ' \
+        'You pull a swirling yellow-green potion from within!'
+      )
+      search_pile.run
+      swirling_name = search_pile.last_pull_name
+
+      search_pile.reset!
+      search_pile::Rewards.reset!
+      search_pile.queue_result(
+        'You hand over 1,000,000 silver and search through a pile of mania prizes.  ' \
+        'You pull a potent yellow-green potion from within!'
+      )
+      search_pile.run
+      potent_name = search_pile.last_pull_name
+
+      expect([swirling_name, potent_name]).to eq(['swirling yellow-green potion', 'potent yellow-green potion'])
+    end
+
+    it 'clears any previous last_pull_name rather than raising when the text does not match the expected shape' do
+      search_pile.last_pull_name = 'stale'
+      search_pile.queue_result('You hand over 1,000,000 silver and search through a pile of mania prizes.')
+      search_pile.run
+      expect(search_pile.last_pull_name).to be_nil
+    end
+
+    it 'retries once told to search again within 30 seconds' do
+      search_pile.queue_result(
+        'In order to search through a pile of mania prizes, it will cost 1,000,000 silver.  ' \
+        'If you want to give it a try SEARCH again within 30 seconds!'
+      )
+      search_pile.queue_result(
+        'You hand over 1,000,000 silver and search through a pile of mania prizes.  ' \
+        'You pull a larger locker contract from within!'
+      )
+      expect(search_pile.run).to be true
+      expect(search_pile.dothistimeout_calls.length).to eq(2)
+    end
+
+    it 'returns false when out of silver, recording nothing' do
+      search_pile.queue_result('You do not have enough silver to SEARCH through a pile of mania prizes.  You need 1,000,000 silver.')
+      expect(search_pile.run).to be false
+      expect(search_pile::Rewards.calls).to be_empty
+    end
+
+    it 'returns false the first time too many items blocks the search, to trigger cleanup once' do
+      search_pile.queue_result('You have too many items to search.')
+      expect(search_pile.run).to be false
+      expect(search_pile.max_inventory).to be true
+    end
+
+    it 'gives up instead of looping forever if still too many items on the very next search' do
+      search_pile.max_inventory = true
+      search_pile.queue_result('You have too many items to search.')
+      search_pile.run
+      expect(search_pile.exited).to be true
     end
   end
 end

--- a/spec/scripts/pilepull_spec.rb
+++ b/spec/scripts/pilepull_spec.rb
@@ -47,6 +47,9 @@ module PilePullRewardsSpec
   RECORD_ITEM_SRC = extract_lic_method(SOURCE, 'record_item', source_path: SOURCE_PATH)
   HANDLE_LOOT_SRC = extract_lic_method(SOURCE, 'handle_loot', source_path: SOURCE_PATH)
   SEARCH_PILE_SRC = extract_lic_method(SOURCE, 'search_pile', source_path: SOURCE_PATH)
+  PERSISTED_DEFAULT_SRC = extract_lic_method(SOURCE, 'persisted_default', source_path: SOURCE_PATH)
+  PARSE_BOOLEAN_FLAG_SRC = extract_lic_method(SOURCE, 'parse_boolean_flag', source_path: SOURCE_PATH)
+  PARSE_CONFIG_ARGS_SRC = extract_lic_method(SOURCE, 'parse_config_args', source_path: SOURCE_PATH)
 
   # Real tier/canonicalization/event-bucketing logic under test, evaluated so
   # bare XMLData and PilePull references resolve to the stand-ins nested here.
@@ -122,12 +125,14 @@ module PilePullRewardsSpec
     end
 
     class << self
-      attr_accessor :keep_spoon, :keep_nexus, :stuck, :last_pull_name
+      attr_accessor :keep_spoon, :keep_nexus, :keep_runner_contract, :keep_locker_contract, :stuck, :last_pull_name
       attr_reader :fput_calls, :sleep_count, :exited, :echoed
 
       def reset!
         @keep_spoon = false
         @keep_nexus = false
+        @keep_runner_contract = true
+        @keep_locker_contract = true
         @stuck = false
         @last_pull_name = nil
         @fput_calls = []
@@ -250,6 +255,49 @@ module PilePullRewardsSpec
       catch(:search_pile_exit) { search_pile }
     end
   end
+
+  # Real config-flag parsing/persistence under test, with CharSettings
+  # stubbed as a plain in-memory hash nested here (never at top level).
+  class ConfigFlags
+    module CharSettings
+      class << self
+        def reset!
+          @store = {}
+        end
+
+        def [](key)
+          (@store ||= {})[key]
+        end
+
+        def []=(key, value)
+          (@store ||= {})[key] = value
+        end
+      end
+    end
+
+    class << self
+      attr_accessor :withdraw_amount, :keep_spoon, :keep_nexus, :keep_runner_contract, :keep_locker_contract
+      attr_reader :echoed
+
+      def reset!
+        @withdraw_amount = 100_000_000
+        @keep_spoon = false
+        @keep_nexus = false
+        @keep_runner_contract = true
+        @keep_locker_contract = true
+        @echoed = []
+        CharSettings.reset!
+      end
+
+      def echo(msg)
+        @echoed << msg
+      end
+    end
+
+    module_eval(PERSISTED_DEFAULT_SRC, SOURCE_PATH)
+    module_eval(PARSE_BOOLEAN_FLAG_SRC, SOURCE_PATH)
+    module_eval(PARSE_CONFIG_ARGS_SRC, SOURCE_PATH)
+  end
 end
 
 RSpec.describe 'pilepull.lic reward tracking' do
@@ -267,6 +315,10 @@ RSpec.describe 'pilepull.lic reward tracking' do
 
   def search_pile
     PilePullRewardsSpec::SearchPile
+  end
+
+  def config
+    PilePullRewardsSpec::ConfigFlags
   end
 
   describe 'Rewards.canonical_name_for' do
@@ -448,9 +500,45 @@ RSpec.describe 'pilepull.lic reward tracking' do
     end
 
     it 'stows anything else that has no special handling' do
-      handle_loot::GameObj.right_hand = fake_hand.new('555', 'a locker runner contract')
+      handle_loot::GameObj.right_hand = fake_hand.new('555', 'an Elanthian Guilds voucher pack')
       handle_loot.run
       expect(handle_loot.fput_calls).to eq(['stow all'])
+    end
+
+    it 'keeps (stows) a locker runner contract by default' do
+      handle_loot::GameObj.right_hand = fake_hand.new('556', 'a locker runner contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['stow all'])
+    end
+
+    it 'trashes a locker runner contract when keep_runner_contract is turned off' do
+      handle_loot.keep_runner_contract = false
+      handle_loot::GameObj.right_hand = fake_hand.new('557', 'a locker runner contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['trash my contract'])
+    end
+
+    # GameObj.right_hand.name can truncate "a locker runner contract" down
+    # to just "runner contract" (see canonical_name_for) -- the dispatch
+    # here has to match on the truncated form too, not just the full name.
+    it 'trashes a truncated "runner contract" hand name the same as the full name' do
+      handle_loot.keep_runner_contract = false
+      handle_loot::GameObj.right_hand = fake_hand.new('558', 'runner contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['trash my contract'])
+    end
+
+    it 'keeps (stows) a larger locker contract by default' do
+      handle_loot::GameObj.right_hand = fake_hand.new('559', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['stow all'])
+    end
+
+    it 'trashes a larger locker contract when keep_locker_contract is turned off' do
+      handle_loot.keep_locker_contract = false
+      handle_loot::GameObj.right_hand = fake_hand.new('560', 'a larger locker contract')
+      handle_loot.run
+      expect(handle_loot.fput_calls).to eq(['trash my contract'])
     end
 
     it 'does not record the same item id twice' do
@@ -594,6 +682,106 @@ RSpec.describe 'pilepull.lic reward tracking' do
       search_pile.queue_result('You have too many items to search.')
       search_pile.run
       expect(search_pile.exited).to be true
+    end
+  end
+
+  describe 'config flag parsing' do
+    before { config.reset! }
+
+    describe 'parse_boolean_flag' do
+      it 'defaults to true when no value is given' do
+        expect(config.parse_boolean_flag(nil)).to be true
+      end
+
+      it 'honors an explicit default_true: false for a bare flag' do
+        expect(config.parse_boolean_flag(nil, default_true: false)).to be false
+      end
+
+      %w[true on 1 yes y TRUE ON YES].each do |value|
+        it "parses #{value.inspect} as true" do
+          expect(config.parse_boolean_flag(value)).to be true
+        end
+      end
+
+      %w[false off 0 no n FALSE OFF NO].each do |value|
+        it "parses #{value.inspect} as false" do
+          expect(config.parse_boolean_flag(value)).to be false
+        end
+      end
+
+      it 'falls back to the default and warns for an unrecognized value' do
+        expect(config.parse_boolean_flag('maybe', default_true: false)).to be false
+        expect(config.echoed.join).to match(/unrecognized value/)
+      end
+    end
+
+    describe 'parse_config_args' do
+      it 'sets and persists the withdraw amount' do
+        remaining = config.parse_config_args(['--withdraw=50000000'])
+        expect(config.withdraw_amount).to eq(50_000_000)
+        expect(config::CharSettings['withdraw_amount']).to eq(50_000_000)
+        expect(remaining).to be_empty
+      end
+
+      it 'accepts --withdraw-amount as an alias and strips commas from the amount' do
+        config.parse_config_args(['--withdraw-amount=50,000,000'])
+        expect(config.withdraw_amount).to eq(50_000_000)
+      end
+
+      it 'turns keep_nexus on and persists it' do
+        config.parse_config_args(['--keep-nexus=on'])
+        expect(config.keep_nexus).to be true
+        expect(config::CharSettings['keep_nexus']).to be true
+      end
+
+      it 'turns keep_runner_contract off and persists it' do
+        config.parse_config_args(['--keep-runner-contract=off'])
+        expect(config.keep_runner_contract).to be false
+        expect(config::CharSettings['keep_runner_contract']).to be false
+      end
+
+      it 'turns keep_locker_contract off and persists it' do
+        config.parse_config_args(['--keep-locker-contract=off'])
+        expect(config.keep_locker_contract).to be false
+      end
+
+      it 'defaults a bare flag with no =value to true' do
+        config.parse_config_args(['--keep-spoon'])
+        expect(config.keep_spoon).to be true
+      end
+
+      it 'leaves an unrelated argument alone' do
+        remaining = config.parse_config_args(['cleanup', '--keep-nexus=on'])
+        expect(remaining).to eq(['cleanup'])
+      end
+
+      it 'combines multiple flags given in one call' do
+        config.parse_config_args(['--withdraw=25000000', '--keep-spoon=on', '--keep-nexus=on'])
+        expect(config.withdraw_amount).to eq(25_000_000)
+        expect(config.keep_spoon).to be true
+        expect(config.keep_nexus).to be true
+      end
+    end
+
+    describe 'persisted_default' do
+      it 'seeds and returns the default the first time a key is read' do
+        expect(config.persisted_default('foo', 42)).to eq(42)
+        expect(config::CharSettings['foo']).to eq(42)
+      end
+
+      # The whole reason this helper exists instead of a bare
+      # `CharSettings[key] ||= default`: `||=` treats a stored `false` as
+      # unset and would keep overwriting it with a truthy default.
+      it 'returns a stored false rather than overwriting it with a truthy default' do
+        config::CharSettings['bar'] = false
+        expect(config.persisted_default('bar', true)).to be false
+        expect(config::CharSettings['bar']).to be false
+      end
+
+      it 'returns an already-stored value as-is without touching it' do
+        config::CharSettings['baz'] = 999
+        expect(config.persisted_default('baz', 1)).to eq(999)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- New script `pilepull.lic` for the Shattered event's treasure pile: searches the pile, disposes of/redeems received prizes (booklets, spoons, nexus orbs, everything else), and a `;pilepull cleanup` mode that bundles/pours/trashes leftover bundlable loot.
- Tracks item rewards and silver spent per character in a local Sequel/SQLite database (`DATA_DIR/pilepull.db`) rather than a shared YAML/JSON file, since multiple characters may run this concurrently and SQLite handles concurrent inserts safely.
- `;pilepull rewards` reports a tier breakdown (common/uncommon/rare/epic/legendary, with % of total) and silver spent, scoped to the current character and current/most-recent Duskruin event by default. `all` combines every character in the database; `history` (or `years`) shows every Duskruin event on record instead of just the latest; the two combine (`;pilepull rewards all history`).
- Each reward is tagged with the Duskruin event it was earned in (Feb/Mar or Aug/Sep of that year), since this script will be reused across multiple future Duskruin runs.

## Test plan
- [x] `ruby -c scripts/pilepull.lic` — syntax check passes
- [x] `rubocop scripts/pilepull.lic` — no offenses
- [x] Verified the Sequel/SQLite reward-tracking logic (tier grouping/percentages, event-key bucketing/sorting, per-character vs. all-characters scoping, current-event vs. history) against a standalone SQLite database outside of Lich, since this can't be exercised through the RSpec harness or a live game session
- [ ] Live smoke test in front of an actual Shattered treasure pile (`;pilepull`, `;pilepull cleanup`, `;pilepull rewards`) — not done, no live event access during this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)