### PR TITLE
Fix Pestilence (716) self-cast duration

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -843,7 +843,7 @@
       <cost type='mana'>15</cost>
    </spell>
    <spell availability='self-cast' name='Pestilence' number='716' type='defense'>
-      <duration span='stackable' multicastable='yes'>20 + Spells.sorcerer</duration>
+      <duration span='stackable' multicastable='yes'>120 + Spells.sorcerer</duration>
       <cost type='mana'>16</cost>
       <message type='start'>A cankerous ripple of vesicles temporarily disfigures your face and travels down your body, leaving a sickly green miasma as it disappears\.</message>
       <message type='end'>You exhale the last of a virulent green mist\.</message>


### PR DESCRIPTION
## Summary

Correct Pestilence's self-cast duration formula from `20 + Spells.sorcerer` to `120 + Spells.sorcerer`.

The live game reports 140 minutes for a character with 20 Sorcerer ranks. [GSWiki documents the duration](https://gswiki.play.net/Pestilence_(716)) as 2 hours plus 60 seconds per Sorcerer spell rank, which matches `120 + ranks` minutes.

## Validation

- Confirmed the XML remains valid.
- Confirmed the corrected formula evaluates to 140 minutes at 20 Sorcerer ranks.
- Confirmed Lich's focused spell specs pass: 35 examples, 0 failures.