### PR TITLE
fix(eloot): v2.11.7 jewelry the gemshop declines can still sell at the pawnshop

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.6
+           version: 2.11.7
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.7 (2026-09-07)
+    - fix: jewelry-tagged items the gemshop won't handle (like some headbands) now get
+      sold at the pawnshop instead of being put back in your loot untouched
   v2.11.6 (2026-09-04)
     - fix: gem/reagent hoard reset could come back empty when run before eloot had looted
       anything yet this session
@@ -353,7 +356,7 @@ module ELoot # Data
   class Data
     attr_accessor :disk, :disk_full, :sacks_full, :ready_method, :settings, :skinners, :skinsheath, :silent_open, :checked_bags,
                   :close_regex, :look_regex, :sacks_closed, :all_loot_categories, :regex_gold_rings, :right_hand, :left_hand, :skin_edged, :skin_blunt,
-                  :coin_hand, :coin_container, :silver_breakdown, :over_max, :pawn_recheck, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables,
+                  :coin_hand, :coin_container, :silver_breakdown, :over_max, :pawn_recheck, :jewelry_wrong_shop, :get_regex, :put_regex, :alchemy_mode, :sell_containers, :local_gemshop, :local_furrier, :log_unlootables,
                   :charm, :gauntlet, :coin_bag, :account_type, :locker, :container_settings, :everything_list, :everything,
                   :only_list, :only, :inventory, :gem_inventory, :alchemy_inventory, :hoard_type, :cache, :locker_city, :use_hoarding, :stash,
                   :items_to_hoard, :hoard_deposit, :inv_save, :deposit_regex, :withdraw_regex, :disk_nouns_regex, :sigil_determination_on_fail, :start_room, :last_called,
@@ -439,6 +442,7 @@ module ELoot # Data
       @silver_breakdown = Hash.new(0)
       @over_max = []
       @pawn_recheck = []
+      @jewelry_wrong_shop = []
       @inv_save = true
 
       $sell_ignore = []
@@ -5760,8 +5764,8 @@ module ELoot # Sells the loot
       { raw: raw, amount: raw.delete(',').to_i }
     end
 
-    def self.appraise(item, location, _data = nil)
-      return if item.type =~ /jewelry/ && location == "Pawnshop"
+    def self.appraise(item, location, _data = nil, skip_jewelry_guard: false, note: nil)
+      return if item.type =~ /jewelry/ && location == "Pawnshop" && !skip_jewelry_guard
 
       amount = 0
       raw = nil
@@ -5776,6 +5780,12 @@ module ELoot # Sells the loot
       end
 
       gemshop_refused = location =~ /gemshop/i && lines.any? { |l| l =~ /not buying anything this valuable today/ }
+
+      # The jeweler doesn't consider this item real jewelry ("That's not quite
+      # my field... I only deal in gems and jewelry"), as opposed to refusing
+      # it for being too valuable. Distinct case: the gemshop is simply the
+      # wrong shop for it.
+      wrong_specialty_refused = location =~ /gemshop/i && lines.any? { |l| l =~ /not quite my field|only deal in gems and jewelry/ }
 
       if amount > limit.to_i || lines.any? { |l| l =~ /not buying anything this valuable today/ }
         message = amount > limit.to_i ? " The #{item} appraises for #{raw}. That's above your settings." : " The #{item} appraises as too valuable to sell."
@@ -5794,8 +5804,9 @@ module ELoot # Sells the loot
             value: amount,
             raw: raw,
             shop: location,
-            stowed: (container.to_s.empty? ? nil : container)
-          }
+            stowed: (container.to_s.empty? ? nil : container),
+            note: note
+          }.compact
         end
 
         # The gemshop wouldn't even quote a price ("not buying anything this
@@ -5810,6 +5821,13 @@ module ELoot # Sells the loot
         else
           Inventory.store_item(container, item)
         end
+      elsif wrong_specialty_refused
+        # The loot data may still list the pawnshop as a valid market for this
+        # item even though the jeweler won't touch it -- queue it for a real
+        # sell attempt there instead of leaving it stuck in your loot forever.
+        (ELoot.data.jewelry_wrong_shop ||= []) << item if item.sellable.include?("pawnshop")
+
+        Inventory.single_drag(item)
       elsif amount.positive? && amount <= limit.to_i
         Sell.sell_item(item, location, ELoot.data.silver_breakdown)
       else
@@ -5870,11 +5888,49 @@ module ELoot # Sells the loot
       ELoot.data.pawn_recheck = []
     end
 
+    # Items the jeweler declined as not being their specialty ("That's not
+    # quite my field... I only deal in gems and jewelry") get a genuine sell
+    # attempt at the pawnshop, since the loot data already lists it as a valid
+    # market for them. Unlike recheck_refused_at_pawnshop (an opt-in,
+    # appraise-only second opinion for items the gemshop found too valuable),
+    # this always runs and always tries to sell -- the gemshop's refusal here
+    # is an unambiguous signal that the pawnshop is the correct shop, not a
+    # fallback. Anything still over the pawnshop limit lands in the over_max
+    # breakdown, same as any other appraisal.
+    def self.retry_wrong_shop_jewelry_at_pawnshop
+      items = Array(ELoot.data.jewelry_wrong_shop).compact
+      return if items.empty?
+
+      ELoot.msg(type: "info", text: " Selling #{items.length} gemshop-declined item(s) at the pawnshop...", space: true)
+
+      pawn = Room.current.find_nearest_by_tag("pawnshop")
+      if pawn.nil?
+        ELoot.msg(type: "info", text: " No pawnshop found nearby; leaving the declined items with your loot.")
+        return
+      end
+      ELoot.go2("pawnshop")
+
+      items.each do |item|
+        next if item.nil?
+
+        # Bring it back to hand (drag reopens containers and refinds by id).
+        Inventory.drag(item)
+        obj = [GameObj.right_hand, GameObj.left_hand].find { |h| h && !h.id.nil? && h.id == item.id }
+        next if obj.nil?
+
+        Sell.appraise(obj, "Pawnshop", ELoot.data.silver_breakdown, skip_jewelry_guard: true, note: "gemshop declined (not jewelry), over pawnshop limit")
+      end
+
+      ELoot.data.jewelry_wrong_shop = []
+    end
+
     # Shared tail for every sell flow: drain any gemshop-refused items to the
-    # pawnshop (no-op unless sell_pawn_recheck is on and something was queued),
+    # pawnshop (no-op unless sell_pawn_recheck is on and something was queued,
+    # or a gemshop-declined non-jewelry item needs a real sell attempt there),
     # then deposit. Keeps the custom entrypoints in step with the main flow.
     def self.finish_sell_run
       Sell.recheck_refused_at_pawnshop
+      Sell.retry_wrong_shop_jewelry_at_pawnshop
       ELoot.silver_deposit(true)
     end
 
@@ -5925,13 +5981,22 @@ module ELoot # Sells the loot
     # Build Terminal::Table rows for items that appraised above the user's
     # gemshop/pawnshop limit (captured during Sell.appraise). Pure and testable:
     # takes the over_max record array, returns rows (arrays / :separator / header
-    # hashes), most valuable first. Items the gemshop refused (re-appraised at the
-    # pawnshop, flagged with :note) are grouped under their own subheading.
+    # hashes), most valuable first. Items flagged with a :note (gemshop refused
+    # or gemshop declined as not real jewelry) are grouped under their own
+    # subheadings, each following its own :note text.
     def self.over_max_rows(records)
       return [] if records.nil? || records.empty?
 
-      refused = records.select { |r| r[:note] }
-      normal  = records - refused
+      # Headings for the distinct :note values that can land in over_max --
+      # keyed on the exact note text set where the record is built
+      # (Sell.appraise, recheck_refused_at_pawnshop, retry_wrong_shop_jewelry_at_pawnshop).
+      note_headings = {
+        "gemshop refused, pawn appraisal"                     => "Gemshop refused, pawn appraisals:",
+        "gemshop declined (not jewelry), over pawnshop limit" => "Gemshop declined (not jewelry), over pawnshop limit:"
+      }
+
+      grouped = records.group_by { |r| r[:note] }
+      normal  = grouped.delete(nil) || []
       by_value = ->(list) { list.sort_by { |r| -r[:value].to_i } }
       item_row = ->(r) { [ELoot.capitalize_words(r[:item].to_s), "   " + (r[:raw] || ELoot.format_number(r[:value])).to_s] }
 
@@ -5949,11 +6014,13 @@ module ELoot # Sells the loot
 
       by_value.call(normal).each { |r| rows << item_row.call(r) }
 
-      if refused.any?
-        rows << :separator if normal.any?
+      section_added = normal.any?
+      grouped.each do |note, items|
+        rows << :separator if section_added
         # Two-cell (not colspan) so the column separator pipe still renders.
-        rows << ['Gemshop refused, pawn appraisals:', '']
-        by_value.call(refused).each { |r| rows << item_row.call(r) }
+        rows << [note_headings.fetch(note, "#{note.capitalize}:"), '']
+        by_value.call(items).each { |r| rows << item_row.call(r) }
+        section_added = true
       end
 
       rows
@@ -7698,6 +7765,7 @@ module ELoot # Starts the script
   ELoot.data.silver_breakdown = Hash.new(0)
   ELoot.data.over_max = []
   ELoot.data.pawn_recheck = []
+  ELoot.data.jewelry_wrong_shop = []
 
   case Script.current.vars[0]
   when /debug/

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -5909,6 +5909,7 @@ module ELoot # Sells the loot
         return
       end
       ELoot.go2("pawnshop")
+      start_silvers = ELoot.silver_check
 
       items.each do |item|
         next if item.nil?
@@ -5921,6 +5922,7 @@ module ELoot # Sells the loot
         Sell.appraise(obj, "Pawnshop", ELoot.data.silver_breakdown, skip_jewelry_guard: true, note: "gemshop declined (not jewelry), over pawnshop limit")
       end
 
+      ELoot.data.silver_breakdown["Pawnshop"] += (ELoot.silver_check - start_silvers)
       ELoot.data.jewelry_wrong_shop = []
     end
 

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -1510,3 +1510,198 @@ RSpec.describe 'ELoot unskinnable-list management' do
     expect(messages.last[:text]).to include('greater earth elemental')
   end
 end
+
+# Regression coverage for a jewelry-typed item (e.g. "plain velvet headband") whose
+# `sellable` still lists the pawnshop, but the gemshop's jeweler declines it as not
+# their specialty ("That's not quite my field... I only deal in gems and jewelry"),
+# rather than quoting a too-high price. Before this fix Sell.appraise treated that as
+# an ordinary "no offer" and just stowed the item back, with no way to ever attempt
+# the pawnshop -- the item would cycle through every future sell run untouched. This
+# also covers the `skip_jewelry_guard:` escape hatch Sell.appraise now takes so the
+# pawnshop retry pass can actually appraise/sell an item its own jewelry/Pawnshop
+# early-return would otherwise unconditionally block.
+#
+# Same extraction approach as the rest of this file: real method bodies pulled from
+# eloot.lic and module_eval'd into a bare harness alongside named stubs for their
+# collaborators (ELoot.get_command/msg/ensure_items/data, StowList, Inventory,
+# Sell.sell_item), so the spec fails loudly instead of silently drifting if the
+# shipped logic changes shape.
+RSpec.describe 'ELoot::Sell.appraise' do
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(eloot_path) }
+
+  let(:item_class) { Struct.new(:id, :name, :type, :sellable) }
+  let(:data_class) { Struct.new(:settings, :over_max, :pawn_recheck, :jewelry_wrong_shop) }
+
+  let(:settings) { { sell_appraise_gemshop: 14_999, sell_appraise_pawnshop: 4_999, sell_pawn_recheck: false } }
+  let(:data) { data_class.new(settings, [], [], []) }
+
+  # What the game sends back in response to the "appraise <item>" command, as the
+  # single matching line get_command would hand back. Each context overrides this
+  # with one of the real merchant responses to drive the branch under test.
+  let(:response) { nil }
+
+  let(:calls) { [] }
+
+  let(:harness) do
+    recorder = calls
+    reply = response
+    data_obj = data
+
+    mod = Module.new
+    mod.define_singleton_method(:get_command) do |command, _regex, **kw|
+      recorder << [:get_command, command, kw]
+      reply.nil? ? [] : [reply]
+    end
+    mod.define_singleton_method(:msg) { |**kw| recorder << [:msg, kw] }
+    mod.define_singleton_method(:ensure_items) { |**kw| recorder << [:ensure_items, kw] }
+    mod.define_singleton_method(:data) { data_obj }
+    mod.const_set(:ELoot, mod)
+
+    stow_list = Module.new
+    stow_list.define_singleton_method(:stow_list) { Hash.new('') }
+    mod.const_set(:StowList, stow_list)
+
+    inventory = Module.new
+    inventory.define_singleton_method(:single_drag) { |item| recorder << [:single_drag, item.name] }
+    inventory.define_singleton_method(:store_item) { |container, item| recorder << [:store_item, container, item.name] }
+    mod.const_set(:Inventory, inventory)
+
+    mod.module_eval(extract_lic_method(source, 'parse_appraisal', source_path: eloot_path))
+    mod.define_singleton_method(:sell_item) { |item, place, _data| recorder << [:sell_item, item.name, place] }
+    mod.module_eval(extract_lic_method(source, 'appraise', source_path: eloot_path))
+    mod.const_set(:Sell, mod)
+    mod
+  end
+
+  context 'the gemshop declines an item as not its specialty' do
+    let(:response) { 'The jeweler Etaenia says, "That\'s not quite my field, Renian.  I only deal in gems and jewelry."' }
+    let(:headband) { item_class.new('112890498', 'a plain velvet headband', 'jewelry', 'gemshop,pawnshop') }
+
+    it 'queues the item for a pawnshop sell attempt' do
+      harness.appraise(headband, 'Gemshop')
+
+      expect(data.jewelry_wrong_shop).to eq([headband])
+    end
+
+    it 'stows the item back rather than leaving it in hand' do
+      harness.appraise(headband, 'Gemshop')
+
+      expect(calls).to include([:single_drag, 'a plain velvet headband'])
+    end
+
+    it 'does not record it as over_max or queue it for the appraise-only pawn recheck' do
+      harness.appraise(headband, 'Gemshop')
+
+      expect(data.over_max).to be_empty
+      expect(data.pawn_recheck).to be_empty
+    end
+
+    context 'when the item is not declared sellable at the pawnshop' do
+      let(:headband) { item_class.new('112890498', 'a plain velvet headband', 'jewelry', 'gemshop') }
+
+      it 'does not queue it (nowhere else to sell it)' do
+        harness.appraise(headband, 'Gemshop')
+
+        expect(data.jewelry_wrong_shop).to be_empty
+      end
+    end
+  end
+
+  context 'the gemshop refuses an item as too valuable (distinct from "not my field")' do
+    let(:response) { 'The jeweler says, "I\'m not buying anything this valuable today."' }
+    let(:ring) { item_class.new('1', 'a platinum ring', 'jewelry', 'gemshop,pawnshop') }
+
+    it 'does not queue it for the wrong-shop pawnshop retry' do
+      harness.appraise(ring, 'Gemshop')
+
+      expect(data.jewelry_wrong_shop).to be_empty
+    end
+  end
+
+  context 'the jewelry/Pawnshop early-return guard' do
+    let(:necklace) { item_class.new('1', 'a gold necklace', 'jewelry', 'gemshop,pawnshop') }
+
+    it 'blocks appraisal at the pawnshop by default' do
+      harness.appraise(necklace, 'Pawnshop')
+
+      expect(calls).to be_empty
+    end
+
+    it 'is bypassed with skip_jewelry_guard: true, so the pawnshop retry pass can still appraise it' do
+      harness.appraise(necklace, 'Pawnshop', skip_jewelry_guard: true)
+
+      expect(calls.map(&:first)).to include(:get_command)
+    end
+  end
+
+  context 'a sold item still tags over_max with the note it was appraised with' do
+    let(:response) { 'The jeweler says, "I\'ll give you 50,000 for it if you want to sell it."' }
+    let(:necklace) { item_class.new('1', 'a gold necklace', 'jewelry', 'gemshop,pawnshop') }
+
+    it 'carries the note through into the over_max record when over limit' do
+      harness.appraise(necklace, 'Pawnshop', skip_jewelry_guard: true, note: 'gemshop declined (not jewelry), over pawnshop limit')
+
+      expect(data.over_max.first[:note]).to eq('gemshop declined (not jewelry), over pawnshop limit')
+    end
+  end
+end
+
+# Sell.over_max_rows renders the "Over Max Value" breakdown table. It groups records
+# with no :note together, then groups notes into their own subheadings -- originally
+# just the one "Gemshop refused, pawn appraisals:" case, now generalized so a second,
+# distinct note (added for the gemshop-declined-as-not-jewelry case above) gets its
+# own heading instead of being merged into the first one under a misleading label.
+RSpec.describe 'ELoot::Sell.over_max_rows' do
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(eloot_path) }
+
+  let(:harness) do
+    mod = Module.new
+    eloot = Module.new
+    eloot.define_singleton_method(:capitalize_words) { |s| s.split.map(&:capitalize).join(' ') }
+    eloot.define_singleton_method(:format_number) { |n| n.to_s }
+    mod.const_set(:ELoot, eloot)
+    mod.module_eval(extract_lic_method(source, 'over_max_rows', source_path: eloot_path))
+    mod
+  end
+
+  it 'returns an empty array for no records' do
+    expect(harness.over_max_rows([])).to eq([])
+    expect(harness.over_max_rows(nil)).to eq([])
+  end
+
+  it 'lists un-noted records under the plain header, most valuable first' do
+    records = [
+      { item: 'a small gem', value: 100, raw: '100', stowed: nil },
+      { item: 'a large gem', value: 500, raw: '500', stowed: nil }
+    ]
+
+    rows = harness.over_max_rows(records)
+
+    expect(rows).to include(['A Large Gem', '   500'])
+    expect(rows.index(['A Large Gem', '   500'])).to be < rows.index(['A Small Gem', '   100'])
+  end
+
+  it 'gives each distinct note its own subheading, not a shared one' do
+    records = [
+      { item: 'a heavy diamond', value: 900_000, raw: '900,000', stowed: nil, note: 'gemshop refused, pawn appraisal' },
+      { item: 'a plain velvet headband', value: 200, raw: '200', stowed: nil, note: 'gemshop declined (not jewelry), over pawnshop limit' }
+    ]
+
+    rows = harness.over_max_rows(records)
+
+    expect(rows).to include(['Gemshop refused, pawn appraisals:', ''])
+    expect(rows).to include(['Gemshop declined (not jewelry), over pawnshop limit:', ''])
+    expect(rows).to include(['A Heavy Diamond', '   900,000'])
+    expect(rows).to include(['A Plain Velvet Headband', '   200'])
+  end
+
+  it 'falls back to a capitalized version of the note text for an unmapped note' do
+    records = [{ item: 'a mystery item', value: 10, raw: '10', stowed: nil, note: 'some future refusal reason' }]
+
+    rows = harness.over_max_rows(records)
+
+    expect(rows).to include(['Some future refusal reason:', ''])
+  end
+end

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -1647,6 +1647,107 @@ RSpec.describe 'ELoot::Sell.appraise' do
   end
 end
 
+# retry_wrong_shop_jewelry_at_pawnshop's whole purpose (its second commit, added after
+# review) is the start_silvers/silver_check wrapper that folds ordinary per-item pawnshop
+# sale proceeds into the breakdown -- Sell.sell_item only records proceeds itself when a
+# bulk-sale note is produced, so without this wrapper silvers earned here would silently
+# vanish from the final report. Exercised directly (Sell.appraise stubbed out) so a future
+# edit that drops or misplaces the wrapper fails a test instead of only showing up as a
+# short breakdown total in a live session.
+RSpec.describe 'ELoot::Sell.retry_wrong_shop_jewelry_at_pawnshop' do
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(eloot_path) }
+
+  let(:item_class) { Struct.new(:id, :name, :type, :sellable) }
+  let(:hand_class) { Struct.new(:id) }
+  let(:data_class) { Struct.new(:settings, :over_max, :pawn_recheck, :jewelry_wrong_shop, :silver_breakdown) }
+
+  let(:headband) { item_class.new('1', 'a plain velvet headband', 'jewelry', 'gemshop,pawnshop') }
+  let(:queued) { [headband] }
+  let(:pawn_found) { true }
+  # [before, after] ELoot.silver_check readings the wrapper diffs -- a 250 silver gain.
+  let(:silver_sequence) { [1000, 1250] }
+  let(:calls) { [] }
+
+  let(:data) { data_class.new({}, [], [], queued, Hash.new(0)) }
+
+  let(:harness) do
+    recorder = calls
+    data_obj = data
+    silvers = silver_sequence.dup
+    found = pawn_found
+    hand_item = headband
+    hand_struct = hand_class
+
+    mod = Module.new
+    mod.define_singleton_method(:msg) { |**kw| recorder << [:msg, kw] }
+    mod.define_singleton_method(:go2) { |place| recorder << [:go2, place] }
+    mod.define_singleton_method(:silver_check) { silvers.shift }
+    mod.define_singleton_method(:data) { data_obj }
+    mod.const_set(:ELoot, mod)
+
+    room = Module.new
+    current = Module.new
+    current.define_singleton_method(:find_nearest_by_tag) { |_tag| found ? 'pawnshop-room' : nil }
+    room.define_singleton_method(:current) { current }
+    mod.const_set(:Room, room)
+
+    inventory = Module.new
+    inventory.define_singleton_method(:drag) { |item| recorder << [:drag, item.name] }
+    mod.const_set(:Inventory, inventory)
+
+    game_obj = Module.new
+    game_obj.define_singleton_method(:right_hand) { hand_struct.new(hand_item.id) }
+    game_obj.define_singleton_method(:left_hand) { hand_struct.new(nil) }
+    mod.const_set(:GameObj, game_obj)
+
+    mod.define_singleton_method(:appraise) { |item, place, _data, **kw| recorder << [:appraise, item.id, place, kw] }
+    mod.module_eval(extract_lic_method(source, 'retry_wrong_shop_jewelry_at_pawnshop', source_path: eloot_path))
+    mod.const_set(:Sell, mod)
+    mod
+  end
+
+  it 'does nothing when the queue is empty' do
+    mod = harness
+    empty_data = data_class.new({}, [], [], [], Hash.new(0))
+    mod.define_singleton_method(:data) { empty_data }
+
+    mod.retry_wrong_shop_jewelry_at_pawnshop
+
+    expect(calls).to be_empty
+  end
+
+  context 'when no pawnshop is nearby' do
+    let(:pawn_found) { false }
+
+    it 'reports it and leaves the queue untouched, without ever reading silver_check' do
+      harness.retry_wrong_shop_jewelry_at_pawnshop
+
+      expect(data.jewelry_wrong_shop).to eq([headband])
+      expect(calls.map(&:first)).not_to include(:go2, :appraise)
+    end
+  end
+
+  it 'adds the pawnshop silver delta to the breakdown' do
+    harness.retry_wrong_shop_jewelry_at_pawnshop
+
+    expect(data.silver_breakdown['Pawnshop']).to eq(250)
+  end
+
+  it 'clears the retry queue after processing' do
+    harness.retry_wrong_shop_jewelry_at_pawnshop
+
+    expect(data.jewelry_wrong_shop).to eq([])
+  end
+
+  it 'drags each item and re-appraises it at the pawnshop with the guard bypassed' do
+    harness.retry_wrong_shop_jewelry_at_pawnshop
+
+    expect(calls).to include([:drag, 'a plain velvet headband'])
+    expect(calls).to include([:appraise, '1', 'Pawnshop', { skip_jewelry_guard: true, note: 'gemshop declined (not jewelry), over pawnshop limit' }])
+  end
+end
+
 # Sell.over_max_rows renders the "Over Max Value" breakdown table. It groups records
 # with no :note together, then groups notes into their own subheadings -- originally
 # just the one "Gemshop refused, pawn appraisals:" case, now generalized so a second,


### PR DESCRIPTION
## Summary
- Some jewelry-typed items (e.g. "plain velvet headband") declare `sellable: gemshop,pawnshop`, but the gemshop's jeweler declines them as not their specialty ("That's not quite my field... I only deal in gems and jewelry.") instead of quoting a price. `Sell.appraise` treated that the same as a plain "no offer" and just stowed the item back, with no attempt at the pawnshop — and `appraise`'s own `jewelry`+`Pawnshop` early-return guard would have blocked that path anyway. The item ends up cycling through every future `;eloot sell` run, dragged out and put back, never actually sold.
- Detects this "wrong specialty" refusal distinctly from the existing "too valuable" gemshop-refused case (which already has an opt-in, appraise-only pawnshop recheck). When it fires and the item's `sellable` already lists `pawnshop`, the item is queued and, after the gemshop pass, actually taken to the pawnshop and sold — via a new `skip_jewelry_guard:` keyword on `Sell.appraise` that lets this specific, pre-vetted retry bypass its own jewelry/pawnshop guard.
- Anything still over the pawnshop limit lands in the existing "Over Max Value" breakdown, now grouped under its own subheading instead of being merged into the unrelated "Gemshop refused, pawn appraisals" note.

## Test plan
- [x] Added specs in `spec/scripts/eloot_spec.rb` covering: the new refusal detection and queuing (including the "not declared sellable at pawnshop" no-op case), the guard/`skip_jewelry_guard:` bypass, and the generalized `over_max_rows` note-grouping.
- [x] `bundle exec rspec` — 22011 examples, 0 failures.
- [x] `bundle exec rubocop -A scripts/eloot.lic spec/scripts/eloot_spec.rb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jewelry items declined by the gemshop as outside its specialty are now retried at the pawnshop when eligible.
  * Items that cannot be sold at the pawnshop continue to be stowed safely.
  * Over-limit sale reporting now separates gemshop refusals by reason for clearer results.

* **Improvements**
  * “Over Max Value” breakdowns now use distinct headings for different refusal types.
  * Updated to version 2.11.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->