### PR TITLE
feat(gauntletcharger): migrate to EO as author

### DIFF
--- a/scripts/gauntletcharger.lic
+++ b/scripts/gauntletcharger.lic
@@ -260,6 +260,7 @@ module GauntletCharger
 
   def self.load_tracking
     return {} unless File.exist?(TRACKING_FILE)
+
     data = YAML.load_file(TRACKING_FILE)
     data.is_a?(Hash) ? data : {}
   rescue => e
@@ -279,6 +280,7 @@ module GauntletCharger
   # at max capacity (those don't reflect the item's true value).
   def self.update_tracking(tracking, item_name, value)
     return if tracking.nil?
+
     entry = tracking[item_name] ||= { "count" => 0, "min" => value, "max" => value, "total" => 0 }
     entry["count"] += 1
     entry["min"]    = [entry["min"], value].min
@@ -326,9 +328,9 @@ module GauntletCharger
   #   --wand=silver            (unquoted single token, terminated at whitespace)
   # Returns nil if no --wand flag is present.
   def self.extract_wand_arg(args)
-    if    (m = args.match(/--wand="([^"]+)"/))   then m[1].strip
-    elsif (m = args.match(/--wand='([^']+)'/))   then m[1].strip
-    elsif (m = args.match(/--wand=(\S+)/))       then m[1].strip
+    if    (m = args.match(/--wand="([^"]+)"/)) then m[1].strip
+    elsif (m = args.match(/--wand='([^']+)'/)) then m[1].strip
+    elsif (m = args.match(/--wand=(\S+)/))     then m[1].strip
     else  nil
     end
   end
@@ -340,7 +342,7 @@ module GauntletCharger
   #   :clear    - flag present with empty value
   #   String    - flag value
   def self.extract_exclude_arg(args)
-    if    args =~ /--exclude=""|--exclude=''/    then :clear
+    if    args =~ /--exclude=""|--exclude=''/ then :clear
     elsif (m = args.match(/--exclude="([^"]+)"/)) then m[1].strip
     elsif (m = args.match(/--exclude='([^']+)'/)) then m[1].strip
     elsif (m = args.match(/--exclude=(\S+)/))     then m[1].strip
@@ -451,6 +453,7 @@ module GauntletCharger
     results = Lich::Util.issue_command("analyze my gauntlet", /^You analyze .+ sense that the creator has provided the following information:/, quiet: true, silent: true, usexml: true)
     match = results.filter_map { |s| s.match(/Energy Reserves:\s+(\d+)\s*\/\s*(\d+)/) }.first
     return nil unless match
+
     { current: match[1].to_i, capacity: match[2].to_i }
   end
 
@@ -478,6 +481,7 @@ module GauntletCharger
 
     20.times do
       break if GameObj.containers.keys.include?(container.id) && container.contents.is_a?(Array)
+
       sleep 0.1
     end
 
@@ -488,13 +492,16 @@ module GauntletCharger
     StowList.check(silent: true, quiet: true) unless StowList.valid?
     StowList.stow_list.each_with_object([]) { |(_, container), acc|
       next if container.nil?
+
       hydrate_container!(container) if container.contents.nil? || container.contents.empty?
       next if container.contents.nil? || container.contents.empty?
+
       container.contents.each do |item|
         next unless CHARGE_ITEMS.key?(item.name)
         next if nocrystals && crystal?(item.name)
         next if nowands && wand?(item.name)
         next if exclude && exclude.match?(item.name)
+
         acc << item
       end
     }.uniq

--- a/scripts/gauntletcharger.lic
+++ b/scripts/gauntletcharger.lic
@@ -1,0 +1,666 @@
+=begin
+  A script for charging a mage's gauntlet with ayanad crystals and wands
+
+  Usage:
+    ;gauntletcharger
+    ;gauntletcharger --wand="silver wand"
+    ;gauntletcharger --wand="(?:silver|iron|metal) wand"
+    ;gauntletcharger --exclude="oaken wand"
+    ;gauntletcharger --exclude=""
+    ;gauntletcharger --nocrystals
+    ;gauntletcharger --nowands
+    ;gauntletcharger --reserve=2
+    ;gauntletcharger --noreserve
+    ;gauntletcharger --reset
+    ;gauntletcharger --stats
+    ;gauntletcharger --nostats
+    ;gauntletcharger help
+
+  Options:
+    --wand="<pattern>"     Regex pattern for preferred final wand(s). These wands are used
+                           last and when within 100 energy of full. Other wands are used
+                           freely as long as a matching final wand remains in reserve.
+                           If regular wands run out before deficit drops below 100, final
+                           wands are used to finish the job, even though this may briefly
+                           change the gauntlet's damage type before the matching wand caps
+                           it. If no matching final wand is available at all, wand usage
+                           stops to prevent the gauntlet being left on an undesired type.
+    --exclude="<pattern>"  Regex pattern; items whose names match are excluded from charge
+                           fodder entirely. Pass --exclude="" to clear a saved pattern.
+    --nocrystals           Skip ayanad crystals entirely, only use wands.
+    --nowands              Skip wands entirely, only use ayanad crystals.
+    --reserve=N            Number of final wands to reserve for next run (default: 1).
+    --noreserve            Shorthand for --reserve=0. Use all final wands if needed.
+    --reset                Clear all saved settings back to defaults.
+    --stats                Enable per-item absorption tracking and show stats. Persistent.
+    --nostats              Disable tracking (default).
+    help, --help           Show usage information and current saved settings.
+
+  Settings:
+    All CLI options are automatically saved per-character. Running ;gauntletcharger
+    without arguments uses the last saved settings. Use --reset to restore defaults.
+
+        author: elanthia-online
+          game: Gemstone
+          tags: mage gauntlet
+       version: 1.7.0
+
+  Changelog
+    v1.7.0 - 2026-05-17
+      - changed --stats is now opt-in; tracking is OFF by default
+      - changed --stats both enables persistent tracking and displays the report
+      - added --nostats to disable tracking
+      - added --exclude="<pattern>" to filter items out of charge fodder;
+        clearable via --exclude="" or --reset
+    v1.6.0 - 2026-05-06
+      - track per-item energy absorption (count/min/max/avg) to data file
+      - new --stats flag to display absorption statistics
+      - skip recording when absorption caps the gauntlet (true value unknown)
+    v1.5.3 - 2026-05-05
+      - populate StowList if not valid
+      - hydrate StowList containers via open + look-in when contents are
+        nil/empty, so first-run-after-login still finds charge fodder
+    v1.5.2 - 2026-05-05
+      - fix --wand= parser eating subsequent flags when value was unquoted
+      - fix wand?() rejecting multi-word and hyphenated wand names
+      - validate wand regex before persisting to CharSettings
+      - return instead of exit on invalid wand pattern
+      - use Regexp.union and explicit MatchData for push response parsing
+      - use .nil?-aware reads for boolean settings
+      - corrected "polishyed bloodwood wand" -> "polished bloodwood wand"
+    v1.5.1 - 2026-05-01
+      - use [Mana Reserve: X/Y] response from push for accurate energy tracking
+    v1.5.0 - 2026-04-24
+      - use [Mana Reserve: X/Y] response from push for accurate energy tracking
+      - eliminates extra analyze round-trip after each item
+    v1.4.0 - 2026-04-24
+      - CLI args auto-save, removed --save flag
+    v1.3.0 - 2026-04-24
+      - added persistent CharSettings with --save, --reset
+      - added configurable --reserve=N
+      - help now displays current saved settings
+    v1.2.0 - 2026-04-24
+      - added --noreserve flag and final wand reservation logic
+    v1.1.0 - 2026-04-24
+      - added --nocrystals, --nowands, and help flags
+    v1.0.0 - 2026-04-22
+      - initial release
+
+=end
+
+module GauntletCharger
+  CHARGE_ITEMS = {
+    # Crystals
+    "n'ayanad crystal"            => 100,  # validated
+    "t'ayanad crystal"            => 80,   # validated
+    "s'ayanad crystal"            => 60,   # validated
+    "ayanad crystal"              => 40,   # validated
+
+    # Old Style Wands
+    "oaken wand"                  => 0, # validated, no dmg type change
+    "polished bloodwood wand"     => 0, # validated
+    "twisted wand"                => 0, # validated
+    "smooth bone wand"            => 0, # validated
+    "clear glass wand"            => 0, # validated
+    "pale thanot wand"            => 0, # validated
+    "iron wand"                   => 0, # validated
+    "silver wand"                 => 0, # validated
+    "aquamarine wand"             => 0, # validated
+    "golden wand"                 => 0, # validated
+    "metal wand"                  => 0, # validated
+    "green coral wand"            => 0, # validated
+    "slender blue wand"           => 0, # validated
+    "crystal wand"                => 0, # validated
+    "smooth amber wand"           => 0, # validated
+
+    # New Style Wands
+    "black walnut wand"           => 0, # validated
+    "blackthorn wand"             => 0, # validated
+    "bronze wand"                 => 0, # validated
+    "copper wand"                 => 0, # validated
+    "cracked ivory wand"          => 0, # validated
+    "dark amethyst wand"          => 0, # validated
+    "drake wand"                  => 0, # validated
+    "fluted black stone wand"     => 0, # validated
+    "lapis lazuli wand"           => 0, # validated
+    "rainbow glaes wand"          => 0, # validated
+    "rowan wand"                  => 0, # validated
+    "white starstone wand"        => 0, # validated
+    "whorled quartz wand"         => 0, # validated
+    "electrum wand"               => 0, # ??
+    "gnarled yew wand"            => 0, # ??
+    "mithril wand"                => 0, # ??
+    "nacre-inlaid alabaster wand" => 0, # ??
+    "poisonwood wand"             => 0, # ??
+    "wavy driftwood wand"         => 0, # ??
+    "white linden wand"           => 0, # ??
+  }.freeze unless defined?(CHARGE_ITEMS)
+
+  MANA_RESERVE_PATTERN = /\[Mana Reserve: (\d+)\/(\d+)\]/.freeze unless defined?(MANA_RESERVE_PATTERN)
+
+  PUSH_RESPONSE_PATTERN = Regexp.union(MANA_RESERVE_PATTERN, /energy reserve is full/) unless defined?(PUSH_RESPONSE_PATTERN)
+
+  DEFAULTS = {
+    wand: nil,
+    exclude: nil,
+    nocrystals: false,
+    nowands: false,
+    reserve: 1,
+    stats: false,
+  }.freeze unless defined?(DEFAULTS)
+
+  TRACKING_FILE = File.join(DATA_DIR, "gauntletenergytracking.yaml") unless defined?(TRACKING_FILE)
+
+  unless defined?(HELP_TEXT)
+    HELP_TEXT = <<~HELP
+      ;gauntletcharger -- Charge a mage's gauntlet with ayanad crystals and wands
+
+      Usage:
+        ;gauntletcharger                                   Charge using saved/default settings
+        ;gauntletcharger --wand="silver wand"              Set preferred final wand
+        ;gauntletcharger --wand="(?:silver|iron) wand"     Set final wand via regex
+        ;gauntletcharger --exclude="oaken wand"            Exclude items matching pattern
+        ;gauntletcharger --exclude=""                      Clear saved exclude pattern
+        ;gauntletcharger --nocrystals                      Skip crystals, only use wands
+        ;gauntletcharger --nowands                         Skip wands, only use crystals
+        ;gauntletcharger --reserve=2                       Reserve 2 final wands for next run
+        ;gauntletcharger --noreserve                       Use all final wands (--reserve=0)
+        ;gauntletcharger --reset                           Reset to defaults
+        ;gauntletcharger --stats                           Enable tracking + show stats
+        ;gauntletcharger --nostats                         Disable tracking
+        ;gauntletcharger help                              Show this help
+
+      Options:
+        --wand="<pattern>"   Regex pattern for preferred final wand(s). Final wands are
+                             preferred last and used exclusively when within 100 energy
+                             of full. If regular wands run out before deficit drops below
+                             100, final wands fill the gap (subject to --reserve). If no
+                             matching final wand exists at all, wand usage stops entirely
+                             to preserve the gauntlet's damage type.
+
+        --exclude="<pattern>" Regex pattern; items in your StowList whose names match are
+                              excluded from charge fodder entirely. Pass --exclude="" to
+                              clear a saved pattern without resetting other settings.
+
+        --nocrystals         Do not use any ayanad crystals. Only wands will be consumed.
+
+        --nowands            Do not use any wands. Only ayanad crystals will be consumed.
+
+        --reserve=N          Number of final wands to keep in reserve (default: 1).
+                             Prevents using the last N final wands so one is available
+                             on the next run. Clamped to (found - 1) so at least one
+                             can always be used.
+
+        --noreserve          Shorthand for --reserve=0. Consumes all final wands if needed.
+
+        --reset              Clear all saved settings and revert to defaults.
+
+        --stats              Enable persistent per-item absorption tracking (count, min,
+                             max, average energy) and display the report. Tracking is
+                             off by default; samples that cap the gauntlet at maximum
+                             capacity are excluded, since the item's true value cannot
+                             be measured then.
+
+        --nostats            Disable persistent absorption tracking.
+
+      Notes:
+        - All CLI options are automatically saved per-character.
+        - Running without arguments uses the last saved settings.
+        - --nocrystals and --nowands cannot be combined.
+        - --nowands and --wand cannot be combined.
+        - Crystals are selected to minimize waste (best-fit to remaining deficit).
+        - Wand energy values vary; energy is tracked via the [Mana Reserve] response.
+    HELP
+  end
+
+  def self.crystal?(name)
+    CHARGE_ITEMS.key?(name) && name.end_with?("crystal")
+  end
+
+  # Use CHARGE_ITEMS as the source of truth so multi-word and hyphenated
+  # wand names ("polished bloodwood wand", "nacre-inlaid alabaster wand")
+  # are correctly recognized for --nowands filtering and partitioning.
+  def self.wand?(name)
+    CHARGE_ITEMS.key?(name) && name.end_with?("wand")
+  end
+
+  def self.setting_or_default(key)
+    val = CharSettings[key]
+    val.nil? ? DEFAULTS[key] : val
+  end
+
+  def self.load_settings
+    {
+      wand: setting_or_default(:wand),
+      exclude: setting_or_default(:exclude),
+      nocrystals: setting_or_default(:nocrystals),
+      nowands: setting_or_default(:nowands),
+      reserve: setting_or_default(:reserve),
+      stats: setting_or_default(:stats),
+    }
+  end
+
+  def self.save_settings(options)
+    CharSettings[:wand]       = options[:wand]
+    CharSettings[:exclude]    = options[:exclude]
+    CharSettings[:nocrystals] = options[:nocrystals]
+    CharSettings[:nowands]    = options[:nowands]
+    CharSettings[:reserve]    = options[:reserve]
+    CharSettings[:stats]      = options[:stats]
+  end
+
+  def self.reset_settings
+    CharSettings[:wand]       = DEFAULTS[:wand]
+    CharSettings[:exclude]    = DEFAULTS[:exclude]
+    CharSettings[:nocrystals] = DEFAULTS[:nocrystals]
+    CharSettings[:nowands]    = DEFAULTS[:nowands]
+    CharSettings[:reserve]    = DEFAULTS[:reserve]
+    CharSettings[:stats]      = DEFAULTS[:stats]
+  end
+
+  def self.load_tracking
+    return {} unless File.exist?(TRACKING_FILE)
+    data = YAML.load_file(TRACKING_FILE)
+    data.is_a?(Hash) ? data : {}
+  rescue => e
+    respond "** Error loading tracking file: #{e.message}"
+    {}
+  end
+
+  def self.save_tracking(data)
+    File.open(TRACKING_FILE, "w") { |f| f.write(YAML.dump(data)) }
+  rescue => e
+    respond "** Error saving tracking file: #{e.message}"
+  end
+
+  # Update an in-memory tracking hash with a single absorption sample.
+  # No-op when tracking is nil (tracking disabled via --nostats).
+  # Caller is responsible for filtering out samples that capped the gauntlet
+  # at max capacity (those don't reflect the item's true value).
+  def self.update_tracking(tracking, item_name, value)
+    return if tracking.nil?
+    entry = tracking[item_name] ||= { "count" => 0, "min" => value, "max" => value, "total" => 0 }
+    entry["count"] += 1
+    entry["min"]    = [entry["min"], value].min
+    entry["max"]    = [entry["max"], value].max
+    entry["total"] += value
+  end
+
+  def self.show_stats
+    data = load_tracking
+    if data.empty?
+      respond "** No energy absorption data recorded yet."
+      return
+    end
+
+    sorted = data.sort_by { |name, _| name }
+    name_width = [sorted.map { |name, _| name.length }.max, 4].max
+    fmt = "  %-#{name_width}s  %5s  %4s  %4s  %6s"
+
+    respond "** Gauntlet Energy Absorption Statistics (file: #{TRACKING_FILE}):"
+    respond ""
+    respond format(fmt, "Item", "Count", "Min", "Max", "Avg")
+    respond format(fmt, "-" * name_width, "-----", "----", "----", "------")
+
+    sorted.each do |name, stats|
+      count = stats["count"].to_i
+      avg   = count > 0 ? (stats["total"].to_f / count) : 0.0
+      respond format(fmt, name, count, stats["min"], stats["max"], format("%.1f", avg))
+    end
+  end
+
+  def self.display_settings
+    saved = load_settings
+    respond "  Current settings:"
+    respond "    wand:       #{saved[:wand] || '(none)'}"
+    respond "    exclude:    #{saved[:exclude] || '(none)'}"
+    respond "    nocrystals: #{saved[:nocrystals]}"
+    respond "    nowands:    #{saved[:nowands]}"
+    respond "    reserve:    #{saved[:reserve]}"
+    respond "    stats:      #{saved[:stats]}"
+  end
+
+  # Extract the value of --wand=... handling three forms:
+  #   --wand="silver wand"     (double-quoted)
+  #   --wand='silver wand'     (single-quoted)
+  #   --wand=silver            (unquoted single token, terminated at whitespace)
+  # Returns nil if no --wand flag is present.
+  def self.extract_wand_arg(args)
+    if    (m = args.match(/--wand="([^"]+)"/))   then m[1].strip
+    elsif (m = args.match(/--wand='([^']+)'/))   then m[1].strip
+    elsif (m = args.match(/--wand=(\S+)/))       then m[1].strip
+    else  nil
+    end
+  end
+
+  # Extract --exclude=... value. Same quoting forms as --wand, plus an explicit
+  # empty form (--exclude="" or --exclude='') which clears any saved value.
+  # Returns:
+  #   nil       - flag not present
+  #   :clear    - flag present with empty value
+  #   String    - flag value
+  def self.extract_exclude_arg(args)
+    if    args =~ /--exclude=""|--exclude=''/    then :clear
+    elsif (m = args.match(/--exclude="([^"]+)"/)) then m[1].strip
+    elsif (m = args.match(/--exclude='([^']+)'/)) then m[1].strip
+    elsif (m = args.match(/--exclude=(\S+)/))     then m[1].strip
+    else  nil
+    end
+  end
+
+  def self.parse_args
+    args = Script.current.vars[0] || ""
+    options = {}
+
+    if args =~ /\b(?:help|--help)\b/
+      options[:help] = true
+      return options
+    end
+
+    if args.include?("--reset")
+      options[:reset] = true
+      return options
+    end
+
+    saved = load_settings
+    has_cli_args = args.strip.length > 0
+
+    options[:nocrystals] = args.include?("--nocrystals") ? true : saved[:nocrystals]
+    options[:nowands]    = args.include?("--nowands")    ? true : saved[:nowands]
+
+    # --stats enables tracking + flags report display; --nostats disables tracking.
+    # --nostats wins if both are somehow present (explicit-off is safer than on).
+    if args.include?("--nostats")
+      options[:stats] = false
+    elsif args.include?("--stats")
+      options[:stats] = true
+      options[:show_stats] = true
+    else
+      options[:stats] = saved[:stats]
+    end
+
+    if args =~ /--reserve=(\d+)/
+      options[:reserve] = $1.to_i
+    elsif args.include?("--noreserve")
+      options[:reserve] = 0
+    else
+      options[:reserve] = saved[:reserve]
+    end
+
+    wand_arg = extract_wand_arg(args)
+    options[:wand] = wand_arg.nil? ? saved[:wand] : wand_arg
+
+    exclude_arg = extract_exclude_arg(args)
+    options[:exclude] =
+      case exclude_arg
+      when nil    then saved[:exclude]
+      when :clear then nil
+      else exclude_arg
+      end
+
+    # Validate regex(es) BEFORE persisting, so a bad pattern can't lock the
+    # user out on subsequent runs.
+    if options[:wand]
+      begin
+        options[:final_wand] = Regexp.new(options[:wand])
+      rescue RegexpError => e
+        respond "** Invalid wand pattern: #{e.message}"
+        return nil
+      end
+    end
+
+    if options[:exclude]
+      begin
+        options[:exclude_regex] = Regexp.new(options[:exclude])
+      rescue RegexpError => e
+        respond "** Invalid exclude pattern: #{e.message}"
+        return nil
+      end
+    end
+
+    # auto-save when CLI args are provided (only after validation passes)
+    if has_cli_args
+      save_settings(
+        wand: options[:wand],
+        exclude: options[:exclude],
+        nocrystals: options[:nocrystals],
+        nowands: options[:nowands],
+        reserve: options[:reserve],
+        stats: options[:stats],
+      )
+    end
+
+    options
+  end
+
+  def self.validate_args(options)
+    if options[:nocrystals] && options[:nowands]
+      respond "** Cannot combine --nocrystals and --nowands -- nothing would be used."
+      return false
+    end
+
+    if options[:nowands] && options[:final_wand]
+      respond "** Cannot combine --nowands and --wand -- conflicting options."
+      return false
+    end
+
+    true
+  end
+
+  def self.energy_info
+    results = Lich::Util.issue_command("analyze my gauntlet", /^You analyze .+ sense that the creator has provided the following information:/, quiet: true, silent: true, usexml: true)
+    match = results.filter_map { |s| s.match(/Energy Reserves:\s+(\d+)\s*\/\s*(\d+)/) }.first
+    return nil unless match
+    { current: match[1].to_i, capacity: match[2].to_i }
+  end
+
+  # Try to populate a container's .contents when it's nil/empty by opening
+  # and peeking inside. Returns true if contents are usable afterward.
+  def self.hydrate_container!(container)
+    return false if container.nil?
+    return true  if container.contents.is_a?(Array) && !container.contents.empty?
+
+    # Assume the container is closed and open it
+    lines = Lich::Util.issue_command(
+      "open ##{container.id}",
+      /<exposeContainer|That is already open|<container|There doesn't seem to be any way to do that.|You/,
+      usexml: true, silent: true, quiet: true
+    )
+    return false if lines.any? { |l| l =~ /There doesn't seem to be any way to do that./ }
+
+    # Check out what's inside
+    lines = Lich::Util.issue_command(
+      "look in ##{container.id}",
+      /<exposeContainer|<dialogData|<container|you glance|There is nothing/i,
+      usexml: true, silent: true, quiet: true
+    )
+    return false if lines.any? { |l| l =~ /You glance|There is nothing/i }
+
+    20.times do
+      break if GameObj.containers.keys.include?(container.id) && container.contents.is_a?(Array)
+      sleep 0.1
+    end
+
+    container.contents.is_a?(Array)
+  end
+
+  def self.charge_fodder(nocrystals: false, nowands: false, exclude: nil)
+    StowList.check(silent: true, quiet: true) unless StowList.valid?
+    StowList.stow_list.each_with_object([]) { |(_, container), acc|
+      next if container.nil?
+      hydrate_container!(container) if container.contents.nil? || container.contents.empty?
+      next if container.contents.nil? || container.contents.empty?
+      container.contents.each do |item|
+        next unless CHARGE_ITEMS.key?(item.name)
+        next if nocrystals && crystal?(item.name)
+        next if nowands && wand?(item.name)
+        next if exclude && exclude.match?(item.name)
+        acc << item
+      end
+    }.uniq
+  end
+
+  def self.best_crystal(crystals, deficit)
+    exact = crystals.select { |item| CHARGE_ITEMS[item.name] <= deficit }
+    if exact.any?
+      exact.max_by { |item| CHARGE_ITEMS[item.name] }
+    else
+      crystals.min_by { |item| CHARGE_ITEMS[item.name] }
+    end
+  end
+
+  def self.charge!
+    options = parse_args
+    return if options.nil?
+
+    if options[:help]
+      HELP_TEXT.each_line { |line| respond line.chomp }
+      respond ""
+      display_settings
+      return
+    end
+
+    if options[:reset]
+      reset_settings
+      respond "** Settings reset to defaults."
+      display_settings
+      return
+    end
+
+    if options[:show_stats]
+      show_stats
+      return
+    end
+
+    return unless validate_args(options)
+
+    final_wand  = options[:final_wand]
+    exclude     = options[:exclude_regex]
+    nocrystals  = options[:nocrystals]
+    nowands     = options[:nowands]
+
+    info = energy_info
+
+    unless info
+      respond "** Could not read gauntlet energy. Is it in your inventory?"
+      return
+    end
+
+    current = info[:current]
+    capacity = info[:capacity]
+    deficit = capacity - current
+
+    if deficit <= 600
+      respond "** Gauntlet is already fully charged (#{current}/#{capacity})."
+      return
+    end
+
+    respond "** Gauntlet: #{current}/#{capacity} -- need #{deficit} energy"
+    respond "** Final wand pattern: /#{final_wand.source}/" if final_wand
+    respond "** Exclude pattern: /#{exclude.source}/" if exclude
+    respond "** Skipping crystals" if nocrystals
+    respond "** Skipping wands" if nowands
+
+    fodder = charge_fodder(nocrystals: nocrystals, nowands: nowands, exclude: exclude)
+    if fodder.empty?
+      respond "** No charge items found in your containers."
+      return
+    end
+
+    crystals, wands = fodder.partition { |item| crystal?(item.name) }
+    if final_wand
+      regular_wands, final_wands = wands.partition { |item| !final_wand.match?(item.name) }
+      if final_wands.empty?
+        respond "** Warning: No wands matching /#{final_wand.source}/ found in your containers."
+      end
+    else
+      regular_wands = wands
+      final_wands = []
+    end
+
+    # reserve N final wands for next run, clamped so at least one can be used
+    reserve = [options[:reserve], [final_wands.length - 1, 0].max].min
+    if reserve > 0
+      respond "** Reserving #{reserve} of #{final_wands.length} final wands for next run"
+    end
+
+    charged = 0
+    # Only load/save tracking data when stats tracking is enabled. update_tracking
+    # is a no-op when passed nil, so the absorption loop is unchanged.
+    tracking = options[:stats] ? load_tracking : nil
+    empty_hands
+
+    while deficit > 0
+      item = best_crystal(crystals, deficit)
+
+      if item.nil?
+        if final_wand
+          if final_wands.length > reserve
+            if deficit <= 100
+              item = final_wands.shift
+            else
+              # Permissive fallback: prefer regular wands while available, but
+              # spend final wands rather than leaving the gauntlet undercharged.
+              item = regular_wands.shift || final_wands.shift
+            end
+          else
+            respond "** Reserving final wand(s) -- skipping remaining wands to preserve damage type"
+            break
+          end
+        else
+          item = regular_wands.shift
+        end
+      else
+        crystals.delete(item)
+      end
+
+      break unless item
+
+      fput "get ##{item.id}"
+      result = dothistimeout("push my gauntlet", 5, PUSH_RESPONSE_PATTERN)
+
+      item_value = 0
+      if result.is_a?(String) && result =~ /energy reserve is full/
+        respond "** Gauntlet is already full"
+        fput "stow all"
+        break
+      elsif result.is_a?(String) && (m = result.match(MANA_RESERVE_PATTERN))
+        new_current = m[1].to_i
+        item_value = new_current - current
+        # Only record measured samples that didn't cap the gauntlet, since a
+        # cap truncates the item's true value (e.g. an 80-energy crystal
+        # absorbed at 1990/2000 reads as 10).
+        if item_value > 0 && new_current < capacity
+          update_tracking(tracking, item.name, item_value)
+        end
+        current = new_current
+      elsif CHARGE_ITEMS[item.name] > 0
+        # Static fallback (push response not captured): use known crystal
+        # value to keep totals roughly accurate, but skip tracking since
+        # this isn't a measurement.
+        item_value = CHARGE_ITEMS[item.name]
+        current += item_value
+      else
+        # fallback: re-analyze if push response was not captured (e.g. timeout)
+        updated = energy_info
+        if updated
+          item_value = updated[:current] - current
+          current = updated[:current]
+          if item_value > 0 && current < capacity
+            update_tracking(tracking, item.name, item_value)
+          end
+        end
+      end
+
+      charged += item_value
+      deficit -= item_value
+      respond "** Absorbed #{item.name} (+#{item_value}) -- #{[current, capacity].min}/#{capacity}"
+    end
+    fill_hands
+
+    save_tracking(tracking) if tracking
+    respond "** Done. Charged #{charged} energy total."
+  end
+end
+
+GauntletCharger.charge!


### PR DESCRIPTION
This script allows charging a mage's gauntlet using ayanad crystals and wands, with various command-line options for customization.

Resolves #2261 as a separate usable script that can be used while resting, ideally before selling or as an in-between script in eloot.