### PR TITLE
fix(eloot): v2.11.8 locksmith pool full-container recovery could pause and wait for manual intervention

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,14 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.7
+           version: 2.11.8
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.8 (2026-09-09)
+    - fix: eloot could pause and wait for you to clear space by hand when the locksmith
+      pool handed back a box and your containers were already full. It now sells off
+      whatever's in the box directly (no need to stow it first) and clears out the rest
+      of your loot too before going back for the next box, instead of getting stuck.
   v2.11.7 (2026-09-07)
     - fix: jewelry-tagged items the gemshop won't handle (like some headbands) now get
       sold at the pawnshop instead of being put back in your loot untouched
@@ -5280,10 +5285,10 @@ module ELoot # Room looting
       ELoot.msg(type: "debug", text: "End of method")
     end
 
-    # Stow a single box item during looting. In the locksmith pool return context,
-    # when all containers are full, recover by selling to free space and resuming
-    # instead of pausing. Returns :recovered when a sell-and-return recovery re-looted
-    # the whole box (the caller should stop iterating); nil otherwise.
+    # Stow a single box item during looting. In the locksmith pool return context, when
+    # all containers are full, recover with the sell-in-place recovery instead of
+    # pausing. Returns :recovered when a recovery re-looted the whole box (the caller
+    # should stop iterating); nil otherwise.
     # @return [Symbol, nil]
     def self.stow_box_item(thing, box, location, data, sell_recovered)
       item_name = thing.respond_to?(:name) ? thing.name : thing.inspect
@@ -5294,13 +5299,12 @@ module ELoot # Room looting
         return nil
       end
 
-      has_disk = (ELoot.data.settings[:use_disk] || ELoot.data.settings[:use_disk_group]) && ELoot.data.disk_full.value?(false)
       room_tags = Room.current.tags
       sell_allowed = !ELoot.data.pool_command
-      recover = Loot.pool_full_recovery?(room_tags: room_tags, has_disk: has_disk, sell_allowed: sell_allowed, attempted: sell_recovered)
-      ELoot.msg(type: "debug", text: "stow_box_item: containers full for #{item_name} | pool_full_recovery? => #{recover} (room_tags: #{room_tags.inspect}, has_disk: #{has_disk}, sell_allowed: #{sell_allowed}, attempted: #{sell_recovered})")
+      recover = Loot.pool_full_recovery?(room_tags: room_tags, sell_allowed: sell_allowed, attempted: sell_recovered)
+      ELoot.msg(type: "debug", text: "stow_box_item: containers full for #{item_name} | pool_full_recovery? => #{recover} (room_tags: #{room_tags.inspect}, sell_allowed: #{sell_allowed}, attempted: #{sell_recovered})")
 
-      return Loot.pool_sell_recovery(box, location, data) if recover
+      return Loot.pool_direct_sell_recovery(box, location, data) if recover
 
       # Fall back to the existing manual pause.
       ELoot.msg(type: "debug", text: "stow_box_item: recovery not applicable for #{item_name}, falling back to manual pause")
@@ -5308,25 +5312,127 @@ module ELoot # Room looting
       nil
     end
 
-    # Decide whether to run the sell-and-return recovery instead of pausing when a box
+    # Decide whether to run the sell-in-place recovery instead of pausing when a box
     # item cannot be stored and all sacks are full. Pure predicate: all state is passed
     # as arguments so it is unit-testable without a game connection. It emits no debug
     # itself (that would break the standalone spec that evals it in isolation); the
     # decision and its inputs are logged by the caller, stow_box_item.
     # @param room_tags [Array<String>] Room.current.tags
-    # @param has_disk [Boolean] whether the box can be set aside on a disk
     # @param sell_allowed [Boolean] false during a standalone ;eloot pool command
     # @param attempted [Boolean] true if recovery already ran for this box
     # @return [Boolean]
-    def self.pool_full_recovery?(room_tags:, has_disk:, sell_allowed:, attempted:)
+    def self.pool_full_recovery?(room_tags:, sell_allowed:, attempted:)
       return false unless sell_allowed
       return false if attempted
-      return false unless has_disk
       room_tags.any? { |t| t =~ /locksmith/i }
     end
 
-    # Sell-and-return recovery for a full inventory during a locksmith pool return.
-    # Returns the stuck item to the box, sets the box aside on a disk, runs a
+    # Sells everything left in `box` that has somewhere to sell it, one trip per shop
+    # needed rather than one trip per item -- so a box with several unstowable items
+    # does not send the pool return back and forth to town once per item. Routes each
+    # remaining item through Sell.check_items (the same eligibility/exclusion rules --
+    # sell_loot_types, sell_exclude, cursed/bound guards, alchemy-mode reagent keeps,
+    # ... -- the normal sell trip already applies) instead of re-deriving them here, so
+    # this only ever sells an item the normal sell trip would have sold too. The box
+    # stays held in the other hand throughout: each item is dragged into hand, sold, and
+    # the next is dragged in, without ever calling anything that frees both hands.
+    # @param box [GameObj] the box being looted, held in one hand
+    # @param data [Hash] silver breakdown ledger, forwarded to appraise/sell_item
+    # @return [void]
+    def self.sell_box_contents(box, data)
+      routed = box.contents.to_a.filter_map do |item|
+        next if $sell_ignore.include?(item.id)
+
+        locations = Sell.check_items(items: [item])
+        next if locations.empty?
+
+        shop = locations.include?("gemshop") ? "gemshop" : locations.first
+        [item, shop]
+      end
+      return if routed.empty?
+
+      rooms = routed.map(&:last).uniq.filter_map { |shop| Room.current.find_nearest_by_tag(shop) }.uniq
+      return if rooms.empty?
+
+      _prev, distances = Room.current.dijkstra
+      rooms.sort_by! { |room| distances[room] }
+
+      rooms.each do |room_id|
+        shop_tags = Room[room_id].tags
+        items_here = routed.select { |_item, shop| shop_tags.include?(shop) }
+        next if items_here.empty?
+
+        ELoot.go2(room_id)
+
+        items_here.each do |item, shop|
+          next unless box.contents.to_a.include?(item)
+          next if $sell_ignore.include?(item.id)
+
+          Inventory.drag(item)
+
+          case shop
+          when "gemshop"
+            Sell.appraise(item, "Gemshop", data)
+          when "pawnshop"
+            Sell.appraise(item, "Pawnshop", data)
+          else
+            Sell.sell_item(item, shop, data)
+          end
+        end
+      end
+    end
+
+    # Sell-in-place recovery for a full inventory during a locksmith pool return.
+    # Sells everything left in the box that's sellable directly out of hand (see
+    # sell_box_contents) instead of setting the box aside, so no disk is required. If
+    # that empties the box, it is trashed on the spot -- no hand conflict, since it is
+    # now empty -- and a normal skip_boxes sell trip clears whatever else is clogging
+    # the sacks before the pool return resumes. If a genuine keeper (something with
+    # nowhere to sell) is still in there, this hands off to the disk-park recovery,
+    # which parks the box, runs the same kind of sell trip, and finishes looting it with
+    # real free space -- or, without a disk, pauses with a clear message.
+    # @return [Symbol] :recovered
+    def self.pool_direct_sell_recovery(box, location, data)
+      data ||= Hash.new(0)
+      box_name = box.respond_to?(:name) ? box.name : box.inspect
+      ELoot.msg(type: "debug", text: "pool_direct_sell_recovery: start | box=#{box_name} location=#{location.inspect} room=#{Room.current.id}")
+      ELoot.msg(type: "info", text: " Containers full. Selling the box's sellable contents directly, then resuming the pool return.")
+
+      # Put anything currently in hand (the stuck item) back into the box before selling.
+      [GameObj.right_hand, GameObj.left_hand].each do |held|
+        next if held.nil? || held.name == "Empty" || held.id.nil?
+        next if held.id == box.id
+        ELoot.msg(type: "debug", text: "pool_direct_sell_recovery: returning #{held.name} to box before selling")
+        ELoot.get_command("_drag ##{held.id} ##{box.id}", ELoot.data.put_regex, silent: true, quiet: true)
+      end
+
+      pool_room = Room.current.id
+      Loot.sell_box_contents(box, data)
+
+      ELoot.go2(pool_room)
+      Inventory.drag(box) unless ELoot.in_hand?(box)
+
+      unless box.contents.to_a.empty?
+        ELoot.msg(type: "debug", text: "pool_direct_sell_recovery: #{box.contents.to_a.length} item(s) left in #{box_name} with nowhere to sell; handing off to the disk-park recovery")
+        return Loot.pool_sell_recovery(box, location, data)
+      end
+
+      # The box drained completely -- trash it now, while it is still in hand and
+      # empty, then clear whatever else is clogging the sacks before going back for
+      # the rest of the pool.
+      ELoot.msg(type: "debug", text: "pool_direct_sell_recovery: #{box_name} emptied by direct sale; trashing it and running a general sell trip")
+      Sell.save_trash_box(box)
+      Sell.sell(skip_boxes: true)
+      ELoot.data.sacks_full = { "last cleared" => [Time.now.strftime('%Y-%m-%d %H:%M:%S'), Room.current.id, Script.current.vars[0]] }
+      ELoot.reset_disk_full
+      ELoot.go2(pool_room)
+
+      :recovered
+    end
+
+    # Sell-and-return recovery for a full inventory during a locksmith pool return,
+    # used when sell-in-place could not fully drain the box (a genuine keeper is still
+    # in there). Returns the stuck item to the box, sets the box aside on a disk, runs a
     # box-skipping sell trip to free container space, then returns to the pool and
     # re-loots the box. Falls back to the existing manual pause when the box cannot be
     # set aside on a disk.
@@ -5335,7 +5441,7 @@ module ELoot # Room looting
       data ||= Hash.new(0)
       box_name = box.respond_to?(:name) ? box.name : box.inspect
       ELoot.msg(type: "debug", text: "pool_sell_recovery: start | box=#{box_name} location=#{location.inspect} room=#{Room.current.id}")
-      ELoot.msg(type: "info", text: " Containers full. Selling to free space, then resuming the pool return.")
+      ELoot.msg(type: "info", text: " #{box.contents.to_a.length} item(s) left with nowhere to sell. Parking the box, selling off the rest, then resuming the pool return.")
 
       # Put anything currently in hand (the stuck item) back into the box we are looting.
       [GameObj.right_hand, GameObj.left_hand].each do |held|

--- a/spec/scripts/eloot_spec.rb
+++ b/spec/scripts/eloot_spec.rb
@@ -2,9 +2,7 @@
 
 require_relative '../spec_helper'
 
-# RSpec for ELoot::Loot.pool_full_recovery? (the sell-and-return recovery decision).
-#
-# Run: rspec pool_full_recovery_spec.rb
+# RSpec for ELoot::Loot.pool_full_recovery? (the sell-in-place recovery decision).
 #
 # eloot.lic cannot be required standalone -- it depends on the Lich runtime (GameObj,
 # Script, Spell, Map, ...) and executes a main block on load. Rather than copy the
@@ -30,14 +28,14 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
 
   # Fully-passing baseline; each example overrides only the field under test.
   let(:base) do
-    { room_tags: ['locksmith pool', 'town'], has_disk: true, sell_allowed: true, attempted: false }
+    { room_tags: ['locksmith pool', 'town'], sell_allowed: true, attempted: false }
   end
 
   def recover?(**overrides)
     predicate.pool_full_recovery?(**base.merge(overrides))
   end
 
-  context 'at a locksmith pool with a disk, selling allowed, first attempt' do
+  context 'at a locksmith pool, selling allowed, first attempt' do
     it 'runs the recovery' do
       expect(recover?).to be true
     end
@@ -66,10 +64,6 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
       expect(recover?(sell_allowed: false)).to be false
     end
 
-    it 'does not recover with no disk to set the box aside' do
-      expect(recover?(has_disk: false)).to be false
-    end
-
     it 'does not recover if recovery already ran for this box' do
       expect(recover?(attempted: true)).to be false
     end
@@ -77,11 +71,266 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
 
   context 'guard precedence (a failing guard wins even at a locksmith pool)' do
     it 'sell_allowed:false overrides an otherwise-eligible state' do
-      expect(recover?(sell_allowed: false, has_disk: true, attempted: false)).to be false
+      expect(recover?(sell_allowed: false, attempted: false)).to be false
     end
 
     it 'attempted:true overrides an otherwise-eligible state' do
-      expect(recover?(attempted: true, has_disk: true, sell_allowed: true)).to be false
+      expect(recover?(attempted: true, sell_allowed: true)).to be false
+    end
+  end
+end
+
+# RSpec for ELoot::Loot.sell_box_contents -- the batching step of the sell-in-place
+# recovery. Routes every remaining box item through Sell.check_items (stubbed here to
+# the same per-item eligibility contract the real method has: an array of shop tags, or
+# empty when nothing there sells it) and visits each distinct shop once, not once per
+# item -- the whole point of selling in a batch instead of one item at a time.
+RSpec.describe 'ELoot::Loot.sell_box_contents' do
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(eloot_path) }
+
+  let(:item_class) { Struct.new(:id, :name) }
+  let(:calls) { [] }
+
+  # item name => Sell.check_items(items: [item]) result, so each context only has to
+  # say where an item sells rather than restub the whole method.
+  let(:routing) { {} }
+
+  let(:box_contents) { [] }
+  let(:box) { Struct.new(:id, :name, :contents).new('box-1', 'a strongbox', box_contents) }
+
+  let(:harness) do
+    recorder = calls
+    routes = routing
+
+    mod = Module.new
+    mod.define_singleton_method(:go2) { |place| recorder << [:go2, place] }
+    mod.const_set(:ELoot, mod)
+
+    room = Module.new
+    current = Module.new
+    current.define_singleton_method(:find_nearest_by_tag) { |shop| "#{shop}-room" }
+    current.define_singleton_method(:dijkstra) { [nil, Hash.new(0)] }
+    room.define_singleton_method(:current) { current }
+    room.define_singleton_method(:[]) do |room_id|
+      Struct.new(:tags).new([room_id.to_s.sub(/-room\z/, '')])
+    end
+    mod.const_set(:Room, room)
+
+    inventory = Module.new
+    inventory.define_singleton_method(:drag) { |item| recorder << [:drag, item.name] }
+    mod.const_set(:Inventory, inventory)
+
+    mod.define_singleton_method(:check_items) { |items:| routes[items.first.name] || [] }
+    mod.define_singleton_method(:appraise) { |item, place, _data| recorder << [:appraise, item.name, place] }
+    mod.define_singleton_method(:sell_item) { |item, place, _data| recorder << [:sell_item, item.name, place] }
+    mod.const_set(:Sell, mod)
+
+    mod.module_eval(extract_lic_method(source, 'sell_box_contents', source_path: eloot_path))
+    mod
+  end
+
+  let(:data) { Hash.new(0) }
+
+  before { $sell_ignore = [] }
+
+  context 'nothing in the box sells anywhere' do
+    let(:box_contents) { [item_class.new('1', 'a marble-lined runic codex')] }
+    let(:routing) { { 'a marble-lined runic codex' => [] } }
+
+    it 'never travels' do
+      harness.sell_box_contents(box, data)
+
+      expect(calls).to be_empty
+    end
+  end
+
+  context 'several items split across two shops' do
+    let(:nugget) { item_class.new('1', 'a gold nugget') }
+    let(:bracer) { item_class.new('2', 'a platinum bracer') }
+    let(:ingot) { item_class.new('3', 'a gold ingot') }
+    let(:box_contents) { [nugget, bracer, ingot] }
+    let(:routing) do
+      {
+        'a gold nugget'     => ['gemshop'],
+        'a platinum bracer' => ['gemshop', 'pawnshop'],
+        'a gold ingot'      => ['gemshop']
+      }
+    end
+
+    it 'visits the gemshop exactly once for every item routed there' do
+      harness.sell_box_contents(box, data)
+
+      expect(calls.count { |c| c.first == :go2 }).to eq(1)
+      expect(calls).to include(
+        [:drag, 'a gold nugget'], [:appraise, 'a gold nugget', 'Gemshop'],
+        [:drag, 'a platinum bracer'], [:appraise, 'a platinum bracer', 'Gemshop'],
+        [:drag, 'a gold ingot'], [:appraise, 'a gold ingot', 'Gemshop']
+      )
+    end
+  end
+
+  context 'an item sellable only at the pawnshop, alongside a gemshop-only item' do
+    let(:spur) { item_class.new('1', 'a drake yierka-spur') }
+    let(:orb) { item_class.new('2', 'a shimmering blue orb') }
+    let(:box_contents) { [spur, orb] }
+    let(:routing) do
+      { 'a drake yierka-spur' => ['pawnshop'], 'a shimmering blue orb' => ['gemshop'] }
+    end
+
+    it 'makes one trip per distinct shop, not one per item' do
+      harness.sell_box_contents(box, data)
+
+      expect(calls.select { |c| c.first == :go2 }).to contain_exactly([:go2, 'pawnshop-room'], [:go2, 'gemshop-room'])
+    end
+  end
+
+  context 'sellable somewhere other than the two appraisal shops' do
+    let(:crate) { item_class.new('1', 'a battered antique faewood crate') }
+    let(:box_contents) { [crate] }
+    let(:routing) { { 'a battered antique faewood crate' => ['consignment'] } }
+
+    it 'sells it directly rather than appraising it' do
+      harness.sell_box_contents(box, data)
+
+      expect(calls).to include([:go2, 'consignment-room'], [:sell_item, 'a battered antique faewood crate', 'consignment'])
+    end
+  end
+
+  context 'an item already queued elsewhere ($sell_ignore)' do
+    let(:ring) { item_class.new('1', 'a gold ring') }
+    let(:box_contents) { [ring] }
+    let(:routing) { { 'a gold ring' => ['gemshop'] } }
+
+    before { $sell_ignore = ['1'] }
+
+    it 'is skipped entirely' do
+      harness.sell_box_contents(box, data)
+
+      expect(calls).to be_empty
+    end
+  end
+end
+
+# RSpec for ELoot::Loot.pool_direct_sell_recovery -- the sell-in-place recovery itself.
+# stow_box_item runs this once per box (see pool_full_recovery? above), not once per
+# item, so it has to settle the whole box's remaining contents in one pass: sell
+# whatever sell_box_contents can, then either the box is empty (trash it and clear the
+# rest of the run's backlog) or something is left with nowhere to sell it (hand off to
+# the existing disk-park recovery instead of pausing outright).
+RSpec.describe 'ELoot::Loot.pool_direct_sell_recovery' do
+  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(eloot_path) }
+
+  let(:hand_class) { Struct.new(:id, :name) }
+  let(:empty_hand) { hand_class.new(nil, 'Empty') }
+  let(:box_contents) { [] }
+  let(:box) { Struct.new(:id, :name, :contents).new('box-1', 'a strongbox', box_contents) }
+  let(:calls) { [] }
+  let(:data) { Hash.new(0) }
+
+  # sell_box_contents removes whatever it sold from the box; the spec controls the
+  # outcome directly by handing sell_box_contents a block that mutates box_contents.
+  let(:drains_box) { true }
+
+  let(:harness) do
+    recorder = calls
+    drains = drains_box
+    contents = box_contents
+    the_box = box
+    empty = empty_hand
+
+    mod = Module.new
+    mod.define_singleton_method(:msg) { |**kw| recorder << [:msg, kw] }
+    mod.define_singleton_method(:go2) { |place| recorder << [:go2, place] }
+    mod.define_singleton_method(:get_command) { |cmd, _regex, **kw| recorder << [:get_command, cmd, kw]; [] }
+    mod.define_singleton_method(:in_hand?) { |item| item.id == the_box.id }
+    data_obj = Object.new
+    data_obj.define_singleton_method(:put_regex) { /put/ }
+    data_obj.define_singleton_method(:sacks_full=) { |val| recorder << [:sacks_full=, val] }
+    mod.define_singleton_method(:data) { data_obj }
+    mod.define_singleton_method(:reset_disk_full) { recorder << [:reset_disk_full] }
+    mod.const_set(:ELoot, mod)
+
+    room = Module.new
+    current = Module.new
+    current.define_singleton_method(:id) { 'pool-room' }
+    room.define_singleton_method(:current) { current }
+    mod.const_set(:Room, room)
+
+    gameobj = Module.new
+    gameobj.define_singleton_method(:right_hand) { empty }
+    gameobj.define_singleton_method(:left_hand) { empty }
+    mod.const_set(:GameObj, gameobj)
+
+    inventory = Module.new
+    inventory.define_singleton_method(:drag) { |item| recorder << [:drag, item.name] }
+    mod.const_set(:Inventory, inventory)
+
+    script = Module.new
+    current_script = Object.new
+    current_script.define_singleton_method(:name) { 'eloot' }
+    current_script.define_singleton_method(:vars) { ['start'] }
+    script.define_singleton_method(:current) { current_script }
+    mod.const_set(:Script, script)
+
+    mod.define_singleton_method(:sell_box_contents) do |b, _data|
+      recorder << [:sell_box_contents, b.name]
+      contents.clear if drains
+    end
+    mod.define_singleton_method(:pool_sell_recovery) do |b, location, _data|
+      recorder << [:pool_sell_recovery, b.name, location]
+      :recovered
+    end
+    mod.define_singleton_method(:box_loot) { |*args| recorder << [:box_loot, *args] }
+    mod.const_set(:Loot, mod)
+
+    sell = Module.new
+    sell.define_singleton_method(:save_trash_box) { |b| recorder << [:save_trash_box, b.name] }
+    sell.define_singleton_method(:sell) { |**kw| recorder << [:sell, kw] }
+    mod.const_set(:Sell, sell)
+
+    mod.module_eval(extract_lic_method(source, 'pool_direct_sell_recovery', source_path: eloot_path))
+    mod
+  end
+
+  context 'sell_box_contents drains the box completely' do
+    let(:box_contents) { [] }
+    let(:drains_box) { true }
+
+    it 'trashes the box, runs a general sell trip, and returns to the pool room' do
+      result = harness.pool_direct_sell_recovery(box, 'Icemule Trace', data)
+
+      expect(result).to eq(:recovered)
+      expect(calls).to include(
+        [:sell_box_contents, 'a strongbox'],
+        [:save_trash_box, 'a strongbox'],
+        [:sell, { skip_boxes: true }],
+        [:reset_disk_full]
+      )
+      expect(calls.map(&:first)).not_to include(:pool_sell_recovery, :box_loot)
+
+      # sell_box_contents (freeing the box) must happen before it's trashed, which
+      # must happen before the general sell trip clears the rest of the backlog.
+      order = calls.map(&:first)
+      expect(order.index(:sell_box_contents)).to be < order.index(:save_trash_box)
+      expect(order.index(:save_trash_box)).to be < order.index(:sell)
+
+      # Ends back at the pool room, ready for pool_return's loop to continue.
+      expect(calls.select { |c| c.first == :go2 }.last).to eq([:go2, 'pool-room'])
+    end
+  end
+
+  context 'sell_box_contents leaves something with nowhere to sell it' do
+    let(:box_contents) { [Struct.new(:id, :name).new('99', 'an ascension jewel')] }
+    let(:drains_box) { false }
+
+    it 'hands off to the disk-park recovery instead of trashing the box' do
+      result = harness.pool_direct_sell_recovery(box, 'Icemule Trace', data)
+
+      expect(result).to eq(:recovered)
+      expect(calls).to include([:pool_sell_recovery, 'a strongbox', 'Icemule Trace'])
+      expect(calls.map(&:first)).not_to include(:save_trash_box, :sell)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Locksmith pool box retrieval could pause and wait for `;unpause` when a box came back and your sacks/disk were already full -- the existing sell-and-return recovery only kicked in for players carrying a disk, so everyone else got stuck (reported: a player retrieving 15-20 boxes from the pool had to manually `;eloot kill` / `;eloot sell` repeatedly).
- Adds a sell-in-place recovery, run once per box (not once per item, to avoid a round trip per unstowable item): sell everything left in the box that has somewhere to sell it -- one trip per shop needed, routed through the same `Sell.check_items` eligibility rules the normal sell trip already applies -- then either trash the now-empty box and clear the rest of the backlog with a normal sell trip, or, if a genuine keeper is still in there, hand off to the existing disk-park recovery.
- No disk required for the common case (pool box loot is almost always sellable); the disk-park recovery remains as the fallback for genuine non-sellable leftovers, and is now reachable without needing a disk pre-check since it already falls back to a clear pause message on its own.

## Test plan
- [x] `ruby -c scripts/eloot.lic` -- syntax OK
- [x] `bundle exec rubocop scripts/eloot.lic spec/scripts/eloot_spec.rb` -- no offenses
- [x] `bundle exec rspec spec/scripts/eloot_spec.rb` -- 134 examples, 0 failures (adds coverage for `pool_full_recovery?`, `sell_box_contents`, and `pool_direct_sell_recovery`)
- [ ] Not yet verified in-game -- only exercised via the RSpec harness (mocked commands/responses). Recommend an in-game pass on a character with a genuinely full inventory before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)