### PR TITLE
feat(eloot.lic): add guarded room cleanup API

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -2507,6 +2507,106 @@ module ELoot # Main methods
     @@data
   end
 
+  # Capture the exact state a room-only pass must restore before success.
+  # The nested tool journal remains mutable so an interrupted sheath command
+  # can be reconciled without guessing whether it reached the game.
+  def self.build_room_recovery(owner)
+    { owner: owner, room: Room.current.id, epoch: XMLData.room_count,
+      scope: @room_scope, data: data, right: GameObj.right_hand, left: GameObj.left_hand, tool_stows: {},
+      tools: [[:skin_weapon, :skin_sheath], [:skin_weapon_blunt, :skin_sheath_blunt]].map { |weapon, sheath|
+        [ReadyList.ready_list[weapon], ReadyList.ready_list[sheath] || StowList.stow_list[:default]].freeze
+      }.freeze }.freeze
+  end
+  private_class_method :build_room_recovery
+
+  # Reject stale, displaced, or cross-owner recovery attempts before inventory
+  # helpers can issue a command.
+  def self.validate_room_recovery_context!(recovery, owner:)
+    unless recovery && recovery[:owner].equal?(owner) && owner.equal?(Script.current) && owner.execution_guard_active?
+      raise RoomScopeError, 'No matching guarded eLoot recovery is available'
+    end
+    unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
+      raise RoomScopeError, 'eLoot recovery context changed'
+    end
+
+    true
+  end
+  private_class_method :validate_room_recovery_context!
+
+  # Confirm both original hands and standing posture from live state.
+  def self.verify_room_restoration!(recovery)
+    originals = recovery.values_at(:right, :left).map { |item| item&.id }
+    current = [GameObj.right_hand, GameObj.left_hand].map { |item| item&.id }
+    raise RoomScopeError, 'eLoot equipment restoration was not verified' unless current == originals && standing?
+
+    true
+  end
+  private_class_method :verify_room_restoration!
+
+  # Prepare the ordinary eLoot profile and transient room-loot state without
+  # enabling any standalone travel, selling, or background work.
+  def self.prepare_room_inventory!(version)
+    if Status.dead? || Spell['Berserk'].active?
+      raise RoomScopeError, 'Cannot clean up while dead or berserking'
+    end
+    unless data && data.respond_to?(:version) && data.version == version && @room_inventory_ready
+      @room_inventory_ready = false
+      waitrt?
+      ELoot.load(ELoot.load_profile)
+      ELoot.set_inventory
+    end
+    unless Group.checked?
+      Lich::Util.issue_command('group', /^You are (?:grouped|leading|not currently)/, /GROUP HELP for a list of other options\./, usexml: false, quiet: true, silent: true)
+      raise RoomScopeError, 'eLoot group inventory is unverified; run GROUP and retry' unless Group.checked?
+    end
+    unless data.settings[:track_full_sacks]
+      data.sacks_full = { 'last cleared' => [Time.now.strftime('%Y-%m-%d %H:%M:%S'), Room.current.id, 'room cleanup'] }
+    end
+    ELoot.disk_usage
+    ELoot.reset_disk_full(rebuild: !data.settings[:track_full_sacks])
+    data.pool_command = false
+  end
+  private_class_method :prepare_room_inventory!
+
+  # Observe delayed sheath updates from an interrupted command. Never resend an
+  # uncertain stow: absence of the hand update is a recovery failure.
+  def self.reconcile_room_tool_stows!(recovery, owner)
+    recovery.fetch(:tool_stows, {}).each_value do |attempt|
+      next if attempt[:settled]
+
+      20.times do
+        owner.check_execution_guard!
+        validate_room_recovery_context!(recovery, owner: owner)
+        break unless ELoot.in_hand?(attempt[:item])
+
+        owner.execution_sleep(0.1)
+      end
+      owner.check_execution_guard!
+      validate_room_recovery_context!(recovery, owner: owner)
+      raise RoomScopeError, 'Previous skinning tool stow is unconfirmed; refusing duplicate command' if ELoot.in_hand?(attempt[:item])
+    end
+  end
+  private_class_method :reconcile_room_tool_stows!
+
+  # Stow only known borrowed tools, then restore the exact original hands and
+  # standing posture through eLoot's ordinary inventory machinery.
+  def self.restore_room_equipment!(recovery)
+    originals = [recovery[:right], recovery[:left]].map { |item| item&.id }
+    [GameObj.right_hand, GameObj.left_hand].each do |held|
+      next if held&.id.nil? || originals.include?(held.id)
+
+      tool, bag = recovery[:tools].find { |candidate, _| candidate && candidate.id == held.id }
+      raise RoomScopeError, 'Unexpected held item prevents eLoot recovery' unless tool && bag
+
+      Inventory.store_item(bag, tool, true)
+      raise RoomScopeError, 'Skinning tool restoration was not observed' if ELoot.in_hand?(tool)
+    end
+    data.right_hand, data.left_hand = recovery.values_at(:right, :left)
+    Inventory.return_hands
+    dothistimeout('stand', 3, /You stand|You quickly roll|You are already standing/) unless standing?
+  end
+  private_class_method :restore_room_equipment!
+
   # Reuse the ordinary eLoot inventory/filter/stow routines on the guarded caller.
   # This is room cleanup only: no selling, travel, sorter or background readers.
   # @param corpse_ids [Array<String, Integer>] frozen array of positive exact IDs
@@ -2535,49 +2635,27 @@ module ELoot # Main methods
 
     ids = corpse_ids.map { |id| id.to_s.dup.freeze }.freeze
     token = Object.new
+    recovery = nil
     acquire_room_lease(token)
     begin
-      @room_recovery = nil
+      raise RoomScopeError, 'eLoot equipment recovery is pending; restore it before another room cleanup' if @room_recovery
+
       @room_scope = { owner: owner, script_name: script_name, version: version }.freeze
       owner.check_execution_guard!
-      if Status.dead? || Spell['Berserk'].active?
-        raise RoomScopeError, 'Cannot clean up while dead or berserking'
-      end
-      unless data && data.respond_to?(:version) && data.version == version && @room_inventory_ready
-        @room_inventory_ready = false
-        waitrt?
-        ELoot.load(ELoot.load_profile)
-        ELoot.set_inventory
-      end
-      unless Group.checked?
-        Lich::Util.issue_command('group', /^You are (?:grouped|leading|not currently)/, /GROUP HELP for a list of other options\./, usexml: false, quiet: true, silent: true)
-        raise RoomScopeError, 'eLoot group inventory is unverified; run GROUP and retry' unless Group.checked?
-      end
-      unless data.settings[:track_full_sacks]
-        data.sacks_full = { 'last cleared' => [Time.now.strftime('%Y-%m-%d %H:%M:%S'), Room.current.id, 'room cleanup'] }
-      end
-      ELoot.disk_usage
-      ELoot.reset_disk_full(rebuild: !data.settings[:track_full_sacks])
-      data.pool_command = false
-      if recoverable
-        @room_recovery = { owner: owner, room: Room.current.id, epoch: XMLData.room_count,
-                           scope: @room_scope, data: data, right: GameObj.right_hand, left: GameObj.left_hand, tool_stows: {},
-                           tools: [[:skin_weapon, :skin_sheath], [:skin_weapon_blunt, :skin_sheath_blunt]].map { |weapon, sheath|
-                             [ReadyList.ready_list[weapon], ReadyList.ready_list[sheath] || StowList.stow_list[:default]].freeze
-                           }.freeze }.freeze
-      end
+      prepare_room_inventory!(version)
+      recovery = build_room_recovery(owner)
+      @room_recovery = recovery
       corpses = GameObj.dead.to_a.select { |corpse| ids.include?(corpse.id.to_s) }
       ELoot.loot(corpses: corpses, floor: floor)
       Inventory.close_sell_containers if data.settings[:keep_closed]
       owner.check_execution_guard!
-      if @room_recovery && ([GameObj.right_hand, GameObj.left_hand].map { |item| item&.id } != @room_recovery.values_at(:right, :left).map { |item| item&.id } || !standing?)
-        raise RoomScopeError, 'eLoot equipment restoration was not verified'
-      end
+      verify_room_restoration!(recovery)
       @room_recovery = nil
       { outcome: :complete }.freeze
     rescue SystemExit
       raise RoomScopeError, 'eLoot could not finish room cleanup; check its preceding inventory message'
     ensure
+      @room_recovery = nil if recovery && !recoverable && @room_recovery.equal?(recovery)
       @@data = nil unless @room_inventory_ready
       @room_scope = nil
       release_room_lease(token)
@@ -2590,53 +2668,17 @@ module ELoot # Main methods
   # @return [Hash] completion only after original hands and standing are observed
   def self.restore_room_hands(owner:)
     recovery = @room_recovery
-    unless recovery && recovery[:owner].equal?(owner) && owner.equal?(Script.current) && owner.execution_guard_active?
-      raise RoomScopeError, 'No matching guarded eLoot recovery is available'
-    end
-    unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
-      raise RoomScopeError, 'eLoot recovery context changed'
-    end
+    validate_room_recovery_context!(recovery, owner: owner)
     token = Object.new
     acquire_room_lease(token)
     begin
-      @room_recovery = nil
       @room_scope = recovery[:scope]
       owner.check_execution_guard!
-      # An interrupted wait is not proof that a sheath command was unsent.
-      # Observe its delayed hand update before selecting any recovery commands.
-      recovery.fetch(:tool_stows, {}).each_value do |attempt|
-        next if attempt[:settled]
-
-        20.times do
-          owner.check_execution_guard!
-          unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
-            raise RoomScopeError, 'eLoot recovery context changed'
-          end
-          break unless ELoot.in_hand?(attempt[:item])
-
-          owner.execution_sleep(0.1)
-        end
-        owner.check_execution_guard!
-        unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
-          raise RoomScopeError, 'eLoot recovery context changed'
-        end
-        raise RoomScopeError, 'Previous skinning tool stow is unconfirmed; refusing duplicate command' if ELoot.in_hand?(attempt[:item])
-      end
-      originals = [recovery[:right], recovery[:left]].map { |item| item&.id }
-      [GameObj.right_hand, GameObj.left_hand].each do |held|
-        next if held&.id.nil? || originals.include?(held.id)
-        tool, bag = recovery[:tools].find { |candidate, _| candidate && candidate.id == held.id }
-        raise RoomScopeError, 'Unexpected held item prevents eLoot recovery' unless tool && bag
-        Inventory.store_item(bag, tool, true)
-        raise RoomScopeError, 'Skinning tool restoration was not observed' if ELoot.in_hand?(tool)
-      end
-      data.right_hand, data.left_hand = recovery.values_at(:right, :left)
-      Inventory.return_hands
-      dothistimeout('stand', 3, /You stand|You quickly roll|You are already standing/) unless standing?
+      reconcile_room_tool_stows!(recovery, owner)
+      restore_room_equipment!(recovery)
       owner.check_execution_guard!
-      unless [GameObj.right_hand, GameObj.left_hand].map { |item| item&.id } == originals && standing?
-        raise RoomScopeError, 'eLoot equipment restoration was not verified'
-      end
+      verify_room_restoration!(recovery)
+      @room_recovery = nil if @room_recovery.equal?(recovery)
       { outcome: :complete }.freeze
     rescue SystemExit
       raise RoomScopeError, 'eLoot equipment recovery could not finish'
@@ -3823,6 +3865,15 @@ end
 
 module ELoot # Inventory methods
   module Inventory
+    # Room-scoped callers may begin with ordinary held items that are absent
+    # from READY. Preserve legacy standalone failure behavior outside that API.
+    def self.ready_item_key(item)
+      match = ReadyList.ready_list.find { |key, value| ELoot.data.original_readylist.include?(key) && value.id == item.id }
+      return match&.first if ELoot.room_scope?
+
+      match[0]
+    end
+
     def self.container_contents(container, time: 3)
       ELoot.msg(type: "debug", text: "container: #{container.inspect}")
 
@@ -4002,7 +4053,7 @@ module ELoot # Inventory methods
     def self.free_hands(right: false, left: false, both: false)
       if (right || both) && checkright
         # Are we holding a ready_list weapon? If so put it into its sheath
-        if !GameObj.right_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.right_hand.id }&.first)
+        if !GameObj.right_hand.id.nil? && (ready_item = Inventory.ready_item_key(GameObj.right_hand))
           Inventory.stow_ready_list(ready_item, GameObj.right_hand)
         end
         if checkright
@@ -4011,7 +4062,7 @@ module ELoot # Inventory methods
       end
 
       if (left || both) && checkleft
-        if !GameObj.left_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.left_hand.id }&.first)
+        if !GameObj.left_hand.id.nil? && (ready_item = Inventory.ready_item_key(GameObj.left_hand))
           Inventory.stow_ready_list(ready_item, GameObj.left_hand)
         end
         if checkleft
@@ -4089,7 +4140,7 @@ module ELoot # Inventory methods
 
       # Check Right Hand
       unless ELoot.data.right_hand.id.nil? || ELoot.data.right_hand.id == GameObj.right_hand.id
-        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.right_hand.id }&.first)
+        if (ready_item = Inventory.ready_item_key(ELoot.data.right_hand))
           Inventory.return_ready_list(ready_item, ELoot.data.right_hand)
         else
           Inventory.drag(ELoot.data.right_hand, 'right')
@@ -4098,7 +4149,7 @@ module ELoot # Inventory methods
 
       # Check Left Hand
       unless ELoot.data.left_hand.id.nil? || ELoot.data.left_hand.id == GameObj.left_hand.id
-        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.left_hand.id }&.first)
+        if (ready_item = Inventory.ready_item_key(ELoot.data.left_hand))
           Inventory.return_ready_list(ready_item, ELoot.data.left_hand)
         else
           Inventory.drag(ELoot.data.left_hand, 'left')

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -2522,7 +2522,7 @@ module ELoot # Main methods
     unless owner.equal?(Script.current) && owner.respond_to?(:execution_guard_active?) && owner.execution_guard_active?
       raise RoomScopeError, 'eLoot room cleanup requires the current guarded script owner'
     end
-    unless corpse_ids.is_a?(Array) && corpse_ids.frozen? && corpse_ids.all? { |id| (id.is_a?(String) || id.is_a?(Integer)) && id.to_s.match?(/\A[1-9]\d*\z/) } && [true, false].include?(floor) && [true, false].include?(recoverable)
+    unless corpse_ids.is_a?(Array) && corpse_ids.frozen? && !corpse_ids.empty? && corpse_ids.all? { |id| (id.is_a?(String) || id.is_a?(Integer)) && id.to_s.match?(/\A[1-9]\d*\z/) } && [true, false].include?(floor) && [true, false].include?(recoverable)
       raise ArgumentError, 'eLoot room cleanup requires frozen positive corpse IDs and a boolean floor option'
     end
     version = @room_api_versions && @room_api_versions[script_name]

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,14 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.7
+           version: 2.12.0
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.12.0 (2026-09-10)
+    - feature: add a guarded room-only API for bounded callers to skin, search,
+      loot, and verify restoration of borrowed skinning tools and original hands
+    - safety: reject overlapping runs, selling, travel, sorters, and other
+      operations outside the admitted room-cleanup scope
   v2.11.7 (2026-09-07)
     - fix: jewelry-tagged items the gemshop won't handle (like some headbands) now get
       sold at the pawnshop instead of being put back in your loot untouched
@@ -214,6 +219,30 @@
     - bugfix for box loot to deposit coins if too many coins on yourself to be able to loot coins from box
     - change class checks to is_a? checks
 =end
+
+# Reserve the shared eLoot definitions/state before any normal script startup.
+# A callable room pass and a standalone invocation must never overlap.
+module ELoot
+  ROOM_LOOT_API_VERSION = 1 unless const_defined?(:ROOM_LOOT_API_VERSION, false)
+  ROOM_API_MUTEX = Mutex.new unless const_defined?(:ROOM_API_MUTEX, false)
+  class RoomScopeError < StandardError; end unless const_defined?(:RoomScopeError, false)
+
+  def self.acquire_room_lease(token)
+    ROOM_API_MUTEX.synchronize do
+      raise RoomScopeError, 'eLoot is already running; wait for it to finish' if @room_api_lease
+
+      @room_api_lease = token
+    end
+  end
+
+  def self.release_room_lease(token)
+    ROOM_API_MUTEX.synchronize { @room_api_lease = nil if @room_api_lease.equal?(token) }
+  end
+end
+
+eloot_load_token = Object.new
+ELoot.acquire_room_lease(eloot_load_token)
+before_dying { ELoot.release_room_lease(eloot_load_token) }
 
 # Check version of Lich for compatibility
 lich_gem_requires = Script.list.find { |x| x.name == Script.current.name }.inspect[/required: Lich >= (\d+\.\d+\.\d+)/i, 1]
@@ -1949,6 +1978,7 @@ module ELoot # Profile loading/saving and settings
   end
 
   def self.load(settings)
+    @room_inventory_ready = false
     @@data = Data.new(settings)
     # Migrate old overflow settings to new format
     ELoot.migrate_overflow_settings(ELoot.data.settings)
@@ -2312,6 +2342,7 @@ module ELoot # Sets Inventory
   end
 
   def self.set_inventory # main start up inventory method
+    @room_inventory_ready = false
     # Check account type
     ELoot.data.account_type = Account.subscription
 
@@ -2387,6 +2418,7 @@ module ELoot # Sets Inventory
     Inventory.close_sell_containers
 
     ELoot.validate_setup
+    @room_inventory_ready = true
   end
 
   def self.set_selling_containers(type: nil)
@@ -2475,7 +2507,186 @@ module ELoot # Main methods
     @@data
   end
 
-  def self.loot
+  # Reuse the ordinary eLoot inventory/filter/stow routines on the guarded caller.
+  # This is room cleanup only: no selling, travel, sorter or background readers.
+  # @param corpse_ids [Array<String, Integer>] frozen array of positive exact IDs
+  # @param floor [Boolean] whether to include normal room-floor pickup
+  # @param owner [Script] current script with an active native execution guard
+  # @param script_name [String] name of the definitions-only eLoot bootstrap script
+  # @param recoverable [Boolean] retain exact-owner equipment context on failure
+  # @return [Hash] frozen { outcome: :complete } after successful cleanup
+  # @raise [ArgumentError] invalid IDs or floor option
+  # @raise [RoomScopeError] unavailable owner/API, overlap, or room-only restriction
+  # @raise [ScriptExecutionGuard::Interrupted] native cancellation or policy denial
+  def self.room_loot(corpse_ids:, floor:, owner:, script_name: 'eloot', recoverable: false)
+    unless owner.equal?(Script.current) && owner.respond_to?(:execution_guard_active?) && owner.execution_guard_active?
+      raise RoomScopeError, 'eLoot room cleanup requires the current guarded script owner'
+    end
+    unless corpse_ids.is_a?(Array) && corpse_ids.frozen? && corpse_ids.all? { |id| (id.is_a?(String) || id.is_a?(Integer)) && id.to_s.match?(/\A[1-9]\d*\z/) } && [true, false].include?(floor) && [true, false].include?(recoverable)
+      raise ArgumentError, 'eLoot room cleanup requires frozen positive corpse IDs and a boolean floor option'
+    end
+    version = @room_api_versions && @room_api_versions[script_name]
+    raise RoomScopeError, 'Load the matching eLoot room API before cleanup' unless version
+
+    ids = corpse_ids.map { |id| id.to_s.dup.freeze }.freeze
+    token = Object.new
+    acquire_room_lease(token)
+    begin
+      @room_recovery = nil
+      @room_scope = { owner: owner, script_name: script_name, version: version }.freeze
+      owner.check_execution_guard!
+      if Status.dead? || Spell['Berserk'].active?
+        raise RoomScopeError, 'Cannot clean up while dead or berserking'
+      end
+      unless data && data.respond_to?(:version) && data.version == version && @room_inventory_ready
+        @room_inventory_ready = false
+        waitrt?
+        ELoot.load(ELoot.load_profile)
+        ELoot.set_inventory
+      end
+      unless Group.checked?
+        Lich::Util.issue_command('group', /^You are (?:grouped|leading|not currently)/, /GROUP HELP for a list of other options\./, usexml: false, quiet: true, silent: true)
+        raise RoomScopeError, 'eLoot group inventory is unverified; run GROUP and retry' unless Group.checked?
+      end
+      unless data.settings[:track_full_sacks]
+        data.sacks_full = { 'last cleared' => [Time.now.strftime('%Y-%m-%d %H:%M:%S'), Room.current.id, 'room cleanup'] }
+      end
+      ELoot.disk_usage
+      ELoot.reset_disk_full(rebuild: !data.settings[:track_full_sacks])
+      data.pool_command = false
+      if recoverable
+        @room_recovery = { owner: owner, room: Room.current.id, epoch: XMLData.room_count,
+                           scope: @room_scope, data: data, right: GameObj.right_hand, left: GameObj.left_hand, tool_stows: {},
+                           tools: [[:skin_weapon, :skin_sheath], [:skin_weapon_blunt, :skin_sheath_blunt]].map { |weapon, sheath|
+                             [ReadyList.ready_list[weapon], ReadyList.ready_list[sheath] || StowList.stow_list[:default]].freeze
+                           }.freeze }.freeze
+      end
+      corpses = GameObj.dead.to_a.select { |corpse| ids.include?(corpse.id.to_s) }
+      ELoot.loot(corpses: corpses, floor: floor)
+      Inventory.close_sell_containers if data.settings[:keep_closed]
+      owner.check_execution_guard!
+      if @room_recovery && ([GameObj.right_hand, GameObj.left_hand].map { |item| item&.id } != @room_recovery.values_at(:right, :left).map { |item| item&.id } || !standing?)
+        raise RoomScopeError, 'eLoot equipment restoration was not verified'
+      end
+      @room_recovery = nil
+      { outcome: :complete }.freeze
+    rescue SystemExit
+      raise RoomScopeError, 'eLoot could not finish room cleanup; check its preceding inventory message'
+    ensure
+      @@data = nil unless @room_inventory_ready
+      @room_scope = nil
+      release_room_lease(token)
+    end
+  end
+
+  # One-shot recovery of this exact owner's interrupted room pass. The caller
+  # supplies a fresh, bounded native guard; this API never clears cancellation.
+  # Only known borrowed skinning tools may be stowed, not arbitrary held items.
+  # @return [Hash] completion only after original hands and standing are observed
+  def self.restore_room_hands(owner:)
+    recovery = @room_recovery
+    unless recovery && recovery[:owner].equal?(owner) && owner.equal?(Script.current) && owner.execution_guard_active?
+      raise RoomScopeError, 'No matching guarded eLoot recovery is available'
+    end
+    unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
+      raise RoomScopeError, 'eLoot recovery context changed'
+    end
+    token = Object.new
+    acquire_room_lease(token)
+    begin
+      @room_recovery = nil
+      @room_scope = recovery[:scope]
+      owner.check_execution_guard!
+      # An interrupted wait is not proof that a sheath command was unsent.
+      # Observe its delayed hand update before selecting any recovery commands.
+      recovery.fetch(:tool_stows, {}).each_value do |attempt|
+        next if attempt[:settled]
+
+        20.times do
+          owner.check_execution_guard!
+          unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
+            raise RoomScopeError, 'eLoot recovery context changed'
+          end
+          break unless ELoot.in_hand?(attempt[:item])
+
+          owner.execution_sleep(0.1)
+        end
+        owner.check_execution_guard!
+        unless recovery[:data].equal?(data) && Room.current.id == recovery[:room] && XMLData.room_count == recovery[:epoch]
+          raise RoomScopeError, 'eLoot recovery context changed'
+        end
+        raise RoomScopeError, 'Previous skinning tool stow is unconfirmed; refusing duplicate command' if ELoot.in_hand?(attempt[:item])
+      end
+      originals = [recovery[:right], recovery[:left]].map { |item| item&.id }
+      [GameObj.right_hand, GameObj.left_hand].each do |held|
+        next if held&.id.nil? || originals.include?(held.id)
+        tool, bag = recovery[:tools].find { |candidate, _| candidate && candidate.id == held.id }
+        raise RoomScopeError, 'Unexpected held item prevents eLoot recovery' unless tool && bag
+        Inventory.store_item(bag, tool, true)
+        raise RoomScopeError, 'Skinning tool restoration was not observed' if ELoot.in_hand?(tool)
+      end
+      data.right_hand, data.left_hand = recovery.values_at(:right, :left)
+      Inventory.return_hands
+      dothistimeout('stand', 3, /You stand|You quickly roll|You are already standing/) unless standing?
+      owner.check_execution_guard!
+      unless [GameObj.right_hand, GameObj.left_hand].map { |item| item&.id } == originals && standing?
+        raise RoomScopeError, 'eLoot equipment restoration was not verified'
+      end
+      { outcome: :complete }.freeze
+    rescue SystemExit
+      raise RoomScopeError, 'eLoot equipment recovery could not finish'
+    ensure
+      @room_scope = nil
+      release_room_lease(token)
+    end
+  end
+
+  def self.room_scope?
+    @room_scope && @room_scope[:owner].equal?(Script.current)
+  end
+
+  # Retain an uncertain tool-stow attempt across native guard unwinding. Mark
+  # before entering the command helper: an exception cannot prove non-dispatch.
+  # Ordinary eLoot and unrelated inventory handling do not use this journal.
+  # @return [Hash, nil] mutable acknowledgement record for this room pass only
+  def self.record_room_tool_stow(item, bag)
+    return unless room_scope? && @room_recovery
+    return unless @room_recovery[:tools].any? { |tool, sheath| tool && sheath && tool.id == item.id && sheath.id == bag.id }
+
+    attempt = { item: item, settled: false }
+    @room_recovery[:tool_stows][item.id] = attempt
+    attempt
+  end
+
+  def self.room_checkpoint!(error = nil)
+    return unless room_scope?
+
+    raise error if error.is_a?(RoomScopeError)
+
+    @room_scope[:owner].check_execution_guard!
+  end
+
+  def self.refuse_room_operation!(operation)
+    raise RoomScopeError, "eLoot room cleanup cannot #{operation}" if room_scope?
+  end
+
+  # Only these eLoot receivers use the shim; normal scripts retain Kernel.sleep.
+  module RoomScopedWait
+    def sleep(*arguments)
+      return super unless ELoot.room_scope?
+
+      ELoot.room_checkpoint!
+      raise RoomScopeError, 'eLoot room cleanup requires a bounded sleep' unless arguments.size == 1
+
+      ELoot.room_owner.execution_sleep(arguments.first)
+    end
+  end
+
+  def self.room_owner
+    @room_scope && @room_scope[:owner]
+  end
+
+  def self.loot(corpses: nil, floor: true)
     if Spell['Berserk'].active?
       ELoot.msg(type: "info", text: " Berserk is active and preventing you from looting.")
       return
@@ -2489,9 +2700,9 @@ module ELoot # Main methods
 
     ELoot.change_stance(100) if ELoot.data.settings[:loot_defensive]
 
-    Loot.skin if ELoot.data.settings[:skin_enable]
-    Loot.search
-    Loot.room
+    Loot.skin(corpses || GameObj.dead.to_a) if ELoot.data.settings[:skin_enable]
+    Loot.search(corpses || GameObj.dead.to_a)
+    Loot.room if floor
 
     # use coin hand if we have it
     ELoot.use_coin_hand
@@ -2500,6 +2711,7 @@ module ELoot # Main methods
   end
 
   def self.sell
+    ELoot.refuse_room_operation!('sell')
     Sell.sell
   end
 end
@@ -2581,6 +2793,7 @@ module ELoot # Script utility type methods
     # The integration hook persists between script runs, but ELoot.data does not.
     # Seed the current run before deciding whether a new hook is needed.
     ELoot.data.disk = Disk.mine.nil? ? nil : GameObj[Disk.mine.id]
+    return if ELoot.respond_to?(:room_scope?) && ELoot.room_scope?
     return if DownstreamHook.list.include?("eloot_diskintegration")
 
     eloot_diskintegration = proc { |server|
@@ -2651,7 +2864,8 @@ module ELoot # Script utility type methods
 
       ELoot.msg(type: "debug", text: "command: #{command} | lines - #{lines}")
       raise if lines.any? { |l| l =~ rt_regex }
-    rescue
+    rescue => error
+      ELoot.room_checkpoint!(error)
       ELoot.wait_rt
       retry
     end
@@ -2675,6 +2889,8 @@ module ELoot # Script utility type methods
   end
 
   def self.get_script_version
+    return @room_scope[:version] if room_scope?
+
     data = Script.list.find { |x| x.name == Script.current.name }.inspect
     return data[/version: (\d+\.\d+\.\d+)/i, 1]
   end
@@ -2789,7 +3005,7 @@ module ELoot # Script utility type methods
   def self.msg(type: "yellow", text: "", space: false)
     # color options - set type to use (eg: yellow, orange, teal, green, plain)
 
-    return if type == "debug" && (!ELoot.data.settings[:debug] && !ELoot.data.settings[:debug_file])
+    return if type == "debug" && (!ELoot.data.settings[:debug] && (!ELoot.data.settings[:debug_file] || room_scope?))
 
     # Make sure its a string
     text = text.to_s
@@ -2811,7 +3027,7 @@ module ELoot # Script utility type methods
     end
     respond '' if space
 
-    if ELoot.data.settings[:debug_file]
+    if !room_scope? && ELoot.data.settings[:debug_file]
       ELoot.data.debug_logger.log(text)
     end
   end
@@ -3237,6 +3453,7 @@ module ELoot # Game utility type methods
   end
 
   def self.go2(place)
+    ELoot.refuse_room_operation!('travel')
     ELoot.msg(type: "debug", text: "place: #{place}")
     fput('unhide') if (hidden? || invisible?)
 
@@ -3332,6 +3549,7 @@ module ELoot # Game utility type methods
   end
 
   def self.silver_deposit(deposit_bag = false)
+    ELoot.refuse_room_operation!('deposit at a bank')
     ELoot.msg(type: "debug")
 
     if ELoot.data.coin_hand && deposit_bag && ELoot.data.settings[:sell_deposit_coinhand]
@@ -3563,7 +3781,8 @@ module ELoot # Game utility type methods
           ELoot.data.gambling_kit_full = true
           ELoot.wait_rt
         end
-      rescue
+      rescue => error
+        ELoot.room_checkpoint!(error)
         retry
       end
     end
@@ -3778,7 +3997,7 @@ module ELoot # Inventory methods
     def self.free_hands(right: false, left: false, both: false)
       if (right || both) && checkright
         # Are we holding a ready_list weapon? If so put it into its sheath
-        if !GameObj.right_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.right_hand.id }[0])
+        if !GameObj.right_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.right_hand.id }&.first)
           Inventory.stow_ready_list(ready_item, GameObj.right_hand)
         end
         if checkright
@@ -3787,7 +4006,7 @@ module ELoot # Inventory methods
       end
 
       if (left || both) && checkleft
-        if !GameObj.left_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.left_hand.id }[0])
+        if !GameObj.left_hand.id.nil? && (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == GameObj.left_hand.id }&.first)
           Inventory.stow_ready_list(ready_item, GameObj.left_hand)
         end
         if checkleft
@@ -3865,7 +4084,7 @@ module ELoot # Inventory methods
 
       # Check Right Hand
       unless ELoot.data.right_hand.id.nil? || ELoot.data.right_hand.id == GameObj.right_hand.id
-        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.right_hand.id }[0])
+        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.right_hand.id }&.first)
           Inventory.return_ready_list(ready_item, ELoot.data.right_hand)
         else
           Inventory.drag(ELoot.data.right_hand, 'right')
@@ -3874,7 +4093,7 @@ module ELoot # Inventory methods
 
       # Check Left Hand
       unless ELoot.data.left_hand.id.nil? || ELoot.data.left_hand.id == GameObj.left_hand.id
-        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.left_hand.id }[0])
+        if (ready_item = ReadyList.ready_list.find { |k, v| ELoot.data.original_readylist.include?(k) && v.id == ELoot.data.left_hand.id }&.first)
           Inventory.return_ready_list(ready_item, ELoot.data.left_hand)
         else
           Inventory.drag(ELoot.data.left_hand, 'left')
@@ -3944,12 +4163,14 @@ module ELoot # Inventory methods
             end
           end
         end
-      rescue
+      rescue => error
+        ELoot.room_checkpoint!(error)
         retry
       end
 
       # If item wasn't stored, pause and address
       unless stored
+        ELoot.refuse_room_operation!('continue with full containers; make space and retry')
         if Room.current.tags.any?(/locksmith|locksmith pool/i) && (gold_ingot = [GameObj.right_hand, GameObj.left_hand].find { |obj| obj.name =~ /gold ingot/ })
           Sell.handle_ingot(gold_ingot)
         elsif on_full == :signal
@@ -4052,6 +4273,8 @@ module ELoot # Inventory methods
       ELoot.msg(type: "debug", text: "bag: #{bag.inspect} | item: #{item.inspect}")
       return if item.nil? || item.name == "Empty"
 
+      pending_stow = ELoot.record_room_tool_stow(item, bag) if is_skinner
+
       5.times do
         lines = ELoot.get_command("_drag ##{item.id} ##{bag.id}", ELoot.data.put_regex)
 
@@ -4109,6 +4332,8 @@ module ELoot # Inventory methods
 
       # Give up and return false
       return false
+    ensure
+      pending_stow[:settled] = true if pending_stow && !ELoot.in_hand?(item)
     end
 
     def self.stow_ready_list(ready_item, item)
@@ -5019,6 +5244,7 @@ module ELoot # Room looting
     end
 
     def self.box_loot(box, location = nil, data = nil, sell_recovered: false) # Loots box contents
+      ELoot.refuse_room_operation!('open locksmith boxes')
       ELoot.msg(type: "debug", text: "box_loot: box=#{box.respond_to?(:name) ? box.name : box.inspect} location=#{location.inspect} sell_recovered=#{sell_recovered}")
       if box.type == "box"
         line = ELoot.get_res("open ##{box.id}", /open|locked/)
@@ -7422,6 +7648,7 @@ module ELoot # Sells the loot
     end
 
     def self.pool(deposit: false, check: false)
+      ELoot.refuse_room_operation!('use the locksmith pool')
       room = Room.current.id
       ELoot.data.right_hand = GameObj.right_hand
       ELoot.data.left_hand = GameObj.left_hand
@@ -7622,6 +7849,7 @@ module ELoot # Sells the loot
     end
 
     def self.sell(skip_boxes: false) # Main sell method
+      ELoot.refuse_room_operation!('sell')
       ELoot.msg(type: "debug", text: "sell: skip_boxes=#{skip_boxes}")
       fput('unhide') if (hidden? || invisible?)
 
@@ -7691,6 +7919,18 @@ module ELoot # Sells the loot
     end
   end
 end
+
+module ELoot
+  extend RoomScopedWait
+  Inventory.extend(RoomScopedWait)
+  Loot.extend(RoomScopedWait)
+  @room_api_versions ||= {}
+  @room_api_versions[Script.current.name] = ELoot.get_script_version
+end
+
+# Native child bootstrap loads definitions only. The caller waits for this exact
+# child to exit before acquiring the room lease and running under its own guard.
+exit if Script.current.vars[0] == '--load-room-api'
 
 module ELoot # Starts the script
   if Script.current.vars[1] =~ /ver/i

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -2511,14 +2511,19 @@ module ELoot # Main methods
   # This is room cleanup only: no selling, travel, sorter or background readers.
   # @param corpse_ids [Array<String, Integer>] frozen array of positive exact IDs
   # @param floor [Boolean] whether to include normal room-floor pickup
-  # @param owner [Script] current script with an active native execution guard
+  # @param owner [Script] current script with an active Lich execution guard
   # @param script_name [String] name of the definitions-only eLoot bootstrap script
   # @param recoverable [Boolean] retain exact-owner equipment context on failure
+  # @note The caller installs the guard; eLoot consumes Script's protocol but
+  #   never creates, broadens, or clears the caller's authorization.
   # @return [Hash] frozen { outcome: :complete } after successful cleanup
   # @raise [ArgumentError] invalid IDs or floor option
   # @raise [RoomScopeError] unavailable owner/API, overlap, or room-only restriction
   # @raise [ScriptExecutionGuard::Interrupted] native cancellation or policy denial
   def self.room_loot(corpse_ids:, floor:, owner:, script_name: 'eloot', recoverable: false)
+    unless defined?(Script::EXECUTION_GUARD_PROTOCOL) && Script::EXECUTION_GUARD_PROTOCOL == 1
+      raise RoomScopeError, 'eLoot room cleanup requires the Lich execution guard protocol'
+    end
     unless owner.equal?(Script.current) && owner.respond_to?(:execution_guard_active?) && owner.execution_guard_active?
       raise RoomScopeError, 'eLoot room cleanup requires the current guarded script owner'
     end

--- a/spec/scripts/eloot/loot_spec.rb
+++ b/spec/scripts/eloot/loot_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 # RSpec for ELoot::Loot.pool_full_recovery? (the sell-and-return recovery decision).
 #
@@ -22,7 +22,7 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
   # Sourcing the real method keeps this spec from drifting from the shipped code; if the
   # source or method cannot be found, it fails loudly rather than passing on a stale copy.
   let(:predicate) do
-    path = find_lic_source('eloot.lic', from: __dir__)
+    path = find_lic_source('eloot.lic', from: File.expand_path('..', __dir__))
     body = extract_lic_method(File.read(path), 'pool_full_recovery?', source_path: path)
 
     Module.new { module_eval(body) }
@@ -87,7 +87,7 @@ RSpec.describe 'ELoot::Loot.pool_full_recovery?' do
 end
 
 RSpec.describe 'ELoot disk-backed box routing' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -203,7 +203,7 @@ end
 # or method cannot be found the spec fails loudly rather than passing on a stale copy.
 
 RSpec.describe 'ELoot::Loot.loot_specials' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:method_body) { extract_lic_method(File.read(eloot_path), 'loot_specials', source_path: eloot_path) }
 
@@ -366,7 +366,7 @@ end
 # the shipped source.
 
 RSpec.describe 'ELoot box-looting call sites' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -438,7 +438,7 @@ end
 # never opens, so the predicate and the routing are pinned here.
 
 RSpec.describe 'ELoot::Sell.town_openable?' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -533,7 +533,7 @@ RSpec.describe 'ELoot::Sell.town_openable?' do
 end
 
 RSpec.describe 'ELoot::Sell.process_boxes routing' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -582,7 +582,7 @@ end
 # of its own, though, so it is exercised for real against a small stand-in for Sell/ELoot.
 
 RSpec.describe 'ELoot::Sell locksmith_priority routing' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -740,7 +740,7 @@ RSpec.describe 'ELoot::Sell.gem_bounty_override?' do
       File.expand_path('../eloot.lic', __dir__),
       File.expand_path('../../eloot.lic', __dir__),
       File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+      File.expand_path('../../../scripts/eloot.lic', __dir__) # spec/scripts/eloot/ -> scripts/
     ].find { |p| File.exist?(p) }
     raise "eloot.lic not found (looked relative to #{__dir__})" unless path
 
@@ -829,7 +829,7 @@ RSpec.describe 'ELoot::Sell.box_in_hand' do
       File.expand_path('../eloot.lic', __dir__),
       File.expand_path('../../eloot.lic', __dir__),
       File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+      File.expand_path('../../../scripts/eloot.lic', __dir__) # spec/scripts/eloot/ -> scripts/
     ].find { |p| File.exist?(p) }
     raise "eloot.lic not found (looked relative to #{__dir__})" unless path
 
@@ -1037,7 +1037,7 @@ RSpec.describe 'ELoot::Sell.locksmith insufficient-silver retry' do
       File.expand_path('../eloot.lic', __dir__),
       File.expand_path('../../eloot.lic', __dir__),
       File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+      File.expand_path('../../../scripts/eloot.lic', __dir__) # spec/scripts/eloot/ -> scripts/
     ].find { |p| File.exist?(p) }
     raise "eloot.lic not found (looked relative to #{__dir__})" unless path
 
@@ -1112,7 +1112,7 @@ RSpec.describe 'ELoot::Sell.process_boxes gem-bounty predicate reuse' do
       File.expand_path('../eloot.lic', __dir__),
       File.expand_path('../../eloot.lic', __dir__),
       File.expand_path('../scripts/eloot.lic', __dir__),
-      File.expand_path('../../scripts/eloot.lic', __dir__) # spec/scripts/ -> scripts/
+      File.expand_path('../../../scripts/eloot.lic', __dir__) # spec/scripts/eloot/ -> scripts/
     ].find { |p| File.exist?(p) }
     raise "eloot.lic not found (looked relative to #{__dir__})" unless path
 
@@ -1149,7 +1149,7 @@ end
 # the spec fails loudly rather than passing on a stale copy.
 
 RSpec.describe 'ELoot.marked_unsellable?' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -1234,7 +1234,7 @@ RSpec.describe 'ELoot.marked_unsellable?' do
 end
 
 RSpec.describe 'ELoot.toss' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -1408,7 +1408,7 @@ end
 # source, the same way the box-looting call sites above are pinned.
 
 RSpec.describe 'ELoot trash/drop call sites' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
 
   let(:source) { File.read(eloot_path) }
 
@@ -1446,7 +1446,7 @@ RSpec.describe 'ELoot trash/drop call sites' do
 end
 
 RSpec.describe 'ELoot unskinnable-list management' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
   let(:source) { File.read(eloot_path) }
   let(:settings) { { unskinnable: ['massive troll king', 'greater earth elemental'] } }
   let(:data) { Struct.new(:settings).new(settings) }
@@ -1527,7 +1527,7 @@ end
 # Sell.sell_item), so the spec fails loudly instead of silently drifting if the
 # shipped logic changes shape.
 RSpec.describe 'ELoot::Sell.appraise' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
   let(:source) { File.read(eloot_path) }
 
   let(:item_class) { Struct.new(:id, :name, :type, :sellable) }
@@ -1655,7 +1655,7 @@ end
 # edit that drops or misplaces the wrapper fails a test instead of only showing up as a
 # short breakdown total in a live session.
 RSpec.describe 'ELoot::Sell.retry_wrong_shop_jewelry_at_pawnshop' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
   let(:source) { File.read(eloot_path) }
 
   let(:item_class) { Struct.new(:id, :name, :type, :sellable) }
@@ -1754,7 +1754,7 @@ end
 # distinct note (added for the gemshop-declined-as-not-jewelry case above) gets its
 # own heading instead of being merged into the first one under a misleading label.
 RSpec.describe 'ELoot::Sell.over_max_rows' do
-  let(:eloot_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:eloot_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
   let(:source) { File.read(eloot_path) }
 
   let(:harness) do

--- a/spec/scripts/eloot/room_scope_spec.rb
+++ b/spec/scripts/eloot/room_scope_spec.rb
@@ -49,11 +49,22 @@ RSpec.describe 'eLoot guarded room API' do
                    right_hand: nil, left_hand: nil, pool_command: true)
   end
 
+  def set_harness_const(name, value)
+    harness.send(:remove_const, name) if harness.const_defined?(name, false)
+    harness.const_set(name, value)
+  end
+
   def prepare_world
     harness.const_set(:Status, Object.new.tap { |value| value.define_singleton_method(:dead?) { false } })
     harness.const_set(:Spell, Object.new.tap { |value| value.define_singleton_method(:[]) { |_| Struct.new(:active?).new(false) } })
     harness.const_set(:Group, Object.new.tap { |value| value.define_singleton_method(:checked?) { true } })
-    harness.const_set(:GameObj, OpenStruct.new(dead: [corpse, Struct.new(:id).new('999')], right_hand: :sword, left_hand: :shield))
+    right = Struct.new(:id).new('10')
+    left = Struct.new(:id).new('20')
+    harness.const_set(:GameObj, OpenStruct.new(dead: [corpse, Struct.new(:id).new('999')], right_hand: right, left_hand: left))
+    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
+    harness.const_set(:ReadyList, OpenStruct.new(ready_list: {}))
+    harness.const_set(:StowList, OpenStruct.new(stow_list: {}))
     api.class_variable_set(:@@data, data)
     api.instance_variable_set(:@room_inventory_ready, true)
     api.define_singleton_method(:disk_usage) {}
@@ -65,6 +76,7 @@ RSpec.describe 'eLoot guarded room API' do
     api::Loot.define_singleton_method(:room) { log << :floor }
     api::Inventory.define_singleton_method(:return_hands) { log << :hands }
     api::Inventory.define_singleton_method(:close_sell_containers) { log << :close }
+    allow(api).to receive(:standing?).and_return(true)
   end
 
   def run_room(**overrides)
@@ -84,8 +96,17 @@ RSpec.describe 'eLoot guarded room API' do
     expect(result).to eq(outcome: :complete)
     expect(result).to be_frozen
     expect(calls).to eq([[:skin, ['123']], [:search, ['123']], :coins, :hands, :close])
-    expect([data.right_hand, data.left_hand]).to eq([:sword, :shield])
+    expect([data.right_hand, data.left_hand]).to eq([harness::GameObj.right_hand, harness::GameObj.left_hand])
     expect(api.room_scope?).to be_falsey
+  end
+
+  it 'verifies hand and posture restoration before default calls report completion' do
+    prepare_world
+    replacement = Struct.new(:id).new('99')
+    world = harness::GameObj
+    api::Inventory.define_singleton_method(:return_hands) { world.right_hand = replacement }
+    expect { run_room }.to raise_error(api::RoomScopeError, /restoration was not verified/)
+    expect(api.instance_variable_get(:@room_recovery)).to be_nil
   end
 
   it 'uses the same room pickup routine when floor cleanup is requested' do
@@ -102,10 +123,10 @@ RSpec.describe 'eLoot guarded room API' do
     sheath = Struct.new(:id).new('12')
     harness::GameObj.right_hand = sword
     harness::GameObj.left_hand = empty
-    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
-    harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
-    harness.const_set(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
-    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: sheath }))
+    set_harness_const(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    set_harness_const(:XMLData, OpenStruct.new(room_count: 1))
+    set_harness_const(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
+    set_harness_const(:StowList, OpenStruct.new(stow_list: { default: sheath }))
     allow(api).to receive(:standing?).and_return(true)
     world = harness::GameObj
     api::Loot.define_singleton_method(:skin) do |_items|
@@ -120,10 +141,26 @@ RSpec.describe 'eLoot guarded room API' do
     expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /recovery/)
   end
 
+  it 'requires pending recoverable equipment state to be resolved before another room pass' do
+    prepare_world
+    set_harness_const(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    set_harness_const(:XMLData, OpenStruct.new(room_count: 1))
+    set_harness_const(:ReadyList, OpenStruct.new(ready_list: {}))
+    set_harness_const(:StowList, OpenStruct.new(stow_list: {}))
+    allow(api::Loot).to receive(:search).and_raise('interrupted pass')
+    expect { run_room(recoverable: true) }.to raise_error('interrupted pass')
+    recovery = api.instance_variable_get(:@room_recovery)
+    expect(recovery).not_to be_nil
+
+    allow(api::Loot).to receive(:search)
+    expect { run_room(recoverable: true) }.to raise_error(api::RoomScopeError, /recovery is pending/)
+    expect(api.instance_variable_get(:@room_recovery)).to equal(recovery)
+  end
+
   it 'refuses recovery after displacement or for a different owner before any inventory helper' do
     prepare_world
-    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 101)))
-    harness.const_set(:XMLData, OpenStruct.new(room_count: 2))
+    set_harness_const(:Room, OpenStruct.new(current: OpenStruct.new(id: 101)))
+    set_harness_const(:XMLData, OpenStruct.new(room_count: 2))
     api.instance_variable_set(:@room_recovery, { owner: owner, data: data, room: 100, epoch: 1 })
     expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /context changed/)
     expect { api.restore_room_hands(owner: Object.new) }.to raise_error(api::RoomScopeError, /recovery/)
@@ -139,10 +176,10 @@ RSpec.describe 'eLoot guarded room API' do
       sheath = Struct.new(:id, :name, :contents).new('12', 'test sheath', [])
       world = harness::GameObj
       world.right_hand, world.left_hand = sword, empty
-      harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
-      harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
-      harness.const_set(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
-      harness.const_set(:StowList, OpenStruct.new(stow_list: { default: sheath }))
+      set_harness_const(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+      set_harness_const(:XMLData, OpenStruct.new(room_count: 1))
+      set_harness_const(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
+      set_harness_const(:StowList, OpenStruct.new(stow_list: { default: sheath }))
       allow(api).to receive(:standing?).and_return(true)
       allow(api).to receive(:msg)
       wires = []
@@ -193,16 +230,18 @@ RSpec.describe 'eLoot guarded room API' do
 
   it 'does not stow an unrelated new item held during recovery' do
     prepare_world
-    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
-    harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
+    set_harness_const(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    set_harness_const(:XMLData, OpenStruct.new(room_count: 1))
     empty = Struct.new(:id).new(nil)
     sword = Struct.new(:id).new('10')
     harness::GameObj.right_hand = sword
     harness::GameObj.left_hand = Struct.new(:id).new('99')
     api.instance_variable_set(:@room_recovery, { owner: owner, data: data, room: 100, epoch: 1,
                                                scope: { owner: owner }, right: sword, left: empty, tools: [] })
+    recovery = api.instance_variable_get(:@room_recovery)
     expect(api::Inventory).not_to receive(:store_item)
     expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /Unexpected held item/)
+    expect(api.instance_variable_get(:@room_recovery)).to equal(recovery)
     expect(calls).to be_empty
     expect(api.room_scope?).to be_falsey
   end
@@ -250,7 +289,7 @@ RSpec.describe 'eLoot guarded room API' do
     prepare_world
     api.class_variable_set(:@@data, nil)
     harness.const_set(:Char, OpenStruct.new(name: 'OfflineFixture'))
-    harness.const_set(:XMLData, OpenStruct.new(game: 'GSIV'))
+    set_harness_const(:XMLData, OpenStruct.new(game: 'GSIV'))
     lich = Module.new
     messaging = Module.new
     messaging.define_singleton_method(:msg) { |*_| }
@@ -366,7 +405,7 @@ RSpec.describe 'eLoot guarded room API' do
 
   it 'does not swallow sticky cancellation in inventory retries' do
     prepare_world
-    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: :bag }))
+    set_harness_const(:StowList, OpenStruct.new(stow_list: { default: :bag }))
     data.sacks_full = {}
     item = OpenStruct.new(name: 'ruby', type: 'gem')
     allow(api).to receive(:msg)
@@ -433,7 +472,7 @@ RSpec.describe 'eLoot guarded room API' do
   it 'turns full containers into an actionable error without pausing or selling ingots' do
     prepare_world
     bag = OpenStruct.new(name: 'bag')
-    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: bag }))
+    set_harness_const(:StowList, OpenStruct.new(stow_list: { default: bag }))
     data.sacks_full = {}
     item = OpenStruct.new(name: 'gold ingot', type: 'gem')
     allow(api).to receive(:msg)
@@ -454,7 +493,7 @@ RSpec.describe 'eLoot guarded room API' do
     left = OpenStruct.new(id: '71', name: 'topaz')
     harness::GameObj.right_hand = right
     harness::GameObj.left_hand = left
-    harness.const_set(:ReadyList, OpenStruct.new(ready_list: {}))
+    set_harness_const(:ReadyList, OpenStruct.new(ready_list: {}))
     data.original_readylist = []
     allow(api::Inventory).to receive(:checkright).and_return(true)
     allow(api::Inventory).to receive(:checkleft).and_return(true)
@@ -462,8 +501,8 @@ RSpec.describe 'eLoot guarded room API' do
     expect(api::Inventory).not_to receive(:return_ready_list)
     expect(api::Inventory).to receive(:single_drag).with(right)
     expect(api::Inventory).to receive(:single_drag).with(left)
-    expect(api::Inventory).to receive(:drag).with(right, 'right')
-    expect(api::Inventory).to receive(:drag).with(left, 'left')
+    expect(api::Inventory).to receive(:drag).with(right, 'right') { harness::GameObj.right_hand = right }
+    expect(api::Inventory).to receive(:drag).with(left, 'left') { harness::GameObj.left_hand = left }
     allow(api::Loot).to receive(:search) do
       api::Inventory.free_hands(both: true)
       harness::GameObj.right_hand = OpenStruct.new(id: nil)

--- a/spec/scripts/eloot/room_scope_spec.rb
+++ b/spec/scripts/eloot/room_scope_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 require 'ostruct'
 require 'tmpdir'
 
 RSpec.describe 'eLoot guarded room API' do
-  let(:source_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source_path) { find_lic_source('eloot.lic', from: File.expand_path('..', __dir__)) }
   let(:source) { File.read(source_path) }
   let(:owner) do
     Object.new.tap do |value|

--- a/spec/scripts/eloot/room_scope_spec.rb
+++ b/spec/scripts/eloot/room_scope_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'eLoot guarded room API' do
       class << self
         attr_accessor :current, :list
       end
-    end
+    end.tap { |value| value.const_set(:EXECUTION_GUARD_PROTOCOL, 1) }
   end
   let(:harness) do
     namespace = Module.new
@@ -271,6 +271,12 @@ RSpec.describe 'eLoot guarded room API' do
     expect { run_room(owner: Object.new) }.to raise_error(api::RoomScopeError, /current guarded/)
     allow(owner).to receive(:execution_guard_active?).and_return(false)
     expect { run_room }.to raise_error(api::RoomScopeError, /current guarded/)
+    expect(api.data).to be_nil
+  end
+
+  it 'requires the native Lich execution-guard protocol before initialization' do
+    script_class.send(:remove_const, :EXECUTION_GUARD_PROTOCOL)
+    expect { run_room }.to raise_error(api::RoomScopeError, /execution guard protocol/)
     expect(api.data).to be_nil
   end
 

--- a/spec/scripts/eloot_room_scope_spec.rb
+++ b/spec/scripts/eloot_room_scope_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe 'eLoot guarded room API' do
   end
 
   it 'rejects malformed corpse IDs and nonboolean floor choices' do
-    [[], ['0'].freeze, ['#123'].freeze, ['1;look'].freeze, [Object.new].freeze].each do |ids|
+    [[].freeze, ['0'].freeze, ['#123'].freeze, ['1;look'].freeze, [Object.new].freeze].each do |ids|
       expect { run_room(corpse_ids: ids) }.to raise_error(ArgumentError)
     end
     expect { run_room(floor: 'yes') }.to raise_error(ArgumentError)

--- a/spec/scripts/eloot_room_scope_spec.rb
+++ b/spec/scripts/eloot_room_scope_spec.rb
@@ -1,0 +1,468 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'ostruct'
+require 'tmpdir'
+
+RSpec.describe 'eLoot guarded room API' do
+  let(:source_path) { find_lic_source('eloot.lic', from: __dir__) }
+  let(:source) { File.read(source_path) }
+  let(:owner) do
+    Object.new.tap do |value|
+      value.define_singleton_method(:execution_guard_active?) { true }
+      value.define_singleton_method(:check_execution_guard!) { true }
+      value.define_singleton_method(:execution_sleep) { |_seconds| true }
+      value.define_singleton_method(:name) { 'bigshot' }
+    end
+  end
+  let(:script_class) do
+    Class.new do
+      class << self
+        attr_accessor :current, :list
+      end
+    end
+  end
+  let(:harness) do
+    namespace = Module.new
+    namespace.const_set(:Script, script_class)
+    namespace.const_set(:LICH_VERSION, '5.21.0')
+    namespace.define_singleton_method(:before_dying) { |&block| (@cleanup ||= []) << block }
+    namespace.define_singleton_method(:cleanup) { @cleanup.each(&:call); @cleanup.clear }
+    loader = Struct.new(:name, :vars).new('eloot', ['--load-room-api'])
+    loader.define_singleton_method(:inspect) { 'version: 1.2.3 required: Lich >= 5.19.0' }
+    script_class.current = loader
+    script_class.list = [loader]
+    hide_const('Gtk') if defined?(Gtk)
+    begin
+      namespace.module_eval(source, source_path)
+    rescue SystemExit
+      namespace.cleanup
+    end
+    script_class.current = owner
+    namespace
+  end
+  let(:api) { harness.const_get(:ELoot) }
+  let(:calls) { [] }
+  let(:corpse) { Struct.new(:id).new('123') }
+  let(:data) do
+    OpenStruct.new(version: '1.2.3', settings: { track_full_sacks: true, skin_enable: true, keep_closed: true },
+                   right_hand: nil, left_hand: nil, pool_command: true)
+  end
+
+  def prepare_world
+    harness.const_set(:Status, Object.new.tap { |value| value.define_singleton_method(:dead?) { false } })
+    harness.const_set(:Spell, Object.new.tap { |value| value.define_singleton_method(:[]) { |_| Struct.new(:active?).new(false) } })
+    harness.const_set(:Group, Object.new.tap { |value| value.define_singleton_method(:checked?) { true } })
+    harness.const_set(:GameObj, OpenStruct.new(dead: [corpse, Struct.new(:id).new('999')], right_hand: :sword, left_hand: :shield))
+    api.class_variable_set(:@@data, data)
+    api.instance_variable_set(:@room_inventory_ready, true)
+    api.define_singleton_method(:disk_usage) {}
+    api.define_singleton_method(:reset_disk_full) { |**| }
+    log = calls
+    api.define_singleton_method(:use_coin_hand) { log << :coins }
+    api::Loot.define_singleton_method(:skin) { |items| log << [:skin, items.map(&:id)] }
+    api::Loot.define_singleton_method(:search) { |items| log << [:search, items.map(&:id)] }
+    api::Loot.define_singleton_method(:room) { log << :floor }
+    api::Inventory.define_singleton_method(:return_hands) { log << :hands }
+    api::Inventory.define_singleton_method(:close_sell_containers) { log << :close }
+  end
+
+  def run_room(**overrides)
+    api.room_loot(corpse_ids: ['123'].freeze, floor: false, owner: owner, **overrides)
+  end
+
+  it 'loads the entire production file without entering normal startup' do
+    expect(api::ROOM_LOOT_API_VERSION).to eq(1)
+    expect(api.data).to be_nil
+    expect(api.instance_variable_get(:@room_api_lease)).to be_nil
+    expect(api.instance_variable_get(:@room_api_versions)).to eq('eloot' => '1.2.3')
+  end
+
+  it 'passes only authorized corpses through normal skin/search and restores hands without a floor sweep' do
+    prepare_world
+    result = run_room
+    expect(result).to eq(outcome: :complete)
+    expect(result).to be_frozen
+    expect(calls).to eq([[:skin, ['123']], [:search, ['123']], :coins, :hands, :close])
+    expect([data.right_hand, data.left_hand]).to eq([:sword, :shield])
+    expect(api.room_scope?).to be_falsey
+  end
+
+  it 'uses the same room pickup routine when floor cleanup is requested' do
+    prepare_world
+    run_room(floor: true)
+    expect(calls).to include(:floor)
+  end
+
+  it 'restores the borrowed skinning tool after an interrupted room pass without resuming loot' do
+    prepare_world
+    sword = Struct.new(:id).new('10')
+    knife = Struct.new(:id).new('11')
+    empty = Struct.new(:id).new(nil)
+    sheath = Struct.new(:id).new('12')
+    harness::GameObj.right_hand = sword
+    harness::GameObj.left_hand = empty
+    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
+    harness.const_set(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
+    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: sheath }))
+    allow(api).to receive(:standing?).and_return(true)
+    world = harness::GameObj
+    api::Loot.define_singleton_method(:skin) do |_items|
+      world.left_hand = knife
+      raise 'command budget exhausted'
+    end
+    expect { run_room(recoverable: true) }.to raise_error('command budget exhausted')
+    expect(api::Inventory).to receive(:store_item).with(sheath, knife, true) { harness::GameObj.left_hand = empty }
+    expect(api.restore_room_hands(owner: owner)).to eq(outcome: :complete)
+    expect(harness::GameObj.left_hand.id).to be_nil
+    expect(calls).to eq([:hands])
+    expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /recovery/)
+  end
+
+  it 'refuses recovery after displacement or for a different owner before any inventory helper' do
+    prepare_world
+    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 101)))
+    harness.const_set(:XMLData, OpenStruct.new(room_count: 2))
+    api.instance_variable_set(:@room_recovery, { owner: owner, data: data, room: 100, epoch: 1 })
+    expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /context changed/)
+    expect { api.restore_room_hands(owner: Object.new) }.to raise_error(api::RoomScopeError, /recovery/)
+    expect(calls).to be_empty
+  end
+
+  %i[arrives observed missing revoked moved].each do |response|
+    it "never duplicates an uncertain sheath command when the delayed response is #{response}" do
+      prepare_world
+      sword = Struct.new(:id).new('10')
+      knife = Struct.new(:id, :name).new('11', 'test knife')
+      empty = Struct.new(:id).new(nil)
+      sheath = Struct.new(:id, :name, :contents).new('12', 'test sheath', [])
+      world = harness::GameObj
+      world.right_hand, world.left_hand = sword, empty
+      harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+      harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
+      harness.const_set(:ReadyList, OpenStruct.new(ready_list: { skin_weapon: knife, skin_sheath: sheath }))
+      harness.const_set(:StowList, OpenStruct.new(stow_list: { default: sheath }))
+      allow(api).to receive(:standing?).and_return(true)
+      allow(api).to receive(:msg)
+      wires = []
+      allow(api).to receive(:get_command) do |command, _pattern|
+        wires << command
+        raise 'interrupted waiting for sheath response' if wires.length == 1
+
+        world.left_hand = empty
+        []
+      end
+      inventory = api::Inventory
+      api::Loot.define_singleton_method(:skin) do |_items|
+        world.left_hand = knife
+        inventory.store_item(sheath, knife, true)
+      end
+      expect { run_room(recoverable: true) }.to raise_error('interrupted waiting for sheath response')
+      world.left_hand = empty if response == :observed
+      # The original XML hand update arrives during a guarded observation wait.
+      sleeps = []
+      room = harness::Room.current
+      owner.define_singleton_method(:execution_sleep) do |seconds|
+        sleeps << seconds
+        world.left_hand = empty if response == :arrives
+        room.id = 101 if response == :moved
+      end
+      owner.define_singleton_method(:check_execution_guard!) do
+        raise 'revoked' if response == :revoked && !sleeps.empty?
+        true
+      end
+      case response
+      when :observed
+        expect(api.restore_room_hands(owner: owner)).to eq(outcome: :complete)
+        expect(sleeps).to be_empty
+      when :arrives
+        expect(api.restore_room_hands(owner: owner)).to eq(outcome: :complete)
+        expect(sleeps.length).to eq(1)
+      when :missing
+        expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /refusing duplicate/)
+        expect(sleeps.sum).to be_within(0.001).of(2)
+      when :revoked
+        expect { api.restore_room_hands(owner: owner) }.to raise_error('revoked')
+      when :moved
+        expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /context changed/)
+      end
+      expect(wires).to eq(['_drag #11 #12'])
+    end
+  end
+
+  it 'does not stow an unrelated new item held during recovery' do
+    prepare_world
+    harness.const_set(:Room, OpenStruct.new(current: OpenStruct.new(id: 100)))
+    harness.const_set(:XMLData, OpenStruct.new(room_count: 1))
+    empty = Struct.new(:id).new(nil)
+    sword = Struct.new(:id).new('10')
+    harness::GameObj.right_hand = sword
+    harness::GameObj.left_hand = Struct.new(:id).new('99')
+    api.instance_variable_set(:@room_recovery, { owner: owner, data: data, room: 100, epoch: 1,
+                                               scope: { owner: owner }, right: sword, left: empty, tools: [] })
+    expect(api::Inventory).not_to receive(:store_item)
+    expect { api.restore_room_hands(owner: owner) }.to raise_error(api::RoomScopeError, /Unexpected held item/)
+    expect(calls).to be_empty
+    expect(api.room_scope?).to be_falsey
+  end
+
+  it 'retains the real room filters, exclusion precedence, and native single-item pickup choice' do
+    original = api::Loot.method(:room)
+    prepare_world
+    api::Loot.define_singleton_method(:room, original)
+    ruby = OpenStruct.new(id: '20', name: 'ruby', noun: 'ruby', type: 'gem')
+    topaz = OpenStruct.new(id: '21', name: 'topaz', noun: 'topaz', type: 'gem')
+    harness::GameObj.loot = [ruby, topaz]
+    harness.const_set(:Bounty, OpenStruct.new(task: OpenStruct.new(heirloom?: false)))
+    data.settings.merge!(loot_types: ['gem'], loot_keep: ['ruby', 'topaz'], unlootable: [], crumbly: [])
+    data.reject_loot_names = ['nothing']
+    data.reject_loot_nouns = ['nothing']
+    data.disk_nouns_regex = /disk/
+    data.loot_exclude_regex = /topaz/
+    data.loot_keep_regex = /nothing/
+    data.allowed_special_types = []
+    data.all_loot_categories = ['gem']
+    allow(api).to receive(:msg)
+    allow(api::Inventory).to receive(:open_loot_containers)
+    allow(api::Inventory).to receive(:free_hand)
+    expect(api::Inventory).to receive(:single_loot).with(ruby)
+    expect(api::Inventory).not_to receive(:single_loot).with(topaz)
+    expect(api::Loot).not_to receive(:loot_all)
+    run_room(floor: true)
+  end
+
+  it 'initializes with the eLoot profile and explicit eLoot version, never Bigshot metadata' do
+    prepare_world
+    api.class_variable_set(:@@data, nil)
+    profile = { loot_types: ['gem'] }
+    expect(api).to receive(:waitrt?)
+    expect(api).to receive(:load_profile).and_return(profile)
+    expect(api).to receive(:load).with(profile) do
+      expect(api.get_script_version).to eq('1.2.3')
+      api.class_variable_set(:@@data, data)
+    end
+    expect(api).to receive(:set_inventory) { api.instance_variable_set(:@room_inventory_ready, true) }
+    run_room
+  end
+
+  it 'loads and writes ordinary defaults when the first eLoot profile does not yet exist' do
+    prepare_world
+    api.class_variable_set(:@@data, nil)
+    harness.const_set(:Char, OpenStruct.new(name: 'OfflineFixture'))
+    harness.const_set(:XMLData, OpenStruct.new(game: 'GSIV'))
+    lich = Module.new
+    messaging = Module.new
+    messaging.define_singleton_method(:msg) { |*_| }
+    lich.const_set(:Messaging, messaging)
+    harness.const_set(:Lich, lich)
+    expect(messaging).to receive(:msg).with('info', /Loading defaults/)
+    allow(api).to receive(:waitrt?)
+    expect(api).to receive(:load).with(api.defaults_hash) { api.class_variable_set(:@@data, data) }
+    expect(api).to receive(:set_inventory) { api.instance_variable_set(:@room_inventory_ready, true) }
+    Dir.mktmpdir('eloot-room-profile-') do |directory|
+      harness.const_set(:DATA_DIR, directory)
+      run_room
+      expect(File.read(File.join(directory, 'GSIV', 'OfflineFixture', 'eloot.yaml'))).to include('loot_types')
+    end
+  end
+
+  it 'requires the current owner and active native guard before initialization' do
+    expect { run_room(owner: Object.new) }.to raise_error(api::RoomScopeError, /current guarded/)
+    allow(owner).to receive(:execution_guard_active?).and_return(false)
+    expect { run_room }.to raise_error(api::RoomScopeError, /current guarded/)
+    expect(api.data).to be_nil
+  end
+
+  it 'discards partially initialized data after an inventory failure and retries initialization' do
+    prepare_world
+    api.instance_variable_set(:@room_inventory_ready, false)
+    allow(api).to receive(:waitrt?)
+    allow(api).to receive(:load_profile).and_return({})
+    allow(api).to receive(:load) { api.class_variable_set(:@@data, data) }
+    expect(api).to receive(:set_inventory).ordered.and_raise(api::RoomScopeError, 'inventory unavailable')
+    expect { run_room }.to raise_error(api::RoomScopeError, /inventory unavailable/)
+    expect(api.data).to be_nil
+    expect(api).to receive(:set_inventory).ordered do
+      api.instance_variable_set(:@room_inventory_ready, true)
+    end
+    expect(run_room).to eq(outcome: :complete)
+  end
+
+  it 'preserves separate fresh corpse observations in ordinary skin and search calls' do
+    prepare_world
+    allow(api).to receive(:sleep)
+    allow(api::Loot).to receive(:skin) { |_| harness::GameObj.dead = [] }
+    expect(api::Loot).to receive(:search).with([])
+    api.loot
+  end
+
+  it 'rejects malformed corpse IDs and nonboolean floor choices' do
+    [[], ['0'].freeze, ['#123'].freeze, ['1;look'].freeze, [Object.new].freeze].each do |ids|
+      expect { run_room(corpse_ids: ids) }.to raise_error(ArgumentError)
+    end
+    expect { run_room(floor: 'yes') }.to raise_error(ArgumentError)
+  end
+
+  it 'releases only its own lease and refuses overlapping room or standalone work' do
+    prepare_world
+    token = Object.new
+    api.acquire_room_lease(token)
+    api.release_room_lease(Object.new)
+    expect { run_room }.to raise_error(api::RoomScopeError, /already running/)
+    expect { harness.module_eval(source, source_path) }.to raise_error(api::RoomScopeError, /already running/)
+    api.release_room_lease(token)
+    expect(run_room).to eq(outcome: :complete)
+  end
+
+  it 'unwinds the scope on cancellation without issuing hand-restoration commands' do
+    prepare_world
+    allow(api::Loot).to receive(:search).and_raise(api::RoomScopeError, 'cancelled')
+    expect { run_room }.to raise_error(api::RoomScopeError, 'cancelled')
+    expect(calls).not_to include(:hands, :close)
+    expect(api.instance_variable_get(:@room_api_lease)).to be_nil
+    expect(api.room_scope?).to be_falsey
+  end
+
+  it 'makes all three module receivers sleep through the guarded owner only in scope' do
+    prepare_world
+    expect(owner).to receive(:execution_sleep).with(0.2)
+    expect(owner).to receive(:execution_sleep).with(0.1).twice
+    allow(api::Loot).to receive(:search) do
+      api::Loot.sleep(0.1)
+      api::Inventory.sleep(0.1)
+    end
+    run_room
+    expect(api.sleep(0)).to eq(0)
+  end
+
+  it 'blocks sell, travel, banking, and box processing before their first side effect' do
+    prepare_world
+    allow(api::Loot).to receive(:search) do
+      [-> { api.go2('gemshop') }, -> { api.sell }, -> { api::Sell.sell },
+       -> { api.silver_deposit }, -> { api::Loot.box_loot(nil) }, -> { api::Sell.pool }].each do |operation|
+        expect(&operation).to raise_error(api::RoomScopeError, /cannot/)
+      end
+    end
+    run_room
+  end
+
+  it 'seeds the current disk without installing a persistent parser hook' do
+    original = api.method(:disk_usage)
+    prepare_world
+    api.define_singleton_method(:disk_usage, original)
+    data.settings[:use_disk] = true
+    harness.const_set(:Disk, OpenStruct.new(mine: Struct.new(:id).new('44')))
+    allow(harness::GameObj).to receive(:[]).with('44').and_return(:disk)
+    run_room
+    expect(data.disk).to eq(:disk)
+  end
+
+  it 'does not swallow sticky cancellation in inventory retries' do
+    prepare_world
+    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: :bag }))
+    data.sacks_full = {}
+    item = OpenStruct.new(name: 'ruby', type: 'gem')
+    allow(api).to receive(:msg)
+    allow(api::Inventory).to receive(:single_drag_box).and_return(false)
+    allow(api::Inventory).to receive(:stunned?).and_return(false)
+    error = Class.new(StandardError)
+    allow(api::Inventory).to receive(:store_item) do
+      allow(owner).to receive(:check_execution_guard!).and_raise(error, 'cancelled')
+      raise error, 'cancelled'
+    end
+    allow(api::Loot).to receive(:search) { api::Inventory.single_drag(item) }
+    expect { run_room }.to raise_error(error, 'cancelled')
+    expect(api.instance_variable_get(:@room_api_lease)).to be_nil
+  end
+
+  it 'does not start or use a file logger for a debug-file profile during room cleanup' do
+    prepare_world
+    data.settings[:debug_file] = true
+    data.debug_logger = nil
+    expect(api::DebugLogger).not_to receive(:new)
+    allow(api::Loot).to receive(:search) { api.msg(type: 'debug', text: 'room pass') }
+    expect(run_room).to eq(outcome: :complete)
+    expect(data.settings[:debug_file]).to be(true)
+  end
+
+  it 'does not swallow sticky cancellation in command retries' do
+    prepare_world
+    util = Module.new
+    lich = Module.new
+    lich.const_set(:Util, util)
+    harness.const_set(:Lich, lich)
+    error = Class.new(StandardError)
+    util.define_singleton_method(:issue_command) { |*_, **_| }
+    allow(util).to receive(:issue_command) do
+      allow(owner).to receive(:check_execution_guard!).and_raise(error, 'cancelled')
+      raise error, 'cancelled'
+    end
+    allow(api::Loot).to receive(:search) { api.get_command('look', /look/) }
+    expect { run_room }.to raise_error(error, 'cancelled')
+  end
+
+  it 'does not swallow sticky cancellation in coin-container retries' do
+    original = api.method(:use_coin_hand)
+    prepare_world
+    api.define_singleton_method(:use_coin_hand, original)
+    data.coin_hand = OpenStruct.new(id: '40')
+    data.coin_bag = OpenStruct.new(id: '41')
+    allow(api).to receive(:msg)
+    allow(api).to receive(:silver_check).and_return(1)
+    allow(api::Inventory).to receive(:free_hand)
+    util = Module.new
+    lich = Module.new
+    lich.const_set(:Util, util)
+    harness.const_set(:Lich, lich)
+    error = Class.new(StandardError)
+    util.define_singleton_method(:issue_command) { |*_, **_| }
+    allow(util).to receive(:issue_command) do
+      allow(owner).to receive(:check_execution_guard!).and_raise(error, 'cancelled')
+      raise error, 'cancelled'
+    end
+    expect { run_room }.to raise_error(error, 'cancelled')
+  end
+
+  it 'turns full containers into an actionable error without pausing or selling ingots' do
+    prepare_world
+    bag = OpenStruct.new(name: 'bag')
+    harness.const_set(:StowList, OpenStruct.new(stow_list: { default: bag }))
+    data.sacks_full = {}
+    item = OpenStruct.new(name: 'gold ingot', type: 'gem')
+    allow(api).to receive(:msg)
+    allow(api::Inventory).to receive(:single_drag_box).and_return(false)
+    allow(api::Inventory).to receive(:stunned?).and_return(false)
+    allow(api::Inventory).to receive(:store_item).and_return(false)
+    expect(owner).not_to receive(:pause)
+    expect(api::Sell).not_to receive(:handle_ingot)
+    allow(api::Loot).to receive(:search) { api::Inventory.single_drag(item) }
+    expect { run_room }.to raise_error(api::RoomScopeError, /full containers/)
+  end
+
+  it 'stows and restores occupied non-READY hands through the normal inventory methods' do
+    original = api::Inventory.method(:return_hands)
+    prepare_world
+    api::Inventory.define_singleton_method(:return_hands, original)
+    right = OpenStruct.new(id: '70', name: 'ruby')
+    left = OpenStruct.new(id: '71', name: 'topaz')
+    harness::GameObj.right_hand = right
+    harness::GameObj.left_hand = left
+    harness.const_set(:ReadyList, OpenStruct.new(ready_list: {}))
+    data.original_readylist = []
+    allow(api::Inventory).to receive(:checkright).and_return(true)
+    allow(api::Inventory).to receive(:checkleft).and_return(true)
+    expect(api::Inventory).not_to receive(:stow_ready_list)
+    expect(api::Inventory).not_to receive(:return_ready_list)
+    expect(api::Inventory).to receive(:single_drag).with(right)
+    expect(api::Inventory).to receive(:single_drag).with(left)
+    expect(api::Inventory).to receive(:drag).with(right, 'right')
+    expect(api::Inventory).to receive(:drag).with(left, 'left')
+    allow(api::Loot).to receive(:search) do
+      api::Inventory.free_hands(both: true)
+      harness::GameObj.right_hand = OpenStruct.new(id: nil)
+      harness::GameObj.left_hand = OpenStruct.new(id: nil)
+    end
+    run_room
+  end
+end


### PR DESCRIPTION
## Summary

- add a guarded room-only API that reuses eLoot's existing skin, search, filter, storage, and hand-restoration behavior
- accept only an exact current script owner, frozen positive corpse IDs, and an active native execution guard
- reject overlapping runs and operations outside room cleanup, including selling, travel, banking, box processing, sorters, and background readers
- retain a bounded recovery record when an interrupted skinning pass may have borrowed a tool; a retry cannot erase it before recovery succeeds
- verify the original hands and standing state before every successful return, including the default non-recoverable path

## Lich dependency

Ordinary `;eloot` behavior is unchanged. Only callers of the new `ELoot.room_loot` API require elanthia-online/lich-5#1575.

The dependency is on the script-instance execution-guard protocol introduced there:

- eLoot requires `Script::EXECUTION_GUARD_PROTOCOL == 1`
- it verifies that `owner` is the exact `Script.current` and that `owner.execution_guard_active?` is true
- it uses `owner.check_execution_guard!` at room-cleanup boundaries
- it routes scoped eLoot waits through `owner.execution_sleep`

eLoot does **not** install a guard itself. A supervising caller installs the policy with `owner.with_execution_guard`; eLoot consumes that already-active authority without broadening or clearing it.

This was split from elanthia-online/scripts#2456 at maintainer request so eLoot history and blame remain script-scoped. That Bigshot expansion has since been retired in favor of EO Hunter. This PR is therefore an independent composable API proposal, not a current EO Hunter dependency; ordinary eLoot and EO Hunter behavior do not depend on its merge.

eLoot specs are organized under `spec/scripts/eloot/`; smaller script suites remain flat.

## Review hardening

- split room preparation, recovery validation, delayed-tool reconciliation, and equipment restoration into focused helpers
- reject a second room pass while recoverable equipment state is pending
- retain recovery state across failed recovery attempts and clear it only after verified success
- keep the historical standalone READY-list behavior outside the guarded room API

## Verification

- room API suite: 32 examples, 0 failures
- complete eLoot directory suite: 160 examples, 0 failures
- changed eLoot script and specifications pass RuboCop
- changed files pass Ruby syntax validation
- the previously reviewed combined integration stack passed the full EO Scripts suite: 22,685 examples, 0 failures

Live room-scoped eLoot acceptance remains explicitly pending; the completed refuge acceptance used loot disabled.
