### PR TITLE
fix(BlackArts): v1.3.6 mushroom and ayana forage name handling

### DIFF
--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -6,10 +6,13 @@
   contributors: Deysh, Tysong, Gob
           game: Gemstone
           tags: alchemy
-       version: 1.3.5
+       version: 1.3.6
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.6 (2026-09-09)
+    - fix: foraging for mushrooms could grab the wrong mushroom or come up empty
+    - fix: foraging for an ayana weed/lichen/berry/root went to the right room but foraged for the wrong herb
   v1.3.5 (2025-07-30)
     - fix for returning mortar after grinding task
   v1.3.4 (2025-06-19)
@@ -4196,6 +4199,45 @@ module BlackArts
       return location_list
     end
 
+    # Mushrooms the game hands you under a longer name than it accepts in a
+    # FORAGE command: SENSE, room tags and the item itself all say "white hook
+    # mushroom", but you forage for "white mushroom".  Same table ebounty.lic
+    # uses in its find_herb_stow_list method, keyed the other way round.
+    # full item name (as tagged on the room) => name to use with FORAGE
+    def self.mushroom_forage_names
+      {
+        'black hook mushroom'     => 'black mushroom',
+        'black trafel mushroom'   => 'trafel mushroom',
+        'red trafel mushroom'     => 'red mushroom',
+        'soft white mushroom'     => 'soft mushroom',
+        'white hook mushroom'     => 'white mushroom',
+        'withered black mushroom' => 'withered mushroom',
+      }
+    end
+
+    # Herbs the game refers to by an outright different name in places (bounty
+    # text, older room tags) than the one it uses for the item.
+    # alternate name => name the game actually uses
+    def self.herb_aliases
+      {
+        'trollear mushroom' => 'trollfear mushroom',
+      }
+    end
+
+    # Reduce the many names an herb answers to down to the one the game uses for
+    # the item, which is also what tags.lic writes into the room tag.  Room tag
+    # lookups (forage_find, Guild.check_locations) and the FORAGE command have to
+    # agree on this or we travel to the right room and then forage for the wrong
+    # thing.  ebounty.lic normalizes the same names the same way.
+    def self.normalize_herb(herbname)
+      herbname = herbname.to_s.strip
+
+      return 'ayana leaf' if herbname =~ /^(?:some )?ayana (?:weed|lichen|berry|root)$/
+      return "ayana'al leaf" if herbname =~ /^(?:some )?ayana'al (?:weed|lichen|berry|root)$/
+
+      Util.herb_aliases[herbname] || Util.mushroom_forage_names.key(herbname) || herbname
+    end
+
     def self.fix_name(foragename)
       if foragename =~ /\w+ of (.*?)$/ then foragename = $1
       elsif foragename.include?('iceblossom') then foragename = 'iceblossom'
@@ -4208,7 +4250,7 @@ module BlackArts
       elsif foragename == 'discolored fleshbinder bud' then foragename = 'fleshbinder bud'
       elsif foragename == 'slime-covered grave blossom' then foragename = 'grave blossom'
       elsif foragename == 'fragrant white lily' then foragename = 'white lily'
-      elsif foragename == 'trollfear mushroom' then foragename = 'mushroom'
+      elsif Util.mushroom_forage_names.key?(foragename) then foragename = Util.mushroom_forage_names[foragename]
       elsif foragename == 'vermilion fire lily' then foragename = 'fire lily'
       elsif foragename == 'orange tiger lily' then foragename = 'tiger lily'
       elsif foragename == 'golden flaeshorn berry' then foragename = 'flaeshorn berry'
@@ -7843,9 +7885,15 @@ module BlackArts
           Util.msg('error', " error: failed to find a location for #{herb}.")
           exit
         end
-        # Make sure we are searching for the right thing
-        herb = herb.gsub(/^some /, "")
-        forage_item = Util.fix_name(herb)
+        # Make sure we are searching for the right thing.  forage_find looked for
+        # rooms tagged with the normalized name, so forage for that same herb
+        # rather than whatever name we were handed.  herb_key keeps the original
+        # forage_list key, which normalizing/stripping below would no longer match.
+        herb_key = herb
+        herb = Util.normalize_herb(herb)
+        forage_item = Util.fix_name(herb.gsub(/^some /, ""))
+        # herb_doses is keyed by the full "some <herb>" name
+        herb_dose = BlackArts.data.herb_doses[herb_key] || BlackArts.data.herb_doses[herb] || 1
         found_count = 0
 
         Hunting.pre_hunt
@@ -7895,13 +7943,8 @@ module BlackArts
               if forage_result =~ /^You forage briefly and manage to find/
                 item = [GameObj.right_hand, GameObj.left_hand].find { |i| i.noun != nil }
 
-                if BlackArts.data.herb_doses[forage_item]
-                  forage_list[herb] = forage_list[herb] - BlackArts.data.herb_doses[forage_item]
-                  found_count += BlackArts.data.herb_doses[forage_item]
-                else
-                  forage_list[herb] = forage_list[herb] - 1
-                  found_count += 1
-                end
+                forage_list[herb_key] = forage_list[herb_key].to_i - herb_dose
+                found_count += herb_dose
 
                 Inventory.store_item(BlackArts.data.sacks["herb"], item)
 
@@ -7948,9 +7991,7 @@ module BlackArts
 
     def self.forage_find(herb)
       Util.msg("debug", "Actions.forage_find: herb - #{herb}")
-      herb = herb.strip
-      herb = 'ayana leaf' if herb =~ /ayana (weed|lichen|berry|root)/
-      herb = "ayana'al leaf" if herb =~ /ayana'al (weed|lichen|berry|root)/
+      herb = Util.normalize_herb(herb)
 
       herb_alt = herb.gsub(/^some /, "")
       herb_fix = Util.fix_name(herb_alt)

--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -5113,10 +5113,10 @@ end
 module BlackArts
   class Data
     attr_accessor :settings, :dir, :sacks, :remaining_herbs, :herb, :forage_result, :forage_injury, :reagent, :remaining_reagents,
-                   :note, :note_names, :sea_water_flask, :sea_water_vial, :bundled_herb, :ingredient_count, :correct_herb_count, :put_regex, :get_regex, :herb_doses,
-                   :last_alchemy_buy, :alchemy_grind_history, :recipes, :consignment_list, :current_admin, :skin, :skin_number, :creature, :guild_skill, :locations, :ranks,
-                   :need_empty_flask, :start_room, :start_town, :current_room, :no_forage, :mortar_check, :cauldron, :note_withdrawal, :note_refresh, :visited_towns,
-                   :west_guilds, :east_guilds, :all_guilds, :cities, :boundaries, :gld_skills, :shadow_container, :shadow_item, :demon_id
+                  :note, :note_names, :sea_water_flask, :sea_water_vial, :bundled_herb, :ingredient_count, :correct_herb_count, :put_regex, :get_regex, :herb_doses,
+                  :last_alchemy_buy, :alchemy_grind_history, :recipes, :consignment_list, :current_admin, :skin, :skin_number, :creature, :guild_skill, :locations, :ranks,
+                  :need_empty_flask, :start_room, :start_town, :current_room, :no_forage, :mortar_check, :cauldron, :note_withdrawal, :note_refresh, :visited_towns,
+                  :west_guilds, :east_guilds, :all_guilds, :cities, :boundaries, :gld_skills, :shadow_container, :shadow_item, :demon_id
 
     def initialize(settings)
       @settings = settings

--- a/scripts/BlackArts.lic
+++ b/scripts/BlackArts.lic
@@ -5112,7 +5112,7 @@ end
 # Data
 module BlackArts
   class Data
-    attr_accessor  :settings, :dir, :sacks, :remaining_herbs, :herb, :forage_result, :forage_injury, :reagent, :remaining_reagents,
+    attr_accessor :settings, :dir, :sacks, :remaining_herbs, :herb, :forage_result, :forage_injury, :reagent, :remaining_reagents,
                    :note, :note_names, :sea_water_flask, :sea_water_vial, :bundled_herb, :ingredient_count, :correct_herb_count, :put_regex, :get_regex, :herb_doses,
                    :last_alchemy_buy, :alchemy_grind_history, :recipes, :consignment_list, :current_admin, :skin, :skin_number, :creature, :guild_skill, :locations, :ranks,
                    :need_empty_flask, :start_room, :start_town, :current_room, :no_forage, :mortar_check, :cauldron, :note_withdrawal, :note_refresh, :visited_towns,


### PR DESCRIPTION
Brings BlackArts' herb-name handling in line with what `ebounty.lic` already does, so the room lookup and the `FORAGE` command agree on what we're actually looking for.

## Background

Room tags carry the **full** item name — `tags.lic` builds `@herb_list` from `FORAGE SENSE` output, which reports `white hook mushroom`, `red trafel mushroom`, `black hook mushroom`, `withered black mushroom`. The `FORAGE` verb (and the game's own bounty forage link) wants the short form: `white mushroom`, `red mushroom`. `ebounty.lic` reconciles the two in `find_herb_stow_list`; BlackArts had no equivalent.

## Changes

- **`fix_name` collapsed `trollfear mushroom` to a bare `mushroom`.** Inherited from `betazzherb.lic`, from back when trollfear was the only mushroom that needed it. Post-PnC that's ambiguous — `forage for mushroom` in a room with several mushrooms hands back the wrong one, which BlackArts then stores and counts toward the target.
- **Added the short/full mushroom table** from ebounty's `find_herb_stow_list`, keyed the other way round (`Util.mushroom_forage_names`): white hook, black hook, red trafel, black trafel, withered black, soft white.
- **Added the `trollear` → `trollfear` alias** (`Util.herb_aliases`), matching ebounty's `forage_find`/`forage_bounty`. `;blackarts forage trollear mushroom x5` previously found no rooms at all and bailed with `failed to find a location`.
- **The ayana fix was only in half the path.** `Actions.forage_find` normalized `ayana weed|lichen|berry|root` → `ayana leaf` to pick rooms, but `Actions.forage` built its `FORAGE` command from the *un*-normalized name — so it travelled to the right room and then foraged for the wrong herb. Both now go through the new `Util.normalize_herb`.
- **`herb_doses` lookups never matched.** Keys are `some acantha leaf`, but the lookup used `forage_item`, which has had `some ` stripped, so every bundled herb counted as 1 per pick instead of its dose value. Now keyed on the original name.

## Behavior change worth flagging

The `herb_doses` fix means bundled herbs count their real dose value — acantha now counts 10 per pick rather than 1, so you forage roughly 10x less of the 13 bundled herbs. That matches the tracker's semantics (`tracker[:forage]` counts doses needed, one per `add some <herb>` step, and `check_ingredient` decrements bundles per dose), and is plainly what the original `if BlackArts.data.herb_doses[forage_item]` branch was written to do — it was just unreachable.

## Testing

- `bundle exec rubocop scripts/BlackArts.lic` — clean
- `bundle exec rspec` — 22095 examples, 0 failures (no BlackArts specs exist; no-regression check only)
- Normalization tables exercised directly against every mushroom and ayana variant in the recipe list, plus the existing `fix_name` cases (`sprig of lavender`, `azure iceblossom`, `blue mold`, `giant glowing toadstool`) to confirm no collateral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)