### PR TITLE
fix(pilepull): v1.3.4 fix ;pilepull logs crashing on a non-UTF-8 byte in a log line

### DIFF
--- a/scripts/pilepull.lic
+++ b/scripts/pilepull.lic
@@ -42,10 +42,13 @@
        requirements:
         - sequel gem
         - terminal-table gem
-           version: 1.3.3
+           version: 1.3.4
 
   Improvements:
   Major_change.feature_addition.bugfix
+  v1.3.4 (2026-09-10)
+    - Fix ";pilepull logs" crashing ("invalid byte sequence in UTF-8") on
+      a log file containing a stray non-UTF-8 byte.
   v1.3.3 (2026-09-10)
     - Fix ";pilepull logs" counting every search twice for any session that
       was run with --debug: the debug output itself was getting picked up
@@ -658,6 +661,16 @@ module PilePull
         year, month = match[1].to_i, match[2].to_i
 
         File.foreach(path) do |line|
+          # Real session logs occasionally contain a byte sequence that
+          # isn't valid UTF-8 (a stray control byte from a rough
+          # disconnect, a client-side encoding hiccup, etc.) -- String#match
+          # raises ArgumentError on those instead of just failing to match,
+          # which would abort the whole multi-GB scan over one bad line in
+          # one file. #scrub replaces any invalid bytes with the Unicode
+          # replacement character so matching degrades gracefully (that
+          # line simply won't match DATE_HEADER/PULL_LINE) instead of
+          # crashing the run.
+          line = line.scrub
           if (header = line.match(DATE_HEADER))
             year, month = header[1].to_i, header[2].to_i
             next

--- a/spec/scripts/pilepull_spec.rb
+++ b/spec/scripts/pilepull_spec.rb
@@ -1106,6 +1106,26 @@ RSpec.describe 'pilepull.lic reward tracking' do
         expect { log_scan.scan_file(missing_path, 'Pickasso', totals) }.not_to raise_error
         expect(log_scan.echoed.join).to match(/could not read log/)
       end
+
+      # Regression: a real session log can contain a line with a byte
+      # sequence that isn't valid UTF-8 (a stray control byte from a rough
+      # disconnect, a client-side encoding hiccup, etc.). String#match
+      # raises ArgumentError on an invalid-encoding string rather than just
+      # failing to match, which crashed the entire scan on one bad line in
+      # one file out of a character's whole log history.
+      it 'does not crash on a line containing an invalid UTF-8 byte sequence, and still parses the rest of the file' do
+        path = File.join(tmp_dir, '2026-03-01_15-47-17.log')
+        File.open(path, 'wb') do |f|
+          f.write("18:58:20: #{[0xFF, 0xFE].pack('C*')}garbled text\n")
+          f.write("18:58:21: You hand over 1,000,000 silver and search through a pile of mania prizes.  You pull a glowing orb from within!\n")
+        end
+
+        expect { log_scan.scan_file(path, 'Pickasso', totals) }.not_to raise_error
+
+        event_key = log_scan_rewards.event_key_for(2026, 3)
+        bucket = totals[['Pickasso', event_key]]
+        expect(bucket[:items][['rare', 'glowing orb']]).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Follow-up to #2461: a real session log can contain a line with a byte sequence that isn't valid UTF-8 (a stray control byte from a rough disconnect, a client-side encoding hiccup, etc.)
- `String#match` raises `ArgumentError: invalid byte sequence in UTF-8` on an invalid-encoding string rather than just failing to match, which crashed the entire `;pilepull logs` scan on one bad line in one file out of a character's whole log history — hit in real usage right after #2461 merged
- Each line read from a log file is now `.scrub`'d before matching, so a bad line just fails to match `DATE_HEADER`/`PULL_LINE` instead of aborting the run

## Test plan
- [x] Added a regression spec that writes a raw invalid UTF-8 byte sequence into a fixture log line; confirmed it fails with the exact same `ArgumentError` without the fix and passes with it
- [x] `bundle exec rspec spec/scripts/pilepull_spec.rb` (125 examples, 0 failures)
- [x] `bundle exec rspec` (full suite, 22132 examples, 0 failures)
- [x] `rubocop` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)