### PR TITLE
feat(effect-list): cooldowns for spells that lock out their targets

### DIFF
--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -129,12 +129,13 @@
    <spell availability='all' name='Searing Light' number='135' type='attack'>
       <cost type='mana'>7</cost>
    </spell>
-   <spell availability='all' name='Wall of Force' number='140' type='defense' target-cooldown='270'>
+   <spell availability='all' name='Wall of Force' number='140' type='defense'>
       <duration cast-type='self' span='refreshable'>1.5</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>40</cost>
       <bonus type='bolt-ds'>100</bonus>
       <bonus type='physical-ds'>100</bonus>
+      <cooldown type='target'>270</cooldown>
       <message type='start'>A wall of force surrounds you\.</message>
       <message type='end'>The wall of force disappears from around you\.</message>
       <message type='target-start'>A wall of force surrounds (?&lt;noun&gt;[A-Z][a-z]+)\.</message>
@@ -192,12 +193,13 @@
       <duration cast-type='target'>if (history = reget) and (history = history.reverse) and (line = history.index { |l| l =~ /^A pall of silence settles over you\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 0.5 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
       <cost type='mana'>10</cost>
    </spell>
-   <spell availability='group' name='Bravery' number='211' type='offense' group-cooldown='180'>
+   <spell availability='group' name='Bravery' number='211' type='offense'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[211].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>11</cost>
       <bonus type='bolt-as'>15</bonus>
       <bonus type='physical-as'>15</bonus>
+      <cooldown type='group'>180</cooldown>
       <message type='start'>You (?:and your group stand tall and )?feel more confident\.</message>
       <message type='end'>You feel less confident\.</message>
    </spell>
@@ -215,12 +217,13 @@
       <message type='start'>An unseen force envelops you, restricting all movement\.</message>
       <message type='end'>The restricting force that envelops you dissolves away\.</message>
    </spell>
-   <spell availability='group' name='Heroism' number='215' type='offense' group-cooldown='180'>
+   <spell availability='group' name='Heroism' number='215' type='offense'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[215].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>15</cost>
       <bonus type='bolt-as'>25+(Skills.slblessings/10)</bonus>
       <bonus type='physical-as'>25+(Skills.slblessings/10)</bonus>
+      <cooldown type='group'>180</cooldown>
       <message type='start'>A brilliant aura surrounds you and (?:sinks into your skin|your group)\.  You feel charged with extra vitality\.</message>
       <message type='end'>The brilliant aura fades away from you\.</message>
    </spell>
@@ -237,12 +240,13 @@
       <message type='start'>You infuse your .*?spirit with the mana necessary to maintain its corporeal form\.</message>
       <message type='end'>(?:An?|The).*? spirit fades into ethereal form and wafts away\.</message>
    </spell>
-   <spell availability='group' name='Spell Shield' number='219' type='defense' group-cooldown='360'>
+   <spell availability='group' name='Spell Shield' number='219' type='defense'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[219].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>2</duration>
       <cost type='mana'>19</cost>
       <bonus type='bolt-ds'>30</bonus>
       <bonus type='spirit-td'>30</bonus>
+      <cooldown type='group'>360</cooldown>
       <message type='start'>An opalescent aura surrounds you(?: and your group)?\.</message>
       <message type='end'>The opalescent aura fades from around you\.</message>
    </spell>
@@ -537,9 +541,10 @@
    <spell availability='all' name='Hand of Tonis' number='505' stance='yes' type='attack'>
       <cost type='mana'>5</cost>
    </spell>
-   <spell availability='all' name='Celerity' number='506' type='utility' target-cooldown='240'>
+   <spell availability='all' name='Celerity' number='506' type='utility'>
       <duration span='refreshable'>1</duration>
       <cost type='mana'>6</cost>
+      <cooldown type='target'>240</cooldown>
       <message type='start'>You (?:and your group )?suddenly start moving light\-footedly\.</message>
       <message type='end'>You suddenly feel less light\-footed\.</message>
       <message type='target-start'>(?&lt;noun&gt;[A-Z][a-z]+) suddenly starts moving light-footedly\.</message>

--- a/scripts/effect-list.xml
+++ b/scripts/effect-list.xml
@@ -129,7 +129,7 @@
    <spell availability='all' name='Searing Light' number='135' type='attack'>
       <cost type='mana'>7</cost>
    </spell>
-   <spell availability='all' name='Wall of Force' number='140' type='defense'>
+   <spell availability='all' name='Wall of Force' number='140' type='defense' target-cooldown='270'>
       <duration cast-type='self' span='refreshable'>1.5</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>40</cost>
@@ -137,6 +137,7 @@
       <bonus type='physical-ds'>100</bonus>
       <message type='start'>A wall of force surrounds you\.</message>
       <message type='end'>The wall of force disappears from around you\.</message>
+      <message type='target-start'>A wall of force surrounds (?&lt;noun&gt;[A-Z][a-z]+)\.</message>
    </spell>
    <spell availability='all' name='Calm' number='201' type='attack'>
       <cost type='mana'>1</cost>
@@ -191,7 +192,7 @@
       <duration cast-type='target'>if (history = reget) and (history = history.reverse) and (line = history.index { |l| l =~ /^A pall of silence settles over you\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 0.5 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
       <cost type='mana'>10</cost>
    </spell>
-   <spell availability='group' name='Bravery' number='211' type='offense'>
+   <spell availability='group' name='Bravery' number='211' type='offense' group-cooldown='180'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[211].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>11</cost>
@@ -214,7 +215,7 @@
       <message type='start'>An unseen force envelops you, restricting all movement\.</message>
       <message type='end'>The restricting force that envelops you dissolves away\.</message>
    </spell>
-   <spell availability='group' name='Heroism' number='215' type='offense'>
+   <spell availability='group' name='Heroism' number='215' type='offense' group-cooldown='180'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[215].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>1</duration>
       <cost type='mana'>15</cost>
@@ -236,7 +237,7 @@
       <message type='start'>You infuse your .*?spirit with the mana necessary to maintain its corporeal form\.</message>
       <message type='end'>(?:An?|The).*? spirit fades into ethereal form and wafts away\.</message>
    </spell>
-   <spell availability='group' name='Spell Shield' number='219' type='defense'>
+   <spell availability='group' name='Spell Shield' number='219' type='defense' group-cooldown='360'>
       <duration cast-type='self' span='stackable' multicastable='yes'>(Spell[219].known? ? 120 : 20) + Spells.majorspiritual</duration>
       <duration cast-type='target' span='refreshable'>2</duration>
       <cost type='mana'>19</cost>
@@ -536,11 +537,12 @@
    <spell availability='all' name='Hand of Tonis' number='505' stance='yes' type='attack'>
       <cost type='mana'>5</cost>
    </spell>
-   <spell availability='all' name='Celerity' number='506' type='utility'>
+   <spell availability='all' name='Celerity' number='506' type='utility' target-cooldown='240'>
       <duration span='refreshable'>1</duration>
       <cost type='mana'>6</cost>
       <message type='start'>You (?:and your group )?suddenly start moving light\-footedly\.</message>
       <message type='end'>You suddenly feel less light\-footed\.</message>
+      <message type='target-start'>(?&lt;noun&gt;[A-Z][a-z]+) suddenly starts moving light-footedly\.</message>
    </spell>
    <spell availability='self-cast' name='Elemental Deflection' number='507' type='defense'>
       <duration span='stackable' multicastable='yes'>(Spell[507].known? ? 120 : 20) + Spells.majorelemental</duration>


### PR DESCRIPTION
## Summary

Five spells stop a character from receiving them again for a while, and nothing in the effect list said so. Companion to elanthia-online/lich-5#1597, which reads these and tracks the cooldowns per character; without that PR these attributes are inert, and without this one its code has no data to act on. Either can merge first.

Two shapes, so two attributes.

**`group-cooldown`** -- the lockout a group (EVOKE) casting puts on each target. Bravery (211) and Heroism (215) at 180s, Spell Shield (219) at 360s. The caster's own start message names the group, which is how Lich tells a group casting apart from a self-cast.

**`target-cooldown`** -- the lockout a spell puts on the one character it lands on. Wall of Force (140) at 270s, Celerity (506) at 240s. It belongs to that character whoever cast it, so it pairs with a **`target-start`** message: the third-person line naming them, with the name captured as `(?<noun>...)`.

```xml
<spell ... number='140' ... target-cooldown='270'>
   <message type='target-start'>A wall of force surrounds (?&lt;noun&gt;[A-Z][a-z]+)\.</message>
```

Lengths are from the spell pages on the wiki. Existing attributes and messages are untouched, so a Lich that does not know these names ignores them.

Deliberately left out: Rapid Fire (515), whose recovery starts when the effect ends and scales with the target's Elemental Mana Control rather than being a constant; Barkskin (605), whose cooldown starts when the spell absorbs a hit, an event with no fixed relationship to the casting; and Invisibility (916) and Resist Nature (620), whose group versions have no per-target lockout.

## Test plan

- [x] XML parses under Ox with the same options Lich uses (`mode: :generic, skip: :skip_none`)
- [x] All five entries read back with the expected attribute values and messages
- [x] The two `target-start` patterns match the real game lines and capture the name, and do not match the second-person lines, the group-casting line, or a pet's line
- [x] In game on a live install: Wall of Force cast on a character reads 268.98 seconds left a moment later, from 0.0 before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
