### PR TITLE
fix(eloot): v2.11.10 stunned-loot hang and massive boulder skinning

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.8
+           version: 2.11.9
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.9 (2026-09-12)
+    - fix: eloot could get stuck indefinitely trying to store a looted item while stunned
+      during a heavy fight, requiring a manual restart
   v2.11.8 (2026-09-09)
     - fix: eloot could pause and wait for you to clear space by hand when the locksmith
       pool handed back a box and your containers were already full. It now sells off
@@ -3919,38 +3922,34 @@ module ELoot # Inventory methods
       end
       overflow_keys.each { |key| containers << StowList.stow_list[key] }
 
-      begin
-        containers.each_with_index do |bag, index|
-          if stunned?
-            ELoot.wait_rt
-            raise
-          end
-          next if bag && ELoot.data.sacks_full.keys.include?(bag.name)
+      containers.each_with_index do |bag, index|
+        if stunned?
+          ELoot.msg(type: "debug", text: "single_drag: character stunned, waiting for it to clear")
+          wait_while { stunned? }
+        end
+        next if bag && ELoot.data.sacks_full.keys.include?(bag.name)
 
-          if bag.nil?
-            case index
-            when 0
-              # Skip if item-specific container not set (this is normal)
-            when 1
-              ELoot.msg(type: "yellow", text: " No default container identified. This shouldn't happen.")
-              ELoot.msg(type: "yellow", text: "   Check your STOW settings. Exiting")
-              exit
-            else
-              # Overflow container not identified (this is normal if not all overflow containers are set)
-              overflow_num = index - 1
-              ELoot.msg(type: "info", text: " Skipping overflow container #{overflow_num}. No container identified.")
-            end
+        if bag.nil?
+          case index
+          when 0
+            # Skip if item-specific container not set (this is normal)
+          when 1
+            ELoot.msg(type: "yellow", text: " No default container identified. This shouldn't happen.")
+            ELoot.msg(type: "yellow", text: "   Check your STOW settings. Exiting")
+            exit
           else
-            result = Inventory.store_item(bag, item)
-            if result
-              ELoot.box_phase(item) if phase_thing
-              stored = true
-              break
-            end
+            # Overflow container not identified (this is normal if not all overflow containers are set)
+            overflow_num = index - 1
+            ELoot.msg(type: "info", text: " Skipping overflow container #{overflow_num}. No container identified.")
+          end
+        else
+          result = Inventory.store_item(bag, item)
+          if result
+            ELoot.box_phase(item) if phase_thing
+            stored = true
+            break
           end
         end
-      rescue
-        retry
       end
 
       # If item wasn't stored, pause and address

--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -21,6 +21,8 @@
   v2.11.9 (2026-09-12)
     - fix: eloot could get stuck indefinitely trying to store a looted item while stunned
       during a heavy fight, requiring a manual restart
+    - fix: massive boulders were being skinned with a regular blade instead of a blunt
+      weapon like their fellow stone-hided creatures
   v2.11.8 (2026-09-09)
     - fix: eloot could pause and wait for you to clear space by hand when the locksmith
       pool handed back a box and your containers were already full. It now sells off
@@ -5838,8 +5840,8 @@ module ELoot # Room looting
 
       return if objs.empty?
 
-      blunts = objs.find_all { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin/i }
-      normals = objs.reject { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin/i }
+      blunts = objs.find_all { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin|massive boulder/i }
+      normals = objs.reject { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin|massive boulder/i }
 
       skin_obj_types(normals, :normal)
       skin_obj_types(blunts, :blunt)


### PR DESCRIPTION
## Summary
- **Hang fix:** eloot could hang indefinitely mid-loot, requiring a manual `;k el` + `;el reload`.
  Root cause: `single_drag`'s per-container loop used a bare `raise` to abort the current iteration whenever `stunned?` was true, caught by a bare `rescue; retry` with no attempt cap and **no logging anywhere on that path** (`stunned?`, `ELoot.wait_rt`, `raise`, `rescue`, `retry` are all silent). If the character stayed stunned (e.g. repeated stuns in a heavy fight), this spun forever with zero output — indistinguishable from a genuine hang from the log. Replaced it with the `wait_while { stunned? }` idiom already used elsewhere in this codebase for the same purpose, plus a one-time debug message so it's visible when eloot is waiting out a stun instead of silently stuck.

  Diagnosed from a user-submitted debug log: the last two lines before the hang were the `single_drag`/`single_drag_box` entry debug for an item, followed by ~85 seconds (by the game's own prompt timestamps) of complete eloot silence — no further debug lines, no game commands sent — while combat/room text kept flowing normally, until the script was manually killed and reloaded. Every other branch of that loop (`store_item`, "sacks full", "no default container", "skipping overflow container") logs something; the stun-retry path is the only one that logs nothing at all, which is what points at it here.

- **Skinning fix:** `Loot.skin` routes krynch, stone mastiff, krag dweller, and cavern urchin to the blunt-weapon skinner since a blade doesn't work on their hides, but left `massive boulder` out of that list despite it being the same kind of stone-hided creature, so it fell through to the regular (bladed) skinner. Added it to both regexes.

## Test plan
- [x] `bundle exec rubocop scripts/eloot.lic` — no offenses
- [x] `bundle exec rspec spec/scripts/eloot_spec.rb` — 134 examples, 0 failures
- [ ] Manual in-game verification during a stun-heavy fight (I don't have a live session to reproduce the exact repro path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where looting could become stuck while the character was stunned during intense combat.
  * Improved container storage so looted items are stored after the character recovers from stun.
  * Fixed skinning for massive boulders by ensuring the appropriate blunt weapon is used.
  * Updated the release version to v2.11.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->