### PR TITLE
fix(eloot): v2.11.9 massive boulders skinned with the wrong tool type

### DIFF
--- a/scripts/eloot.lic
+++ b/scripts/eloot.lic
@@ -15,9 +15,12 @@
               game: Gemstone
               tags: loot
           required: Lich >= 5.15.0
-           version: 2.11.8
+           version: 2.11.9
   Improvements:
   Major_change.feature_addition.bugfix
+  v2.11.9 (2026-09-12)
+    - fix: massive boulders were being skinned with a regular blade instead of a blunt
+      weapon like their fellow stone-hided creatures
   v2.11.8 (2026-09-09)
     - fix: eloot could pause and wait for you to clear space by hand when the locksmith
       pool handed back a box and your containers were already full. It now sells off
@@ -5839,8 +5842,8 @@ module ELoot # Room looting
 
       return if objs.empty?
 
-      blunts = objs.find_all { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin/i }
-      normals = objs.reject { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin/i }
+      blunts = objs.find_all { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin|massive boulder/i }
+      normals = objs.reject { |obj| obj.name =~ /krynch|stone mastiff|krag dweller|cavern urchin|massive boulder/i }
 
       skin_obj_types(normals, :normal)
       skin_obj_types(blunts, :blunt)


### PR DESCRIPTION
## Summary
- \`Loot.skin\` routes stone-hided creatures (krynch, stone mastiff, krag dweller, cavern urchin) to the blunt-weapon skinner instead of the default blade, since a blade doesn't work on their hides.
- \`massive boulder\` is the same kind of stone-hided creature but was missing from both the blunt-match and the blunt-exclude regex, so it fell through to the regular (bladed) skinner.
- Added it to both regexes so it's routed to the blunt skinner like its fellow stone-hided creatures.

## Test plan
- [x] `bundle exec rubocop scripts/eloot.lic` — no offenses
- [x] `bundle exec rspec spec/scripts/eloot_spec.rb` — 134 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)